### PR TITLE
Spike 3: shared localhost tab and pane layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,14 @@ Processes and credential *files* stay on the pane host’s Mac (not uploaded to 
 
 ## Status
 
-Spike 2 provides one host-created, fixed-grid shared terminal pane over an authenticated Iroh
-connection. It intentionally has no tabs, splits, resize protocol, or multiple panes yet.
+Spike 3 provides a localhost shared layout for up to eight members. The coordinator owns a
+revisioned tab/split tree; every pane is a fixed-grid PTY owned by the member that created it.
+Each process serves its own locally hosted panes directly to the other admitted members.
+
+This is still a dogfooding spike: relay/internet validation, disconnect grace, coordinator
+failover, presence, and dynamic resize remain later work. The protocol deliberately has no
+resize message: each pane grid is fixed when that pane is created and is letterboxed or clipped
+by smaller local rectangles.
 
 ## Local Spike 1
 
@@ -52,7 +58,7 @@ the child shell or vt100 parser: larger windows leave extra cells blank and smal
 the upper-left fixed viewport. Dynamic resize is intentionally outside Spike 1 and the MVP wire
 protocol.
 
-To dogfood the shared host/guest pane:
+To dogfood the shared layout on one Mac:
 
 ```text
 Terminal 1: cargo run -- create
@@ -60,14 +66,27 @@ Terminal 2: cargo run -- join <printed 10-character code>
 ```
 
 `create` prints `Join with: p2pmux join <CODE>`, waits for Enter so you can copy it, then
-enters the host shell. The same code stays in the host status bar. `join` renders that remote pane.
+enters the shared-layout TUI. The same code stays in the footer. `join` first receives the
+authoritative layout, then attaches directly to every remote pane.
 Short join codes resolve through a restrictive local cache on the same Mac, so they are for current
 dogfooding only; they work while the corresponding `create` process is alive and are removed when
 it exits. Long `p2pmux-v1:` tickets remain accepted for backwards compatibility.
 
-Only one peer controls input at a time: after about eight seconds of idle time another guest can
-type to hop in; while someone is actively typing, press F9 to take control. F10 exits only
-the local p2pmux view.
+Only one peer controls each pane at a time: after about eight seconds of idle time another member
+can type to hop in; while someone is actively typing, press F9 to force Take control of the
+**focused** pane. F10 exits only the local p2pmux view.
+
+Shared-layout commands are local mux chords and never reach a PTY:
+
+- `Ctrl+P`, then `N` — split the focused pane. The new fixed-grid PTY runs on the requester’s Mac.
+- `Ctrl+P`, then `X` — delete the focused pane. Only that pane’s host may delete it.
+- `Ctrl+P`, then arrows — move focus.
+- `Ctrl+T`, then `N` — create a tab with a local PTY on the requester’s Mac.
+- `Ctrl+T`, then `X` — delete the current tab only when the requester hosts every pane in it.
+- `Ctrl+T`, then left/right — switch tabs; `Esc` cancels a chord.
+
+The final pane in a tab must be removed by deleting its tab; the final tab cannot be deleted.
+Nested 50/50 splits are part of Spike 3 (depth 4, at most 8 panes per tab, at most 9 tabs).
 
 Slow viewers may receive coalesced screen deltas and then a fresh snapshot to recover. Resizing an
 outer terminal crops or letterboxes the immutable host grid; it never resizes the host PTY.

--- a/docs/MVP_DESIGN.md
+++ b/docs/MVP_DESIGN.md
@@ -25,10 +25,13 @@ Brew-installable macOS terminal mux: each pane’s process runs on its host’s 
 - **Roles:** **coordinator** serializes shared structural state (layout, admission, lifecycle). **Pane host** = whose Mac runs that PTY (not exclusive control rights).
 - **Trust:** all members fully trusted; full shell control when they are controller.
 - **Visibility:** everyone sees every pane; no private panes.
-- **Split/close:** any member may split or close any **available** pane (with close confirmation).
+- **Spike 3 structural authority:** any admitted member may split a pane or create a tab; the new
+  fixed-grid PTY runs on that requester’s Mac. Only a pane’s host may delete that pane. A tab may
+  be deleted only by a member that hosts every pane in it. There is no close confirmation in this
+  spike; stale requests are rejected rather than replayed.
 - **Input:** one controller per pane; **idle → hop in and type, no approval**; if controller is **actively typing**, explicit **Take control** required.
-- **Disconnect grace:** **5 minutes** — departed host’s panes = unavailable placeholders; no input to those PTYs; reconnect within grace restores; after grace coordinator removes placeholders.
-- **Coordinator disconnect:** session **continues**; that host’s panes unavailable; see Coordinator failover.
+- **Later-spike disconnect behavior:** 5-minute unavailable placeholders and coordinator failover
+  are MVP goals, not implemented by Spike 3.
 - **Layout:** nested binary 50/50; **depth ≤ 4**; **≤ 8 panes/tab**; max **9 tabs**.
 - **Latency:** ≈ same-region SSH; relay normal
 - **Non-goals:** cloud VM execution, sandbox/ACL tiers, Win/Linux, drag-resize, mosh prediction, private panes, per-person ticket revocation in v1
@@ -37,10 +40,9 @@ Brew-installable macOS terminal mux: each pane’s process runs on its host’s 
 
 1. You `create` → reusable join ticket → first shell on your Mac. You start as coordinator.
 2. Others `join <ticket>` (up to 8). Everyone sees the same tabs/panes.
-3. Shells run on whoever **hosts** that pane’s Mac. Others watch; when idle they hop in and type; if someone’s mid-typing, use Take control.
-4. Anyone can split any available pane (new shell starts on the splitter’s Mac). Anyone can close a pane (confirm).
-5. If someone disconnects: their hosted panes go idle/unavailable for 5 minutes (session keeps going). If they return in time, panes come back.
-6. If the coordinator disconnects: same grace for their panes; structural edits pause briefly; if they don’t return, another member becomes coordinator (see below).
+3. Shells run on whoever **hosts** that pane’s Mac. Others watch; when idle they hop in and type; if someone’s mid-typing, press F9 to Take control of the focused pane.
+4. Any member can split an available pane or create a tab; the requester hosts the new PTY. Only the host can delete a pane. A member can delete a tab only when it owns every pane in that tab.
+5. Spike 3 is localhost layout/control work. Disconnect grace and coordinator failover remain later spikes.
 
 ## 4. Architecture
 
@@ -80,13 +82,19 @@ If coordinator disconnects:
 - Typing: explicit **Take control** (visible handoff).
 - Control serialized so two streams never hit one PTY.
 
-### Splits
+### Spike 3 layout and deletion
 
-Any member splits any available pane → **new PTY on the splitter’s machine**; 50/50; depth≤4; ≤8 panes/tab. All panes visible to all.
+Any member splits any available pane or creates a tab → **new PTY on the requester’s machine**;
+50/50 nested splits; depth≤4; ≤8 panes/tab; ≤9 tabs. All panes are visible to all. A pane host
+alone may delete its pane. Deleting a tab requires the requester to host every leaf in that tab.
+The last pane in a tab must be removed by deleting the tab; the final tab is retained.
 
-### Close
+### Spike 3 controls
 
-Any member may close any available leaf pane (confirm; kills that PTY; sibling expands). Placeholders during grace aren’t manually closable; restored or pruned after grace.
+`Ctrl+P` then `N` splits; `Ctrl+P` then `X` requests focused-pane deletion; `Ctrl+P` plus arrows
+moves focus. `Ctrl+T` then `N` creates a tab; `Ctrl+T` then `X` requests tab deletion; `Ctrl+T`
+plus left/right switches tabs; `Esc` cancels. These mux chords are consumed locally. F9 forces
+Take control of the focused pane and F10 exits the local view. Pane grids never resize.
 
 ### Disconnect grace (any member)
 
@@ -120,7 +128,10 @@ See [SPIKE_PLAN.md](./SPIKE_PLAN.md).
 
 ## 10. MVP success criteria
 
-Two (then more) Macs join via reusable ticket; shared layout; both host panes; anyone can split available panes; idle hop-in typing; Take control when busy; presence; locality of processes; encrypted P2P/relay; ≈ SSH feel; disconnect grace works; coordinator leave does not kill whole session.
+Two (then more) Macs join via reusable ticket; shared layout; both host panes; anyone can split
+available panes; pane hosts delete their own panes; all-host tabs can be deleted; idle hop-in
+typing; Take control when busy; presence; locality of processes; encrypted P2P/relay; ≈ SSH feel;
+disconnect grace works; coordinator leave does not kill whole session.
 
 ## Caveat (honest)
 

--- a/docs/SPIKE_PLAN.md
+++ b/docs/SPIKE_PLAN.md
@@ -30,32 +30,39 @@ Include control lease basics.
 
 **Done when:** guest typing feels good on localhost; dropping an update forces resync; slow guest doesn’t stall the PTY.
 
-### Spike 3 — Real internet
+### Spike 3 — Localhost shared layout (host-owned delete)
 
-Same code, two Macs / different networks. Show **direct | relayed**. Reusable ticket join.
+Up to eight local processes share coordinator-authoritative tabs and nested 50/50 splits. Every
+new pane/tab PTY runs on the creating member’s Mac and serves direct pane streams from that member.
+The coordinator reserves a pane, the creator registers its PTY, then reports ready before the
+layout commit exposes it.
 
-**Done when:** typing works over relay if needed; disconnect grace behavior matches the design.
+Commands: `Ctrl+P` then `N`/`X`/arrows; `Ctrl+T` then `N`/`X`/left/right; `Esc` cancels; F9 is
+focused-pane Take control; F10 exits. Pane grids are fixed at creation. Pane deletion is host-only;
+tab deletion requires every pane in that tab to be hosted by the requester. Maximums: 8 members,
+9 tabs, 8 panes/tab, split depth 4.
 
-### Spike 4 — N-member roster + split-any + presence + idle hop-in
+**Done when:** `create` plus one or more local `join` processes show the same tree; each creator
+hosts only its own new PTYs; late join receives layout then direct snapshots/leases; deletion
+authority and stale/limit rejection work; retrying direct subscription survives a transient roster
+race.
 
-Still dogfood with 2; exercise coordinator layout commits, anyone-can-split, presence, idle hop-in / Take control when typing.
+### Spike 4 — Real internet + presence
 
-**Done when:** joiner-created/split panes host on splitter’s machine; stale/over-limit layout ops rejected; leave behaviors match failure table.
+Run the shared-layout protocol on two Macs / different networks. Show **direct | relayed** and
+add presence without changing host-owned deletion or fixed grids.
 
-### Spike 5 — Tabs + nested splits
+**Done when:** pane control and layout work over relay if needed; presence is coherent.
 
-Exercise tree: L/R then split right top/bottom; max 9 tabs / depth 4 / ≤8 panes.
-
-**Done when:** all members see the same tree; late join gets one coherent bootstrap (layout + ownership + screen snapshots).
-
-### Spike 6 — Disconnect grace + coordinator failover
+### Spike 5 — Disconnect grace + coordinator failover
 
 5-minute placeholders; structural freeze during coordinator grace; earliest-join promotion.
 
-### Spike 7 — Brew formula
+### Spike 6 — Brew formula
 
 Last. Source-build tap is enough for dogfood.
 
 ## Non-goals during spikes
 
-Drag/resize, >8 peers, mosh prediction, custom relay deploy, short codes before Spike 3 works, sandbox/ACL tiers.
+Drag/resize, >8 peers, mosh prediction, custom relay deploy, sandbox/ACL tiers. Short local codes
+are only dogfooding convenience; portable ticket distribution is validated in Spike 4.

--- a/docs/superpowers/plans/2026-07-25-localhost-shared-layout.md
+++ b/docs/superpowers/plans/2026-07-25-localhost-shared-layout.md
@@ -18,6 +18,7 @@
 - PTY grids are fixed at pane creation. Every viewer letterboxes or clips a fixed grid; no resize protocol is added.
 - `Ctrl+P`, then `N`/`X` creates/deletes the selected pane. `Ctrl+T`, then `N`/`X` creates/deletes the selected tab. `Ctrl+P`, arrows move pane selection; `Ctrl+T`, left/right switch tabs; `Esc` cancels a chord. `F9` and `F10` retain the currently locked take-control/quit behavior.
 - A request rejected for a stale revision refreshes the UI state but is never automatically replayed.
+- This spike's host-owned deletion and `F9`/`F10` controls supersede the older close-confirmation and `Ctrl+Q` shared-control design wording. The documentation task must make `docs/MVP_DESIGN.md`, `docs/SPIKE_PLAN.md`, and the shared-control design agree.
 
 ## Files and boundaries
 
@@ -57,6 +58,7 @@
 - [ ] Write failing frame round-trip and validation tests for `SessionSnapshot`, `LayoutRequest`, `PaneReservation`, `PaneReady`, `LayoutCommit`, `LayoutReject`, and `PaneSubscribe`.
 - [ ] Verify the tests fail because v1 has none of these bodies.
 - [ ] Bump protocol version and ALPN to v2. Keep screens out of state commits; member addresses are bounded serialized `EndpointAddr` data and pane descriptors refer to a member ID.
+- [ ] Define explicit action payloads: `LayoutRequest { request_id, base_revision, action }`, `CreatePane { target_pane_id, axis, grid_rows, grid_cols }`, `DeletePane { pane_id }`, `CreateTab { grid_rows, grid_cols }`, and `DeleteTab { tab_id }`. `PaneReservation` and `PaneReady` both carry the same coordinator-generated reservation ID. The coordinator rejects readiness for an expired, mismatched, or already-consumed reservation. It derives the owner from the authenticated control connection; it never trusts a host ID supplied by a request.
 - [ ] Preserve size, identity, and malformed-frame checks for every new message.
 - [ ] Run protocol and transport tests, then commit `feat: add shared-layout protocol v2`.
 
@@ -69,7 +71,7 @@
 - [ ] Write failing loopback tests for capped admission, initial snapshot, full commit broadcast, stale rejection, and foreign-delete rejection.
 - [ ] Verify the new tests fail against the single fixed-pane API.
 - [ ] Replace the one-shot post-Welcome setup with a persistent member-control stream. Authenticate the connection peer, record its endpoint address, and broadcast full commits after admission or structural changes.
-- [ ] Make the coordinator hold one pending create reservation. It validates a request, sends an ID reservation, accepts `PaneReady`, then atomically commits; timeout/failure leaves state unchanged.
+- [ ] Make the coordinator hold one pending create reservation. It validates a request, sends an ID reservation, accepts `PaneReady` only from the authenticated reservation creator, then atomically commits; timeout/failure leaves state unchanged. `CreateTab` uses the same reservation path and reserves both the tab and its required initial pane.
 - [ ] Run `cargo test --test session_layout` and the existing handshake tests; commit `feat: coordinate revisioned shared layouts`.
 
 ### Task 5: Generalize direct pane streams
@@ -79,6 +81,7 @@
 - [ ] Write failing loopback tests showing two arbitrary pane IDs can independently deliver an actual initial `ControlLease`, Snapshot, and Delta; reject a subscription from a nonmember or for a mismatched host/pane.
 - [ ] Verify they fail because `DEFAULT_PANE_ID` is hard-coded.
 - [ ] Add a registry of local pane channels and a `PaneSubscribe` handshake. Every process accepts pane connections; viewers reconcile commit descriptors to local panes or remote subscriptions.
+- [ ] A late joiner may see the snapshot before a pane host has processed the membership commit. Treat a host's `NotMember` subscription rejection as transient: retry after the next commit and with a bounded localhost backoff until the admission deadline. Cover that race in the loopback test.
 - [ ] Keep a dedicated direct connection/stream bundle per viewed remote pane in this initial localhost implementation. Do not allow one pane's writer to block another's screen or input path.
 - [ ] Remove the guest's synthetic initial lease and keep only host-emitted lease state.
 - [ ] Run session stream/layout tests; commit `feat: stream panes from their owning members`.
@@ -109,9 +112,9 @@
 
 ### Task 8: Documentation and automated verification
 
-**Files:** Modify `README.md`, `docs/MVP_DESIGN.md`, `docs/SPIKE_PLAN.md`.
+**Files:** Modify `README.md`, `docs/MVP_DESIGN.md`, `docs/SPIKE_PLAN.md`, `docs/superpowers/specs/2026-07-25-shared-control-ui-design.md`.
 
-- [ ] Add localhost instructions and the exact ownership/chord rules; move nested-split completion to Spike 3.
+- [ ] Add localhost instructions and the exact ownership/chord rules; move nested-split completion to Spike 3. Reconcile the existing shared-control design with the host-owned-delete and `F9`/`F10` rules before claiming the MVP document is authoritative.
 - [ ] Run `cargo fmt --check`, `cargo test`, and `cargo clippy --all-targets --all-features -- -D warnings`.
 - [ ] Commit `docs: document localhost shared layout`.
 

--- a/docs/superpowers/plans/2026-07-25-localhost-shared-layout.md
+++ b/docs/superpowers/plans/2026-07-25-localhost-shared-layout.md
@@ -1,0 +1,123 @@
+# Spike 3 Localhost Shared Layout Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use `superpowers:subagent-driven-development`. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let localhost session members create tabs and panes whose PTYs run on the creator's Mac, while permitting deletes only by the pane host (or the host of every pane in a tab).
+
+**Architecture:** A coordinator owns a full, revisioned `SessionState` (membership, pane descriptors, tabs, and split trees) and publishes whole-state commits over one persistent member-control stream. Each pane still uses independent direct host-to-viewer Snapshot/Delta and control/lease streams. A create operation is prepared before its PTY starts, then committed only after its creator reports the pane ready.
+
+**Tech Stack:** Rust 2024, Tokio, Iroh 1.0, Prost, ratatui/crossterm, portable-pty, vt100.
+
+---
+
+## Locked behavior and invariants
+
+- At most 8 members, 9 tabs, 8 panes/tab, and split depth 4.
+- The layout always retains at least one tab, and every tab retains at least one pane. A last leaf cannot be deleted; its owner can delete its tab when another tab exists.
+- New panes split the selected leaf 50/50. The requesting TUI chooses `LeftRight` or `TopBottom` from its local rectangle and sends that axis.
+- PTY grids are fixed at pane creation. Every viewer letterboxes or clips a fixed grid; no resize protocol is added.
+- `Ctrl+P`, then `N`/`X` creates/deletes the selected pane. `Ctrl+T`, then `N`/`X` creates/deletes the selected tab. `Ctrl+P`, arrows move pane selection; `Ctrl+T`, left/right switch tabs; `Esc` cancels a chord. `F9` and `F10` retain the currently locked take-control/quit behavior.
+- A request rejected for a stale revision refreshes the UI state but is never automatically replayed.
+
+## Files and boundaries
+
+| File | Responsibility |
+| --- | --- |
+| `src/layout.rs` | Pure state model, limits, validation, and structural reducer. |
+| `src/protocol.rs` | v2 envelopes, serialized bounded member addresses, layout messages, and validation. |
+| `src/transport.rs` | v2 ALPN and existing framed-stream primitives. |
+| `src/session.rs` | Coordinator/member control stream, pane registry, direct pane subscriptions, and reconciliation events. |
+| `src/tui.rs` | Multi-pane local/remote view state, rectangles, focus, chords, and host PTY lifecycle. |
+| `src/cli.rs` | Starts the coordinator/member runtime and routes terminal events to it. |
+| `tests/layout.rs` | Deterministic reducer coverage. |
+| `tests/protocol.rs`, `tests/session_stream.rs`, `tests/session_layout.rs` | Wire, direct-pane, and localhost session integration coverage. |
+
+## Chunk 1: Pure state and protocol boundary
+
+### Task 1: Commit this plan
+
+**Files:** Create `docs/superpowers/plans/2026-07-25-localhost-shared-layout.md`
+
+- [ ] Commit this plan without source changes.
+
+### Task 2: Add the pure layout reducer
+
+**Files:** Create `src/layout.rs`, `tests/layout.rs`; modify `src/lib.rs`.
+
+- [ ] Write failing tests for initial state, right/down split, depth/tab/pane limits, sibling expansion, host-only pane delete, all-host tab delete, stale revisions, and last leaf/tab rejection.
+- [ ] Run `cargo test --test layout` and observe the missing-module failure.
+- [ ] Implement only the tested reducer with coordinator-generated numeric IDs and full-state commits.
+- [ ] Run `cargo fmt --all && cargo test --test layout`.
+- [ ] Commit `feat: add pure shared layout reducer`.
+
+### Task 3: Introduce protocol v2
+
+**Files:** Modify `src/protocol.rs`, `src/transport.rs`, `tests/protocol.rs`, `tests/transport.rs`.
+
+- [ ] Write failing frame round-trip and validation tests for `SessionSnapshot`, `LayoutRequest`, `PaneReservation`, `PaneReady`, `LayoutCommit`, `LayoutReject`, and `PaneSubscribe`.
+- [ ] Verify the tests fail because v1 has none of these bodies.
+- [ ] Bump protocol version and ALPN to v2. Keep screens out of state commits; member addresses are bounded serialized `EndpointAddr` data and pane descriptors refer to a member ID.
+- [ ] Preserve size, identity, and malformed-frame checks for every new message.
+- [ ] Run protocol and transport tests, then commit `feat: add shared-layout protocol v2`.
+
+## Chunk 2: Coordinator and per-pane transport
+
+### Task 4: Add the coordinator session state machine
+
+**Files:** Modify `src/session.rs`; create `tests/session_layout.rs`.
+
+- [ ] Write failing loopback tests for capped admission, initial snapshot, full commit broadcast, stale rejection, and foreign-delete rejection.
+- [ ] Verify the new tests fail against the single fixed-pane API.
+- [ ] Replace the one-shot post-Welcome setup with a persistent member-control stream. Authenticate the connection peer, record its endpoint address, and broadcast full commits after admission or structural changes.
+- [ ] Make the coordinator hold one pending create reservation. It validates a request, sends an ID reservation, accepts `PaneReady`, then atomically commits; timeout/failure leaves state unchanged.
+- [ ] Run `cargo test --test session_layout` and the existing handshake tests; commit `feat: coordinate revisioned shared layouts`.
+
+### Task 5: Generalize direct pane streams
+
+**Files:** Modify `src/session.rs`, `tests/session_stream.rs`.
+
+- [ ] Write failing loopback tests showing two arbitrary pane IDs can independently deliver an actual initial `ControlLease`, Snapshot, and Delta; reject a subscription from a nonmember or for a mismatched host/pane.
+- [ ] Verify they fail because `DEFAULT_PANE_ID` is hard-coded.
+- [ ] Add a registry of local pane channels and a `PaneSubscribe` handshake. Every process accepts pane connections; viewers reconcile commit descriptors to local panes or remote subscriptions.
+- [ ] Keep a dedicated direct connection/stream bundle per viewed remote pane in this initial localhost implementation. Do not allow one pane's writer to block another's screen or input path.
+- [ ] Remove the guest's synthetic initial lease and keep only host-emitted lease state.
+- [ ] Run session stream/layout tests; commit `feat: stream panes from their owning members`.
+
+## Chunk 3: Runtime and TUI
+
+### Task 6: Connect session runtime to local PTY lifecycles
+
+**Files:** Modify `src/cli.rs`, `src/session.rs`, `src/tui.rs`; extend `tests/session_layout.rs`.
+
+- [ ] Write failing tests for the create reservation sequence: a pane appears in a commit only after registration and a failed registration produces no layout mutation.
+- [ ] Verify the test fails.
+- [ ] Add bounded TUI-to-session and session-to-TUI commands. The TUI registers channels for each local PTY before reporting `PaneReady`; deletion unregisters only after its commit and then shuts down that PTY.
+- [ ] Start the coordinator's default pane through the same registry path; joining starts with no local pane and subscribes after its snapshot.
+- [ ] Run the affected tests; commit `feat: manage local pane lifecycles through session runtime`.
+
+### Task 7: Render and operate the multi-pane TUI
+
+**Files:** Modify `src/tui.rs`; extend its unit tests.
+
+- [ ] Write failing ratatui `TestBackend` tests for tab bar/recursive rectangles, focus movement, fixed-grid clipping, chord consumption, and request routing for each create/delete command.
+- [ ] Verify they fail against the single-pane renderer.
+- [ ] Replace separate one-pane host/guest loops with one multi-pane loop. Render host badges and lease state; render layout immediately but disable pane input until its Snapshot and ControlLease arrive.
+- [ ] Route normal typing, paste, and F9 only to the focused pane. Keep mux chords out of every PTY.
+- [ ] Run TUI and full test suites; commit `feat: add tabs splits and pane chords to tui`.
+
+## Chunk 4: Completion checks
+
+### Task 8: Documentation and automated verification
+
+**Files:** Modify `README.md`, `docs/MVP_DESIGN.md`, `docs/SPIKE_PLAN.md`.
+
+- [ ] Add localhost instructions and the exact ownership/chord rules; move nested-split completion to Spike 3.
+- [ ] Run `cargo fmt --check`, `cargo test`, and `cargo clippy --all-targets --all-features -- -D warnings`.
+- [ ] Commit `docs: document localhost shared layout`.
+
+### Task 9: Manual acceptance and PR
+
+- [ ] Build the binary and run one `create` plus at least two `join` processes on localhost in separate terminals/PTYs.
+- [ ] Verify: each member creates a pane; foreign delete is rejected; host delete succeeds; tab create/delete works; a mixed tab delete is rejected; a late join receives all panes; F10 exits cleanly.
+- [ ] Fix every failure and repeat this acceptance sequence until it passes.
+- [ ] Inspect status/diff, run the final suite, push `codex/spike3-shared-layout`, and open a PR targeting `main`.

--- a/docs/superpowers/specs/2026-07-25-shared-control-ui-design.md
+++ b/docs/superpowers/specs/2026-07-25-shared-control-ui-design.md
@@ -1,0 +1,55 @@
+# Shared Control UI Design
+
+## Goal
+
+Make the host and guest experience describe and enforce the same shared-control
+model, make control state unmistakable in the pane chrome, and remove
+function-key shortcuts that collide with macOS media keys.
+
+## Interaction model
+
+There is no forced takeover command. A member gains control by sending ordinary
+input to a pane whose current controller has been idle for the existing eight
+second timeout. The claiming input, including its first character, is buffered
+until the host accepts the lease claim, then forwarded to the shell. While a
+controller is actively typing, other members cannot interrupt; their input is
+not forwarded and they wait until the pane becomes idle before trying again.
+`Ctrl+Q` is the only TUI command and exits p2pmux. The TUI consumes it before
+forwarding any other input to the hosted shell, including a nested Zellij
+session.
+
+The pane host's existing `LeaseManager` remains authoritative. It serializes
+concurrent idle claims; the first accepted claim advances the lease epoch and
+the other claimant receives the published current lease, clears its buffered
+input, and remains a spectator. Stale claim and input epochs are rejected by the
+same manager. This change does not make the timeout configurable.
+
+## Shared help and permissions
+
+Host and guest render the identical control-help text: `type to claim idle |
+active typing is protected | Ctrl+Q quit`. The host may retain its join ticket
+in a separate status prefix, but it must not replace or alter that control help.
+The current prototype has one shared pane, so its UI must not imply host-only
+privilege or advertise a manual handoff action.
+
+## Control-pane chrome
+
+The controlled pane has a distinct border in both renderers. When the controller
+is actively typing, use a vivid red-orange border and the top-left label `this
+user is typing`. When the same controller remains assigned but becomes idle,
+retain the border, use a muted gray-orange color, and label it `this user has
+control`. This differentiates active input from idle ownership without changing
+the lease protocol. Before a guest receives its first lease, render no
+control-state border and prefix the same shared help with `waiting for control
+state | `; a disconnect continues to terminate the TUI with its existing error.
+
+## Testing
+
+Add unit coverage around TUI-facing control state and input-command selection so
+the shared help, Ctrl+Q handling, and active/idle chrome cannot regress. Cover
+the first keystroke following an idle claim, concurrent/stale claim rejection,
+and the pre-lease state. Update README instructions so neither F9/F10 nor forced
+takeover is advertised. Run the full Cargo test suite. Finally run `p2pmux
+create` in one terminal and `p2pmux join <ticket>` in another, exercising idle
+automatic handoff, active-input protection, the two border states, common footer
+text, and Ctrl+Q shutdown on both sides.

--- a/docs/superpowers/specs/2026-07-25-shared-control-ui-design.md
+++ b/docs/superpowers/specs/2026-07-25-shared-control-ui-design.md
@@ -2,21 +2,27 @@
 
 ## Goal
 
-Make the host and guest experience describe and enforce the same shared-control
-model, make control state unmistakable in the pane chrome, and remove
-function-key shortcuts that collide with macOS media keys.
+Make every member render and operate the same shared tab/split layout while preserving the
+authority of the member that hosts each PTY. This is the Spike 3 localhost design; later
+internet, presence, disconnect-grace, and failover work must not be implied as complete.
 
 ## Interaction model
 
-There is no forced takeover command. A member gains control by sending ordinary
-input to a pane whose current controller has been idle for the existing eight
-second timeout. The claiming input, including its first character, is buffered
-until the host accepts the lease claim, then forwarded to the shell. While a
-controller is actively typing, other members cannot interrupt; their input is
-not forwarded and they wait until the pane becomes idle before trying again.
-`Ctrl+Q` is the only TUI command and exits p2pmux. The TUI consumes it before
-forwarding any other input to the hosted shell, including a nested Zellij
-session.
+One controller leases each pane. A member gains control by ordinary input when the current
+controller has been idle for the existing eight-second timeout; the claiming input is buffered
+until the host accepts the lease claim. While a controller is actively typing, F9 forces Take
+control of the **focused** pane. F10 exits only the local p2pmux view.
+
+The local mux consumes its commands before any focused PTY receives them:
+
+- `Ctrl+P`, then `N` splits the focused pane; `X` requests deletion; arrows move focus.
+- `Ctrl+T`, then `N` creates a tab; `X` requests tab deletion; left/right switch tabs.
+- `Esc` cancels a pending chord.
+
+The new PTY for a split or tab runs on the requester’s Mac with a fixed creation grid. A pane’s
+host alone may delete it. A tab deletion succeeds only when the requester hosts every pane in
+that tab. The last pane in a tab is removed by deleting the tab; the final tab cannot be deleted.
+All splits are nested 50/50 (depth 4; up to 8 panes/tab and 9 tabs).
 
 The pane host's existing `LeaseManager` remains authoritative. It serializes
 concurrent idle claims; the first accepted claim advances the lease epoch and
@@ -26,30 +32,22 @@ same manager. This change does not make the timeout configurable.
 
 ## Shared help and permissions
 
-Host and guest render the identical control-help text: `type to claim idle |
-active typing is protected | Ctrl+Q quit`. The host may retain its join ticket
-in a separate status prefix, but it must not replace or alter that control help.
-The current prototype has one shared pane, so its UI must not imply host-only
-privilege or advertise a manual handoff action.
+Every member renders the same tab bar, focused-pane chrome, host badge, and controller state.
+The footer communicates `Ctrl+P panes | Ctrl+T tabs | F9 control | F10 quit`; the coordinator
+may append its join code. Focus never grants control. The UI shows reservation, rejection, and
+waiting-for-snapshot/lease status without blocking pane drain or layout control.
 
 ## Control-pane chrome
 
-The controlled pane has a distinct border in both renderers. When the controller
-is actively typing, use a vivid red-orange border and the top-left label `this
-user is typing`. When the same controller remains assigned but becomes idle,
-retain the border, use a muted gray-orange color, and label it `this user has
-control`. This differentiates active input from idle ownership without changing
-the lease protocol. Before a guest receives its first lease, render no
-control-state border and prefix the same shared help with `waiting for control
-state | `; a disconnect continues to terminate the TUI with its existing error.
+The focused pane has a distinct border. Pane chrome identifies its host and the current controller
+as typing, idle, or waiting for the first lease. Before screen/lease bootstrap, the leaf remains in
+the authoritative layout with a compact waiting state. Remote screen data is letterboxed or
+clipped inside its leaf; no client resizes the host PTY.
 
 ## Testing
 
-Add unit coverage around TUI-facing control state and input-command selection so
-the shared help, Ctrl+Q handling, and active/idle chrome cannot regress. Cover
-the first keystroke following an idle claim, concurrent/stale claim rejection,
-and the pre-lease state. Update README instructions so neither F9/F10 nor forced
-takeover is advertised. Run the full Cargo test suite. Finally run `p2pmux
-create` in one terminal and `p2pmux join <ticket>` in another, exercising idle
-automatic handoff, active-input protection, the two border states, common footer
-text, and Ctrl+Q shutdown on both sides.
+Cover chord consumption, focus, fixed-grid geometry, lease transitions, coordinator request /
+reservation / ready / commit lifecycle, host-only deletion, all-host tab deletion, and remote
+subscription retry after a transient failure. Run the full Cargo suite and strict clippy. Finally
+run `p2pmux create` in one terminal and `p2pmux join <ticket>` in another, exercising split,
+pane delete, tab create/delete, F9, and F10 on both processes.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,22 +2,19 @@
 
 use std::{
     error::Error,
-    future::Future,
     io::{self, Write},
-    pin::Pin,
     str::FromStr,
 };
 
 use clap::{Parser, Subcommand};
-use portable_pty::PtySize;
 
 use crate::{
-    lease::LeaseManager,
     rendezvous::{LocalRendezvous, RendezvousError},
-    screen::HostScreen,
-    session::{DEFAULT_PANE_ID, HostPaneChannels, HostSession, SessionError, join_pane},
+    session::{
+        HostSession, LayoutControlEvent, SharedLayoutHost, join_layout, layout_snapshot_from_state,
+    },
     ticket::{JoinTicket, TICKET_PREFIX},
-    transport::{Transport, TransportError},
+    transport::Transport,
 };
 
 /// The temporary p2pmux command-line interface.
@@ -72,7 +69,28 @@ async fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
                 writeln!(stdout, "{TRUST_WARNING}\n")?;
                 stdout.flush()?;
             }
-            let host = HostSession::create().await?;
+            let (cols, rows) = crossterm::terminal::size()?;
+            let shell_rows = rows.max(3).saturating_sub(2);
+            let host = SharedLayoutHost::new(HostSession::create().await?, shell_rows, cols)?;
+            let host_peer_id = host.ticket().endpoint_addr().id.as_bytes().to_vec();
+            let initial =
+                crate::tui::SharedLocalPane::spawn(1, shell_rows, cols, host_peer_id.clone())?;
+            let pane_server = host.pane_server();
+            pane_server.register_local_pane(
+                crate::protocol::PaneDescriptor {
+                    pane_id: 1,
+                    host_peer_id,
+                    grid_rows: u32::from(shell_rows),
+                    grid_cols: u32::from(cols),
+                },
+                initial.channels(),
+            )?;
+            let snapshot = host.session_snapshot()?;
+            let layout =
+                layout_snapshot_from_state(snapshot.state.as_ref().ok_or("missing host layout")?)
+                    .map_err(|error| io::Error::other(format!("invalid host layout: {error:?}")))?;
+            let dispatcher = host.incoming_dispatcher(pane_server.clone())?;
+            let dispatcher_task = tokio::spawn(async move { dispatcher.accept_loop().await });
             let rendezvous = LocalRendezvous::for_current_user()?.publish(host.ticket())?;
             let join_code = rendezvous.code().to_string();
             {
@@ -93,10 +111,28 @@ async fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
                 drop(stdout);
             }
             wait_for_enter()?;
-            // run_host moves terminal I/O to a blocking thread, so no StdoutLock may survive.
-            let result = run_host(host, join_code).await;
+            // SharedLayoutRuntime moves terminal I/O to a blocking thread, so no StdoutLock may survive.
+            let handle = tokio::runtime::Handle::current();
+            let session_id = host.ticket().session_id().to_vec();
+            let result = tokio::task::spawn_blocking(move || -> Result<(), String> {
+                let mut runtime = crate::tui::SharedLayoutRuntime::host(
+                    host,
+                    pane_server,
+                    layout,
+                    initial,
+                    join_code,
+                    handle,
+                )
+                .map_err(|error| error.to_string())?;
+                runtime.set_session_id(session_id);
+                runtime.run().map_err(|error| error.to_string())
+            })
+            .await?;
+            dispatcher_task.abort();
+            let _ = dispatcher_task.await;
             rendezvous.remove()?;
-            result
+            result.map_err(io::Error::other)?;
+            Ok(())
         }
         Command::Join { ticket } => {
             {
@@ -105,11 +141,38 @@ async fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
                 stdout.flush()?;
             }
             let ticket = resolve_join_ticket(&ticket)?;
-            let pane = join_pane(Transport::bind().await?, ticket).await?;
+            let transport = Transport::bind().await?;
+            let mut member = join_layout(transport, ticket.clone()).await?;
+            let state = match member.events.recv().await {
+                Some(LayoutControlEvent::Snapshot(snapshot)) => {
+                    snapshot.state.ok_or("missing layout snapshot")?
+                }
+                Some(_) => return Err(io::Error::other("expected initial layout snapshot").into()),
+                None => {
+                    return Err(
+                        io::Error::other("layout coordinator disconnected during join").into(),
+                    );
+                }
+            };
+            let pane_server = member.pane_server(ticket.session_id().to_vec())?;
+            pane_server.replace_roster_from_layout(&state)?;
+            let pane_acceptor = pane_server.clone();
+            let pane_accept_task = tokio::spawn(async move { pane_acceptor.accept_loop().await });
+            let handle = tokio::runtime::Handle::current();
             let guest_result = tokio::task::spawn_blocking(move || {
-                crate::tui::run_guest(pane).map_err(|error| error.to_string())
+                crate::tui::SharedLayoutRuntime::member_from_state(
+                    member,
+                    pane_server,
+                    ticket.session_id().to_vec(),
+                    state,
+                    handle,
+                )
+                .and_then(|runtime| runtime.run())
+                .map_err(|error| error.to_string())
             })
             .await?;
+            pane_accept_task.abort();
+            let _ = pane_accept_task.await;
             guest_result.map_err(io::Error::other)?;
             Ok(())
         }
@@ -134,139 +197,8 @@ fn wait_for_enter() -> io::Result<()> {
     Ok(())
 }
 
-async fn run_host(host: HostSession, join_code: String) -> Result<(), Box<dyn Error>> {
-    let (cols, rows) = crossterm::terminal::size()?;
-    // Reserve one row for the join-code status bar.
-    let shell_rows = rows.max(2).saturating_sub(1);
-    let size = PtySize {
-        rows: shell_rows,
-        cols,
-        pixel_width: 0,
-        pixel_height: 0,
-    };
-    let host_peer_id = host.ticket().endpoint_addr().id.as_bytes().to_vec();
-    let screen = HostScreen::new(shell_rows, cols)?;
-    let (screen_tx, screen_rx) = tokio::sync::watch::channel(screen.current_frame().clone());
-    let lease = LeaseManager::new(host_peer_id.clone(), std::time::Instant::now());
-    let (lease_tx, lease_rx) = tokio::sync::watch::channel(lease.state().clone());
-    let (control_tx, control_rx) = tokio::sync::mpsc::channel(256);
-    let runtime = crate::tui::HostPaneRuntime::new(
-        size,
-        host_peer_id.clone(),
-        screen_tx.clone(),
-        lease_tx,
-        control_rx,
-        join_code,
-    )?;
-    let accept_task = {
-        let accept_host = host.clone();
-        let serve_host = host.clone();
-        tokio::spawn(async move {
-            accept_until_closed(
-                move || {
-                    let host = accept_host.clone();
-                    Box::pin(async move { host.accept_incoming().await })
-                        as Pin<Box<dyn Future<Output = Result<_, SessionError>> + Send>>
-                },
-                move |incoming| {
-                    let pane = HostPaneChannels {
-                        pane_id: DEFAULT_PANE_ID.to_vec(),
-                        host_peer_id: host_peer_id.clone(),
-                        screen_rx: screen_rx.clone(),
-                        lease_rx: lease_rx.clone(),
-                        control_tx: control_tx.clone(),
-                    };
-                    let host = serve_host.clone();
-                    tokio::spawn(async move {
-                        let _ = host.serve_peer(incoming, pane).await;
-                    });
-                },
-            )
-            .await;
-        })
-    };
-    let result = tokio::task::spawn_blocking(move || {
-        crate::tui::run_host(runtime).map_err(|error| error.to_string())
-    })
-    .await?;
-    accept_task.abort();
-    host.close().await;
-    result.map_err(io::Error::other)?;
-    Ok(())
-}
-
-async fn accept_until_closed<T, Accept, Handle>(mut accept: Accept, mut handle: Handle)
-where
-    Accept: FnMut() -> Pin<Box<dyn Future<Output = Result<T, SessionError>> + Send>>,
-    Handle: FnMut(T),
-{
-    loop {
-        match accept().await {
-            Ok(incoming) => handle(incoming),
-            Err(error) if endpoint_is_closed(&error) => return,
-            Err(error) if !idle_accept_timed_out(&error) => {
-                eprintln!("p2pmux accept failed; continuing to listen: {error}");
-            }
-            Err(_) => {}
-        }
-    }
-}
-
-fn endpoint_is_closed(error: &SessionError) -> bool {
-    matches!(error, SessionError::Transport(TransportError::Closed))
-}
-
-fn idle_accept_timed_out(error: &SessionError) -> bool {
-    matches!(
-        error,
-        SessionError::Transport(TransportError::TimedOut("incoming accept"))
-    )
-}
-
 #[cfg(test)]
 mod tests {
-    use std::{
-        collections::VecDeque,
-        future::Future,
-        pin::Pin,
-        sync::{Arc, Mutex},
-    };
-
-    use crate::{session::SessionError, transport::TransportError};
-
-    use super::accept_until_closed;
-
-    #[tokio::test]
-    async fn accept_loop_keeps_accepting_after_an_idle_timeout() {
-        let results = Arc::new(Mutex::new(VecDeque::from([
-            Err(SessionError::Transport(TransportError::TimedOut(
-                "incoming accept",
-            ))),
-            Ok("joined"),
-            Err(SessionError::Transport(TransportError::Closed)),
-        ])));
-        let accepted = Arc::new(Mutex::new(Vec::new()));
-        let next = results.clone();
-        let handled = accepted.clone();
-
-        accept_until_closed(
-            move || {
-                let next = next.clone();
-                Box::pin(async move {
-                    next.lock()
-                        .expect("results lock")
-                        .pop_front()
-                        .expect("loop should stop when endpoint closes")
-                })
-                    as Pin<Box<dyn Future<Output = Result<&'static str, SessionError>> + Send>>
-            },
-            move |incoming| handled.lock().expect("accepted lock").push(incoming),
-        )
-        .await;
-
-        assert_eq!(*accepted.lock().expect("accepted lock"), vec!["joined"]);
-    }
-
     #[test]
     fn create_releases_stdout_before_starting_the_host_tui() {
         let source = include_str!("cli.rs");
@@ -283,7 +215,7 @@ mod tests {
                 .find("drop(stdout);")
                 .expect("stdout is released")
                 < create_arm
-                    .find("run_host(host, join_code).await")
+                    .find("SharedLayoutRuntime::host(")
                     .expect("host TUI starts"),
             "create must release stdout before the host TUI runs on a blocking thread"
         );

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -70,18 +70,22 @@ async fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
                 stdout.flush()?;
             }
             let (cols, rows) = crossterm::terminal::size()?;
-            let shell_rows = rows.max(3).saturating_sub(2);
-            let host = SharedLayoutHost::new(HostSession::create().await?, shell_rows, cols)?;
+            let (shell_rows, shell_cols) = crate::tui::initial_root_pane_grid(cols, rows);
+            let host = SharedLayoutHost::new(HostSession::create().await?, shell_rows, shell_cols)?;
             let host_peer_id = host.ticket().endpoint_addr().id.as_bytes().to_vec();
-            let initial =
-                crate::tui::SharedLocalPane::spawn(1, shell_rows, cols, host_peer_id.clone())?;
+            let initial = crate::tui::SharedLocalPane::spawn(
+                1,
+                shell_rows,
+                shell_cols,
+                host_peer_id.clone(),
+            )?;
             let pane_server = host.pane_server();
             pane_server.register_local_pane(
                 crate::protocol::PaneDescriptor {
                     pane_id: 1,
                     host_peer_id,
                     grid_rows: u32::from(shell_rows),
-                    grid_cols: u32::from(cols),
+                    grid_cols: u32::from(shell_cols),
                 },
                 initial.channels(),
             )?;

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -67,6 +67,12 @@ pub struct PaneReservation {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+pub struct InvalidatedReservation {
+    pub reservation_id: ReservationId,
+    pub creator_peer_id: Vec<u8>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ReservationCommit {
     Pane { pane_id: PaneId },
     Tab { tab_id: TabId, pane_id: PaneId },
@@ -254,7 +260,7 @@ impl SessionState {
         base_revision: u64,
         peer_id: Vec<u8>,
         endpoint_addr: Vec<u8>,
-    ) -> Result<(), LayoutError> {
+    ) -> Result<Option<InvalidatedReservation>, LayoutError> {
         self.check_mutation(base_revision)?;
         validate_peer_id(&peer_id)?;
         validate_endpoint_addr(&endpoint_addr)?;
@@ -269,7 +275,7 @@ impl SessionState {
             endpoint_addr,
         });
         self.advance_revision();
-        Ok(())
+        Ok(self.invalidate_reservation())
     }
 
     pub fn update_member_endpoint(
@@ -277,7 +283,7 @@ impl SessionState {
         base_revision: u64,
         peer_id: &[u8],
         endpoint_addr: Vec<u8>,
-    ) -> Result<(), LayoutError> {
+    ) -> Result<Option<InvalidatedReservation>, LayoutError> {
         self.check_mutation(base_revision)?;
         validate_endpoint_addr(&endpoint_addr)?;
         let member = self
@@ -287,7 +293,7 @@ impl SessionState {
             .ok_or(LayoutError::NotMember)?;
         member.endpoint_addr = endpoint_addr;
         self.advance_revision();
-        Ok(())
+        Ok(self.invalidate_reservation())
     }
 
     pub fn reserve_pane(
@@ -457,6 +463,23 @@ impl SessionState {
         reservation_id: ReservationId,
     ) -> Result<(), LayoutError> {
         self.match_reservation(creator, reservation_id)?;
+        self.pending_reservation = None;
+        Ok(())
+    }
+
+    pub fn fail_reservation(
+        &mut self,
+        creator: &[u8],
+        base_revision: u64,
+        reservation_id: ReservationId,
+    ) -> Result<(), LayoutError> {
+        let reservation = self.match_reservation(creator, reservation_id)?;
+        if reservation.base_revision != base_revision {
+            return Err(LayoutError::StaleRevision {
+                expected: reservation.base_revision,
+                got: base_revision,
+            });
+        }
         self.pending_reservation = None;
         Ok(())
     }
@@ -663,6 +686,15 @@ impl SessionState {
 
     fn next_id(&self, id: u64) -> Result<u64, LayoutError> {
         id.checked_add(1).ok_or(LayoutError::IdExhausted)
+    }
+
+    fn invalidate_reservation(&mut self) -> Option<InvalidatedReservation> {
+        self.pending_reservation
+            .take()
+            .map(|reservation| InvalidatedReservation {
+                reservation_id: reservation.reservation_id,
+                creator_peer_id: reservation.creator_peer_id,
+            })
     }
 
     fn tab_index_for_pane(&self, pane_id: PaneId) -> Option<usize> {

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -93,6 +93,7 @@ enum PendingReservationKind {
 struct PendingReservation {
     reservation_id: ReservationId,
     creator_peer_id: Vec<u8>,
+    base_revision: u64,
     kind: PendingReservationKind,
 }
 
@@ -312,6 +313,7 @@ impl SessionState {
         self.pending_reservation = Some(PendingReservation {
             reservation_id,
             creator_peer_id: creator.to_vec(),
+            base_revision,
             kind: PendingReservationKind::Pane {
                 pane_id,
                 target_pane_id,
@@ -353,6 +355,7 @@ impl SessionState {
         self.pending_reservation = Some(PendingReservation {
             reservation_id,
             creator_peer_id: creator.to_vec(),
+            base_revision,
             kind: PendingReservationKind::Tab {
                 tab_id,
                 pane_id,
@@ -373,8 +376,14 @@ impl SessionState {
         base_revision: u64,
         reservation_id: ReservationId,
     ) -> Result<ReservationCommit, LayoutError> {
-        self.check_mutation(base_revision)?;
         let reservation = self.match_reservation(creator, reservation_id)?;
+        if reservation.base_revision != base_revision {
+            return Err(LayoutError::StaleRevision {
+                expected: reservation.base_revision,
+                got: base_revision,
+            });
+        }
+        self.check_mutation(base_revision)?;
         match reservation.kind {
             PendingReservationKind::Pane {
                 pane_id,

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -1,0 +1,417 @@
+use std::collections::BTreeMap;
+
+pub const MAX_MEMBERS: usize = 8;
+pub const MAX_TABS: usize = 9;
+pub const MAX_PANES_PER_TAB: usize = 8;
+pub const MAX_SPLIT_DEPTH: usize = 4;
+
+pub type PaneId = u64;
+pub type TabId = u64;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Axis {
+    LeftRight,
+    TopBottom,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Node {
+    Leaf {
+        pane_id: PaneId,
+    },
+    Split {
+        axis: Axis,
+        first: Box<Node>,
+        second: Box<Node>,
+    },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Member {
+    pub peer_id: Vec<u8>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Pane {
+    pub pane_id: PaneId,
+    pub host_peer_id: Vec<u8>,
+    pub grid_rows: u16,
+    pub grid_cols: u16,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Tab {
+    pub tab_id: TabId,
+    pub root: Node,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SessionState {
+    pub revision: u64,
+    pub members: Vec<Member>,
+    pub tabs: Vec<Tab>,
+    pub panes: BTreeMap<PaneId, Pane>,
+    next_tab_id: TabId,
+    next_pane_id: PaneId,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum LayoutError {
+    StaleRevision { expected: u64, got: u64 },
+    RevisionExhausted,
+    MemberLimit,
+    AlreadyMember,
+    NotMember,
+    TabLimit,
+    PaneLimit,
+    SplitDepthLimit,
+    InvalidGrid,
+    UnknownPane { pane_id: PaneId },
+    UnknownTab { tab_id: TabId },
+    NotPaneHost { pane_id: PaneId },
+    NotTabHost { tab_id: TabId },
+    LastPaneInTab { tab_id: TabId },
+    LastTab,
+    IdExhausted,
+}
+
+impl SessionState {
+    pub fn new(initial_host: Vec<u8>, grid_rows: u16, grid_cols: u16) -> Result<Self, LayoutError> {
+        validate_grid(grid_rows, grid_cols)?;
+
+        let initial_pane = Pane {
+            pane_id: 1,
+            host_peer_id: initial_host.clone(),
+            grid_rows,
+            grid_cols,
+        };
+        let mut panes = BTreeMap::new();
+        panes.insert(initial_pane.pane_id, initial_pane);
+
+        Ok(Self {
+            revision: 1,
+            members: vec![Member {
+                peer_id: initial_host,
+            }],
+            tabs: vec![Tab {
+                tab_id: 1,
+                root: Node::Leaf { pane_id: 1 },
+            }],
+            panes,
+            next_tab_id: 2,
+            next_pane_id: 2,
+        })
+    }
+
+    pub fn add_member(&mut self, base_revision: u64, peer_id: Vec<u8>) -> Result<(), LayoutError> {
+        self.check_mutation(base_revision)?;
+        if self.members.iter().any(|member| member.peer_id == peer_id) {
+            return Err(LayoutError::AlreadyMember);
+        }
+        if self.members.len() >= MAX_MEMBERS {
+            return Err(LayoutError::MemberLimit);
+        }
+
+        self.members.push(Member { peer_id });
+        self.advance_revision();
+        Ok(())
+    }
+
+    pub fn create_pane(
+        &mut self,
+        requester: &[u8],
+        base_revision: u64,
+        target_pane_id: PaneId,
+        axis: Axis,
+        grid_rows: u16,
+        grid_cols: u16,
+    ) -> Result<PaneId, LayoutError> {
+        self.check_mutation(base_revision)?;
+        self.require_member(requester)?;
+        validate_grid(grid_rows, grid_cols)?;
+
+        let tab_index =
+            self.tab_index_for_pane(target_pane_id)
+                .ok_or(LayoutError::UnknownPane {
+                    pane_id: target_pane_id,
+                })?;
+        if self.pane_ids_in_tab_at(tab_index).len() >= MAX_PANES_PER_TAB {
+            return Err(LayoutError::PaneLimit);
+        }
+        let target_depth = self.tabs[tab_index]
+            .root
+            .leaf_depth(target_pane_id)
+            .expect("tab_index_for_pane found the leaf");
+        if target_depth >= MAX_SPLIT_DEPTH {
+            return Err(LayoutError::SplitDepthLimit);
+        }
+
+        let pane_id = self.next_pane_id;
+        let next_pane_id = self.next_id(pane_id)?;
+        let split = Node::Split {
+            axis,
+            first: Box::new(Node::Leaf {
+                pane_id: target_pane_id,
+            }),
+            second: Box::new(Node::Leaf { pane_id }),
+        };
+        let replaced = self.tabs[tab_index]
+            .root
+            .replace_leaf(target_pane_id, split);
+        debug_assert!(replaced);
+        self.panes.insert(
+            pane_id,
+            Pane {
+                pane_id,
+                host_peer_id: requester.to_vec(),
+                grid_rows,
+                grid_cols,
+            },
+        );
+        self.next_pane_id = next_pane_id;
+        self.advance_revision();
+        Ok(pane_id)
+    }
+
+    pub fn create_tab(
+        &mut self,
+        requester: &[u8],
+        base_revision: u64,
+        grid_rows: u16,
+        grid_cols: u16,
+    ) -> Result<TabId, LayoutError> {
+        self.check_mutation(base_revision)?;
+        self.require_member(requester)?;
+        validate_grid(grid_rows, grid_cols)?;
+        if self.tabs.len() >= MAX_TABS {
+            return Err(LayoutError::TabLimit);
+        }
+
+        let tab_id = self.next_tab_id;
+        let pane_id = self.next_pane_id;
+        let next_tab_id = self.next_id(tab_id)?;
+        let next_pane_id = self.next_id(pane_id)?;
+        self.panes.insert(
+            pane_id,
+            Pane {
+                pane_id,
+                host_peer_id: requester.to_vec(),
+                grid_rows,
+                grid_cols,
+            },
+        );
+        self.tabs.push(Tab {
+            tab_id,
+            root: Node::Leaf { pane_id },
+        });
+        self.next_tab_id = next_tab_id;
+        self.next_pane_id = next_pane_id;
+        self.advance_revision();
+        Ok(tab_id)
+    }
+
+    pub fn delete_pane(
+        &mut self,
+        requester: &[u8],
+        base_revision: u64,
+        pane_id: PaneId,
+    ) -> Result<(), LayoutError> {
+        self.check_mutation(base_revision)?;
+        self.require_member(requester)?;
+        let pane = self
+            .panes
+            .get(&pane_id)
+            .ok_or(LayoutError::UnknownPane { pane_id })?;
+        if pane.host_peer_id != requester {
+            return Err(LayoutError::NotPaneHost { pane_id });
+        }
+        let tab_index = self
+            .tab_index_for_pane(pane_id)
+            .ok_or(LayoutError::UnknownPane { pane_id })?;
+        if self.pane_ids_in_tab_at(tab_index).len() == 1 {
+            return Err(LayoutError::LastPaneInTab {
+                tab_id: self.tabs[tab_index].tab_id,
+            });
+        }
+
+        let root = self.tabs[tab_index].root.clone();
+        self.tabs[tab_index].root = root
+            .remove_leaf(pane_id)
+            .expect("a non-singleton tab retains a root after deleting one leaf");
+        self.panes.remove(&pane_id);
+        self.advance_revision();
+        Ok(())
+    }
+
+    pub fn delete_tab(
+        &mut self,
+        requester: &[u8],
+        base_revision: u64,
+        tab_id: TabId,
+    ) -> Result<(), LayoutError> {
+        self.check_mutation(base_revision)?;
+        self.require_member(requester)?;
+        if self.tabs.len() == 1 {
+            return Err(LayoutError::LastTab);
+        }
+        let tab_index = self
+            .tabs
+            .iter()
+            .position(|tab| tab.tab_id == tab_id)
+            .ok_or(LayoutError::UnknownTab { tab_id })?;
+        let pane_ids = self.pane_ids_in_tab_at(tab_index);
+        if pane_ids.iter().any(|pane_id| {
+            self.panes
+                .get(pane_id)
+                .is_none_or(|pane| pane.host_peer_id != requester)
+        }) {
+            return Err(LayoutError::NotTabHost { tab_id });
+        }
+
+        self.tabs.remove(tab_index);
+        for pane_id in pane_ids {
+            self.panes.remove(&pane_id);
+        }
+        self.advance_revision();
+        Ok(())
+    }
+
+    pub fn pane_ids_in_tab(&self, tab_id: TabId) -> Vec<PaneId> {
+        self.tabs
+            .iter()
+            .find(|tab| tab.tab_id == tab_id)
+            .map(|tab| tab.root.pane_ids())
+            .unwrap_or_default()
+    }
+
+    fn check_mutation(&self, base_revision: u64) -> Result<(), LayoutError> {
+        if base_revision != self.revision {
+            return Err(LayoutError::StaleRevision {
+                expected: self.revision,
+                got: base_revision,
+            });
+        }
+        self.revision
+            .checked_add(1)
+            .ok_or(LayoutError::RevisionExhausted)?;
+        Ok(())
+    }
+
+    fn require_member(&self, peer_id: &[u8]) -> Result<(), LayoutError> {
+        self.members
+            .iter()
+            .any(|member| member.peer_id == peer_id)
+            .then_some(())
+            .ok_or(LayoutError::NotMember)
+    }
+
+    fn next_id(&self, id: u64) -> Result<u64, LayoutError> {
+        id.checked_add(1).ok_or(LayoutError::IdExhausted)
+    }
+
+    fn advance_revision(&mut self) {
+        self.revision = self
+            .revision
+            .checked_add(1)
+            .expect("check_mutation verified revision can advance");
+    }
+
+    fn tab_index_for_pane(&self, pane_id: PaneId) -> Option<usize> {
+        self.tabs
+            .iter()
+            .position(|tab| tab.root.contains_leaf(pane_id))
+    }
+
+    fn pane_ids_in_tab_at(&self, tab_index: usize) -> Vec<PaneId> {
+        self.tabs[tab_index].root.pane_ids()
+    }
+}
+
+impl Node {
+    fn contains_leaf(&self, wanted: PaneId) -> bool {
+        match self {
+            Self::Leaf { pane_id } => *pane_id == wanted,
+            Self::Split { first, second, .. } => {
+                first.contains_leaf(wanted) || second.contains_leaf(wanted)
+            }
+        }
+    }
+
+    fn leaf_depth(&self, wanted: PaneId) -> Option<usize> {
+        match self {
+            Self::Leaf { pane_id } => (*pane_id == wanted).then_some(0),
+            Self::Split { first, second, .. } => first
+                .leaf_depth(wanted)
+                .or_else(|| second.leaf_depth(wanted))
+                .map(|depth| depth + 1),
+        }
+    }
+
+    fn pane_ids(&self) -> Vec<PaneId> {
+        match self {
+            Self::Leaf { pane_id } => vec![*pane_id],
+            Self::Split { first, second, .. } => {
+                let mut pane_ids = first.pane_ids();
+                pane_ids.extend(second.pane_ids());
+                pane_ids
+            }
+        }
+    }
+
+    fn replace_leaf(&mut self, wanted: PaneId, replacement: Node) -> bool {
+        match self {
+            Self::Leaf { pane_id } if *pane_id == wanted => {
+                *self = replacement;
+                true
+            }
+            Self::Leaf { .. } => false,
+            Self::Split { first, second, .. } => {
+                first.replace_leaf(wanted, replacement.clone())
+                    || second.replace_leaf(wanted, replacement)
+            }
+        }
+    }
+
+    fn remove_leaf(self, wanted: PaneId) -> Option<Node> {
+        match self {
+            Self::Leaf { pane_id } => (pane_id != wanted).then_some(Self::Leaf { pane_id }),
+            Self::Split {
+                axis,
+                first,
+                second,
+            } => {
+                if first.contains_leaf(wanted) {
+                    match first.remove_leaf(wanted) {
+                        Some(first) => Some(Self::Split {
+                            axis,
+                            first: Box::new(first),
+                            second,
+                        }),
+                        None => Some(*second),
+                    }
+                } else if second.contains_leaf(wanted) {
+                    match second.remove_leaf(wanted) {
+                        Some(second) => Some(Self::Split {
+                            axis,
+                            first,
+                            second: Box::new(second),
+                        }),
+                        None => Some(*first),
+                    }
+                } else {
+                    Some(Self::Split {
+                        axis,
+                        first,
+                        second,
+                    })
+                }
+            }
+        }
+    }
+}
+
+fn validate_grid(grid_rows: u16, grid_cols: u16) -> Result<(), LayoutError> {
+    (grid_rows > 0 && grid_cols > 0)
+        .then_some(())
+        .ok_or(LayoutError::InvalidGrid)
+}

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -1,12 +1,15 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 pub const MAX_MEMBERS: usize = 8;
 pub const MAX_TABS: usize = 9;
 pub const MAX_PANES_PER_TAB: usize = 8;
 pub const MAX_SPLIT_DEPTH: usize = 4;
+/// Maximum serialized endpoint-address size accepted by this pure model.
+pub const MAX_ENDPOINT_ADDR_BYTES: usize = 4096;
 
 pub type PaneId = u64;
 pub type TabId = u64;
+pub type ReservationId = u64;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Axis {
@@ -29,6 +32,7 @@ pub enum Node {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Member {
     pub peer_id: Vec<u8>,
+    pub endpoint_addr: Vec<u8>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -46,13 +50,60 @@ pub struct Tab {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct SessionState {
+pub struct LayoutSnapshot {
     pub revision: u64,
     pub members: Vec<Member>,
     pub tabs: Vec<Tab>,
     pub panes: BTreeMap<PaneId, Pane>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PaneReservation {
+    pub reservation_id: ReservationId,
+    pub pane_id: PaneId,
+    pub tab_id: Option<TabId>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ReservationCommit {
+    Pane { pane_id: PaneId },
+    Tab { tab_id: TabId, pane_id: PaneId },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum PendingReservationKind {
+    Pane {
+        pane_id: PaneId,
+        target_pane_id: PaneId,
+        axis: Axis,
+        grid_rows: u16,
+        grid_cols: u16,
+    },
+    Tab {
+        tab_id: TabId,
+        pane_id: PaneId,
+        grid_rows: u16,
+        grid_cols: u16,
+    },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct PendingReservation {
+    reservation_id: ReservationId,
+    creator_peer_id: Vec<u8>,
+    kind: PendingReservationKind,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SessionState {
+    revision: u64,
+    members: Vec<Member>,
+    tabs: Vec<Tab>,
+    panes: BTreeMap<PaneId, Pane>,
     next_tab_id: TabId,
     next_pane_id: PaneId,
+    next_reservation_id: ReservationId,
+    pending_reservation: Option<PendingReservation>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -62,6 +113,7 @@ pub enum LayoutError {
     MemberLimit,
     AlreadyMember,
     NotMember,
+    InvalidEndpointAddress,
     TabLimit,
     PaneLimit,
     SplitDepthLimit,
@@ -72,13 +124,23 @@ pub enum LayoutError {
     NotTabHost { tab_id: TabId },
     LastPaneInTab { tab_id: TabId },
     LastTab,
+    ReservationPending,
+    UnknownReservation { reservation_id: ReservationId },
+    ReservationCreatorMismatch,
+    ReservationInvalid,
+    InvalidSnapshot,
     IdExhausted,
 }
 
 impl SessionState {
-    pub fn new(initial_host: Vec<u8>, grid_rows: u16, grid_cols: u16) -> Result<Self, LayoutError> {
+    pub fn new(
+        initial_host: Vec<u8>,
+        endpoint_addr: Vec<u8>,
+        grid_rows: u16,
+        grid_cols: u16,
+    ) -> Result<Self, LayoutError> {
         validate_grid(grid_rows, grid_cols)?;
-
+        validate_endpoint_addr(&endpoint_addr)?;
         let initial_pane = Pane {
             pane_id: 1,
             host_peer_id: initial_host.clone(),
@@ -86,12 +148,12 @@ impl SessionState {
             grid_cols,
         };
         let mut panes = BTreeMap::new();
-        panes.insert(initial_pane.pane_id, initial_pane);
-
+        panes.insert(1, initial_pane);
         Ok(Self {
             revision: 1,
             members: vec![Member {
                 peer_id: initial_host,
+                endpoint_addr,
             }],
             tabs: vec![Tab {
                 tab_id: 1,
@@ -100,20 +162,300 @@ impl SessionState {
             panes,
             next_tab_id: 2,
             next_pane_id: 2,
+            next_reservation_id: 1,
+            pending_reservation: None,
         })
     }
 
-    pub fn add_member(&mut self, base_revision: u64, peer_id: Vec<u8>) -> Result<(), LayoutError> {
+    pub fn revision(&self) -> u64 {
+        self.revision
+    }
+
+    pub fn snapshot(&self) -> LayoutSnapshot {
+        LayoutSnapshot {
+            revision: self.revision,
+            members: self.members.clone(),
+            tabs: self.tabs.clone(),
+            panes: self.panes.clone(),
+        }
+    }
+
+    pub fn members(&self) -> &[Member] {
+        &self.members
+    }
+
+    pub fn tabs(&self) -> &[Tab] {
+        &self.tabs
+    }
+
+    pub fn pane(&self, pane_id: PaneId) -> Option<&Pane> {
+        self.panes.get(&pane_id)
+    }
+
+    pub fn panes(&self) -> impl Iterator<Item = &Pane> {
+        self.panes.values()
+    }
+
+    pub fn validate_snapshot(snapshot: &LayoutSnapshot) -> Result<(), LayoutError> {
+        if snapshot.revision == 0
+            || snapshot.members.is_empty()
+            || snapshot.members.len() > MAX_MEMBERS
+            || snapshot.tabs.is_empty()
+            || snapshot.tabs.len() > MAX_TABS
+        {
+            return Err(LayoutError::InvalidSnapshot);
+        }
+        let mut peer_ids = BTreeSet::new();
+        for member in &snapshot.members {
+            if member.peer_id.is_empty()
+                || !peer_ids.insert(&member.peer_id)
+                || validate_endpoint_addr(&member.endpoint_addr).is_err()
+            {
+                return Err(LayoutError::InvalidSnapshot);
+            }
+        }
+        let mut tab_ids = BTreeSet::new();
+        let mut pane_ids = BTreeSet::new();
+        for tab in &snapshot.tabs {
+            if !tab_ids.insert(tab.tab_id) {
+                return Err(LayoutError::InvalidSnapshot);
+            }
+            let before = pane_ids.len();
+            if !tab.root.collect_pane_ids(0, &mut pane_ids)
+                || pane_ids.len() - before > MAX_PANES_PER_TAB
+            {
+                return Err(LayoutError::InvalidSnapshot);
+            }
+        }
+        if pane_ids.len() != snapshot.panes.len()
+            || snapshot.panes.len() > MAX_TABS * MAX_PANES_PER_TAB
+        {
+            return Err(LayoutError::InvalidSnapshot);
+        }
+        for (pane_id, pane) in &snapshot.panes {
+            if *pane_id != pane.pane_id
+                || !pane_ids.contains(pane_id)
+                || validate_grid(pane.grid_rows, pane.grid_cols).is_err()
+                || !peer_ids.contains(&pane.host_peer_id)
+            {
+                return Err(LayoutError::InvalidSnapshot);
+            }
+        }
+        Ok(())
+    }
+
+    pub fn add_member(
+        &mut self,
+        base_revision: u64,
+        peer_id: Vec<u8>,
+        endpoint_addr: Vec<u8>,
+    ) -> Result<(), LayoutError> {
         self.check_mutation(base_revision)?;
+        validate_endpoint_addr(&endpoint_addr)?;
         if self.members.iter().any(|member| member.peer_id == peer_id) {
             return Err(LayoutError::AlreadyMember);
         }
         if self.members.len() >= MAX_MEMBERS {
             return Err(LayoutError::MemberLimit);
         }
-
-        self.members.push(Member { peer_id });
+        self.members.push(Member {
+            peer_id,
+            endpoint_addr,
+        });
         self.advance_revision();
+        Ok(())
+    }
+
+    pub fn update_member_endpoint(
+        &mut self,
+        base_revision: u64,
+        peer_id: &[u8],
+        endpoint_addr: Vec<u8>,
+    ) -> Result<(), LayoutError> {
+        self.check_mutation(base_revision)?;
+        validate_endpoint_addr(&endpoint_addr)?;
+        let member = self
+            .members
+            .iter_mut()
+            .find(|member| member.peer_id == peer_id)
+            .ok_or(LayoutError::NotMember)?;
+        member.endpoint_addr = endpoint_addr;
+        self.advance_revision();
+        Ok(())
+    }
+
+    pub fn reserve_pane(
+        &mut self,
+        creator: &[u8],
+        base_revision: u64,
+        target_pane_id: PaneId,
+        axis: Axis,
+        grid_rows: u16,
+        grid_cols: u16,
+    ) -> Result<PaneReservation, LayoutError> {
+        self.check_reservation(base_revision)?;
+        self.require_member(creator)?;
+        validate_grid(grid_rows, grid_cols)?;
+        self.ensure_no_reservation()?;
+        self.validate_pane_create(target_pane_id)?;
+        let pane_id = self.next_pane_id;
+        let reservation_id = self.next_reservation_id;
+        let next_pane_id = self.next_id(pane_id)?;
+        let next_reservation_id = self.next_id(reservation_id)?;
+        self.next_pane_id = next_pane_id;
+        self.next_reservation_id = next_reservation_id;
+        self.pending_reservation = Some(PendingReservation {
+            reservation_id,
+            creator_peer_id: creator.to_vec(),
+            kind: PendingReservationKind::Pane {
+                pane_id,
+                target_pane_id,
+                axis,
+                grid_rows,
+                grid_cols,
+            },
+        });
+        Ok(PaneReservation {
+            reservation_id,
+            pane_id,
+            tab_id: None,
+        })
+    }
+
+    pub fn reserve_tab(
+        &mut self,
+        creator: &[u8],
+        base_revision: u64,
+        grid_rows: u16,
+        grid_cols: u16,
+    ) -> Result<PaneReservation, LayoutError> {
+        self.check_reservation(base_revision)?;
+        self.require_member(creator)?;
+        validate_grid(grid_rows, grid_cols)?;
+        self.ensure_no_reservation()?;
+        if self.tabs.len() >= MAX_TABS {
+            return Err(LayoutError::TabLimit);
+        }
+        let tab_id = self.next_tab_id;
+        let pane_id = self.next_pane_id;
+        let reservation_id = self.next_reservation_id;
+        let next_tab_id = self.next_id(tab_id)?;
+        let next_pane_id = self.next_id(pane_id)?;
+        let next_reservation_id = self.next_id(reservation_id)?;
+        self.next_tab_id = next_tab_id;
+        self.next_pane_id = next_pane_id;
+        self.next_reservation_id = next_reservation_id;
+        self.pending_reservation = Some(PendingReservation {
+            reservation_id,
+            creator_peer_id: creator.to_vec(),
+            kind: PendingReservationKind::Tab {
+                tab_id,
+                pane_id,
+                grid_rows,
+                grid_cols,
+            },
+        });
+        Ok(PaneReservation {
+            reservation_id,
+            pane_id,
+            tab_id: Some(tab_id),
+        })
+    }
+
+    pub fn pane_ready(
+        &mut self,
+        creator: &[u8],
+        base_revision: u64,
+        reservation_id: ReservationId,
+    ) -> Result<ReservationCommit, LayoutError> {
+        self.check_mutation(base_revision)?;
+        let reservation = self.match_reservation(creator, reservation_id)?;
+        match reservation.kind {
+            PendingReservationKind::Pane {
+                pane_id,
+                target_pane_id,
+                axis,
+                grid_rows,
+                grid_cols,
+            } => {
+                self.validate_pane_create(target_pane_id)?;
+                let tab_index = self
+                    .tab_index_for_pane(target_pane_id)
+                    .ok_or(LayoutError::ReservationInvalid)?;
+                let split = Node::Split {
+                    axis,
+                    first: Box::new(Node::Leaf {
+                        pane_id: target_pane_id,
+                    }),
+                    second: Box::new(Node::Leaf { pane_id }),
+                };
+                if !self.tabs[tab_index]
+                    .root
+                    .replace_leaf(target_pane_id, split)
+                {
+                    return Err(LayoutError::ReservationInvalid);
+                }
+                self.panes.insert(
+                    pane_id,
+                    Pane {
+                        pane_id,
+                        host_peer_id: creator.to_vec(),
+                        grid_rows,
+                        grid_cols,
+                    },
+                );
+                self.pending_reservation = None;
+                self.advance_revision();
+                Ok(ReservationCommit::Pane { pane_id })
+            }
+            PendingReservationKind::Tab {
+                tab_id,
+                pane_id,
+                grid_rows,
+                grid_cols,
+            } => {
+                if self.tabs.len() >= MAX_TABS {
+                    return Err(LayoutError::ReservationInvalid);
+                }
+                self.tabs.push(Tab {
+                    tab_id,
+                    root: Node::Leaf { pane_id },
+                });
+                self.panes.insert(
+                    pane_id,
+                    Pane {
+                        pane_id,
+                        host_peer_id: creator.to_vec(),
+                        grid_rows,
+                        grid_cols,
+                    },
+                );
+                self.pending_reservation = None;
+                self.advance_revision();
+                Ok(ReservationCommit::Tab { tab_id, pane_id })
+            }
+        }
+    }
+
+    pub fn cancel_reservation(
+        &mut self,
+        creator: &[u8],
+        reservation_id: ReservationId,
+    ) -> Result<(), LayoutError> {
+        self.match_reservation(creator, reservation_id)?;
+        self.pending_reservation = None;
+        Ok(())
+    }
+
+    pub fn expire_reservation(&mut self, reservation_id: ReservationId) -> Result<(), LayoutError> {
+        let pending = self
+            .pending_reservation
+            .as_ref()
+            .ok_or(LayoutError::UnknownReservation { reservation_id })?;
+        if pending.reservation_id != reservation_id {
+            return Err(LayoutError::UnknownReservation { reservation_id });
+        }
+        self.pending_reservation = None;
         Ok(())
     }
 
@@ -126,51 +468,18 @@ impl SessionState {
         grid_rows: u16,
         grid_cols: u16,
     ) -> Result<PaneId, LayoutError> {
-        self.check_mutation(base_revision)?;
-        self.require_member(requester)?;
-        validate_grid(grid_rows, grid_cols)?;
-
-        let tab_index =
-            self.tab_index_for_pane(target_pane_id)
-                .ok_or(LayoutError::UnknownPane {
-                    pane_id: target_pane_id,
-                })?;
-        if self.pane_ids_in_tab_at(tab_index).len() >= MAX_PANES_PER_TAB {
-            return Err(LayoutError::PaneLimit);
-        }
-        let target_depth = self.tabs[tab_index]
-            .root
-            .leaf_depth(target_pane_id)
-            .expect("tab_index_for_pane found the leaf");
-        if target_depth >= MAX_SPLIT_DEPTH {
-            return Err(LayoutError::SplitDepthLimit);
-        }
-
-        let pane_id = self.next_pane_id;
-        let next_pane_id = self.next_id(pane_id)?;
-        let split = Node::Split {
+        let reservation = self.reserve_pane(
+            requester,
+            base_revision,
+            target_pane_id,
             axis,
-            first: Box::new(Node::Leaf {
-                pane_id: target_pane_id,
-            }),
-            second: Box::new(Node::Leaf { pane_id }),
-        };
-        let replaced = self.tabs[tab_index]
-            .root
-            .replace_leaf(target_pane_id, split);
-        debug_assert!(replaced);
-        self.panes.insert(
-            pane_id,
-            Pane {
-                pane_id,
-                host_peer_id: requester.to_vec(),
-                grid_rows,
-                grid_cols,
-            },
-        );
-        self.next_pane_id = next_pane_id;
-        self.advance_revision();
-        Ok(pane_id)
+            grid_rows,
+            grid_cols,
+        )?;
+        match self.pane_ready(requester, base_revision, reservation.reservation_id)? {
+            ReservationCommit::Pane { pane_id } => Ok(pane_id),
+            ReservationCommit::Tab { .. } => unreachable!("pane reservation commits a pane"),
+        }
     }
 
     pub fn create_tab(
@@ -180,34 +489,11 @@ impl SessionState {
         grid_rows: u16,
         grid_cols: u16,
     ) -> Result<TabId, LayoutError> {
-        self.check_mutation(base_revision)?;
-        self.require_member(requester)?;
-        validate_grid(grid_rows, grid_cols)?;
-        if self.tabs.len() >= MAX_TABS {
-            return Err(LayoutError::TabLimit);
+        let reservation = self.reserve_tab(requester, base_revision, grid_rows, grid_cols)?;
+        match self.pane_ready(requester, base_revision, reservation.reservation_id)? {
+            ReservationCommit::Tab { tab_id, .. } => Ok(tab_id),
+            ReservationCommit::Pane { .. } => unreachable!("tab reservation commits a tab"),
         }
-
-        let tab_id = self.next_tab_id;
-        let pane_id = self.next_pane_id;
-        let next_tab_id = self.next_id(tab_id)?;
-        let next_pane_id = self.next_id(pane_id)?;
-        self.panes.insert(
-            pane_id,
-            Pane {
-                pane_id,
-                host_peer_id: requester.to_vec(),
-                grid_rows,
-                grid_cols,
-            },
-        );
-        self.tabs.push(Tab {
-            tab_id,
-            root: Node::Leaf { pane_id },
-        });
-        self.next_tab_id = next_tab_id;
-        self.next_pane_id = next_pane_id;
-        self.advance_revision();
-        Ok(tab_id)
     }
 
     pub fn delete_pane(
@@ -218,6 +504,7 @@ impl SessionState {
     ) -> Result<(), LayoutError> {
         self.check_mutation(base_revision)?;
         self.require_member(requester)?;
+        self.ensure_no_reservation()?;
         let pane = self
             .panes
             .get(&pane_id)
@@ -233,11 +520,10 @@ impl SessionState {
                 tab_id: self.tabs[tab_index].tab_id,
             });
         }
-
         let root = self.tabs[tab_index].root.clone();
         self.tabs[tab_index].root = root
             .remove_leaf(pane_id)
-            .expect("a non-singleton tab retains a root after deleting one leaf");
+            .expect("non-singleton tab retains a root");
         self.panes.remove(&pane_id);
         self.advance_revision();
         Ok(())
@@ -251,14 +537,15 @@ impl SessionState {
     ) -> Result<(), LayoutError> {
         self.check_mutation(base_revision)?;
         self.require_member(requester)?;
-        if self.tabs.len() == 1 {
-            return Err(LayoutError::LastTab);
-        }
+        self.ensure_no_reservation()?;
         let tab_index = self
             .tabs
             .iter()
             .position(|tab| tab.tab_id == tab_id)
             .ok_or(LayoutError::UnknownTab { tab_id })?;
+        if self.tabs.len() == 1 {
+            return Err(LayoutError::LastTab);
+        }
         let pane_ids = self.pane_ids_in_tab_at(tab_index);
         if pane_ids.iter().any(|pane_id| {
             self.panes
@@ -267,7 +554,6 @@ impl SessionState {
         }) {
             return Err(LayoutError::NotTabHost { tab_id });
         }
-
         self.tabs.remove(tab_index);
         for pane_id in pane_ids {
             self.panes.remove(&pane_id);
@@ -282,6 +568,10 @@ impl SessionState {
             .find(|tab| tab.tab_id == tab_id)
             .map(|tab| tab.root.pane_ids())
             .unwrap_or_default()
+    }
+
+    fn check_reservation(&self, base_revision: u64) -> Result<(), LayoutError> {
+        self.check_mutation(base_revision)
     }
 
     fn check_mutation(&self, base_revision: u64) -> Result<(), LayoutError> {
@@ -305,8 +595,49 @@ impl SessionState {
             .ok_or(LayoutError::NotMember)
     }
 
-    fn next_id(&self, id: u64) -> Result<u64, LayoutError> {
-        id.checked_add(1).ok_or(LayoutError::IdExhausted)
+    fn ensure_no_reservation(&self) -> Result<(), LayoutError> {
+        self.pending_reservation
+            .is_none()
+            .then_some(())
+            .ok_or(LayoutError::ReservationPending)
+    }
+
+    fn match_reservation(
+        &self,
+        creator: &[u8],
+        reservation_id: ReservationId,
+    ) -> Result<PendingReservation, LayoutError> {
+        let pending = self
+            .pending_reservation
+            .as_ref()
+            .ok_or(LayoutError::UnknownReservation { reservation_id })?;
+        if pending.reservation_id != reservation_id {
+            return Err(LayoutError::UnknownReservation { reservation_id });
+        }
+        if pending.creator_peer_id != creator {
+            return Err(LayoutError::ReservationCreatorMismatch);
+        }
+        Ok(pending.clone())
+    }
+
+    fn validate_pane_create(&self, target_pane_id: PaneId) -> Result<(), LayoutError> {
+        let tab_index =
+            self.tab_index_for_pane(target_pane_id)
+                .ok_or(LayoutError::UnknownPane {
+                    pane_id: target_pane_id,
+                })?;
+        if self.pane_ids_in_tab_at(tab_index).len() >= MAX_PANES_PER_TAB {
+            return Err(LayoutError::PaneLimit);
+        }
+        if self.tabs[tab_index]
+            .root
+            .leaf_depth(target_pane_id)
+            .expect("found target leaf")
+            >= MAX_SPLIT_DEPTH
+        {
+            return Err(LayoutError::SplitDepthLimit);
+        }
+        Ok(())
     }
 
     fn advance_revision(&mut self) {
@@ -314,6 +645,10 @@ impl SessionState {
             .revision
             .checked_add(1)
             .expect("check_mutation verified revision can advance");
+    }
+
+    fn next_id(&self, id: u64) -> Result<u64, LayoutError> {
+        id.checked_add(1).ok_or(LayoutError::IdExhausted)
     }
 
     fn tab_index_for_pane(&self, pane_id: PaneId) -> Option<usize> {
@@ -354,6 +689,17 @@ impl Node {
                 let mut pane_ids = first.pane_ids();
                 pane_ids.extend(second.pane_ids());
                 pane_ids
+            }
+        }
+    }
+
+    fn collect_pane_ids(&self, depth: usize, pane_ids: &mut BTreeSet<PaneId>) -> bool {
+        match self {
+            Self::Leaf { pane_id } => pane_ids.insert(*pane_id),
+            Self::Split { first, second, .. } => {
+                depth < MAX_SPLIT_DEPTH
+                    && first.collect_pane_ids(depth + 1, pane_ids)
+                    && second.collect_pane_ids(depth + 1, pane_ids)
             }
         }
     }
@@ -414,4 +760,10 @@ fn validate_grid(grid_rows: u16, grid_cols: u16) -> Result<(), LayoutError> {
     (grid_rows > 0 && grid_cols > 0)
         .then_some(())
         .ok_or(LayoutError::InvalidGrid)
+}
+
+fn validate_endpoint_addr(endpoint_addr: &[u8]) -> Result<(), LayoutError> {
+    (!endpoint_addr.is_empty() && endpoint_addr.len() <= MAX_ENDPOINT_ADDR_BYTES)
+        .then_some(())
+        .ok_or(LayoutError::InvalidEndpointAddress)
 }

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -4,6 +4,8 @@ pub const MAX_MEMBERS: usize = 8;
 pub const MAX_TABS: usize = 9;
 pub const MAX_PANES_PER_TAB: usize = 8;
 pub const MAX_SPLIT_DEPTH: usize = 4;
+/// Maximum peer-identifier size, aligned with the protocol boundary.
+pub const MAX_PEER_ID_BYTES: usize = 64;
 /// Maximum serialized endpoint-address size accepted by this pure model.
 pub const MAX_ENDPOINT_ADDR_BYTES: usize = 4096;
 
@@ -209,7 +211,7 @@ impl SessionState {
         }
         let mut peer_ids = BTreeSet::new();
         for member in &snapshot.members {
-            if member.peer_id.is_empty()
+            if validate_peer_id(&member.peer_id).is_err()
                 || !peer_ids.insert(&member.peer_id)
                 || validate_endpoint_addr(&member.endpoint_addr).is_err()
             {
@@ -772,7 +774,7 @@ fn validate_endpoint_addr(endpoint_addr: &[u8]) -> Result<(), LayoutError> {
 }
 
 fn validate_peer_id(peer_id: &[u8]) -> Result<(), LayoutError> {
-    (!peer_id.is_empty())
+    (!peer_id.is_empty() && peer_id.len() <= MAX_PEER_ID_BYTES)
         .then_some(())
         .ok_or(LayoutError::InvalidPeerId)
 }

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -296,6 +296,49 @@ impl SessionState {
         Ok(self.invalidate_reservation())
     }
 
+    /// Removes a departed non-final member and every pane it hosted. Tabs with no remaining
+    /// leaves disappear; mixed tabs collapse around the departed leaves in one revision.
+    pub fn remove_member(
+        &mut self,
+        peer_id: &[u8],
+    ) -> Result<Option<InvalidatedReservation>, LayoutError> {
+        self.require_member(peer_id)?;
+        if self.members.len() == 1 {
+            return Err(LayoutError::InvalidSnapshot);
+        }
+        self.revision
+            .checked_add(1)
+            .ok_or(LayoutError::RevisionExhausted)?;
+        let removed_panes = self
+            .panes
+            .values()
+            .filter(|pane| pane.host_peer_id == peer_id)
+            .map(|pane| pane.pane_id)
+            .collect::<BTreeSet<_>>();
+        let mut tabs = Vec::with_capacity(self.tabs.len());
+        for tab in self.tabs.drain(..) {
+            let mut root = Some(tab.root);
+            for pane_id in &removed_panes {
+                root = root.and_then(|root| root.remove_leaf(*pane_id));
+            }
+            if let Some(root) = root {
+                tabs.push(Tab {
+                    tab_id: tab.tab_id,
+                    root,
+                });
+            }
+        }
+        if tabs.is_empty() {
+            return Err(LayoutError::InvalidSnapshot);
+        }
+        self.members.retain(|member| member.peer_id != peer_id);
+        self.panes
+            .retain(|pane_id, _| !removed_panes.contains(pane_id));
+        self.tabs = tabs;
+        self.advance_revision();
+        Ok(self.invalidate_reservation())
+    }
+
     pub fn reserve_pane(
         &mut self,
         creator: &[u8],

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -113,6 +113,7 @@ pub enum LayoutError {
     MemberLimit,
     AlreadyMember,
     NotMember,
+    InvalidPeerId,
     InvalidEndpointAddress,
     TabLimit,
     PaneLimit,
@@ -140,6 +141,7 @@ impl SessionState {
         grid_cols: u16,
     ) -> Result<Self, LayoutError> {
         validate_grid(grid_rows, grid_cols)?;
+        validate_peer_id(&initial_host)?;
         validate_endpoint_addr(&endpoint_addr)?;
         let initial_pane = Pane {
             pane_id: 1,
@@ -217,7 +219,7 @@ impl SessionState {
         let mut tab_ids = BTreeSet::new();
         let mut pane_ids = BTreeSet::new();
         for tab in &snapshot.tabs {
-            if !tab_ids.insert(tab.tab_id) {
+            if tab.tab_id == 0 || !tab_ids.insert(tab.tab_id) {
                 return Err(LayoutError::InvalidSnapshot);
             }
             let before = pane_ids.len();
@@ -251,6 +253,7 @@ impl SessionState {
         endpoint_addr: Vec<u8>,
     ) -> Result<(), LayoutError> {
         self.check_mutation(base_revision)?;
+        validate_peer_id(&peer_id)?;
         validate_endpoint_addr(&endpoint_addr)?;
         if self.members.iter().any(|member| member.peer_id == peer_id) {
             return Err(LayoutError::AlreadyMember);
@@ -695,7 +698,7 @@ impl Node {
 
     fn collect_pane_ids(&self, depth: usize, pane_ids: &mut BTreeSet<PaneId>) -> bool {
         match self {
-            Self::Leaf { pane_id } => pane_ids.insert(*pane_id),
+            Self::Leaf { pane_id } => *pane_id != 0 && pane_ids.insert(*pane_id),
             Self::Split { first, second, .. } => {
                 depth < MAX_SPLIT_DEPTH
                     && first.collect_pane_ids(depth + 1, pane_ids)
@@ -766,4 +769,10 @@ fn validate_endpoint_addr(endpoint_addr: &[u8]) -> Result<(), LayoutError> {
     (!endpoint_addr.is_empty() && endpoint_addr.len() <= MAX_ENDPOINT_ADDR_BYTES)
         .then_some(())
         .ok_or(LayoutError::InvalidEndpointAddress)
+}
+
+fn validate_peer_id(peer_id: &[u8]) -> Result<(), LayoutError> {
+    (!peer_id.is_empty())
+        .then_some(())
+        .ok_or(LayoutError::InvalidPeerId)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![forbid(unsafe_code)]
 
 pub mod cli;
+pub mod layout;
 pub mod lease;
 pub mod protocol;
 pub mod pty_host;

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -281,8 +281,8 @@ pub struct LayoutNode {
 
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LayoutSplit {
-    #[prost(enumeration = "SplitAxis", tag = "1")]
-    pub axis: i32,
+    #[prost(enumeration = "SplitAxis", optional, tag = "1")]
+    pub axis: Option<i32>,
     #[prost(message, optional, tag = "2")]
     pub first: Option<LayoutNode>,
     #[prost(message, optional, tag = "3")]
@@ -316,8 +316,8 @@ pub struct LayoutRequest {
 pub struct CreatePane {
     #[prost(uint64, tag = "1")]
     pub target_pane_id: u64,
-    #[prost(enumeration = "SplitAxis", tag = "2")]
-    pub axis: i32,
+    #[prost(enumeration = "SplitAxis", optional, tag = "2")]
+    pub axis: Option<i32>,
     #[prost(uint32, tag = "3")]
     pub grid_rows: u32,
     #[prost(uint32, tag = "4")]
@@ -358,6 +358,8 @@ pub struct PaneReservation {
 pub struct PaneReady {
     #[prost(uint64, tag = "1")]
     pub reservation_id: u64,
+    #[prost(uint64, tag = "2")]
+    pub base_revision: u64,
 }
 
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -525,9 +527,9 @@ fn validate_envelope(envelope: &Envelope) -> Result<(), ProtocolError> {
         envelope::Body::Join(join) => {
             validate_id("join.session_id", &join.session_id, MAX_SESSION_ID_BYTES)?;
             validate_id("join.peer_id", &join.peer_id, MAX_PEER_ID_BYTES)?;
-            validate_field_size(
+            validate_id(
                 "join.endpoint_addr",
-                join.endpoint_addr.len(),
+                &join.endpoint_addr,
                 MAX_ENDPOINT_ADDR_BYTES,
             )?;
         }
@@ -628,6 +630,7 @@ fn validate_envelope(envelope: &Envelope) -> Result<(), ProtocolError> {
         }
         envelope::Body::PaneReady(ready) => {
             validate_nonzero("pane_ready.reservation_id", ready.reservation_id)?;
+            validate_nonzero("pane_ready.base_revision", ready.base_revision)?;
         }
         envelope::Body::LayoutCommit(commit) => {
             validate_nonzero("layout_commit.revision", commit.revision)?;
@@ -684,7 +687,8 @@ fn validate_grid(field: &'static str, rows: u32, cols: u32) -> Result<(), Protoc
     Ok(())
 }
 
-fn validate_axis(field: &'static str, axis: i32) -> Result<(), ProtocolError> {
+fn validate_axis(field: &'static str, axis: Option<i32>) -> Result<(), ProtocolError> {
+    let axis = axis.ok_or(ProtocolError::InvalidLayout(field))?;
     SplitAxis::try_from(axis).map_err(|_| ProtocolError::InvalidLayout(field))?;
     Ok(())
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -678,7 +678,7 @@ fn validate_nonzero(field: &'static str, value: u64) -> Result<(), ProtocolError
 }
 
 fn validate_grid(field: &'static str, rows: u32, cols: u32) -> Result<(), ProtocolError> {
-    if rows == 0 || cols == 0 {
+    if rows == 0 || cols == 0 || rows > u32::from(u16::MAX) || cols > u32::from(u16::MAX) {
         return Err(ProtocolError::InvalidLayout(field));
     }
     Ok(())

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -3,12 +3,13 @@
 use prost::Message;
 use std::fmt;
 
-pub const PROTOCOL_VERSION: u32 = 1;
+pub const PROTOCOL_VERSION: u32 = 2;
 pub const MAX_FRAME_BYTES: usize = 1_048_576;
 pub const MAX_ENVELOPE_BYTES: usize = 1_048_560;
 pub const MAX_PEER_ID_BYTES: usize = 64;
 pub const MAX_SESSION_ID_BYTES: usize = 64;
 pub const MAX_PANE_ID_BYTES: usize = 64;
+pub const MAX_ENDPOINT_ADDR_BYTES: usize = 4096;
 pub const MAX_INPUT_BYTES: usize = 8 * 1024;
 pub const MAX_SNAPSHOT_BYTES: usize = 512 * 1024;
 pub const MAX_DELTA_BYTES: usize = 64 * 1024;
@@ -40,6 +41,7 @@ pub enum ProtocolError {
     },
     InvalidLeaseEpoch(&'static str),
     InvalidScreenSequence(&'static str),
+    InvalidLayout(&'static str),
 }
 
 impl fmt::Display for ProtocolError {
@@ -81,6 +83,9 @@ impl fmt::Display for ProtocolError {
             Self::InvalidScreenSequence(field) => {
                 write!(formatter, "protocol screen sequence {field} is invalid")
             }
+            Self::InvalidLayout(field) => {
+                write!(formatter, "protocol layout field {field} is invalid")
+            }
         }
     }
 }
@@ -101,7 +106,10 @@ pub struct Envelope {
     pub version: u32,
     #[prost(bytes = "vec", tag = "2")]
     pub sender_peer_id: Vec<u8>,
-    #[prost(oneof = "envelope::Body", tags = "10, 11, 12, 13, 14, 15, 16")]
+    #[prost(
+        oneof = "envelope::Body",
+        tags = "10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23"
+    )]
     pub body: Option<envelope::Body>,
 }
 
@@ -122,6 +130,20 @@ pub mod envelope {
         Snapshot(super::Snapshot),
         #[prost(message, tag = "16")]
         Delta(super::Delta),
+        #[prost(message, tag = "17")]
+        SessionSnapshot(super::SessionSnapshot),
+        #[prost(message, tag = "18")]
+        LayoutRequest(super::LayoutRequest),
+        #[prost(message, tag = "19")]
+        PaneReservation(super::PaneReservation),
+        #[prost(message, tag = "20")]
+        PaneReady(super::PaneReady),
+        #[prost(message, tag = "21")]
+        LayoutCommit(super::LayoutCommit),
+        #[prost(message, tag = "22")]
+        LayoutReject(super::LayoutReject),
+        #[prost(message, tag = "23")]
+        PaneSubscribe(super::PaneSubscribe),
     }
 }
 
@@ -131,6 +153,8 @@ pub struct Join {
     pub session_id: Vec<u8>,
     #[prost(bytes = "vec", tag = "2")]
     pub peer_id: Vec<u8>,
+    #[prost(bytes = "vec", tag = "3")]
+    pub endpoint_addr: Vec<u8>,
 }
 
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -199,6 +223,180 @@ pub struct Delta {
     pub sequence: u64,
     #[prost(bytes = "vec", tag = "5")]
     pub changes: Vec<u8>,
+}
+
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SessionSnapshot {
+    #[prost(message, optional, tag = "1")]
+    pub state: Option<LayoutState>,
+}
+
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct LayoutState {
+    #[prost(uint64, tag = "1")]
+    pub revision: u64,
+    #[prost(message, repeated, tag = "2")]
+    pub members: Vec<MemberDescriptor>,
+    #[prost(message, repeated, tag = "3")]
+    pub panes: Vec<PaneDescriptor>,
+    #[prost(message, repeated, tag = "4")]
+    pub tabs: Vec<TabDescriptor>,
+}
+
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MemberDescriptor {
+    #[prost(bytes = "vec", tag = "1")]
+    pub peer_id: Vec<u8>,
+    #[prost(bytes = "vec", tag = "2")]
+    pub endpoint_addr: Vec<u8>,
+}
+
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PaneDescriptor {
+    #[prost(uint64, tag = "1")]
+    pub pane_id: u64,
+    #[prost(bytes = "vec", tag = "2")]
+    pub host_peer_id: Vec<u8>,
+    #[prost(uint32, tag = "3")]
+    pub grid_rows: u32,
+    #[prost(uint32, tag = "4")]
+    pub grid_cols: u32,
+}
+
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TabDescriptor {
+    #[prost(uint64, tag = "1")]
+    pub tab_id: u64,
+    #[prost(message, optional, tag = "2")]
+    pub root: Option<LayoutNode>,
+}
+
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct LayoutNode {
+    #[prost(uint64, optional, tag = "1")]
+    pub leaf_pane_id: Option<u64>,
+    #[prost(message, optional, tag = "2")]
+    pub split: Option<Box<LayoutSplit>>,
+}
+
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct LayoutSplit {
+    #[prost(enumeration = "SplitAxis", tag = "1")]
+    pub axis: i32,
+    #[prost(message, optional, tag = "2")]
+    pub first: Option<LayoutNode>,
+    #[prost(message, optional, tag = "3")]
+    pub second: Option<LayoutNode>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum SplitAxis {
+    LeftRight = 0,
+    TopBottom = 1,
+}
+
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct LayoutRequest {
+    #[prost(uint64, tag = "1")]
+    pub request_id: u64,
+    #[prost(uint64, tag = "2")]
+    pub base_revision: u64,
+    #[prost(message, optional, tag = "3")]
+    pub create_pane: Option<CreatePane>,
+    #[prost(message, optional, tag = "4")]
+    pub delete_pane: Option<DeletePane>,
+    #[prost(message, optional, tag = "5")]
+    pub create_tab: Option<CreateTab>,
+    #[prost(message, optional, tag = "6")]
+    pub delete_tab: Option<DeleteTab>,
+}
+
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CreatePane {
+    #[prost(uint64, tag = "1")]
+    pub target_pane_id: u64,
+    #[prost(enumeration = "SplitAxis", tag = "2")]
+    pub axis: i32,
+    #[prost(uint32, tag = "3")]
+    pub grid_rows: u32,
+    #[prost(uint32, tag = "4")]
+    pub grid_cols: u32,
+}
+
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DeletePane {
+    #[prost(uint64, tag = "1")]
+    pub pane_id: u64,
+}
+
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CreateTab {
+    #[prost(uint32, tag = "1")]
+    pub grid_rows: u32,
+    #[prost(uint32, tag = "2")]
+    pub grid_cols: u32,
+}
+
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DeleteTab {
+    #[prost(uint64, tag = "1")]
+    pub tab_id: u64,
+}
+
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PaneReservation {
+    #[prost(uint64, tag = "1")]
+    pub reservation_id: u64,
+    #[prost(uint64, tag = "2")]
+    pub pane_id: u64,
+    #[prost(uint64, tag = "3")]
+    pub tab_id: u64,
+}
+
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PaneReady {
+    #[prost(uint64, tag = "1")]
+    pub reservation_id: u64,
+}
+
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct LayoutCommit {
+    #[prost(uint64, tag = "1")]
+    pub revision: u64,
+    #[prost(message, optional, tag = "2")]
+    pub state: Option<LayoutState>,
+}
+
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct LayoutReject {
+    #[prost(uint64, tag = "1")]
+    pub request_id: u64,
+    #[prost(enumeration = "LayoutRejectReason", tag = "2")]
+    pub reason: i32,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum LayoutRejectReason {
+    Stale = 1,
+    NotHost = 2,
+    Limit = 3,
+    Malformed = 4,
+    MixedTab = 5,
+    UnknownId = 6,
+    LastPaneOrTab = 7,
+    ReservationFailure = 8,
+}
+
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PaneSubscribe {
+    #[prost(bytes = "vec", tag = "1")]
+    pub session_id: Vec<u8>,
+    #[prost(bytes = "vec", tag = "2")]
+    pub peer_id: Vec<u8>,
+    #[prost(uint64, tag = "3")]
+    pub pane_id: u64,
 }
 
 pub fn encode_frame(envelope: &Envelope) -> Result<Vec<u8>, ProtocolError> {
@@ -327,6 +525,11 @@ fn validate_envelope(envelope: &Envelope) -> Result<(), ProtocolError> {
         envelope::Body::Join(join) => {
             validate_id("join.session_id", &join.session_id, MAX_SESSION_ID_BYTES)?;
             validate_id("join.peer_id", &join.peer_id, MAX_PEER_ID_BYTES)?;
+            validate_field_size(
+                "join.endpoint_addr",
+                join.endpoint_addr.len(),
+                MAX_ENDPOINT_ADDR_BYTES,
+            )?;
         }
         envelope::Body::Welcome(welcome) => {
             validate_id(
@@ -404,6 +607,54 @@ fn validate_envelope(envelope: &Envelope) -> Result<(), ProtocolError> {
             }
             validate_field_size("delta.changes", delta.changes.len(), MAX_DELTA_BYTES)?;
         }
+        envelope::Body::SessionSnapshot(snapshot) => {
+            validate_layout_state(
+                snapshot
+                    .state
+                    .as_ref()
+                    .ok_or(ProtocolError::InvalidLayout("session_snapshot.state"))?,
+            )?;
+        }
+        envelope::Body::LayoutRequest(request) => validate_layout_request(request)?,
+        envelope::Body::PaneReservation(reservation) => {
+            validate_nonzero(
+                "pane_reservation.reservation_id",
+                reservation.reservation_id,
+            )?;
+            validate_nonzero("pane_reservation.pane_id", reservation.pane_id)?;
+        }
+        envelope::Body::PaneReady(ready) => {
+            validate_nonzero("pane_ready.reservation_id", ready.reservation_id)?;
+        }
+        envelope::Body::LayoutCommit(commit) => {
+            validate_nonzero("layout_commit.revision", commit.revision)?;
+            let state = commit
+                .state
+                .as_ref()
+                .ok_or(ProtocolError::InvalidLayout("layout_commit.state"))?;
+            validate_layout_state(state)?;
+            if state.revision != commit.revision {
+                return Err(ProtocolError::InvalidLayout("layout_commit.revision"));
+            }
+        }
+        envelope::Body::LayoutReject(reject) => {
+            validate_nonzero("layout_reject.request_id", reject.request_id)?;
+            LayoutRejectReason::try_from(reject.reason)
+                .map_err(|_| ProtocolError::InvalidLayout("layout_reject.reason"))?;
+        }
+        envelope::Body::PaneSubscribe(subscribe) => {
+            validate_id(
+                "pane_subscribe.session_id",
+                &subscribe.session_id,
+                MAX_SESSION_ID_BYTES,
+            )?;
+            validate_id(
+                "pane_subscribe.peer_id",
+                &subscribe.peer_id,
+                MAX_PEER_ID_BYTES,
+            )?;
+            validate_nonzero("pane_subscribe.pane_id", subscribe.pane_id)?;
+        }
     }
 
     Ok(())
@@ -414,6 +665,142 @@ fn validate_id(field: &'static str, bytes: &[u8], limit: usize) -> Result<(), Pr
         return Err(ProtocolError::EmptyField(field));
     }
     validate_field_size(field, bytes.len(), limit)
+}
+
+fn validate_nonzero(field: &'static str, value: u64) -> Result<(), ProtocolError> {
+    if value == 0 {
+        return Err(ProtocolError::InvalidLayout(field));
+    }
+    Ok(())
+}
+
+fn validate_grid(field: &'static str, rows: u32, cols: u32) -> Result<(), ProtocolError> {
+    if rows == 0 || cols == 0 {
+        return Err(ProtocolError::InvalidLayout(field));
+    }
+    Ok(())
+}
+
+fn validate_axis(field: &'static str, axis: i32) -> Result<(), ProtocolError> {
+    SplitAxis::try_from(axis).map_err(|_| ProtocolError::InvalidLayout(field))?;
+    Ok(())
+}
+
+fn validate_layout_request(request: &LayoutRequest) -> Result<(), ProtocolError> {
+    validate_nonzero("layout_request.request_id", request.request_id)?;
+    validate_nonzero("layout_request.base_revision", request.base_revision)?;
+
+    let actions = usize::from(request.create_pane.is_some())
+        + usize::from(request.delete_pane.is_some())
+        + usize::from(request.create_tab.is_some())
+        + usize::from(request.delete_tab.is_some());
+    if actions != 1 {
+        return Err(ProtocolError::InvalidLayout("layout_request.action"));
+    }
+
+    if let Some(create_pane) = &request.create_pane {
+        validate_nonzero(
+            "layout_request.create_pane.target_pane_id",
+            create_pane.target_pane_id,
+        )?;
+        validate_axis("layout_request.create_pane.axis", create_pane.axis)?;
+        validate_grid(
+            "layout_request.create_pane.grid",
+            create_pane.grid_rows,
+            create_pane.grid_cols,
+        )?;
+    }
+    if let Some(delete_pane) = &request.delete_pane {
+        validate_nonzero("layout_request.delete_pane.pane_id", delete_pane.pane_id)?;
+    }
+    if let Some(create_tab) = &request.create_tab {
+        validate_grid(
+            "layout_request.create_tab.grid",
+            create_tab.grid_rows,
+            create_tab.grid_cols,
+        )?;
+    }
+    if let Some(delete_tab) = &request.delete_tab {
+        validate_nonzero("layout_request.delete_tab.tab_id", delete_tab.tab_id)?;
+    }
+    Ok(())
+}
+
+fn validate_layout_state(state: &LayoutState) -> Result<(), ProtocolError> {
+    validate_nonzero("layout_state.revision", state.revision)?;
+    if state.members.len() > 8 {
+        return Err(ProtocolError::InvalidLayout("layout_state.members"));
+    }
+    if state.panes.len() > 72 {
+        return Err(ProtocolError::InvalidLayout("layout_state.panes"));
+    }
+    if state.tabs.len() > 9 {
+        return Err(ProtocolError::InvalidLayout("layout_state.tabs"));
+    }
+
+    for member in &state.members {
+        validate_id(
+            "layout_state.member.peer_id",
+            &member.peer_id,
+            MAX_PEER_ID_BYTES,
+        )?;
+        validate_id(
+            "layout_state.member.endpoint_addr",
+            &member.endpoint_addr,
+            MAX_ENDPOINT_ADDR_BYTES,
+        )?;
+    }
+    for pane in &state.panes {
+        validate_nonzero("layout_state.pane.pane_id", pane.pane_id)?;
+        validate_id(
+            "layout_state.pane.host_peer_id",
+            &pane.host_peer_id,
+            MAX_PEER_ID_BYTES,
+        )?;
+        validate_grid("layout_state.pane.grid", pane.grid_rows, pane.grid_cols)?;
+    }
+    for tab in &state.tabs {
+        validate_nonzero("layout_state.tab.tab_id", tab.tab_id)?;
+        let root = tab
+            .root
+            .as_ref()
+            .ok_or(ProtocolError::InvalidLayout("layout_state.tab.root"))?;
+        let mut leaves = 0;
+        validate_layout_node(root, 0, &mut leaves)?;
+    }
+    Ok(())
+}
+
+fn validate_layout_node(
+    node: &LayoutNode,
+    depth: usize,
+    leaves: &mut usize,
+) -> Result<(), ProtocolError> {
+    if depth > 4 {
+        return Err(ProtocolError::InvalidLayout("layout_state.node.depth"));
+    }
+    match (node.leaf_pane_id, node.split.as_ref()) {
+        (Some(pane_id), None) => {
+            validate_nonzero("layout_state.node.leaf_pane_id", pane_id)?;
+            *leaves += 1;
+            if *leaves > 8 {
+                return Err(ProtocolError::InvalidLayout("layout_state.node.leaves"));
+            }
+        }
+        (None, Some(split)) => {
+            validate_axis("layout_state.node.split.axis", split.axis)?;
+            let first = split.first.as_ref().ok_or(ProtocolError::InvalidLayout(
+                "layout_state.node.split.first",
+            ))?;
+            let second = split.second.as_ref().ok_or(ProtocolError::InvalidLayout(
+                "layout_state.node.split.second",
+            ))?;
+            validate_layout_node(first, depth + 1, leaves)?;
+            validate_layout_node(second, depth + 1, leaves)?;
+        }
+        _ => return Err(ProtocolError::InvalidLayout("layout_state.node.kind")),
+    }
+    Ok(())
 }
 
 fn validate_field_size(

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -108,7 +108,7 @@ pub struct Envelope {
     pub sender_peer_id: Vec<u8>,
     #[prost(
         oneof = "envelope::Body",
-        tags = "10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23"
+        tags = "10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24"
     )]
     pub body: Option<envelope::Body>,
 }
@@ -144,6 +144,8 @@ pub mod envelope {
         LayoutReject(super::LayoutReject),
         #[prost(message, tag = "23")]
         PaneSubscribe(super::PaneSubscribe),
+        #[prost(message, tag = "24")]
+        PaneFailed(super::PaneFailed),
     }
 }
 
@@ -359,6 +361,18 @@ pub struct PaneReady {
     #[prost(uint64, tag = "1")]
     pub reservation_id: u64,
     #[prost(uint64, tag = "2")]
+    pub base_revision: u64,
+    #[prost(uint64, tag = "3")]
+    pub request_id: u64,
+}
+
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PaneFailed {
+    #[prost(uint64, tag = "1")]
+    pub reservation_id: u64,
+    #[prost(uint64, tag = "2")]
+    pub request_id: u64,
+    #[prost(uint64, tag = "3")]
     pub base_revision: u64,
 }
 
@@ -631,6 +645,12 @@ fn validate_envelope(envelope: &Envelope) -> Result<(), ProtocolError> {
         envelope::Body::PaneReady(ready) => {
             validate_nonzero("pane_ready.reservation_id", ready.reservation_id)?;
             validate_nonzero("pane_ready.base_revision", ready.base_revision)?;
+            validate_nonzero("pane_ready.request_id", ready.request_id)?;
+        }
+        envelope::Body::PaneFailed(failed) => {
+            validate_nonzero("pane_failed.reservation_id", failed.reservation_id)?;
+            validate_nonzero("pane_failed.request_id", failed.request_id)?;
+            validate_nonzero("pane_failed.base_revision", failed.base_revision)?;
         }
         envelope::Body::LayoutCommit(commit) => {
             validate_nonzero("layout_commit.revision", commit.revision)?;

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,7 +1,7 @@
 //! Versioned, length-delimited messages for the future pane transport.
 
 use prost::Message;
-use std::fmt;
+use std::{collections::HashSet, fmt};
 
 pub const PROTOCOL_VERSION: u32 = 2;
 pub const MAX_FRAME_BYTES: usize = 1_048_576;
@@ -350,8 +350,8 @@ pub struct PaneReservation {
     pub reservation_id: u64,
     #[prost(uint64, tag = "2")]
     pub pane_id: u64,
-    #[prost(uint64, tag = "3")]
-    pub tab_id: u64,
+    #[prost(uint64, optional, tag = "3")]
+    pub tab_id: Option<u64>,
 }
 
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -622,6 +622,9 @@ fn validate_envelope(envelope: &Envelope) -> Result<(), ProtocolError> {
                 reservation.reservation_id,
             )?;
             validate_nonzero("pane_reservation.pane_id", reservation.pane_id)?;
+            if let Some(tab_id) = reservation.tab_id {
+                validate_nonzero("pane_reservation.tab_id", tab_id)?;
+            }
         }
         envelope::Body::PaneReady(ready) => {
             validate_nonzero("pane_ready.reservation_id", ready.reservation_id)?;
@@ -728,16 +731,17 @@ fn validate_layout_request(request: &LayoutRequest) -> Result<(), ProtocolError>
 
 fn validate_layout_state(state: &LayoutState) -> Result<(), ProtocolError> {
     validate_nonzero("layout_state.revision", state.revision)?;
-    if state.members.len() > 8 {
+    if !(1..=8).contains(&state.members.len()) {
         return Err(ProtocolError::InvalidLayout("layout_state.members"));
     }
-    if state.panes.len() > 72 {
+    if !(1..=72).contains(&state.panes.len()) {
         return Err(ProtocolError::InvalidLayout("layout_state.panes"));
     }
-    if state.tabs.len() > 9 {
+    if !(1..=9).contains(&state.tabs.len()) {
         return Err(ProtocolError::InvalidLayout("layout_state.tabs"));
     }
 
+    let mut member_ids = HashSet::with_capacity(state.members.len());
     for member in &state.members {
         validate_id(
             "layout_state.member.peer_id",
@@ -749,7 +753,12 @@ fn validate_layout_state(state: &LayoutState) -> Result<(), ProtocolError> {
             &member.endpoint_addr,
             MAX_ENDPOINT_ADDR_BYTES,
         )?;
+        if !member_ids.insert(member.peer_id.as_slice()) {
+            return Err(ProtocolError::InvalidLayout("layout_state.member.peer_id"));
+        }
     }
+
+    let mut pane_ids = HashSet::with_capacity(state.panes.len());
     for pane in &state.panes {
         validate_nonzero("layout_state.pane.pane_id", pane.pane_id)?;
         validate_id(
@@ -758,15 +767,32 @@ fn validate_layout_state(state: &LayoutState) -> Result<(), ProtocolError> {
             MAX_PEER_ID_BYTES,
         )?;
         validate_grid("layout_state.pane.grid", pane.grid_rows, pane.grid_cols)?;
+        if !pane_ids.insert(pane.pane_id) {
+            return Err(ProtocolError::InvalidLayout("layout_state.pane.pane_id"));
+        }
+        if !member_ids.contains(pane.host_peer_id.as_slice()) {
+            return Err(ProtocolError::InvalidLayout(
+                "layout_state.pane.host_peer_id",
+            ));
+        }
     }
+
+    let mut tab_ids = HashSet::with_capacity(state.tabs.len());
+    let mut leaf_pane_ids = HashSet::with_capacity(state.panes.len());
     for tab in &state.tabs {
         validate_nonzero("layout_state.tab.tab_id", tab.tab_id)?;
+        if !tab_ids.insert(tab.tab_id) {
+            return Err(ProtocolError::InvalidLayout("layout_state.tab.tab_id"));
+        }
         let root = tab
             .root
             .as_ref()
             .ok_or(ProtocolError::InvalidLayout("layout_state.tab.root"))?;
         let mut leaves = 0;
-        validate_layout_node(root, 0, &mut leaves)?;
+        validate_layout_node(root, 0, &mut leaves, &mut leaf_pane_ids)?;
+    }
+    if leaf_pane_ids != pane_ids {
+        return Err(ProtocolError::InvalidLayout("layout_state.panes"));
     }
     Ok(())
 }
@@ -775,6 +801,7 @@ fn validate_layout_node(
     node: &LayoutNode,
     depth: usize,
     leaves: &mut usize,
+    leaf_pane_ids: &mut HashSet<u64>,
 ) -> Result<(), ProtocolError> {
     if depth > 4 {
         return Err(ProtocolError::InvalidLayout("layout_state.node.depth"));
@@ -782,6 +809,11 @@ fn validate_layout_node(
     match (node.leaf_pane_id, node.split.as_ref()) {
         (Some(pane_id), None) => {
             validate_nonzero("layout_state.node.leaf_pane_id", pane_id)?;
+            if !leaf_pane_ids.insert(pane_id) {
+                return Err(ProtocolError::InvalidLayout(
+                    "layout_state.node.leaf_pane_id",
+                ));
+            }
             *leaves += 1;
             if *leaves > 8 {
                 return Err(ProtocolError::InvalidLayout("layout_state.node.leaves"));
@@ -795,8 +827,8 @@ fn validate_layout_node(
             let second = split.second.as_ref().ok_or(ProtocolError::InvalidLayout(
                 "layout_state.node.split.second",
             ))?;
-            validate_layout_node(first, depth + 1, leaves)?;
-            validate_layout_node(second, depth + 1, leaves)?;
+            validate_layout_node(first, depth + 1, leaves, leaf_pane_ids)?;
+            validate_layout_node(second, depth + 1, leaves, leaf_pane_ids)?;
         }
         _ => return Err(ProtocolError::InvalidLayout("layout_state.node.kind")),
     }

--- a/src/session.rs
+++ b/src/session.rs
@@ -4,6 +4,7 @@ use std::{
     collections::BTreeMap,
     error::Error,
     fmt,
+    sync::{Arc, Mutex},
     time::{Duration, Instant},
 };
 
@@ -781,6 +782,7 @@ pub enum SessionError {
     UnauthenticatedPeer,
     InvalidPostWelcome,
     PeerTask,
+    Coordinator(CoordinatorError),
 }
 
 impl fmt::Display for SessionError {
@@ -800,6 +802,7 @@ impl fmt::Display for SessionError {
             }
             Self::InvalidPostWelcome => formatter.write_str("invalid post-Welcome message"),
             Self::PeerTask => formatter.write_str("peer stream task stopped unexpectedly"),
+            Self::Coordinator(error) => write!(formatter, "layout coordinator error: {error}"),
         }
     }
 }
@@ -817,6 +820,7 @@ impl Error for SessionError {
             | Self::UnauthenticatedPeer
             | Self::InvalidPostWelcome
             | Self::PeerTask => None,
+            Self::Coordinator(error) => Some(error),
         }
     }
 }
@@ -824,6 +828,12 @@ impl Error for SessionError {
 impl From<TransportError> for SessionError {
     fn from(error: TransportError) -> Self {
         Self::Transport(error)
+    }
+}
+
+impl From<CoordinatorError> for SessionError {
+    fn from(error: CoordinatorError) -> Self {
+        Self::Coordinator(error)
     }
 }
 
@@ -1001,6 +1011,424 @@ impl HostSession {
             )
             .await?;
         Ok(receipt)
+    }
+}
+
+/// A coordinator that keeps the shared layout authoritative while each admitted member has one
+/// independent, long-lived control stream. Pane data streams deliberately remain outside this
+/// type so they can later connect directly to their pane hosts.
+#[derive(Clone)]
+pub struct SharedLayoutHost {
+    host: HostSession,
+    coordinator: Arc<Mutex<LayoutCoordinator>>,
+    peers: Arc<Mutex<BTreeMap<Vec<u8>, mpsc::Sender<Envelope>>>>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum LayoutControlEvent {
+    Snapshot(SessionSnapshot),
+    Reservation(PaneReservation),
+    Commit(LayoutCommit),
+    Reject(LayoutReject),
+    Disconnected,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum LayoutControlQueueError {
+    Full,
+    Closed,
+}
+
+enum LayoutClientMessage {
+    Request(LayoutRequest),
+    Ready(PaneReady),
+    Failed(PaneFailed),
+}
+
+/// The member side of a shared-layout control connection.
+pub struct SharedLayoutMember {
+    pub peer_id: Vec<u8>,
+    pub coordinator_peer_id: Vec<u8>,
+    pub events: mpsc::Receiver<LayoutControlEvent>,
+    outbound: mpsc::Sender<LayoutClientMessage>,
+    transport: Transport,
+    connection: Connection,
+    tasks: Vec<tokio::task::JoinHandle<()>>,
+}
+
+impl SharedLayoutMember {
+    pub fn try_request(&self, request: LayoutRequest) -> Result<(), LayoutControlQueueError> {
+        self.outbound
+            .try_send(LayoutClientMessage::Request(request))
+            .map_err(layout_queue_error)
+    }
+
+    pub fn try_ready(&self, ready: PaneReady) -> Result<(), LayoutControlQueueError> {
+        self.outbound
+            .try_send(LayoutClientMessage::Ready(ready))
+            .map_err(layout_queue_error)
+    }
+
+    pub fn try_failed(&self, failed: PaneFailed) -> Result<(), LayoutControlQueueError> {
+        self.outbound
+            .try_send(LayoutClientMessage::Failed(failed))
+            .map_err(layout_queue_error)
+    }
+
+    pub async fn shutdown(mut self) {
+        for task in &self.tasks {
+            task.abort();
+        }
+        while let Some(task) = self.tasks.pop() {
+            let _ = task.await;
+        }
+        self.connection.close(0u8.into(), b"");
+        self.transport.close().await;
+    }
+}
+
+impl Drop for SharedLayoutMember {
+    fn drop(&mut self) {
+        for task in &self.tasks {
+            task.abort();
+        }
+        self.connection.close(0u8.into(), b"");
+    }
+}
+
+impl SharedLayoutHost {
+    pub fn new(host: HostSession, grid_rows: u16, grid_cols: u16) -> Result<Self, SessionError> {
+        let coordinator_peer_id = host.ticket().endpoint_addr().id.as_bytes().to_vec();
+        let coordinator = LayoutCoordinator::new(
+            coordinator_peer_id,
+            host.ticket().endpoint_addr().clone(),
+            grid_rows,
+            grid_cols,
+        )?;
+        Ok(Self {
+            host,
+            coordinator: Arc::new(Mutex::new(coordinator)),
+            peers: Arc::new(Mutex::new(BTreeMap::new())),
+        })
+    }
+
+    pub fn ticket(&self) -> &JoinTicket {
+        self.host.ticket()
+    }
+
+    /// Accept one authenticated member and then its persistent control stream.
+    pub async fn accept_one_member(&self) -> Result<JoinReceipt, SessionError> {
+        let incoming = self.host.accept_incoming().await?;
+        let connection = timeout(HANDSHAKE_TIMEOUT, incoming)
+            .await
+            .map_err(|_| SessionError::TimedOut("incoming connection"))?
+            .map_err(SessionError::Incoming)?;
+        let result = async {
+            let receipt = self.host.handshake_connection(&connection).await?;
+            let membership = self
+                .coordinator
+                .lock()
+                .map_err(|_| SessionError::PeerTask)?
+                .admit(
+                    receipt.admitted_peer_id.clone(),
+                    receipt.endpoint_addr.clone(),
+                )?;
+
+            // Existing members see the authoritative membership commit before the joining
+            // member receives its snapshot. The joiner snapshot already contains that commit.
+            self.broadcast_commit(membership.commit.clone());
+            if let Some(reject) = membership.invalidated_reservation {
+                self.send_reject(reject);
+            }
+
+            let (writer, reader) = self.transport_open_control(&connection).await?;
+            let peer_id = receipt.admitted_peer_id.clone();
+            let (outbound_tx, outbound_rx) = mpsc::channel(64);
+            self.peers
+                .lock()
+                .map_err(|_| SessionError::PeerTask)?
+                .insert(peer_id.clone(), outbound_tx.clone());
+            let snapshot = self
+                .coordinator
+                .lock()
+                .map_err(|_| SessionError::PeerTask)?
+                .session_snapshot()?;
+            let _ = outbound_tx.try_send(coordinator_envelope(
+                self.host.ticket().endpoint_addr().id.as_bytes(),
+                envelope::Body::SessionSnapshot(snapshot),
+            ));
+
+            tokio::spawn(layout_writer_task(writer, outbound_rx));
+            tokio::spawn(layout_host_reader_task(
+                reader,
+                peer_id,
+                self.host.ticket().endpoint_addr().id.as_bytes().to_vec(),
+                self.coordinator.clone(),
+                self.peers.clone(),
+            ));
+            Ok(receipt)
+        }
+        .await;
+        if result.is_err() {
+            connection.close(0u8.into(), b"");
+        }
+        result
+    }
+
+    pub async fn close(&self) {
+        self.host.close().await;
+    }
+
+    async fn transport_open_control(
+        &self,
+        connection: &Connection,
+    ) -> Result<(crate::transport::FrameWriter, crate::transport::FrameReader), SessionError> {
+        self.host
+            .transport
+            .open_framed_bi(connection)
+            .await
+            .map_err(Into::into)
+    }
+
+    fn broadcast_commit(&self, commit: LayoutCommit) {
+        broadcast_envelope(
+            &self.peers,
+            coordinator_envelope(
+                self.host.ticket().endpoint_addr().id.as_bytes(),
+                envelope::Body::LayoutCommit(commit),
+            ),
+        );
+    }
+
+    fn send_reject(&self, targeted: TargetedLayoutReject) {
+        send_to_peer(
+            &self.peers,
+            &targeted.peer_id,
+            coordinator_envelope(
+                self.host.ticket().endpoint_addr().id.as_bytes(),
+                envelope::Body::LayoutReject(targeted.reject),
+            ),
+        );
+    }
+}
+
+fn layout_queue_error<T>(error: mpsc::error::TrySendError<T>) -> LayoutControlQueueError {
+    match error {
+        mpsc::error::TrySendError::Full(_) => LayoutControlQueueError::Full,
+        mpsc::error::TrySendError::Closed(_) => LayoutControlQueueError::Closed,
+    }
+}
+
+fn coordinator_envelope(sender_peer_id: &[u8], body: envelope::Body) -> Envelope {
+    Envelope {
+        version: PROTOCOL_VERSION,
+        sender_peer_id: sender_peer_id.to_vec(),
+        body: Some(body),
+    }
+}
+
+fn broadcast_envelope(
+    peers: &Arc<Mutex<BTreeMap<Vec<u8>, mpsc::Sender<Envelope>>>>,
+    envelope: Envelope,
+) {
+    let mut peers = match peers.lock() {
+        Ok(peers) => peers,
+        Err(_) => return,
+    };
+    peers.retain(|_, sender| sender.try_send(envelope.clone()).is_ok());
+}
+
+fn send_to_peer(
+    peers: &Arc<Mutex<BTreeMap<Vec<u8>, mpsc::Sender<Envelope>>>>,
+    peer_id: &[u8],
+    envelope: Envelope,
+) {
+    let mut peers = match peers.lock() {
+        Ok(peers) => peers,
+        Err(_) => return,
+    };
+    if peers
+        .get(peer_id)
+        .is_some_and(|sender| sender.try_send(envelope).is_err())
+    {
+        peers.remove(peer_id);
+    }
+}
+
+/// Join a coordinator and establish the persistent member-to-coordinator layout stream.
+pub async fn join_layout(
+    transport: Transport,
+    ticket: JoinTicket,
+) -> Result<SharedLayoutMember, SessionError> {
+    let connection = transport.connect(ticket.endpoint_addr().clone()).await?;
+    let result = async {
+        let receipt = join_handshake(&transport, &connection, &ticket).await?;
+        let (writer, reader) = transport.accept_framed_bi(&connection).await?;
+        let (events_tx, events) = mpsc::channel(128);
+        let (outbound, outbound_rx) = mpsc::channel(64);
+        let peer_id = transport.endpoint_id().as_bytes().to_vec();
+        let coordinator_peer_id = receipt.coordinator_peer_id;
+        let tasks = vec![
+            tokio::spawn(layout_member_reader_task(
+                reader,
+                events_tx,
+                coordinator_peer_id.clone(),
+            )),
+            tokio::spawn(layout_member_writer_task(
+                writer,
+                outbound_rx,
+                peer_id.clone(),
+            )),
+        ];
+        Ok(SharedLayoutMember {
+            peer_id,
+            coordinator_peer_id,
+            events,
+            outbound,
+            transport: transport.clone(),
+            connection: connection.clone(),
+            tasks,
+        })
+    }
+    .await;
+    if result.is_err() {
+        connection.close(0u8.into(), b"");
+        transport.close().await;
+    }
+    result
+}
+
+async fn layout_writer_task(
+    mut writer: crate::transport::FrameWriter,
+    mut outbound: mpsc::Receiver<Envelope>,
+) {
+    while let Some(envelope) = outbound.recv().await {
+        if writer.write_next(&envelope).await.is_err() {
+            return;
+        }
+    }
+}
+
+async fn layout_member_writer_task(
+    mut writer: crate::transport::FrameWriter,
+    mut outbound: mpsc::Receiver<LayoutClientMessage>,
+    peer_id: Vec<u8>,
+) {
+    while let Some(message) = outbound.recv().await {
+        let body = match message {
+            LayoutClientMessage::Request(request) => envelope::Body::LayoutRequest(request),
+            LayoutClientMessage::Ready(ready) => envelope::Body::PaneReady(ready),
+            LayoutClientMessage::Failed(failed) => envelope::Body::PaneFailed(failed),
+        };
+        if writer
+            .write_next(&coordinator_envelope(&peer_id, body))
+            .await
+            .is_err()
+        {
+            return;
+        }
+    }
+}
+
+async fn layout_member_reader_task(
+    mut reader: crate::transport::FrameReader,
+    events_tx: mpsc::Sender<LayoutControlEvent>,
+    coordinator_peer_id: Vec<u8>,
+) {
+    while let Ok(Some(envelope)) = reader.read_next().await {
+        if envelope.sender_peer_id != coordinator_peer_id {
+            break;
+        }
+        let event = match envelope.body {
+            Some(envelope::Body::SessionSnapshot(snapshot)) => {
+                LayoutControlEvent::Snapshot(snapshot)
+            }
+            Some(envelope::Body::PaneReservation(reservation)) => {
+                LayoutControlEvent::Reservation(reservation)
+            }
+            Some(envelope::Body::LayoutCommit(commit)) => LayoutControlEvent::Commit(commit),
+            Some(envelope::Body::LayoutReject(reject)) => LayoutControlEvent::Reject(reject),
+            _ => break,
+        };
+        if events_tx.send(event).await.is_err() {
+            return;
+        }
+    }
+    let _ = events_tx.send(LayoutControlEvent::Disconnected).await;
+}
+
+async fn layout_host_reader_task(
+    mut reader: crate::transport::FrameReader,
+    peer_id: Vec<u8>,
+    coordinator_peer_id: Vec<u8>,
+    coordinator: Arc<Mutex<LayoutCoordinator>>,
+    peers: Arc<Mutex<BTreeMap<Vec<u8>, mpsc::Sender<Envelope>>>>,
+) {
+    while let Ok(Some(envelope)) = reader.read_next().await {
+        if envelope.sender_peer_id != peer_id {
+            break;
+        }
+        match envelope.body {
+            Some(envelope::Body::LayoutRequest(request)) => {
+                let response = match coordinator.lock() {
+                    Ok(mut coordinator) => coordinator.handle_request(&peer_id, request),
+                    Err(_) => break,
+                };
+                dispatch_coordinator_response(&peers, &peer_id, &coordinator_peer_id, response);
+            }
+            Some(envelope::Body::PaneReady(ready)) => {
+                let response = match coordinator.lock() {
+                    Ok(mut coordinator) => coordinator.handle_pane_ready(&peer_id, ready),
+                    Err(_) => break,
+                };
+                dispatch_coordinator_response(&peers, &peer_id, &coordinator_peer_id, response);
+            }
+            Some(envelope::Body::PaneFailed(failed)) => {
+                let reject = match coordinator.lock() {
+                    Ok(mut coordinator) => coordinator.handle_pane_failed(&peer_id, failed),
+                    Err(_) => break,
+                };
+                send_to_peer(
+                    &peers,
+                    &reject.peer_id,
+                    coordinator_envelope(
+                        &coordinator_peer_id,
+                        envelope::Body::LayoutReject(reject.reject),
+                    ),
+                );
+            }
+            _ => break,
+        }
+    }
+    if let Ok(mut peers) = peers.lock() {
+        peers.remove(&peer_id);
+    }
+}
+
+fn dispatch_coordinator_response(
+    peers: &Arc<Mutex<BTreeMap<Vec<u8>, mpsc::Sender<Envelope>>>>,
+    requester_peer_id: &[u8],
+    coordinator_peer_id: &[u8],
+    response: CoordinatorResponse,
+) {
+    match response {
+        CoordinatorResponse::Reservation(reservation) => send_to_peer(
+            peers,
+            requester_peer_id,
+            coordinator_envelope(
+                coordinator_peer_id,
+                envelope::Body::PaneReservation(reservation),
+            ),
+        ),
+        CoordinatorResponse::Commit(commit) => broadcast_envelope(
+            peers,
+            coordinator_envelope(coordinator_peer_id, envelope::Body::LayoutCommit(commit)),
+        ),
+        CoordinatorResponse::Reject(reject) => send_to_peer(
+            peers,
+            requester_peer_id,
+            coordinator_envelope(coordinator_peer_id, envelope::Body::LayoutReject(reject)),
+        ),
     }
 }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -8,7 +8,7 @@ use std::{
     pin::Pin,
     sync::{
         Arc, Mutex,
-        atomic::{AtomicU64, Ordering},
+        atomic::{AtomicBool, AtomicU64, Ordering},
     },
     time::{Duration, Instant},
 };
@@ -18,7 +18,7 @@ use iroh::{
     endpoint::{ConnectingError, Connection, Incoming, SendStream},
 };
 use tokio::{
-    sync::{mpsc, watch},
+    sync::{broadcast, mpsc, watch},
     time::{interval, timeout},
 };
 
@@ -784,17 +784,39 @@ pub struct PaneServer {
     session_id: Vec<u8>,
     local_peer_id: Vec<u8>,
     members: Arc<Mutex<BTreeMap<Vec<u8>, EndpointAddr>>>,
-    panes: Arc<Mutex<BTreeMap<u64, HostPaneChannels>>>,
+    registry: Arc<Mutex<PaneRegistry>>,
+    next_subscription_id: Arc<AtomicU64>,
+    service_errors: broadcast::Sender<SessionServiceError>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum SessionServiceError {
+    PaneConnection,
+    IncomingDispatcherConnection,
+}
+
+#[derive(Default)]
+struct PaneRegistry {
+    panes: BTreeMap<u64, HostPaneChannels>,
+    subscriptions: BTreeMap<u64, BTreeMap<u64, PaneSubscription>>,
+}
+
+struct PaneSubscription {
+    connection: Connection,
+    active: Arc<AtomicBool>,
 }
 
 impl PaneServer {
     pub fn from_host_session(host: &HostSession) -> Self {
+        let (service_errors, _) = broadcast::channel(32);
         Self {
             transport: host.transport.clone(),
             session_id: host.ticket.session_id().to_vec(),
             local_peer_id: host.transport.endpoint_id().as_bytes().to_vec(),
             members: Arc::new(Mutex::new(BTreeMap::new())),
-            panes: Arc::new(Mutex::new(BTreeMap::new())),
+            registry: Arc::new(Mutex::new(PaneRegistry::default())),
+            next_subscription_id: Arc::new(AtomicU64::new(1)),
+            service_errors,
         }
     }
 
@@ -802,13 +824,35 @@ impl PaneServer {
         if session_id.is_empty() {
             return Err(SessionError::InvalidPostWelcome);
         }
+        let (service_errors, _) = broadcast::channel(32);
         Ok(Self {
             local_peer_id: transport.endpoint_id().as_bytes().to_vec(),
             transport,
             session_id,
             members: Arc::new(Mutex::new(BTreeMap::new())),
-            panes: Arc::new(Mutex::new(BTreeMap::new())),
+            registry: Arc::new(Mutex::new(PaneRegistry::default())),
+            next_subscription_id: Arc::new(AtomicU64::new(1)),
+            service_errors,
         })
+    }
+
+    /// Receives unexpected service failures; malformed and unauthenticated peers are rejected
+    /// without creating operational noise.
+    pub fn subscribe_errors(&self) -> broadcast::Receiver<SessionServiceError> {
+        self.service_errors.subscribe()
+    }
+
+    fn report_service_result(
+        &self,
+        source: SessionServiceError,
+        result: &Result<(), SessionError>,
+    ) {
+        if result
+            .as_ref()
+            .is_err_and(|error| !expected_service_error(error))
+        {
+            let _ = self.service_errors.send(source);
+        }
     }
 
     pub fn add_member(
@@ -873,9 +917,10 @@ impl PaneServer {
         {
             return Err(SessionError::InvalidPostWelcome);
         }
-        self.panes
+        self.registry
             .lock()
             .map_err(|_| SessionError::PeerTask)?
+            .panes
             .insert(descriptor.pane_id, channels);
         Ok(())
     }
@@ -891,11 +936,21 @@ impl PaneServer {
     }
 
     pub fn remove_pane(&self, pane_id: u64) -> Result<Option<HostPaneChannels>, SessionError> {
-        Ok(self
-            .panes
-            .lock()
-            .map_err(|_| SessionError::PeerTask)?
-            .remove(&pane_id))
+        let (pane, subscriptions) = {
+            let mut registry = self.registry.lock().map_err(|_| SessionError::PeerTask)?;
+            (
+                registry.panes.remove(&pane_id),
+                registry.subscriptions.remove(&pane_id),
+            )
+        };
+        for subscription in subscriptions
+            .into_iter()
+            .flat_map(|subscribers| subscribers.into_values())
+        {
+            subscription.active.store(false, Ordering::Release);
+            subscription.connection.close(0u8.into(), b"pane removed");
+        }
+        Ok(pane)
     }
 
     pub fn remove_local_pane(
@@ -914,14 +969,28 @@ impl PaneServer {
     /// arrivals. A runtime that multiplexes layout joins and panes should use
     /// [`IncomingDispatcher`] instead of starting this loop alongside another acceptor.
     pub async fn accept_loop(&self) -> Result<(), SessionError> {
+        self.accept_loop_with_timeout(HANDSHAKE_TIMEOUT).await
+    }
+
+    /// Testable accept-loop variant. Idle accept timeouts are retried; closure and other
+    /// transport errors end the loop.
+    pub async fn accept_loop_with_timeout(
+        &self,
+        accept_timeout: Duration,
+    ) -> Result<(), SessionError> {
         let mut tasks = tokio::task::JoinSet::new();
         loop {
             tokio::select! {
-                incoming = self.transport.accept_incoming() => {
-                    let incoming = incoming?;
+                incoming = self.transport.accept_incoming_with_timeout(accept_timeout) => {
+                    let incoming = match incoming {
+                        Ok(incoming) => incoming,
+                        Err(TransportError::TimedOut("incoming accept")) => continue,
+                        Err(error) => return Err(error.into()),
+                    };
                     let server = self.clone();
                     tasks.spawn(async move {
-                        let _ = server.serve_incoming(incoming).await;
+                        let result = server.serve_incoming(incoming).await;
+                        server.report_service_result(SessionServiceError::PaneConnection, &result);
                     });
                 }
                 Some(_) = tasks.join_next(), if !tasks.is_empty() => {}
@@ -969,19 +1038,52 @@ impl PaneServer {
         {
             return Err(SessionError::UnauthenticatedPeer);
         }
-        let pane = self
-            .panes
-            .lock()
-            .map_err(|_| SessionError::PeerTask)?
-            .get(&subscribe.pane_id)
-            .cloned()
-            .ok_or(SessionError::InvalidPostWelcome)?;
+        let subscription_id = self.next_subscription_id.fetch_add(1, Ordering::Relaxed);
+        if subscription_id == 0 {
+            return Err(SessionError::PeerTask);
+        }
+        let active = Arc::new(AtomicBool::new(true));
+        let pane = {
+            let mut registry = self.registry.lock().map_err(|_| SessionError::PeerTask)?;
+            let pane = registry
+                .panes
+                .get(&subscribe.pane_id)
+                .cloned()
+                .ok_or(SessionError::InvalidPostWelcome)?;
+            registry
+                .subscriptions
+                .entry(subscribe.pane_id)
+                .or_default()
+                .insert(
+                    subscription_id,
+                    PaneSubscription {
+                        connection: connection.clone(),
+                        active: active.clone(),
+                    },
+                );
+            pane
+        };
         if pane.host_peer_id != self.local_peer_id
             || pane.pane_id != pane_wire_id(subscribe.pane_id)
         {
             return Err(SessionError::InvalidPostWelcome);
         }
-        serve_direct_pane_streams(&self.transport, connection, remote_peer_id, pane).await
+        let result =
+            serve_direct_pane_streams(&self.transport, connection, remote_peer_id, pane, active)
+                .await;
+        if let Ok(mut registry) = self.registry.lock()
+            && let Some(subscribers) = registry.subscriptions.get_mut(&subscribe.pane_id)
+        {
+            subscribers.remove(&subscription_id);
+            if subscribers.is_empty() {
+                registry.subscriptions.remove(&subscribe.pane_id);
+            }
+        }
+        if is_normal_peer_disconnect(&result) {
+            Ok(())
+        } else {
+            result
+        }
     }
 
     pub async fn close(&self) {
@@ -1189,6 +1291,7 @@ impl HostSession {
                 connection.remote_id().as_bytes().to_vec(),
                 pane.pane_id,
                 pane.control_tx,
+                None,
             ));
             let mut screen_task = screen_task;
             let mut lease_task = lease_task;
@@ -1277,6 +1380,7 @@ impl HostSession {
 #[derive(Clone)]
 pub struct SharedLayoutHost {
     host: HostSession,
+    pane_server: PaneServer,
     coordinator: Arc<Mutex<LayoutCoordinator>>,
     peers: Arc<Mutex<BTreeMap<Vec<u8>, ControlPeer>>>,
     reservation_timeout: Duration,
@@ -1289,6 +1393,33 @@ pub enum LayoutControlEvent {
     Commit(LayoutCommit),
     Reject(LayoutReject),
     Disconnected,
+}
+
+/// Applies authoritative control-plane layout state to a member's local pane registry before the
+/// runtime attempts direct subscriptions described by that state.
+#[derive(Clone)]
+pub struct PaneLayoutReconciler {
+    panes: PaneServer,
+}
+
+impl PaneLayoutReconciler {
+    pub fn new(panes: PaneServer) -> Self {
+        Self { panes }
+    }
+
+    pub fn apply(&self, event: &LayoutControlEvent) -> Result<(), SessionError> {
+        let state = match event {
+            LayoutControlEvent::Snapshot(snapshot) => snapshot.state.as_ref(),
+            LayoutControlEvent::Commit(commit) => commit.state.as_ref(),
+            LayoutControlEvent::Reservation(_)
+            | LayoutControlEvent::Reject(_)
+            | LayoutControlEvent::Disconnected => None,
+        };
+        match state {
+            Some(state) => self.panes.replace_roster_from_layout(state),
+            None => Ok(()),
+        }
+    }
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -1486,6 +1617,7 @@ impl SharedLayoutHost {
         grid_cols: u16,
         reservation_timeout: Duration,
     ) -> Result<Self, SessionError> {
+        let pane_server = host.pane_server();
         let coordinator_peer_id = host.ticket().endpoint_addr().id.as_bytes().to_vec();
         let coordinator = LayoutCoordinator::with_reservation_timeout(
             coordinator_peer_id,
@@ -1497,6 +1629,7 @@ impl SharedLayoutHost {
         )?;
         Ok(Self {
             host,
+            pane_server,
             coordinator: Arc::new(Mutex::new(coordinator)),
             peers: Arc::new(Mutex::new(BTreeMap::new())),
             reservation_timeout,
@@ -1510,7 +1643,7 @@ impl SharedLayoutHost {
     /// Creates the coordinator-owned pane registry. The runtime must keep this registry's roster
     /// and local pane registrations synchronized from authoritative layout commits.
     pub fn pane_server(&self) -> PaneServer {
-        self.host.pane_server()
+        self.pane_server.clone()
     }
 
     /// Creates the only incoming acceptor for an endpoint that serves both layout control and
@@ -1565,6 +1698,13 @@ impl SharedLayoutHost {
                     receipt.endpoint_addr.clone(),
                 )?;
 
+                let state = membership
+                    .commit
+                    .state
+                    .as_ref()
+                    .ok_or(SessionError::InvalidPostWelcome)?;
+                self.pane_server.replace_roster_from_layout(state)?;
+
                 // Existing members see the authoritative membership commit before the joining
                 // member receives its snapshot. The joiner snapshot already contains that commit.
                 self.broadcast_commit(membership.commit.clone());
@@ -1602,6 +1742,7 @@ impl SharedLayoutHost {
                 self.host.ticket().endpoint_addr().id.as_bytes().to_vec(),
                 self.coordinator.clone(),
                 self.peers.clone(),
+                self.pane_server.clone(),
                 self.reservation_timeout,
             ));
             if let Ok(mut slot) = reader_abort.lock() {
@@ -1696,14 +1837,29 @@ impl IncomingDispatcher {
 
     /// Continually accepts connections and dispatches each to an independently managed task.
     pub async fn accept_loop(&self) -> Result<(), SessionError> {
+        self.accept_loop_with_timeout(HANDSHAKE_TIMEOUT).await
+    }
+
+    pub async fn accept_loop_with_timeout(
+        &self,
+        accept_timeout: Duration,
+    ) -> Result<(), SessionError> {
         let mut tasks = tokio::task::JoinSet::new();
         loop {
             tokio::select! {
-                incoming = self.layout.host.accept_incoming() => {
-                    let incoming = incoming?;
+                incoming = self.layout.host.transport.accept_incoming_with_timeout(accept_timeout) => {
+                    let incoming = match incoming {
+                        Ok(incoming) => incoming,
+                        Err(TransportError::TimedOut("incoming accept")) => continue,
+                        Err(error) => return Err(error.into()),
+                    };
                     let dispatcher = self.clone();
                     tasks.spawn(async move {
-                        let _ = dispatcher.dispatch_incoming(incoming).await;
+                        let result = dispatcher.dispatch_incoming(incoming).await;
+                        dispatcher.panes.report_service_result(
+                            SessionServiceError::IncomingDispatcherConnection,
+                            &result,
+                        );
                     });
                 }
                 Some(_) = tasks.join_next(), if !tasks.is_empty() => {}
@@ -1746,6 +1902,26 @@ impl IncomingDispatcher {
         }
         result
     }
+}
+
+fn expected_service_error(error: &SessionError) -> bool {
+    matches!(
+        error,
+        SessionError::TimedOut(_)
+            | SessionError::InvalidJoin
+            | SessionError::InvalidJoinEndpointAddress
+            | SessionError::InvalidWelcome
+            | SessionError::UnauthenticatedPeer
+            | SessionError::InvalidPostWelcome
+            | SessionError::PeerTask
+    )
+}
+
+fn is_normal_peer_disconnect(result: &Result<(), SessionError>) -> bool {
+    matches!(
+        result,
+        Err(SessionError::Transport(TransportError::StreamRead(_)))
+    )
 }
 
 fn layout_queue_error<T>(error: mpsc::error::TrySendError<T>) -> LayoutControlQueueError {
@@ -2001,6 +2177,7 @@ async fn layout_host_reader_task(
     coordinator_peer_id: Vec<u8>,
     coordinator: Arc<Mutex<LayoutCoordinator>>,
     peers: Arc<Mutex<BTreeMap<Vec<u8>, ControlPeer>>>,
+    pane_server: PaneServer,
     reservation_timeout: Duration,
 ) {
     while let Ok(Some(envelope)) = reader.read_next().await {
@@ -2020,7 +2197,13 @@ async fn layout_host_reader_task(
                     }
                     _ => None,
                 };
-                dispatch_coordinator_response(&peers, &peer_id, &coordinator_peer_id, response);
+                dispatch_coordinator_response(
+                    &peers,
+                    &peer_id,
+                    &coordinator_peer_id,
+                    &pane_server,
+                    response,
+                );
                 drop(coordinator_guard);
                 if let Some(reservation_id) = reservation {
                     tokio::spawn(reservation_expiry_task(
@@ -2038,7 +2221,13 @@ async fn layout_host_reader_task(
                     Err(_) => break,
                 };
                 let response = coordinator_guard.handle_pane_ready(&peer_id, ready);
-                dispatch_coordinator_response(&peers, &peer_id, &coordinator_peer_id, response);
+                dispatch_coordinator_response(
+                    &peers,
+                    &peer_id,
+                    &coordinator_peer_id,
+                    &pane_server,
+                    response,
+                );
                 drop(coordinator_guard);
             }
             Some(envelope::Body::PaneFailed(failed)) => {
@@ -2092,6 +2281,7 @@ fn dispatch_coordinator_response(
     peers: &Arc<Mutex<BTreeMap<Vec<u8>, ControlPeer>>>,
     requester_peer_id: &[u8],
     coordinator_peer_id: &[u8],
+    pane_server: &PaneServer,
     response: CoordinatorResponse,
 ) {
     match response {
@@ -2103,10 +2293,15 @@ fn dispatch_coordinator_response(
                 envelope::Body::PaneReservation(reservation),
             ),
         ),
-        CoordinatorResponse::Commit(commit) => broadcast_envelope(
-            peers,
-            coordinator_envelope(coordinator_peer_id, envelope::Body::LayoutCommit(commit)),
-        ),
+        CoordinatorResponse::Commit(commit) => {
+            if let Some(state) = commit.state.as_ref() {
+                let _ = pane_server.replace_roster_from_layout(state);
+            }
+            broadcast_envelope(
+                peers,
+                coordinator_envelope(coordinator_peer_id, envelope::Body::LayoutCommit(commit)),
+            )
+        }
         CoordinatorResponse::Reject(reject) => send_to_peer(
             peers,
             requester_peer_id,
@@ -2126,6 +2321,7 @@ async fn serve_direct_pane_streams(
     connection: &Connection,
     remote_peer_id: Vec<u8>,
     pane: HostPaneChannels,
+    active: Arc<AtomicBool>,
 ) -> Result<(), SessionError> {
     let (screen_writer, _) = transport.open_framed_bi(connection).await?;
     let screen_task = tokio::spawn(screen_writer_task(
@@ -2158,6 +2354,7 @@ async fn serve_direct_pane_streams(
             remote_peer_id,
             pane.pane_id,
             pane.control_tx,
+            Some(active),
         )
         .await
     });
@@ -2271,6 +2468,7 @@ async fn control_reader_task(
     peer_id: Vec<u8>,
     pane_id: Vec<u8>,
     control_tx: mpsc::Sender<HostControlEvent>,
+    active: Option<Arc<AtomicBool>>,
 ) -> Result<(), SessionError> {
     while let Some(envelope) = reader.read_next().await? {
         if envelope.sender_peer_id != peer_id {
@@ -2293,6 +2491,12 @@ async fn control_reader_task(
             }
             _ => return Err(SessionError::InvalidPostWelcome),
         };
+        if active
+            .as_ref()
+            .is_some_and(|active| !active.load(Ordering::Acquire))
+        {
+            return Err(SessionError::InvalidPostWelcome);
+        }
         control_tx
             .send(event)
             .await
@@ -2971,5 +3175,26 @@ mod control_queue_tests {
         ));
         remove_control_peer(&peers, b"member");
         writer_task.abort();
+    }
+
+    #[tokio::test]
+    async fn unexpected_service_failures_are_observable_but_rejections_are_suppressed() {
+        let server = PaneServer::new(Transport::bind().await.expect("transport"), vec![1])
+            .expect("pane server");
+        let mut errors = server.subscribe_errors();
+        let operational = Err(SessionError::Transport(TransportError::Closed));
+        server.report_service_result(SessionServiceError::PaneConnection, &operational);
+        assert_eq!(
+            errors.recv().await.expect("operational failure"),
+            SessionServiceError::PaneConnection
+        );
+        let rejected = Err(SessionError::UnauthenticatedPeer);
+        server.report_service_result(SessionServiceError::PaneConnection, &rejected);
+        assert!(
+            timeout(Duration::from_millis(10), errors.recv())
+                .await
+                .is_err()
+        );
+        server.close().await;
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,6 +1,11 @@
 //! Authenticated Join/Welcome session handshakes over Iroh bi-streams.
 
-use std::{collections::BTreeMap, error::Error, fmt, time::Duration};
+use std::{
+    collections::BTreeMap,
+    error::Error,
+    fmt,
+    time::{Duration, Instant},
+};
 
 use iroh::{
     EndpointAddr, EndpointId,
@@ -17,7 +22,7 @@ use crate::{
     protocol::{
         ControlLease, CreatePane, CreateTab, DeletePane, DeleteTab, Delta, Envelope, Input, Join,
         LayoutCommit, LayoutNode, LayoutReject, LayoutRejectReason, LayoutRequest, LayoutSplit,
-        LayoutState, MemberDescriptor, PROTOCOL_VERSION, PaneDescriptor, PaneReady,
+        LayoutState, MemberDescriptor, PROTOCOL_VERSION, PaneDescriptor, PaneFailed, PaneReady,
         PaneReservation, SessionSnapshot, Snapshot, SplitAxis, TabDescriptor, TakeControl, Welcome,
         envelope,
     },
@@ -27,28 +32,56 @@ use crate::{
 };
 
 pub const DEFAULT_PANE_ID: &[u8] = b"default-pane";
+pub const DEFAULT_RESERVATION_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// In-memory authority for the shared layout. Network code authenticates callers before handing
 /// their protocol messages to this type.
 pub struct LayoutCoordinator {
     state: SessionState,
-    reservation_request_ids: BTreeMap<u64, u64>,
+    reservations: BTreeMap<u64, ReservationContext>,
+    reservation_timeout: Duration,
+}
+
+#[derive(Clone, Debug)]
+struct ReservationContext {
+    request_id: u64,
+    creator_peer_id: Vec<u8>,
+    deadline: Instant,
 }
 
 #[derive(Debug)]
 pub enum CoordinatorError {
     Layout(LayoutError),
+    EndpointIdentityMismatch,
+    InvalidEndpointAddress,
+    EndpointSerialization(serde_json::Error),
 }
 
 impl fmt::Display for CoordinatorError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Layout(error) => write!(formatter, "layout error: {error:?}"),
+            Self::EndpointIdentityMismatch => {
+                formatter.write_str("endpoint identity did not match peer")
+            }
+            Self::InvalidEndpointAddress => {
+                formatter.write_str("endpoint address was empty or invalid")
+            }
+            Self::EndpointSerialization(error) => {
+                write!(formatter, "endpoint address serialization failed: {error}")
+            }
         }
     }
 }
 
-impl Error for CoordinatorError {}
+impl Error for CoordinatorError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::EndpointSerialization(error) => Some(error),
+            _ => None,
+        }
+    }
+}
 
 impl From<LayoutError> for CoordinatorError {
     fn from(error: LayoutError) -> Self {
@@ -63,16 +96,48 @@ pub enum CoordinatorResponse {
     Reject(LayoutReject),
 }
 
+#[derive(Clone, Debug, PartialEq)]
+pub struct TargetedLayoutReject {
+    pub peer_id: Vec<u8>,
+    pub reject: LayoutReject,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct MembershipChange {
+    pub commit: LayoutCommit,
+    pub invalidated_reservation: Option<TargetedLayoutReject>,
+}
+
 impl LayoutCoordinator {
     pub fn new(
         coordinator_peer_id: Vec<u8>,
-        endpoint_addr: Vec<u8>,
+        endpoint_addr: EndpointAddr,
         grid_rows: u16,
         grid_cols: u16,
     ) -> Result<Self, CoordinatorError> {
+        Self::with_reservation_timeout(
+            coordinator_peer_id,
+            endpoint_addr,
+            grid_rows,
+            grid_cols,
+            DEFAULT_RESERVATION_TIMEOUT,
+            Instant::now(),
+        )
+    }
+
+    pub fn with_reservation_timeout(
+        coordinator_peer_id: Vec<u8>,
+        endpoint_addr: EndpointAddr,
+        grid_rows: u16,
+        grid_cols: u16,
+        reservation_timeout: Duration,
+        _now: Instant,
+    ) -> Result<Self, CoordinatorError> {
+        let endpoint_addr = serialized_endpoint(&coordinator_peer_id, endpoint_addr)?;
         Ok(Self {
             state: SessionState::new(coordinator_peer_id, endpoint_addr, grid_rows, grid_cols)?,
-            reservation_request_ids: BTreeMap::new(),
+            reservations: BTreeMap::new(),
+            reservation_timeout,
         })
     }
 
@@ -85,17 +150,42 @@ impl LayoutCoordinator {
     pub fn admit(
         &mut self,
         peer_id: Vec<u8>,
-        endpoint_addr: Vec<u8>,
-    ) -> Result<LayoutCommit, CoordinatorError> {
-        self.state
+        endpoint_addr: EndpointAddr,
+    ) -> Result<MembershipChange, CoordinatorError> {
+        let endpoint_addr = serialized_endpoint(&peer_id, endpoint_addr)?;
+        let invalidated = self
+            .state
             .add_member(self.state.revision(), peer_id, endpoint_addr)?;
-        self.layout_commit()
+        self.membership_change(invalidated)
+    }
+
+    pub fn update_member_endpoint(
+        &mut self,
+        authenticated_peer_id: &[u8],
+        endpoint_addr: EndpointAddr,
+    ) -> Result<MembershipChange, CoordinatorError> {
+        let endpoint_addr = serialized_endpoint(authenticated_peer_id, endpoint_addr)?;
+        let invalidated = self.state.update_member_endpoint(
+            self.state.revision(),
+            authenticated_peer_id,
+            endpoint_addr,
+        )?;
+        self.membership_change(invalidated)
     }
 
     pub fn handle_request(
         &mut self,
         authenticated_peer_id: &[u8],
         request: LayoutRequest,
+    ) -> CoordinatorResponse {
+        self.handle_request_at(authenticated_peer_id, request, Instant::now())
+    }
+
+    pub fn handle_request_at(
+        &mut self,
+        authenticated_peer_id: &[u8],
+        request: LayoutRequest,
+        now: Instant,
     ) -> CoordinatorResponse {
         let request_id = request.request_id;
         let action_count = usize::from(request.create_pane.is_some())
@@ -112,6 +202,7 @@ impl LayoutCoordinator {
                 request.base_revision,
                 create,
                 request_id,
+                now,
             )
         } else if let Some(delete) = request.delete_pane {
             self.delete_pane(authenticated_peer_id, request.base_revision, delete)
@@ -121,6 +212,7 @@ impl LayoutCoordinator {
                 request.base_revision,
                 create,
                 request_id,
+                now,
             )
         } else if let Some(delete) = request.delete_tab {
             self.delete_tab(authenticated_peer_id, request.base_revision, delete)
@@ -139,13 +231,14 @@ impl LayoutCoordinator {
         authenticated_peer_id: &[u8],
         ready: PaneReady,
     ) -> CoordinatorResponse {
-        let request_id = self
-            .reservation_request_ids
-            .get(&ready.reservation_id)
-            .copied()
-            .unwrap_or(ready.reservation_id);
-        if ready.reservation_id == 0 || ready.base_revision == 0 {
-            return reject(request_id, LayoutRejectReason::Malformed);
+        if ready.reservation_id == 0 || ready.base_revision == 0 || ready.request_id == 0 {
+            return reject(ready.request_id, LayoutRejectReason::Malformed);
+        }
+        let Some(context) = self.reservations.get(&ready.reservation_id) else {
+            return reject(ready.request_id, LayoutRejectReason::ReservationFailure);
+        };
+        if context.request_id != ready.request_id {
+            return reject(ready.request_id, LayoutRejectReason::ReservationFailure);
         }
         match self.state.pane_ready(
             authenticated_peer_id,
@@ -153,13 +246,13 @@ impl LayoutCoordinator {
             ready.reservation_id,
         ) {
             Ok(_) => {
-                self.reservation_request_ids.remove(&ready.reservation_id);
+                self.reservations.remove(&ready.reservation_id);
                 match self.layout_commit() {
                     Ok(commit) => CoordinatorResponse::Commit(commit),
-                    Err(error) => reject(request_id, reject_reason(&layout_error(error))),
+                    Err(error) => reject(ready.request_id, reject_reason(&layout_error(error))),
                 }
             }
-            Err(error) => reject(request_id, reject_reason(&error)),
+            Err(error) => reject(ready.request_id, reject_reason(&error)),
         }
     }
 
@@ -170,14 +263,85 @@ impl LayoutCoordinator {
     ) -> Result<(), CoordinatorError> {
         self.state
             .cancel_reservation(authenticated_peer_id, reservation_id)?;
-        self.reservation_request_ids.remove(&reservation_id);
+        self.reservations.remove(&reservation_id);
         Ok(())
     }
 
     pub fn expire_reservation(&mut self, reservation_id: u64) -> Result<(), CoordinatorError> {
         self.state.expire_reservation(reservation_id)?;
-        self.reservation_request_ids.remove(&reservation_id);
+        self.reservations.remove(&reservation_id);
         Ok(())
+    }
+
+    pub fn expire_reservation_at(
+        &mut self,
+        now: Instant,
+    ) -> Result<Option<TargetedLayoutReject>, CoordinatorError> {
+        let Some((&reservation_id, context)) = self.reservations.iter().next() else {
+            return Ok(None);
+        };
+        if now < context.deadline {
+            return Ok(None);
+        }
+        let context = context.clone();
+        self.state.expire_reservation(reservation_id)?;
+        self.reservations.remove(&reservation_id);
+        Ok(Some(targeted_reject(
+            context.creator_peer_id,
+            context.request_id,
+            LayoutRejectReason::ReservationFailure,
+        )))
+    }
+
+    pub fn handle_pane_failed(
+        &mut self,
+        authenticated_peer_id: &[u8],
+        failed: PaneFailed,
+    ) -> TargetedLayoutReject {
+        if failed.reservation_id == 0 || failed.request_id == 0 || failed.base_revision == 0 {
+            return targeted_reject(
+                authenticated_peer_id.to_vec(),
+                failed.request_id,
+                LayoutRejectReason::Malformed,
+            );
+        }
+        let Some(context) = self.reservations.get(&failed.reservation_id) else {
+            return targeted_reject(
+                authenticated_peer_id.to_vec(),
+                failed.request_id,
+                LayoutRejectReason::ReservationFailure,
+            );
+        };
+        if context.request_id != failed.request_id {
+            return targeted_reject(
+                authenticated_peer_id.to_vec(),
+                failed.request_id,
+                LayoutRejectReason::ReservationFailure,
+            );
+        }
+        match self.state.fail_reservation(
+            authenticated_peer_id,
+            failed.base_revision,
+            failed.reservation_id,
+        ) {
+            Ok(()) => match self.reservations.remove(&failed.reservation_id) {
+                Some(context) => targeted_reject(
+                    context.creator_peer_id,
+                    context.request_id,
+                    LayoutRejectReason::ReservationFailure,
+                ),
+                None => targeted_reject(
+                    authenticated_peer_id.to_vec(),
+                    failed.request_id,
+                    LayoutRejectReason::ReservationFailure,
+                ),
+            },
+            Err(error) => targeted_reject(
+                authenticated_peer_id.to_vec(),
+                failed.request_id,
+                reject_reason(&error),
+            ),
+        }
     }
 
     fn reserve_pane(
@@ -186,6 +350,7 @@ impl LayoutCoordinator {
         base_revision: u64,
         create: CreatePane,
         request_id: u64,
+        now: Instant,
     ) -> Result<CoordinatorResponse, LayoutError> {
         let axis = protocol_axis(create.axis)?;
         let (grid_rows, grid_cols) = protocol_grid(create.grid_rows, create.grid_cols)?;
@@ -200,8 +365,14 @@ impl LayoutCoordinator {
             grid_rows,
             grid_cols,
         )?;
-        self.reservation_request_ids
-            .insert(reservation.reservation_id, request_id);
+        self.reservations.insert(
+            reservation.reservation_id,
+            ReservationContext {
+                request_id,
+                creator_peer_id: authenticated_peer_id.to_vec(),
+                deadline: now + self.reservation_timeout,
+            },
+        );
         Ok(CoordinatorResponse::Reservation(protocol_reservation(
             reservation,
         )))
@@ -213,13 +384,20 @@ impl LayoutCoordinator {
         base_revision: u64,
         create: CreateTab,
         request_id: u64,
+        now: Instant,
     ) -> Result<CoordinatorResponse, LayoutError> {
         let (grid_rows, grid_cols) = protocol_grid(create.grid_rows, create.grid_cols)?;
         let reservation =
             self.state
                 .reserve_tab(authenticated_peer_id, base_revision, grid_rows, grid_cols)?;
-        self.reservation_request_ids
-            .insert(reservation.reservation_id, request_id);
+        self.reservations.insert(
+            reservation.reservation_id,
+            ReservationContext {
+                request_id,
+                creator_peer_id: authenticated_peer_id.to_vec(),
+                deadline: now + self.reservation_timeout,
+            },
+        );
         Ok(CoordinatorResponse::Reservation(protocol_reservation(
             reservation,
         )))
@@ -270,11 +448,62 @@ impl LayoutCoordinator {
         SessionState::validate_snapshot(&snapshot)?;
         Ok(protocol_layout_state(snapshot))
     }
+
+    fn membership_change(
+        &mut self,
+        invalidated: Option<crate::layout::InvalidatedReservation>,
+    ) -> Result<MembershipChange, CoordinatorError> {
+        let invalidated_reservation = invalidated.and_then(|reservation| {
+            self.reservations
+                .remove(&reservation.reservation_id)
+                .map(|context| {
+                    targeted_reject(
+                        reservation.creator_peer_id,
+                        context.request_id,
+                        LayoutRejectReason::Stale,
+                    )
+                })
+        });
+        Ok(MembershipChange {
+            commit: self.layout_commit()?,
+            invalidated_reservation,
+        })
+    }
+}
+
+fn serialized_endpoint(
+    peer_id: &[u8],
+    endpoint_addr: EndpointAddr,
+) -> Result<Vec<u8>, CoordinatorError> {
+    if endpoint_addr.is_empty() {
+        return Err(CoordinatorError::InvalidEndpointAddress);
+    }
+    if endpoint_addr.id.as_bytes() != peer_id {
+        return Err(CoordinatorError::EndpointIdentityMismatch);
+    }
+    serde_json::to_vec(&endpoint_addr).map_err(CoordinatorError::EndpointSerialization)
+}
+
+fn targeted_reject(
+    peer_id: Vec<u8>,
+    request_id: u64,
+    reason: LayoutRejectReason,
+) -> TargetedLayoutReject {
+    TargetedLayoutReject {
+        peer_id,
+        reject: LayoutReject {
+            request_id,
+            reason: reason as i32,
+        },
+    }
 }
 
 fn layout_error(error: CoordinatorError) -> LayoutError {
     match error {
         CoordinatorError::Layout(error) => error,
+        CoordinatorError::EndpointIdentityMismatch
+        | CoordinatorError::InvalidEndpointAddress
+        | CoordinatorError::EndpointSerialization(_) => LayoutError::InvalidSnapshot,
     }
 }
 
@@ -537,6 +766,7 @@ pub struct JoinReceipt {
     pub session_id: Vec<u8>,
     pub admitted_peer_id: Vec<u8>,
     pub coordinator_peer_id: Vec<u8>,
+    pub endpoint_addr: EndpointAddr,
 }
 
 #[derive(Debug)]
@@ -754,6 +984,7 @@ impl HostSession {
             session_id: self.ticket.session_id().to_vec(),
             admitted_peer_id: remote_id.as_bytes().to_vec(),
             coordinator_peer_id: coordinator.as_bytes().to_vec(),
+            endpoint_addr,
         };
         self.transport
             .write_frame(
@@ -1028,6 +1259,7 @@ async fn join_handshake(
         session_id: welcome.session_id,
         admitted_peer_id: welcome.admitted_peer_id,
         coordinator_peer_id: welcome.coordinator_peer_id,
+        endpoint_addr: ticket.endpoint_addr().clone(),
     })
 }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -625,6 +625,7 @@ async fn join_handshake(
                 body: Some(envelope::Body::Join(Join {
                     session_id: ticket.session_id().to_vec(),
                     peer_id: client_id.as_bytes().to_vec(),
+                    endpoint_addr: Vec::new(),
                 })),
             },
         )

--- a/src/session.rs
+++ b/src/session.rs
@@ -3,7 +3,7 @@
 use std::{error::Error, fmt, time::Duration};
 
 use iroh::{
-    EndpointId,
+    EndpointAddr, EndpointId,
     endpoint::{ConnectingError, Connection, Incoming},
 };
 use tokio::{
@@ -174,6 +174,7 @@ pub enum SessionError {
     Incoming(ConnectingError),
     TimedOut(&'static str),
     InvalidJoin,
+    InvalidJoinEndpointAddress,
     InvalidWelcome,
     UnauthenticatedPeer,
     InvalidPostWelcome,
@@ -188,6 +189,9 @@ impl fmt::Display for SessionError {
             Self::Incoming(error) => write!(formatter, "incoming handshake failed: {error}"),
             Self::TimedOut(operation) => write!(formatter, "session {operation} timed out"),
             Self::InvalidJoin => formatter.write_str("invalid Join handshake message"),
+            Self::InvalidJoinEndpointAddress => {
+                formatter.write_str("Join endpoint address is malformed or does not match the peer")
+            }
             Self::InvalidWelcome => formatter.write_str("invalid Welcome handshake message"),
             Self::UnauthenticatedPeer => {
                 formatter.write_str("handshake peer identity did not match")
@@ -206,6 +210,7 @@ impl Error for SessionError {
             Self::Incoming(error) => Some(error),
             Self::TimedOut(_)
             | Self::InvalidJoin
+            | Self::InvalidJoinEndpointAddress
             | Self::InvalidWelcome
             | Self::UnauthenticatedPeer
             | Self::InvalidPostWelcome
@@ -361,6 +366,15 @@ impl HostSession {
             || join.peer_id.as_slice() != remote_id.as_bytes()
         {
             return Err(SessionError::UnauthenticatedPeer);
+        }
+        let endpoint_addr: EndpointAddr = serde_json::from_slice(&join.endpoint_addr)
+            .map_err(|_| SessionError::InvalidJoinEndpointAddress)?;
+        if endpoint_addr.is_empty()
+            || endpoint_addr.id.as_bytes() != remote_id.as_bytes()
+            || endpoint_addr.id.as_bytes() != join.peer_id.as_slice()
+            || endpoint_addr.id.as_bytes() != envelope.sender_peer_id.as_slice()
+        {
+            return Err(SessionError::InvalidJoinEndpointAddress);
         }
 
         let coordinator = self.transport.endpoint_id();
@@ -625,7 +639,8 @@ async fn join_handshake(
                 body: Some(envelope::Body::Join(Join {
                     session_id: ticket.session_id().to_vec(),
                     peer_id: client_id.as_bytes().to_vec(),
-                    endpoint_addr: Vec::new(),
+                    endpoint_addr: serde_json::to_vec(&transport.endpoint_addr())
+                        .expect("endpoint address should serialize"),
                 })),
             },
         )

--- a/src/session.rs
+++ b/src/session.rs
@@ -1049,6 +1049,17 @@ impl PaneServer {
         self.remove_pane(pane_id)
     }
 
+    /// Reports whether this member is currently serving the pane. Runtime lifecycle checks use
+    /// this to verify that a committed deletion revokes direct subscriptions before PTY teardown.
+    pub fn has_registered_pane(&self, pane_id: u64) -> Result<bool, SessionError> {
+        Ok(self
+            .registry
+            .lock()
+            .map_err(|_| SessionError::PeerTask)?
+            .panes
+            .contains_key(&pane_id))
+    }
+
     pub async fn accept_one(&self) -> Result<(), SessionError> {
         let incoming = self.transport.accept_incoming().await?;
         self.serve_incoming(incoming).await

--- a/src/session.rs
+++ b/src/session.rs
@@ -15,7 +15,7 @@ use std::{
 
 use iroh::{
     EndpointAddr, EndpointId,
-    endpoint::{ConnectingError, Connection, Incoming},
+    endpoint::{ConnectingError, Connection, Incoming, SendStream},
 };
 use tokio::{
     sync::{mpsc, watch},
@@ -845,6 +845,22 @@ impl PaneServer {
         Ok(())
     }
 
+    /// Replaces the admission roster from a verified authoritative layout commit. The caller's
+    /// layout reconciler is responsible for invoking this before accepting new direct panes.
+    pub fn replace_roster_from_layout(&self, state: &LayoutState) -> Result<(), SessionError> {
+        let members = state
+            .members
+            .iter()
+            .map(|member| {
+                serde_json::from_slice(&member.endpoint_addr)
+                    .map(|endpoint_addr| (member.peer_id.clone(), endpoint_addr))
+                    .map_err(|_| SessionError::InvalidPostWelcome)
+            })
+            .collect::<Result<Vec<(Vec<u8>, EndpointAddr)>, _>>();
+        let members = members?;
+        self.replace_members(members)
+    }
+
     pub fn register_pane(
         &self,
         descriptor: PaneDescriptor,
@@ -864,6 +880,16 @@ impl PaneServer {
         Ok(())
     }
 
+    /// Registers a locally hosted pane after its PTY is ready; the reconciler must remove it when
+    /// a later authoritative commit deletes the pane.
+    pub fn register_local_pane(
+        &self,
+        descriptor: PaneDescriptor,
+        channels: HostPaneChannels,
+    ) -> Result<(), SessionError> {
+        self.register_pane(descriptor, channels)
+    }
+
     pub fn remove_pane(&self, pane_id: u64) -> Result<Option<HostPaneChannels>, SessionError> {
         Ok(self
             .panes
@@ -872,9 +898,35 @@ impl PaneServer {
             .remove(&pane_id))
     }
 
+    pub fn remove_local_pane(
+        &self,
+        pane_id: u64,
+    ) -> Result<Option<HostPaneChannels>, SessionError> {
+        self.remove_pane(pane_id)
+    }
+
     pub async fn accept_one(&self) -> Result<(), SessionError> {
         let incoming = self.transport.accept_incoming().await?;
         self.serve_incoming(incoming).await
+    }
+
+    /// Owns an endpoint accept loop and keeps each pane subscription independent from later
+    /// arrivals. A runtime that multiplexes layout joins and panes should use
+    /// [`IncomingDispatcher`] instead of starting this loop alongside another acceptor.
+    pub async fn accept_loop(&self) -> Result<(), SessionError> {
+        let mut tasks = tokio::task::JoinSet::new();
+        loop {
+            tokio::select! {
+                incoming = self.transport.accept_incoming() => {
+                    let incoming = incoming?;
+                    let server = self.clone();
+                    tasks.spawn(async move {
+                        let _ = server.serve_incoming(incoming).await;
+                    });
+                }
+                Some(_) = tasks.join_next(), if !tasks.is_empty() => {}
+            }
+        }
     }
 
     pub async fn serve_incoming(&self, incoming: Incoming) -> Result<(), SessionError> {
@@ -890,10 +942,18 @@ impl PaneServer {
     }
 
     async fn serve_connection(&self, connection: &Connection) -> Result<(), SessionError> {
-        let remote_peer_id = connection.remote_id().as_bytes().to_vec();
         let (_subscribe_writer, mut subscribe_reader) =
             self.transport.accept_bi(connection).await?;
         let envelope = self.transport.read_frame(&mut subscribe_reader).await?;
+        self.serve_subscribe_connection(connection, envelope).await
+    }
+
+    async fn serve_subscribe_connection(
+        &self,
+        connection: &Connection,
+        envelope: Envelope,
+    ) -> Result<(), SessionError> {
+        let remote_peer_id = connection.remote_id().as_bytes().to_vec();
         let subscribe = match envelope.body {
             Some(envelope::Body::PaneSubscribe(subscribe)) => subscribe,
             _ => return Err(SessionError::InvalidPostWelcome),
@@ -1154,9 +1214,18 @@ impl HostSession {
         &self,
         connection: &Connection,
     ) -> Result<JoinReceipt, SessionError> {
-        let remote_id = connection.remote_id();
         let (mut send, mut recv) = self.transport.accept_bi(connection).await?;
         let envelope = self.transport.read_frame(&mut recv).await?;
+        self.handshake_join(connection, &mut send, envelope).await
+    }
+
+    async fn handshake_join(
+        &self,
+        connection: &Connection,
+        send: &mut SendStream,
+        envelope: Envelope,
+    ) -> Result<JoinReceipt, SessionError> {
+        let remote_id = connection.remote_id();
         let join = match envelope.body {
             Some(envelope::Body::Join(join)) => join,
             _ => return Err(SessionError::InvalidJoin),
@@ -1186,7 +1255,7 @@ impl HostSession {
         };
         self.transport
             .write_frame(
-                &mut send,
+                send,
                 &Envelope {
                     version: PROTOCOL_VERSION,
                     sender_peer_id: coordinator.as_bytes().to_vec(),
@@ -1438,6 +1507,21 @@ impl SharedLayoutHost {
         self.host.ticket()
     }
 
+    /// Creates the coordinator-owned pane registry. The runtime must keep this registry's roster
+    /// and local pane registrations synchronized from authoritative layout commits.
+    pub fn pane_server(&self) -> PaneServer {
+        self.host.pane_server()
+    }
+
+    /// Creates the only incoming acceptor for an endpoint that serves both layout control and
+    /// direct panes. Do not run `accept_one_member` or `PaneServer::accept_loop` beside it.
+    pub fn incoming_dispatcher(
+        &self,
+        panes: PaneServer,
+    ) -> Result<IncomingDispatcher, SessionError> {
+        IncomingDispatcher::new(self.clone(), panes)
+    }
+
     /// Accept one authenticated member and then its persistent control stream.
     pub async fn accept_one_member(&self) -> Result<JoinReceipt, SessionError> {
         let incoming = self.host.accept_incoming().await?;
@@ -1445,9 +1529,32 @@ impl SharedLayoutHost {
             .await
             .map_err(|_| SessionError::TimedOut("incoming connection"))?
             .map_err(SessionError::Incoming)?;
+        let result = async {
+            let (mut join_writer, mut join_reader) =
+                self.host.transport.accept_bi(&connection).await?;
+            let envelope = self.host.transport.read_frame(&mut join_reader).await?;
+            self.accept_join_connection(connection.clone(), &mut join_writer, envelope)
+                .await
+        }
+        .await;
+        if result.is_err() {
+            connection.close(0u8.into(), b"");
+        }
+        result
+    }
+
+    async fn accept_join_connection(
+        &self,
+        connection: Connection,
+        join_writer: &mut SendStream,
+        envelope: Envelope,
+    ) -> Result<JoinReceipt, SessionError> {
         let mut admitted_peer_id = None;
         let result = async {
-            let receipt = self.host.handshake_connection(&connection).await?;
+            let receipt = self
+                .host
+                .handshake_join(&connection, join_writer, envelope)
+                .await?;
             {
                 let mut coordinator_guard = self
                     .coordinator
@@ -1565,6 +1672,79 @@ impl SharedLayoutHost {
                 envelope::Body::LayoutReject(targeted.reject),
             ),
         );
+    }
+}
+
+/// Sole endpoint-level acceptor for a shared-layout runtime. The caller owns roster replacement
+/// and local pane registration on `PaneServer`; this type only authenticates and routes each new
+/// connection.
+#[derive(Clone)]
+pub struct IncomingDispatcher {
+    layout: SharedLayoutHost,
+    panes: PaneServer,
+}
+
+impl IncomingDispatcher {
+    pub fn new(layout: SharedLayoutHost, panes: PaneServer) -> Result<Self, SessionError> {
+        if panes.local_peer_id != layout.host.transport.endpoint_id().as_bytes()
+            || panes.session_id.as_slice() != layout.ticket().session_id()
+        {
+            return Err(SessionError::InvalidPostWelcome);
+        }
+        Ok(Self { layout, panes })
+    }
+
+    /// Continually accepts connections and dispatches each to an independently managed task.
+    pub async fn accept_loop(&self) -> Result<(), SessionError> {
+        let mut tasks = tokio::task::JoinSet::new();
+        loop {
+            tokio::select! {
+                incoming = self.layout.host.accept_incoming() => {
+                    let incoming = incoming?;
+                    let dispatcher = self.clone();
+                    tasks.spawn(async move {
+                        let _ = dispatcher.dispatch_incoming(incoming).await;
+                    });
+                }
+                Some(_) = tasks.join_next(), if !tasks.is_empty() => {}
+            }
+        }
+    }
+
+    async fn dispatch_incoming(&self, incoming: Incoming) -> Result<(), SessionError> {
+        let connection = timeout(HANDSHAKE_TIMEOUT, incoming)
+            .await
+            .map_err(|_| SessionError::TimedOut("incoming connection"))?
+            .map_err(SessionError::Incoming)?;
+        let result = async {
+            let (mut first_writer, mut first_reader) =
+                self.layout.host.transport.accept_bi(&connection).await?;
+            let envelope = self
+                .layout
+                .host
+                .transport
+                .read_frame(&mut first_reader)
+                .await?;
+            match envelope.body.as_ref() {
+                Some(envelope::Body::Join(_)) => self
+                    .layout
+                    .accept_join_connection(connection.clone(), &mut first_writer, envelope)
+                    .await
+                    .map(|_| ()),
+                Some(envelope::Body::PaneSubscribe(_)) => {
+                    drop(first_writer);
+                    self.panes
+                        .serve_subscribe_connection(&connection, envelope)
+                        .await
+                }
+                _ => Err(SessionError::InvalidPostWelcome),
+            }
+        }
+        .await;
+        if result.is_err() {
+            connection.close(0u8.into(), b"");
+        }
+        result
     }
 }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -179,6 +179,11 @@ impl LayoutCoordinator {
         self.membership_change(invalidated)
     }
 
+    pub fn remove_member(&mut self, peer_id: &[u8]) -> Result<MembershipChange, CoordinatorError> {
+        let invalidated = self.state.remove_member(peer_id)?;
+        self.membership_change(invalidated)
+    }
+
     pub fn handle_request(
         &mut self,
         authenticated_peer_id: &[u8],
@@ -297,6 +302,17 @@ impl LayoutCoordinator {
             context.request_id,
             LayoutRejectReason::ReservationFailure,
         )))
+    }
+
+    pub fn expire_reservation_if_at(
+        &mut self,
+        reservation_id: u64,
+        now: Instant,
+    ) -> Result<Option<TargetedLayoutReject>, CoordinatorError> {
+        if !self.reservations.contains_key(&reservation_id) {
+            return Ok(None);
+        }
+        self.expire_reservation_at(now)
     }
 
     pub fn handle_pane_failed(
@@ -1027,6 +1043,7 @@ pub struct SharedLayoutHost {
     host: HostSession,
     coordinator: Arc<Mutex<LayoutCoordinator>>,
     peers: Arc<Mutex<BTreeMap<Vec<u8>, ControlPeer>>>,
+    reservation_timeout: Duration,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -1218,17 +1235,29 @@ impl Drop for SharedLayoutMember {
 
 impl SharedLayoutHost {
     pub fn new(host: HostSession, grid_rows: u16, grid_cols: u16) -> Result<Self, SessionError> {
+        Self::with_reservation_timeout(host, grid_rows, grid_cols, DEFAULT_RESERVATION_TIMEOUT)
+    }
+
+    pub fn with_reservation_timeout(
+        host: HostSession,
+        grid_rows: u16,
+        grid_cols: u16,
+        reservation_timeout: Duration,
+    ) -> Result<Self, SessionError> {
         let coordinator_peer_id = host.ticket().endpoint_addr().id.as_bytes().to_vec();
-        let coordinator = LayoutCoordinator::new(
+        let coordinator = LayoutCoordinator::with_reservation_timeout(
             coordinator_peer_id,
             host.ticket().endpoint_addr().clone(),
             grid_rows,
             grid_cols,
+            reservation_timeout,
+            Instant::now(),
         )?;
         Ok(Self {
             host,
             coordinator: Arc::new(Mutex::new(coordinator)),
             peers: Arc::new(Mutex::new(BTreeMap::new())),
+            reservation_timeout,
         })
     }
 
@@ -1245,20 +1274,22 @@ impl SharedLayoutHost {
             .map_err(SessionError::Incoming)?;
         let result = async {
             let receipt = self.host.handshake_connection(&connection).await?;
-            let membership = self
-                .coordinator
-                .lock()
-                .map_err(|_| SessionError::PeerTask)?
-                .admit(
+            {
+                let mut coordinator_guard = self
+                    .coordinator
+                    .lock()
+                    .map_err(|_| SessionError::PeerTask)?;
+                let membership = coordinator_guard.admit(
                     receipt.admitted_peer_id.clone(),
                     receipt.endpoint_addr.clone(),
                 )?;
 
-            // Existing members see the authoritative membership commit before the joining
-            // member receives its snapshot. The joiner snapshot already contains that commit.
-            self.broadcast_commit(membership.commit.clone());
-            if let Some(reject) = membership.invalidated_reservation {
-                self.send_reject(reject);
+                // Existing members see the authoritative membership commit before the joining
+                // member receives its snapshot. The joiner snapshot already contains that commit.
+                self.broadcast_commit(membership.commit.clone());
+                if let Some(reject) = membership.invalidated_reservation {
+                    self.send_reject(reject);
+                }
             }
 
             let (writer, reader) = self.transport_open_control(&connection).await?;
@@ -1289,6 +1320,7 @@ impl SharedLayoutHost {
                 self.host.ticket().endpoint_addr().id.as_bytes().to_vec(),
                 self.coordinator.clone(),
                 self.peers.clone(),
+                self.reservation_timeout,
             ));
             if let Ok(mut slot) = reader_abort.lock() {
                 *slot = Some(reader_task.abort_handle());
@@ -1300,6 +1332,10 @@ impl SharedLayoutHost {
                 targeted_rx,
                 receipt.admitted_peer_id.clone(),
                 self.peers.clone(),
+                Some((
+                    self.coordinator.clone(),
+                    self.host.ticket().endpoint_addr().id.as_bytes().to_vec(),
+                )),
             ));
             Ok(receipt)
         }
@@ -1402,6 +1438,41 @@ fn remove_control_peer(peers: &Arc<Mutex<BTreeMap<Vec<u8>, ControlPeer>>>, peer_
     }
 }
 
+fn disconnect_or_remove(
+    peers: &Arc<Mutex<BTreeMap<Vec<u8>, ControlPeer>>>,
+    coordinator: Option<&(Arc<Mutex<LayoutCoordinator>>, Vec<u8>)>,
+    peer_id: &[u8],
+) {
+    let Some((coordinator, coordinator_peer_id)) = coordinator else {
+        remove_control_peer(peers, peer_id);
+        return;
+    };
+    let Ok(mut coordinator) = coordinator.lock() else {
+        remove_control_peer(peers, peer_id);
+        return;
+    };
+    remove_control_peer(peers, peer_id);
+    if let Ok(change) = coordinator.remove_member(peer_id) {
+        broadcast_envelope(
+            peers,
+            coordinator_envelope(
+                coordinator_peer_id,
+                envelope::Body::LayoutCommit(change.commit),
+            ),
+        );
+        if let Some(reject) = change.invalidated_reservation {
+            send_to_peer(
+                peers,
+                &reject.peer_id,
+                coordinator_envelope(
+                    coordinator_peer_id,
+                    envelope::Body::LayoutReject(reject.reject),
+                ),
+            );
+        }
+    }
+}
+
 /// Join a coordinator and establish the persistent member-to-coordinator layout stream.
 pub async fn join_layout(
     transport: Transport,
@@ -1452,15 +1523,16 @@ async fn layout_peer_writer_task<W>(
     mut targeted_rx: mpsc::Receiver<SequencedEnvelope>,
     peer_id: Vec<u8>,
     peers: Arc<Mutex<BTreeMap<Vec<u8>, ControlPeer>>>,
+    coordinator: Option<(Arc<Mutex<LayoutCoordinator>>, Vec<u8>)>,
 ) where
     W: ControlFrameSink + 'static,
 {
     let Some(initial) = initial_rx.recv().await else {
-        remove_control_peer(&peers, &peer_id);
+        disconnect_or_remove(&peers, coordinator.as_ref(), &peer_id);
         return;
     };
     if !writer.write_control(&initial).await {
-        remove_control_peer(&peers, &peer_id);
+        disconnect_or_remove(&peers, coordinator.as_ref(), &peer_id);
         return;
     }
     let mut targeted_open = true;
@@ -1504,7 +1576,7 @@ async fn layout_peer_writer_task<W>(
             continue;
         };
         if !writer.write_control(&next.envelope).await {
-            remove_control_peer(&peers, &peer_id);
+            disconnect_or_remove(&peers, coordinator.as_ref(), &peer_id);
             return;
         }
     }
@@ -1564,6 +1636,7 @@ async fn layout_host_reader_task(
     coordinator_peer_id: Vec<u8>,
     coordinator: Arc<Mutex<LayoutCoordinator>>,
     peers: Arc<Mutex<BTreeMap<Vec<u8>, ControlPeer>>>,
+    reservation_timeout: Duration,
 ) {
     while let Ok(Some(envelope)) = reader.read_next().await {
         if envelope.sender_peer_id != peer_id {
@@ -1571,24 +1644,44 @@ async fn layout_host_reader_task(
         }
         match envelope.body {
             Some(envelope::Body::LayoutRequest(request)) => {
-                let response = match coordinator.lock() {
-                    Ok(mut coordinator) => coordinator.handle_request(&peer_id, request),
+                let mut coordinator_guard = match coordinator.lock() {
+                    Ok(coordinator) => coordinator,
                     Err(_) => break,
                 };
+                let response = coordinator_guard.handle_request(&peer_id, request);
+                let reservation = match &response {
+                    CoordinatorResponse::Reservation(reservation) => {
+                        Some(reservation.reservation_id)
+                    }
+                    _ => None,
+                };
                 dispatch_coordinator_response(&peers, &peer_id, &coordinator_peer_id, response);
+                drop(coordinator_guard);
+                if let Some(reservation_id) = reservation {
+                    tokio::spawn(reservation_expiry_task(
+                        reservation_id,
+                        reservation_timeout,
+                        coordinator.clone(),
+                        peers.clone(),
+                        coordinator_peer_id.clone(),
+                    ));
+                }
             }
             Some(envelope::Body::PaneReady(ready)) => {
-                let response = match coordinator.lock() {
-                    Ok(mut coordinator) => coordinator.handle_pane_ready(&peer_id, ready),
+                let mut coordinator_guard = match coordinator.lock() {
+                    Ok(coordinator) => coordinator,
                     Err(_) => break,
                 };
+                let response = coordinator_guard.handle_pane_ready(&peer_id, ready);
                 dispatch_coordinator_response(&peers, &peer_id, &coordinator_peer_id, response);
+                drop(coordinator_guard);
             }
             Some(envelope::Body::PaneFailed(failed)) => {
-                let reject = match coordinator.lock() {
-                    Ok(mut coordinator) => coordinator.handle_pane_failed(&peer_id, failed),
+                let mut coordinator_guard = match coordinator.lock() {
+                    Ok(coordinator) => coordinator,
                     Err(_) => break,
                 };
+                let reject = coordinator_guard.handle_pane_failed(&peer_id, failed);
                 send_to_peer(
                     &peers,
                     &reject.peer_id,
@@ -1597,11 +1690,37 @@ async fn layout_host_reader_task(
                         envelope::Body::LayoutReject(reject.reject),
                     ),
                 );
+                drop(coordinator_guard);
             }
             _ => break,
         }
     }
-    remove_control_peer(&peers, &peer_id);
+    disconnect_or_remove(&peers, Some(&(coordinator, coordinator_peer_id)), &peer_id);
+}
+
+async fn reservation_expiry_task(
+    reservation_id: u64,
+    reservation_timeout: Duration,
+    coordinator: Arc<Mutex<LayoutCoordinator>>,
+    peers: Arc<Mutex<BTreeMap<Vec<u8>, ControlPeer>>>,
+    coordinator_peer_id: Vec<u8>,
+) {
+    tokio::time::sleep(reservation_timeout).await;
+    let Ok(mut coordinator) = coordinator.lock() else {
+        return;
+    };
+    let Ok(Some(reject)) = coordinator.expire_reservation_if_at(reservation_id, Instant::now())
+    else {
+        return;
+    };
+    send_to_peer(
+        &peers,
+        &reject.peer_id,
+        coordinator_envelope(
+            &coordinator_peer_id,
+            envelope::Body::LayoutReject(reject.reject),
+        ),
+    );
 }
 
 fn dispatch_coordinator_response(
@@ -2086,6 +2205,7 @@ mod control_queue_tests {
             targeted_rx,
             b"slow".to_vec(),
             peers.clone(),
+            None,
         )
         .await;
 
@@ -2151,6 +2271,7 @@ mod control_queue_tests {
             slow_targeted_rx,
             b"slow".to_vec(),
             peers.clone(),
+            None,
         ));
         let (healthy_tx, mut healthy_rx) = mpsc::unbounded_channel();
         let healthy_task = tokio::spawn(layout_peer_writer_task(
@@ -2160,6 +2281,7 @@ mod control_queue_tests {
             healthy_targeted_rx,
             b"healthy".to_vec(),
             peers.clone(),
+            None,
         ));
 
         broadcast_envelope(&peers, commit(2));
@@ -2275,6 +2397,7 @@ mod control_queue_tests {
             targeted_rx,
             b"member".to_vec(),
             peers.clone(),
+            None,
         ));
 
         assert_eq!(recorded_rx.recv().await, Some(snapshot));
@@ -2324,6 +2447,7 @@ mod control_queue_tests {
             targeted_rx,
             b"member".to_vec(),
             peers.clone(),
+            None,
         ));
 
         let _initial = recorded_rx.recv().await.expect("initial output");

--- a/src/session.rs
+++ b/src/session.rs
@@ -1272,6 +1272,7 @@ impl SharedLayoutHost {
             .await
             .map_err(|_| SessionError::TimedOut("incoming connection"))?
             .map_err(SessionError::Incoming)?;
+        let mut admitted_peer_id = None;
         let result = async {
             let receipt = self.host.handshake_connection(&connection).await?;
             {
@@ -1291,6 +1292,7 @@ impl SharedLayoutHost {
                     self.send_reject(reject);
                 }
             }
+            admitted_peer_id = Some(receipt.admitted_peer_id.clone());
 
             let (writer, reader) = self.transport_open_control(&connection).await?;
             let peer_id = receipt.admitted_peer_id.clone();
@@ -1341,6 +1343,16 @@ impl SharedLayoutHost {
         }
         .await;
         if result.is_err() {
+            if let Some(peer_id) = admitted_peer_id {
+                disconnect_or_remove(
+                    &self.peers,
+                    Some(&(
+                        self.coordinator.clone(),
+                        self.host.ticket().endpoint_addr().id.as_bytes().to_vec(),
+                    )),
+                    &peer_id,
+                );
+            }
             connection.close(0u8.into(), b"");
         }
         result

--- a/src/session.rs
+++ b/src/session.rs
@@ -1021,7 +1021,7 @@ impl HostSession {
 pub struct SharedLayoutHost {
     host: HostSession,
     coordinator: Arc<Mutex<LayoutCoordinator>>,
-    peers: Arc<Mutex<BTreeMap<Vec<u8>, mpsc::Sender<Envelope>>>>,
+    peers: Arc<Mutex<BTreeMap<Vec<u8>, mpsc::UnboundedSender<Envelope>>>>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -1143,7 +1143,7 @@ impl SharedLayoutHost {
 
             let (writer, reader) = self.transport_open_control(&connection).await?;
             let peer_id = receipt.admitted_peer_id.clone();
-            let (outbound_tx, outbound_rx) = mpsc::channel(64);
+            let (outbound_tx, outbound_rx) = mpsc::unbounded_channel();
             self.peers
                 .lock()
                 .map_err(|_| SessionError::PeerTask)?
@@ -1153,7 +1153,7 @@ impl SharedLayoutHost {
                 .lock()
                 .map_err(|_| SessionError::PeerTask)?
                 .session_snapshot()?;
-            let _ = outbound_tx.try_send(coordinator_envelope(
+            let _ = outbound_tx.send(coordinator_envelope(
                 self.host.ticket().endpoint_addr().id.as_bytes(),
                 envelope::Body::SessionSnapshot(snapshot),
             ));
@@ -1228,30 +1228,31 @@ fn coordinator_envelope(sender_peer_id: &[u8], body: envelope::Body) -> Envelope
 }
 
 fn broadcast_envelope(
-    peers: &Arc<Mutex<BTreeMap<Vec<u8>, mpsc::Sender<Envelope>>>>,
+    peers: &Arc<Mutex<BTreeMap<Vec<u8>, mpsc::UnboundedSender<Envelope>>>>,
     envelope: Envelope,
 ) {
-    let mut peers = match peers.lock() {
+    let peers = match peers.lock() {
         Ok(peers) => peers,
         Err(_) => return,
     };
-    peers.retain(|_, sender| sender.try_send(envelope.clone()).is_ok());
+    for sender in peers.values() {
+        // The unbounded queue isolates this reducer from writer I/O without losing a commit to
+        // temporary backpressure on another admitted member's stream.
+        let _ = sender.send(envelope.clone());
+    }
 }
 
 fn send_to_peer(
-    peers: &Arc<Mutex<BTreeMap<Vec<u8>, mpsc::Sender<Envelope>>>>,
+    peers: &Arc<Mutex<BTreeMap<Vec<u8>, mpsc::UnboundedSender<Envelope>>>>,
     peer_id: &[u8],
     envelope: Envelope,
 ) {
-    let mut peers = match peers.lock() {
+    let peers = match peers.lock() {
         Ok(peers) => peers,
         Err(_) => return,
     };
-    if peers
-        .get(peer_id)
-        .is_some_and(|sender| sender.try_send(envelope).is_err())
-    {
-        peers.remove(peer_id);
+    if let Some(sender) = peers.get(peer_id) {
+        let _ = sender.send(envelope);
     }
 }
 
@@ -1300,7 +1301,7 @@ pub async fn join_layout(
 
 async fn layout_writer_task(
     mut writer: crate::transport::FrameWriter,
-    mut outbound: mpsc::Receiver<Envelope>,
+    mut outbound: mpsc::UnboundedReceiver<Envelope>,
 ) {
     while let Some(envelope) = outbound.recv().await {
         if writer.write_next(&envelope).await.is_err() {
@@ -1362,7 +1363,7 @@ async fn layout_host_reader_task(
     peer_id: Vec<u8>,
     coordinator_peer_id: Vec<u8>,
     coordinator: Arc<Mutex<LayoutCoordinator>>,
-    peers: Arc<Mutex<BTreeMap<Vec<u8>, mpsc::Sender<Envelope>>>>,
+    peers: Arc<Mutex<BTreeMap<Vec<u8>, mpsc::UnboundedSender<Envelope>>>>,
 ) {
     while let Ok(Some(envelope)) = reader.read_next().await {
         if envelope.sender_peer_id != peer_id {
@@ -1406,7 +1407,7 @@ async fn layout_host_reader_task(
 }
 
 fn dispatch_coordinator_response(
-    peers: &Arc<Mutex<BTreeMap<Vec<u8>, mpsc::Sender<Envelope>>>>,
+    peers: &Arc<Mutex<BTreeMap<Vec<u8>, mpsc::UnboundedSender<Envelope>>>>,
     requester_peer_id: &[u8],
     coordinator_peer_id: &[u8],
     response: CoordinatorResponse,
@@ -1798,4 +1799,31 @@ fn validate_welcome(
         return Err(SessionError::UnauthenticatedPeer);
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod control_queue_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn blocked_control_peer_keeps_its_ordered_commit_while_other_peers_receive() {
+        let (slow_tx, mut slow_rx) = mpsc::unbounded_channel();
+        let (fast_tx, mut fast_rx) = mpsc::unbounded_channel();
+        let peers = Arc::new(Mutex::new(BTreeMap::from([
+            (b"slow".to_vec(), slow_tx),
+            (b"fast".to_vec(), fast_tx),
+        ])));
+        let commit = coordinator_envelope(
+            b"coordinator",
+            envelope::Body::LayoutReject(LayoutReject {
+                request_id: 9,
+                reason: LayoutRejectReason::Stale as i32,
+            }),
+        );
+
+        broadcast_envelope(&peers, commit.clone());
+        assert_eq!(fast_rx.recv().await, Some(commit.clone()));
+        assert!(peers.lock().unwrap().contains_key(b"slow".as_slice()));
+        assert_eq!(slow_rx.recv().await, Some(commit));
+    }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -4,6 +4,8 @@ use std::{
     collections::BTreeMap,
     error::Error,
     fmt,
+    future::Future,
+    pin::Pin,
     sync::{Arc, Mutex},
     time::{Duration, Instant},
 };
@@ -1021,7 +1023,7 @@ impl HostSession {
 pub struct SharedLayoutHost {
     host: HostSession,
     coordinator: Arc<Mutex<LayoutCoordinator>>,
-    peers: Arc<Mutex<BTreeMap<Vec<u8>, mpsc::UnboundedSender<Envelope>>>>,
+    peers: Arc<Mutex<BTreeMap<Vec<u8>, ControlPeer>>>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -1043,6 +1045,93 @@ enum LayoutClientMessage {
     Request(LayoutRequest),
     Ready(PaneReady),
     Failed(PaneFailed),
+}
+
+const TARGETED_CONTROL_QUEUE_CAPACITY: usize = 16;
+
+#[derive(Clone)]
+struct ControlMailbox {
+    state_tx: watch::Sender<Option<Envelope>>,
+    targeted_tx: mpsc::Sender<Envelope>,
+}
+
+impl ControlMailbox {
+    fn new() -> (
+        Self,
+        watch::Receiver<Option<Envelope>>,
+        mpsc::Receiver<Envelope>,
+    ) {
+        let (state_tx, state_rx) = watch::channel(None);
+        let (targeted_tx, targeted_rx) = mpsc::channel(TARGETED_CONTROL_QUEUE_CAPACITY);
+        (
+            Self {
+                state_tx,
+                targeted_tx,
+            },
+            state_rx,
+            targeted_rx,
+        )
+    }
+
+    fn publish_state(&self, envelope: Envelope) {
+        self.state_tx.send_replace(Some(envelope));
+    }
+}
+
+struct ControlPeer {
+    mailbox: ControlMailbox,
+    reader_abort: Arc<Mutex<Option<tokio::task::AbortHandle>>>,
+    connection: Option<Connection>,
+}
+
+impl ControlPeer {
+    #[cfg(test)]
+    fn new(
+        mailbox: ControlMailbox,
+        reader_abort: tokio::task::AbortHandle,
+        connection: Option<Connection>,
+    ) -> Self {
+        Self {
+            mailbox,
+            reader_abort: Arc::new(Mutex::new(Some(reader_abort))),
+            connection,
+        }
+    }
+
+    fn pending_reader(mailbox: ControlMailbox, connection: Connection) -> Self {
+        Self {
+            mailbox,
+            reader_abort: Arc::new(Mutex::new(None)),
+            connection: Some(connection),
+        }
+    }
+
+    fn shutdown(self) {
+        if let Ok(mut slot) = self.reader_abort.lock()
+            && let Some(reader_abort) = slot.take()
+        {
+            reader_abort.abort();
+        }
+        if let Some(connection) = self.connection {
+            connection.close(0u8.into(), b"");
+        }
+    }
+}
+
+trait ControlFrameSink: Send {
+    fn write_control<'a>(
+        &'a mut self,
+        envelope: &'a Envelope,
+    ) -> Pin<Box<dyn Future<Output = bool> + Send + 'a>>;
+}
+
+impl ControlFrameSink for crate::transport::FrameWriter {
+    fn write_control<'a>(
+        &'a mut self,
+        envelope: &'a Envelope,
+    ) -> Pin<Box<dyn Future<Output = bool> + Send + 'a>> {
+        Box::pin(async move { self.write_next(envelope).await.is_ok() })
+    }
 }
 
 /// The member side of a shared-layout control connection.
@@ -1143,27 +1232,38 @@ impl SharedLayoutHost {
 
             let (writer, reader) = self.transport_open_control(&connection).await?;
             let peer_id = receipt.admitted_peer_id.clone();
-            let (outbound_tx, outbound_rx) = mpsc::unbounded_channel();
+            let (mailbox, state_rx, targeted_rx) = ControlMailbox::new();
+            let peer = ControlPeer::pending_reader(mailbox.clone(), connection.clone());
+            let reader_abort = peer.reader_abort.clone();
             self.peers
                 .lock()
                 .map_err(|_| SessionError::PeerTask)?
-                .insert(peer_id.clone(), outbound_tx.clone());
+                .insert(peer_id.clone(), peer);
             let snapshot = self
                 .coordinator
                 .lock()
                 .map_err(|_| SessionError::PeerTask)?
                 .session_snapshot()?;
-            let _ = outbound_tx.send(coordinator_envelope(
+            mailbox.publish_state(coordinator_envelope(
                 self.host.ticket().endpoint_addr().id.as_bytes(),
                 envelope::Body::SessionSnapshot(snapshot),
             ));
 
-            tokio::spawn(layout_writer_task(writer, outbound_rx));
-            tokio::spawn(layout_host_reader_task(
+            let reader_task = tokio::spawn(layout_host_reader_task(
                 reader,
                 peer_id,
                 self.host.ticket().endpoint_addr().id.as_bytes().to_vec(),
                 self.coordinator.clone(),
+                self.peers.clone(),
+            ));
+            if let Ok(mut slot) = reader_abort.lock() {
+                *slot = Some(reader_task.abort_handle());
+            }
+            tokio::spawn(layout_peer_writer_task(
+                writer,
+                state_rx,
+                targeted_rx,
+                receipt.admitted_peer_id.clone(),
                 self.peers.clone(),
             ));
             Ok(receipt)
@@ -1227,32 +1327,43 @@ fn coordinator_envelope(sender_peer_id: &[u8], body: envelope::Body) -> Envelope
     }
 }
 
-fn broadcast_envelope(
-    peers: &Arc<Mutex<BTreeMap<Vec<u8>, mpsc::UnboundedSender<Envelope>>>>,
-    envelope: Envelope,
-) {
+fn broadcast_envelope(peers: &Arc<Mutex<BTreeMap<Vec<u8>, ControlPeer>>>, envelope: Envelope) {
     let peers = match peers.lock() {
         Ok(peers) => peers,
         Err(_) => return,
     };
-    for sender in peers.values() {
-        // The unbounded queue isolates this reducer from writer I/O without losing a commit to
-        // temporary backpressure on another admitted member's stream.
-        let _ = sender.send(envelope.clone());
+    for peer in peers.values() {
+        // Full-state broadcasts are revisioned and supersede older ones, so each peer needs only
+        // the latest state while its writer catches up.
+        peer.mailbox.publish_state(envelope.clone());
     }
 }
 
 fn send_to_peer(
-    peers: &Arc<Mutex<BTreeMap<Vec<u8>, mpsc::UnboundedSender<Envelope>>>>,
+    peers: &Arc<Mutex<BTreeMap<Vec<u8>, ControlPeer>>>,
     peer_id: &[u8],
     envelope: Envelope,
 ) {
-    let peers = match peers.lock() {
-        Ok(peers) => peers,
+    let failed_peer = match peers.lock() {
+        Ok(mut peers) => match peers.get(peer_id) {
+            Some(peer) if peer.mailbox.targeted_tx.try_send(envelope).is_ok() => None,
+            Some(_) => peers.remove(peer_id),
+            None => None,
+        },
         Err(_) => return,
     };
-    if let Some(sender) = peers.get(peer_id) {
-        let _ = sender.send(envelope);
+    if let Some(peer) = failed_peer {
+        peer.shutdown();
+    }
+}
+
+fn remove_control_peer(peers: &Arc<Mutex<BTreeMap<Vec<u8>, ControlPeer>>>, peer_id: &[u8]) {
+    let peer = peers
+        .lock()
+        .ok()
+        .and_then(|mut peers| peers.remove(peer_id));
+    if let Some(peer) = peer {
+        peer.shutdown();
     }
 }
 
@@ -1299,12 +1410,41 @@ pub async fn join_layout(
     result
 }
 
-async fn layout_writer_task(
-    mut writer: crate::transport::FrameWriter,
-    mut outbound: mpsc::UnboundedReceiver<Envelope>,
-) {
-    while let Some(envelope) = outbound.recv().await {
-        if writer.write_next(&envelope).await.is_err() {
+async fn layout_peer_writer_task<W>(
+    mut writer: W,
+    mut state_rx: watch::Receiver<Option<Envelope>>,
+    mut targeted_rx: mpsc::Receiver<Envelope>,
+    peer_id: Vec<u8>,
+    peers: Arc<Mutex<BTreeMap<Vec<u8>, ControlPeer>>>,
+) where
+    W: ControlFrameSink + 'static,
+{
+    let mut targeted_open = true;
+    let mut state_open = true;
+    loop {
+        let envelope = tokio::select! {
+            biased;
+            changed = state_rx.changed(), if state_open => match changed {
+                Ok(()) => match state_rx.borrow_and_update().clone() {
+                    Some(envelope) => envelope,
+                    None => continue,
+                },
+                Err(_) => {
+                    state_open = false;
+                    continue;
+                }
+            },
+            targeted = targeted_rx.recv(), if targeted_open => match targeted {
+                Some(envelope) => envelope,
+                None => {
+                    targeted_open = false;
+                    continue;
+                }
+            },
+            else => return,
+        };
+        if !writer.write_control(&envelope).await {
+            remove_control_peer(&peers, &peer_id);
             return;
         }
     }
@@ -1363,7 +1503,7 @@ async fn layout_host_reader_task(
     peer_id: Vec<u8>,
     coordinator_peer_id: Vec<u8>,
     coordinator: Arc<Mutex<LayoutCoordinator>>,
-    peers: Arc<Mutex<BTreeMap<Vec<u8>, mpsc::UnboundedSender<Envelope>>>>,
+    peers: Arc<Mutex<BTreeMap<Vec<u8>, ControlPeer>>>,
 ) {
     while let Ok(Some(envelope)) = reader.read_next().await {
         if envelope.sender_peer_id != peer_id {
@@ -1401,13 +1541,11 @@ async fn layout_host_reader_task(
             _ => break,
         }
     }
-    if let Ok(mut peers) = peers.lock() {
-        peers.remove(&peer_id);
-    }
+    remove_control_peer(&peers, &peer_id);
 }
 
 fn dispatch_coordinator_response(
-    peers: &Arc<Mutex<BTreeMap<Vec<u8>, mpsc::UnboundedSender<Envelope>>>>,
+    peers: &Arc<Mutex<BTreeMap<Vec<u8>, ControlPeer>>>,
     requester_peer_id: &[u8],
     coordinator_peer_id: &[u8],
     response: CoordinatorResponse,
@@ -1803,16 +1941,75 @@ fn validate_welcome(
 
 #[cfg(test)]
 mod control_queue_tests {
+    use std::{future::Future, pin::Pin};
+
     use super::*;
+    use tokio::sync::oneshot;
+
+    struct FailingWriter;
+
+    impl ControlFrameSink for FailingWriter {
+        fn write_control<'a>(
+            &'a mut self,
+            _: &'a Envelope,
+        ) -> Pin<Box<dyn Future<Output = bool> + Send + 'a>> {
+            Box::pin(async { false })
+        }
+    }
+
+    struct StalledWriter {
+        started: Option<oneshot::Sender<()>>,
+        release: Option<oneshot::Receiver<()>>,
+    }
+
+    impl ControlFrameSink for StalledWriter {
+        fn write_control<'a>(
+            &'a mut self,
+            _: &'a Envelope,
+        ) -> Pin<Box<dyn Future<Output = bool> + Send + 'a>> {
+            Box::pin(async move {
+                if let Some(started) = self.started.take() {
+                    let _ = started.send(());
+                }
+                match self.release.take() {
+                    Some(release) => release.await.is_ok(),
+                    None => true,
+                }
+            })
+        }
+    }
+
+    struct RecordingWriter(mpsc::UnboundedSender<Envelope>);
+
+    impl ControlFrameSink for RecordingWriter {
+        fn write_control<'a>(
+            &'a mut self,
+            envelope: &'a Envelope,
+        ) -> Pin<Box<dyn Future<Output = bool> + Send + 'a>> {
+            let sent = self.0.send(envelope.clone()).is_ok();
+            Box::pin(async move { sent })
+        }
+    }
+
+    fn commit(revision: u64) -> Envelope {
+        coordinator_envelope(
+            b"coordinator",
+            envelope::Body::LayoutCommit(LayoutCommit {
+                revision,
+                state: None,
+            }),
+        )
+    }
 
     #[tokio::test]
-    async fn blocked_control_peer_keeps_its_ordered_commit_while_other_peers_receive() {
-        let (slow_tx, mut slow_rx) = mpsc::unbounded_channel();
-        let (fast_tx, mut fast_rx) = mpsc::unbounded_channel();
-        let peers = Arc::new(Mutex::new(BTreeMap::from([
-            (b"slow".to_vec(), slow_tx),
-            (b"fast".to_vec(), fast_tx),
-        ])));
+    async fn failed_writer_removes_the_peer_and_aborts_its_reader() {
+        let peers = Arc::new(Mutex::new(BTreeMap::new()));
+        let (mailbox, state_rx, targeted_rx) = ControlMailbox::new();
+        let reader = tokio::spawn(std::future::pending::<()>());
+        peers.lock().unwrap().insert(
+            b"slow".to_vec(),
+            ControlPeer::new(mailbox.clone(), reader.abort_handle(), None),
+        );
         let commit = coordinator_envelope(
             b"coordinator",
             envelope::Body::LayoutReject(LayoutReject {
@@ -1820,10 +2017,159 @@ mod control_queue_tests {
                 reason: LayoutRejectReason::Stale as i32,
             }),
         );
+        mailbox.publish_state(commit);
 
-        broadcast_envelope(&peers, commit.clone());
-        assert_eq!(fast_rx.recv().await, Some(commit.clone()));
+        layout_peer_writer_task(
+            FailingWriter,
+            state_rx,
+            targeted_rx,
+            b"slow".to_vec(),
+            peers.clone(),
+        )
+        .await;
+
+        assert!(!peers.lock().unwrap().contains_key(b"slow".as_slice()));
+        tokio::task::yield_now().await;
+        assert!(reader.is_finished());
+        assert!(
+            mailbox
+                .targeted_tx
+                .send(coordinator_envelope(
+                    b"coordinator",
+                    envelope::Body::LayoutReject(LayoutReject {
+                        request_id: 10,
+                        reason: LayoutRejectReason::Stale as i32,
+                    }),
+                ))
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn stalled_peer_coalesces_commits_while_a_healthy_peer_receives_the_latest() {
+        let peers = Arc::new(Mutex::new(BTreeMap::new()));
+        let (slow_mailbox, slow_state_rx, slow_targeted_rx) = ControlMailbox::new();
+        let observed_slow_state = slow_state_rx.clone();
+        let slow_reader = tokio::spawn(std::future::pending::<()>());
+        peers.lock().unwrap().insert(
+            b"slow".to_vec(),
+            ControlPeer::new(slow_mailbox, slow_reader.abort_handle(), None),
+        );
+        let (healthy_mailbox, healthy_state_rx, healthy_targeted_rx) = ControlMailbox::new();
+        let healthy_reader = tokio::spawn(std::future::pending::<()>());
+        peers.lock().unwrap().insert(
+            b"healthy".to_vec(),
+            ControlPeer::new(healthy_mailbox, healthy_reader.abort_handle(), None),
+        );
+        let (started_tx, started_rx) = oneshot::channel();
+        let (release_tx, release_rx) = oneshot::channel();
+        let slow_task = tokio::spawn(layout_peer_writer_task(
+            StalledWriter {
+                started: Some(started_tx),
+                release: Some(release_rx),
+            },
+            slow_state_rx,
+            slow_targeted_rx,
+            b"slow".to_vec(),
+            peers.clone(),
+        ));
+        let (healthy_tx, mut healthy_rx) = mpsc::unbounded_channel();
+        let healthy_task = tokio::spawn(layout_peer_writer_task(
+            RecordingWriter(healthy_tx),
+            healthy_state_rx,
+            healthy_targeted_rx,
+            b"healthy".to_vec(),
+            peers.clone(),
+        ));
+
+        broadcast_envelope(&peers, commit(2));
+        started_rx
+            .await
+            .expect("slow writer begins its first commit");
+        broadcast_envelope(&peers, commit(3));
+        broadcast_envelope(&peers, commit(4));
+        assert!(matches!(
+            observed_slow_state.borrow().as_ref(),
+            Some(Envelope {
+                body: Some(envelope::Body::LayoutCommit(LayoutCommit {
+                    revision: 4,
+                    ..
+                })),
+                ..
+            })
+        ));
+        loop {
+            let envelope = healthy_rx.recv().await.expect("healthy delivery");
+            if matches!(
+                envelope.body,
+                Some(envelope::Body::LayoutCommit(LayoutCommit {
+                    revision: 4,
+                    ..
+                }))
+            ) {
+                break;
+            }
+        }
+
+        let _ = release_tx.send(());
+        remove_control_peer(&peers, b"slow");
+        remove_control_peer(&peers, b"healthy");
+        slow_task.abort();
+        healthy_task.abort();
+    }
+
+    #[tokio::test]
+    async fn targeted_queue_overflow_closes_the_peer_before_it_can_keep_reading() {
+        let peers = Arc::new(Mutex::new(BTreeMap::new()));
+        let (mailbox, _state_rx, targeted_rx) = ControlMailbox::new();
+        let reader = tokio::spawn(std::future::pending::<()>());
+        peers.lock().unwrap().insert(
+            b"slow".to_vec(),
+            ControlPeer::new(mailbox.clone(), reader.abort_handle(), None),
+        );
+        for request_id in 1..=TARGETED_CONTROL_QUEUE_CAPACITY {
+            send_to_peer(
+                &peers,
+                b"slow",
+                coordinator_envelope(
+                    b"coordinator",
+                    envelope::Body::LayoutReject(LayoutReject {
+                        request_id: request_id as u64,
+                        reason: LayoutRejectReason::Stale as i32,
+                    }),
+                ),
+            );
+        }
         assert!(peers.lock().unwrap().contains_key(b"slow".as_slice()));
-        assert_eq!(slow_rx.recv().await, Some(commit));
+        send_to_peer(
+            &peers,
+            b"slow",
+            coordinator_envelope(
+                b"coordinator",
+                envelope::Body::LayoutReject(LayoutReject {
+                    request_id: 99,
+                    reason: LayoutRejectReason::Stale as i32,
+                }),
+            ),
+        );
+
+        assert!(!peers.lock().unwrap().contains_key(b"slow".as_slice()));
+        tokio::task::yield_now().await;
+        assert!(reader.is_finished());
+        drop(targeted_rx);
+        assert!(
+            mailbox
+                .targeted_tx
+                .send(coordinator_envelope(
+                    b"coordinator",
+                    envelope::Body::LayoutReject(LayoutReject {
+                        request_id: 100,
+                        reason: LayoutRejectReason::Stale as i32,
+                    }),
+                ))
+                .await
+                .is_err()
+        );
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -23,7 +23,7 @@ use tokio::{
 };
 
 use crate::{
-    layout::{Axis, LayoutError, LayoutSnapshot, Node, SessionState},
+    layout::{Axis, LayoutError, LayoutSnapshot, Member, Node, Pane, SessionState, Tab},
     lease::LeaseState,
     protocol::{
         ControlLease, CreatePane, CreateTab, DeletePane, DeleteTab, Delta, Envelope, Input, Join,
@@ -583,6 +583,73 @@ fn protocol_layout_state(snapshot: LayoutSnapshot) -> LayoutState {
                 root: Some(protocol_node(tab.root)),
             })
             .collect(),
+    }
+}
+
+/// Converts an authoritative wire layout into the I/O-free model consumed by the renderer.
+///
+/// The conversion deliberately reuses the same validation as coordinator state so a malformed
+/// peer message can never become a partially rendered local layout.
+pub fn layout_snapshot_from_state(state: &LayoutState) -> Result<LayoutSnapshot, LayoutError> {
+    let members = state
+        .members
+        .iter()
+        .map(|member| Member {
+            peer_id: member.peer_id.clone(),
+            endpoint_addr: member.endpoint_addr.clone(),
+        })
+        .collect();
+    let panes = state
+        .panes
+        .iter()
+        .map(|pane| {
+            let (grid_rows, grid_cols) = protocol_grid(pane.grid_rows, pane.grid_cols)?;
+            Ok((
+                pane.pane_id,
+                Pane {
+                    pane_id: pane.pane_id,
+                    host_peer_id: pane.host_peer_id.clone(),
+                    grid_rows,
+                    grid_cols,
+                },
+            ))
+        })
+        .collect::<Result<_, LayoutError>>()?;
+    let tabs = state
+        .tabs
+        .iter()
+        .map(|tab| {
+            Ok(Tab {
+                tab_id: tab.tab_id,
+                root: layout_node_from_protocol(
+                    tab.root.as_ref().ok_or(LayoutError::InvalidSnapshot)?,
+                )?,
+            })
+        })
+        .collect::<Result<_, LayoutError>>()?;
+    let snapshot = LayoutSnapshot {
+        revision: state.revision,
+        members,
+        tabs,
+        panes,
+    };
+    SessionState::validate_snapshot(&snapshot)?;
+    Ok(snapshot)
+}
+
+fn layout_node_from_protocol(node: &LayoutNode) -> Result<Node, LayoutError> {
+    match (&node.leaf_pane_id, &node.split) {
+        (Some(pane_id), None) if *pane_id != 0 => Ok(Node::Leaf { pane_id: *pane_id }),
+        (None, Some(split)) => Ok(Node::Split {
+            axis: protocol_axis(split.axis)?,
+            first: Box::new(layout_node_from_protocol(
+                split.first.as_ref().ok_or(LayoutError::InvalidSnapshot)?,
+            )?),
+            second: Box::new(layout_node_from_protocol(
+                split.second.as_ref().ok_or(LayoutError::InvalidSnapshot)?,
+            )?),
+        }),
+        _ => Err(LayoutError::InvalidSnapshot),
     }
 }
 
@@ -1588,6 +1655,11 @@ impl SharedLayoutMember {
         PaneServer::new(self.transport.clone(), session_id)
     }
 
+    /// The endpoint that owns this member's locally hosted panes and outbound subscriptions.
+    pub fn transport(&self) -> Transport {
+        self.transport.clone()
+    }
+
     pub fn try_request(&self, request: LayoutRequest) -> Result<(), LayoutControlQueueError> {
         self.outbound
             .try_send(LayoutClientMessage::Request(request))
@@ -1665,6 +1737,81 @@ impl SharedLayoutHost {
 
     pub fn ticket(&self) -> &JoinTicket {
         self.host.ticket()
+    }
+
+    pub fn address_ready(&self) -> bool {
+        self.host.address_ready()
+    }
+
+    /// Cloned endpoint used for direct subscriptions to panes owned by other members.
+    pub fn transport(&self) -> Transport {
+        self.host.transport.clone()
+    }
+
+    /// Returns the coordinator's current full layout for its own local renderer.
+    pub fn session_snapshot(&self) -> Result<SessionSnapshot, SessionError> {
+        self.coordinator
+            .lock()
+            .map_err(|_| SessionError::PeerTask)?
+            .session_snapshot()
+            .map_err(|_| SessionError::InvalidPostWelcome)
+    }
+
+    /// Applies a request made by the coordinator process itself. Remote peers receive the same
+    /// commit as they would for a member-originated request; the caller applies the returned
+    /// response to its own renderer.
+    pub fn handle_local_request(
+        &self,
+        request: LayoutRequest,
+    ) -> Result<CoordinatorResponse, SessionError> {
+        let peer_id = self.host.transport.endpoint_id().as_bytes().to_vec();
+        let response = self
+            .coordinator
+            .lock()
+            .map_err(|_| SessionError::PeerTask)?
+            .handle_request(&peer_id, request);
+        self.publish_local_response(&response)?;
+        Ok(response)
+    }
+
+    /// Commits a coordinator-local reservation only after its PTY has been registered.
+    pub fn handle_local_ready(
+        &self,
+        ready: PaneReady,
+    ) -> Result<CoordinatorResponse, SessionError> {
+        let peer_id = self.host.transport.endpoint_id().as_bytes().to_vec();
+        let response = self
+            .coordinator
+            .lock()
+            .map_err(|_| SessionError::PeerTask)?
+            .handle_pane_ready(&peer_id, ready);
+        self.publish_local_response(&response)?;
+        Ok(response)
+    }
+
+    /// Cancels a failed coordinator-local spawn and makes the corresponding rejection available
+    /// to the local runtime without advertising an unready pane.
+    pub fn handle_local_failed(&self, failed: PaneFailed) -> Result<LayoutReject, SessionError> {
+        let peer_id = self.host.transport.endpoint_id().as_bytes().to_vec();
+        let rejection = self
+            .coordinator
+            .lock()
+            .map_err(|_| SessionError::PeerTask)?
+            .handle_pane_failed(&peer_id, failed)
+            .reject;
+        Ok(rejection)
+    }
+
+    fn publish_local_response(&self, response: &CoordinatorResponse) -> Result<(), SessionError> {
+        if let CoordinatorResponse::Commit(commit) = response {
+            let state = commit
+                .state
+                .as_ref()
+                .ok_or(SessionError::InvalidPostWelcome)?;
+            self.pane_server.replace_roster_from_layout(state)?;
+            self.broadcast_commit(commit.clone());
+        }
+        Ok(())
     }
 
     /// Creates the coordinator-owned pane registry. The runtime must keep this registry's roster

--- a/src/session.rs
+++ b/src/session.rs
@@ -783,7 +783,6 @@ pub struct PaneServer {
     transport: Transport,
     session_id: Vec<u8>,
     local_peer_id: Vec<u8>,
-    members: Arc<Mutex<BTreeMap<Vec<u8>, EndpointAddr>>>,
     registry: Arc<Mutex<PaneRegistry>>,
     next_subscription_id: Arc<AtomicU64>,
     service_errors: broadcast::Sender<SessionServiceError>,
@@ -797,6 +796,7 @@ pub enum SessionServiceError {
 
 #[derive(Default)]
 struct PaneRegistry {
+    members: BTreeMap<Vec<u8>, EndpointAddr>,
     panes: BTreeMap<u64, HostPaneChannels>,
     subscriptions: BTreeMap<u64, BTreeMap<u64, PaneSubscription>>,
 }
@@ -814,7 +814,6 @@ impl PaneServer {
             transport: host.transport.clone(),
             session_id: host.ticket.session_id().to_vec(),
             local_peer_id: host.transport.endpoint_id().as_bytes().to_vec(),
-            members: Arc::new(Mutex::new(BTreeMap::new())),
             registry: Arc::new(Mutex::new(PaneRegistry::default())),
             next_subscription_id: Arc::new(AtomicU64::new(1)),
             service_errors,
@@ -830,7 +829,6 @@ impl PaneServer {
             local_peer_id: transport.endpoint_id().as_bytes().to_vec(),
             transport,
             session_id,
-            members: Arc::new(Mutex::new(BTreeMap::new())),
             registry: Arc::new(Mutex::new(PaneRegistry::default())),
             next_subscription_id: Arc::new(AtomicU64::new(1)),
             service_errors,
@@ -865,9 +863,10 @@ impl PaneServer {
         {
             return Err(SessionError::InvalidPostWelcome);
         }
-        self.members
+        self.registry
             .lock()
             .map_err(|_| SessionError::PeerTask)?
+            .members
             .insert(peer_id, endpoint_addr);
         Ok(())
     }
@@ -886,9 +885,9 @@ impl PaneServer {
             }
             next.insert(peer_id, endpoint_addr);
         }
-        *self.members.lock().map_err(|_| SessionError::PeerTask)? = next.clone();
         let revoked = {
             let mut registry = self.registry.lock().map_err(|_| SessionError::PeerTask)?;
+            registry.members = next.clone();
             let mut revoked = Vec::new();
             for subscribers in registry.subscriptions.values_mut() {
                 subscribers.retain(|_, subscription| {
@@ -1053,11 +1052,6 @@ impl PaneServer {
         if envelope.sender_peer_id != remote_peer_id
             || subscribe.peer_id != remote_peer_id
             || subscribe.session_id != self.session_id
-            || !self
-                .members
-                .lock()
-                .map_err(|_| SessionError::PeerTask)?
-                .contains_key(&remote_peer_id)
         {
             return Err(SessionError::UnauthenticatedPeer);
         }
@@ -1068,6 +1062,9 @@ impl PaneServer {
         let active = Arc::new(AtomicBool::new(true));
         let pane = {
             let mut registry = self.registry.lock().map_err(|_| SessionError::PeerTask)?;
+            if !registry.members.contains_key(&remote_peer_id) {
+                return Err(SessionError::UnauthenticatedPeer);
+            }
             let pane = registry
                 .panes
                 .get(&subscribe.pane_id)

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,6 +1,6 @@
 //! Authenticated Join/Welcome session handshakes over Iroh bi-streams.
 
-use std::{error::Error, fmt, time::Duration};
+use std::{collections::BTreeMap, error::Error, fmt, time::Duration};
 
 use iroh::{
     EndpointAddr, EndpointId,
@@ -12,10 +12,14 @@ use tokio::{
 };
 
 use crate::{
+    layout::{Axis, LayoutError, LayoutSnapshot, Node, SessionState},
     lease::LeaseState,
     protocol::{
-        ControlLease, Delta, Envelope, Input, Join, PROTOCOL_VERSION, Snapshot, TakeControl,
-        Welcome, envelope,
+        ControlLease, CreatePane, CreateTab, DeletePane, DeleteTab, Delta, Envelope, Input, Join,
+        LayoutCommit, LayoutNode, LayoutReject, LayoutRejectReason, LayoutRequest, LayoutSplit,
+        LayoutState, MemberDescriptor, PROTOCOL_VERSION, PaneDescriptor, PaneReady,
+        PaneReservation, SessionSnapshot, Snapshot, SplitAxis, TabDescriptor, TakeControl, Welcome,
+        envelope,
     },
     screen::ScreenFrame,
     ticket::{JoinTicket, TicketError},
@@ -23,6 +27,374 @@ use crate::{
 };
 
 pub const DEFAULT_PANE_ID: &[u8] = b"default-pane";
+
+/// In-memory authority for the shared layout. Network code authenticates callers before handing
+/// their protocol messages to this type.
+pub struct LayoutCoordinator {
+    state: SessionState,
+    reservation_request_ids: BTreeMap<u64, u64>,
+}
+
+#[derive(Debug)]
+pub enum CoordinatorError {
+    Layout(LayoutError),
+}
+
+impl fmt::Display for CoordinatorError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Layout(error) => write!(formatter, "layout error: {error:?}"),
+        }
+    }
+}
+
+impl Error for CoordinatorError {}
+
+impl From<LayoutError> for CoordinatorError {
+    fn from(error: LayoutError) -> Self {
+        Self::Layout(error)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum CoordinatorResponse {
+    Reservation(PaneReservation),
+    Commit(LayoutCommit),
+    Reject(LayoutReject),
+}
+
+impl LayoutCoordinator {
+    pub fn new(
+        coordinator_peer_id: Vec<u8>,
+        endpoint_addr: Vec<u8>,
+        grid_rows: u16,
+        grid_cols: u16,
+    ) -> Result<Self, CoordinatorError> {
+        Ok(Self {
+            state: SessionState::new(coordinator_peer_id, endpoint_addr, grid_rows, grid_cols)?,
+            reservation_request_ids: BTreeMap::new(),
+        })
+    }
+
+    pub fn session_snapshot(&self) -> Result<SessionSnapshot, CoordinatorError> {
+        Ok(SessionSnapshot {
+            state: Some(self.protocol_layout_state()?),
+        })
+    }
+
+    pub fn admit(
+        &mut self,
+        peer_id: Vec<u8>,
+        endpoint_addr: Vec<u8>,
+    ) -> Result<LayoutCommit, CoordinatorError> {
+        self.state
+            .add_member(self.state.revision(), peer_id, endpoint_addr)?;
+        self.layout_commit()
+    }
+
+    pub fn handle_request(
+        &mut self,
+        authenticated_peer_id: &[u8],
+        request: LayoutRequest,
+    ) -> CoordinatorResponse {
+        let request_id = request.request_id;
+        let action_count = usize::from(request.create_pane.is_some())
+            + usize::from(request.delete_pane.is_some())
+            + usize::from(request.create_tab.is_some())
+            + usize::from(request.delete_tab.is_some());
+        if request_id == 0 || request.base_revision == 0 || action_count != 1 {
+            return reject(request_id, LayoutRejectReason::Malformed);
+        }
+
+        let result = if let Some(create) = request.create_pane {
+            self.reserve_pane(
+                authenticated_peer_id,
+                request.base_revision,
+                create,
+                request_id,
+            )
+        } else if let Some(delete) = request.delete_pane {
+            self.delete_pane(authenticated_peer_id, request.base_revision, delete)
+        } else if let Some(create) = request.create_tab {
+            self.reserve_tab(
+                authenticated_peer_id,
+                request.base_revision,
+                create,
+                request_id,
+            )
+        } else if let Some(delete) = request.delete_tab {
+            self.delete_tab(authenticated_peer_id, request.base_revision, delete)
+        } else {
+            Err(LayoutError::InvalidSnapshot)
+        };
+
+        match result {
+            Ok(response) => response,
+            Err(error) => reject(request_id, reject_reason(&error)),
+        }
+    }
+
+    pub fn handle_pane_ready(
+        &mut self,
+        authenticated_peer_id: &[u8],
+        ready: PaneReady,
+    ) -> CoordinatorResponse {
+        let request_id = self
+            .reservation_request_ids
+            .get(&ready.reservation_id)
+            .copied()
+            .unwrap_or(ready.reservation_id);
+        if ready.reservation_id == 0 || ready.base_revision == 0 {
+            return reject(request_id, LayoutRejectReason::Malformed);
+        }
+        match self.state.pane_ready(
+            authenticated_peer_id,
+            ready.base_revision,
+            ready.reservation_id,
+        ) {
+            Ok(_) => {
+                self.reservation_request_ids.remove(&ready.reservation_id);
+                match self.layout_commit() {
+                    Ok(commit) => CoordinatorResponse::Commit(commit),
+                    Err(error) => reject(request_id, reject_reason(&layout_error(error))),
+                }
+            }
+            Err(error) => reject(request_id, reject_reason(&error)),
+        }
+    }
+
+    pub fn cancel_reservation(
+        &mut self,
+        authenticated_peer_id: &[u8],
+        reservation_id: u64,
+    ) -> Result<(), CoordinatorError> {
+        self.state
+            .cancel_reservation(authenticated_peer_id, reservation_id)?;
+        self.reservation_request_ids.remove(&reservation_id);
+        Ok(())
+    }
+
+    pub fn expire_reservation(&mut self, reservation_id: u64) -> Result<(), CoordinatorError> {
+        self.state.expire_reservation(reservation_id)?;
+        self.reservation_request_ids.remove(&reservation_id);
+        Ok(())
+    }
+
+    fn reserve_pane(
+        &mut self,
+        authenticated_peer_id: &[u8],
+        base_revision: u64,
+        create: CreatePane,
+        request_id: u64,
+    ) -> Result<CoordinatorResponse, LayoutError> {
+        let axis = protocol_axis(create.axis)?;
+        let (grid_rows, grid_cols) = protocol_grid(create.grid_rows, create.grid_cols)?;
+        if create.target_pane_id == 0 {
+            return Err(LayoutError::InvalidSnapshot);
+        }
+        let reservation = self.state.reserve_pane(
+            authenticated_peer_id,
+            base_revision,
+            create.target_pane_id,
+            axis,
+            grid_rows,
+            grid_cols,
+        )?;
+        self.reservation_request_ids
+            .insert(reservation.reservation_id, request_id);
+        Ok(CoordinatorResponse::Reservation(protocol_reservation(
+            reservation,
+        )))
+    }
+
+    fn reserve_tab(
+        &mut self,
+        authenticated_peer_id: &[u8],
+        base_revision: u64,
+        create: CreateTab,
+        request_id: u64,
+    ) -> Result<CoordinatorResponse, LayoutError> {
+        let (grid_rows, grid_cols) = protocol_grid(create.grid_rows, create.grid_cols)?;
+        let reservation =
+            self.state
+                .reserve_tab(authenticated_peer_id, base_revision, grid_rows, grid_cols)?;
+        self.reservation_request_ids
+            .insert(reservation.reservation_id, request_id);
+        Ok(CoordinatorResponse::Reservation(protocol_reservation(
+            reservation,
+        )))
+    }
+
+    fn delete_pane(
+        &mut self,
+        authenticated_peer_id: &[u8],
+        base_revision: u64,
+        delete: DeletePane,
+    ) -> Result<CoordinatorResponse, LayoutError> {
+        if delete.pane_id == 0 {
+            return Err(LayoutError::InvalidSnapshot);
+        }
+        self.state
+            .delete_pane(authenticated_peer_id, base_revision, delete.pane_id)?;
+        Ok(CoordinatorResponse::Commit(
+            self.layout_commit().map_err(layout_error)?,
+        ))
+    }
+
+    fn delete_tab(
+        &mut self,
+        authenticated_peer_id: &[u8],
+        base_revision: u64,
+        delete: DeleteTab,
+    ) -> Result<CoordinatorResponse, LayoutError> {
+        if delete.tab_id == 0 {
+            return Err(LayoutError::InvalidSnapshot);
+        }
+        self.state
+            .delete_tab(authenticated_peer_id, base_revision, delete.tab_id)?;
+        Ok(CoordinatorResponse::Commit(
+            self.layout_commit().map_err(layout_error)?,
+        ))
+    }
+
+    fn layout_commit(&self) -> Result<LayoutCommit, CoordinatorError> {
+        let state = self.protocol_layout_state()?;
+        Ok(LayoutCommit {
+            revision: state.revision,
+            state: Some(state),
+        })
+    }
+
+    fn protocol_layout_state(&self) -> Result<LayoutState, CoordinatorError> {
+        let snapshot = self.state.snapshot();
+        SessionState::validate_snapshot(&snapshot)?;
+        Ok(protocol_layout_state(snapshot))
+    }
+}
+
+fn layout_error(error: CoordinatorError) -> LayoutError {
+    match error {
+        CoordinatorError::Layout(error) => error,
+    }
+}
+
+fn protocol_grid(rows: u32, cols: u32) -> Result<(u16, u16), LayoutError> {
+    let rows = u16::try_from(rows).map_err(|_| LayoutError::InvalidGrid)?;
+    let cols = u16::try_from(cols).map_err(|_| LayoutError::InvalidGrid)?;
+    if rows == 0 || cols == 0 {
+        return Err(LayoutError::InvalidGrid);
+    }
+    Ok((rows, cols))
+}
+
+fn protocol_axis(axis: Option<i32>) -> Result<Axis, LayoutError> {
+    match axis.and_then(|axis| SplitAxis::try_from(axis).ok()) {
+        Some(SplitAxis::LeftRight) => Ok(Axis::LeftRight),
+        Some(SplitAxis::TopBottom) => Ok(Axis::TopBottom),
+        None => Err(LayoutError::InvalidSnapshot),
+    }
+}
+
+fn protocol_reservation(reservation: crate::layout::PaneReservation) -> PaneReservation {
+    PaneReservation {
+        reservation_id: reservation.reservation_id,
+        pane_id: reservation.pane_id,
+        tab_id: reservation.tab_id,
+    }
+}
+
+fn protocol_layout_state(snapshot: LayoutSnapshot) -> LayoutState {
+    LayoutState {
+        revision: snapshot.revision,
+        members: snapshot
+            .members
+            .into_iter()
+            .map(|member| MemberDescriptor {
+                peer_id: member.peer_id,
+                endpoint_addr: member.endpoint_addr,
+            })
+            .collect(),
+        panes: snapshot
+            .panes
+            .into_values()
+            .map(|pane| PaneDescriptor {
+                pane_id: pane.pane_id,
+                host_peer_id: pane.host_peer_id,
+                grid_rows: u32::from(pane.grid_rows),
+                grid_cols: u32::from(pane.grid_cols),
+            })
+            .collect(),
+        tabs: snapshot
+            .tabs
+            .into_iter()
+            .map(|tab| TabDescriptor {
+                tab_id: tab.tab_id,
+                root: Some(protocol_node(tab.root)),
+            })
+            .collect(),
+    }
+}
+
+fn protocol_node(node: Node) -> LayoutNode {
+    match node {
+        Node::Leaf { pane_id } => LayoutNode {
+            leaf_pane_id: Some(pane_id),
+            split: None,
+        },
+        Node::Split {
+            axis,
+            first,
+            second,
+        } => LayoutNode {
+            leaf_pane_id: None,
+            split: Some(Box::new(LayoutSplit {
+                axis: Some(match axis {
+                    Axis::LeftRight => SplitAxis::LeftRight as i32,
+                    Axis::TopBottom => SplitAxis::TopBottom as i32,
+                }),
+                first: Some(protocol_node(*first)),
+                second: Some(protocol_node(*second)),
+            })),
+        },
+    }
+}
+
+fn reject(request_id: u64, reason: LayoutRejectReason) -> CoordinatorResponse {
+    CoordinatorResponse::Reject(LayoutReject {
+        request_id,
+        reason: reason as i32,
+    })
+}
+
+fn reject_reason(error: &LayoutError) -> LayoutRejectReason {
+    match error {
+        LayoutError::StaleRevision { .. } | LayoutError::RevisionExhausted => {
+            LayoutRejectReason::Stale
+        }
+        LayoutError::NotPaneHost { .. } | LayoutError::NotMember => LayoutRejectReason::NotHost,
+        LayoutError::NotTabHost { .. } => LayoutRejectReason::MixedTab,
+        LayoutError::MemberLimit
+        | LayoutError::TabLimit
+        | LayoutError::PaneLimit
+        | LayoutError::SplitDepthLimit
+        | LayoutError::IdExhausted => LayoutRejectReason::Limit,
+        LayoutError::UnknownPane { .. } | LayoutError::UnknownTab { .. } => {
+            LayoutRejectReason::UnknownId
+        }
+        LayoutError::LastPaneInTab { .. } | LayoutError::LastTab => {
+            LayoutRejectReason::LastPaneOrTab
+        }
+        LayoutError::ReservationPending
+        | LayoutError::UnknownReservation { .. }
+        | LayoutError::ReservationCreatorMismatch
+        | LayoutError::ReservationInvalid => LayoutRejectReason::ReservationFailure,
+        LayoutError::InvalidPeerId
+        | LayoutError::InvalidEndpointAddress
+        | LayoutError::InvalidGrid
+        | LayoutError::AlreadyMember
+        | LayoutError::InvalidSnapshot => LayoutRejectReason::Malformed,
+    }
+}
 
 pub struct HostPaneChannels {
     pub pane_id: Vec<u8>,

--- a/src/session.rs
+++ b/src/session.rs
@@ -803,6 +803,7 @@ struct PaneRegistry {
 
 struct PaneSubscription {
     connection: Connection,
+    peer_id: Vec<u8>,
     active: Arc<AtomicBool>,
 }
 
@@ -885,7 +886,29 @@ impl PaneServer {
             }
             next.insert(peer_id, endpoint_addr);
         }
-        *self.members.lock().map_err(|_| SessionError::PeerTask)? = next;
+        *self.members.lock().map_err(|_| SessionError::PeerTask)? = next.clone();
+        let revoked = {
+            let mut registry = self.registry.lock().map_err(|_| SessionError::PeerTask)?;
+            let mut revoked = Vec::new();
+            for subscribers in registry.subscriptions.values_mut() {
+                subscribers.retain(|_, subscription| {
+                    if next.contains_key(&subscription.peer_id) {
+                        true
+                    } else {
+                        subscription.active.store(false, Ordering::Release);
+                        revoked.push(subscription.connection.clone());
+                        false
+                    }
+                });
+            }
+            registry
+                .subscriptions
+                .retain(|_, subscribers| !subscribers.is_empty());
+            revoked
+        };
+        for connection in revoked {
+            connection.close(0u8.into(), b"member departed");
+        }
         Ok(())
     }
 
@@ -1058,6 +1081,7 @@ impl PaneServer {
                     subscription_id,
                     PaneSubscription {
                         connection: connection.clone(),
+                        peer_id: remote_peer_id.clone(),
                         active: active.clone(),
                     },
                 );
@@ -1585,6 +1609,12 @@ impl SharedLayoutMember {
             .map_err(layout_queue_error)
     }
 
+    /// Closes only the persistent coordinator-control connection. Direct pane subscriptions use
+    /// separate connections and must be revoked by the coordinator's authoritative roster update.
+    pub fn disconnect_control(&self) {
+        self.connection.close(0u8.into(), b"control disconnected");
+    }
+
     pub async fn shutdown(mut self) {
         for task in &self.tasks {
             task.abort();
@@ -1758,6 +1788,7 @@ impl SharedLayoutHost {
                 Some((
                     self.coordinator.clone(),
                     self.host.ticket().endpoint_addr().id.as_bytes().to_vec(),
+                    self.pane_server.clone(),
                 )),
             ));
             Ok(receipt)
@@ -1770,6 +1801,7 @@ impl SharedLayoutHost {
                     Some(&(
                         self.coordinator.clone(),
                         self.host.ticket().endpoint_addr().id.as_bytes().to_vec(),
+                        self.pane_server.clone(),
                     )),
                     &peer_id,
                 );
@@ -1979,12 +2011,14 @@ fn remove_control_peer(peers: &Arc<Mutex<BTreeMap<Vec<u8>, ControlPeer>>>, peer_
     }
 }
 
+type CoordinatorDeparture = (Arc<Mutex<LayoutCoordinator>>, Vec<u8>, PaneServer);
+
 fn disconnect_or_remove(
     peers: &Arc<Mutex<BTreeMap<Vec<u8>, ControlPeer>>>,
-    coordinator: Option<&(Arc<Mutex<LayoutCoordinator>>, Vec<u8>)>,
+    coordinator: Option<&CoordinatorDeparture>,
     peer_id: &[u8],
 ) {
-    let Some((coordinator, coordinator_peer_id)) = coordinator else {
+    let Some((coordinator, coordinator_peer_id, pane_server)) = coordinator else {
         remove_control_peer(peers, peer_id);
         return;
     };
@@ -1994,6 +2028,9 @@ fn disconnect_or_remove(
     };
     remove_control_peer(peers, peer_id);
     if let Ok(change) = coordinator.remove_member(peer_id) {
+        if let Some(state) = change.commit.state.as_ref() {
+            let _ = pane_server.replace_roster_from_layout(state);
+        }
         broadcast_envelope(
             peers,
             coordinator_envelope(
@@ -2064,7 +2101,7 @@ async fn layout_peer_writer_task<W>(
     mut targeted_rx: mpsc::Receiver<SequencedEnvelope>,
     peer_id: Vec<u8>,
     peers: Arc<Mutex<BTreeMap<Vec<u8>, ControlPeer>>>,
-    coordinator: Option<(Arc<Mutex<LayoutCoordinator>>, Vec<u8>)>,
+    coordinator: Option<CoordinatorDeparture>,
 ) where
     W: ControlFrameSink + 'static,
 {
@@ -2249,7 +2286,11 @@ async fn layout_host_reader_task(
             _ => break,
         }
     }
-    disconnect_or_remove(&peers, Some(&(coordinator, coordinator_peer_id)), &peer_id);
+    disconnect_or_remove(
+        &peers,
+        Some(&(coordinator, coordinator_peer_id, pane_server)),
+        &peer_id,
+    );
 }
 
 async fn reservation_expiry_task(

--- a/src/session.rs
+++ b/src/session.rs
@@ -6,7 +6,10 @@ use std::{
     fmt,
     future::Future,
     pin::Pin,
-    sync::{Arc, Mutex},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicU64, Ordering},
+    },
     time::{Duration, Instant},
 };
 
@@ -1051,30 +1054,58 @@ const TARGETED_CONTROL_QUEUE_CAPACITY: usize = 16;
 
 #[derive(Clone)]
 struct ControlMailbox {
-    state_tx: watch::Sender<Option<Envelope>>,
-    targeted_tx: mpsc::Sender<Envelope>,
+    initial_tx: mpsc::Sender<Envelope>,
+    state_tx: watch::Sender<Option<SequencedEnvelope>>,
+    targeted_tx: mpsc::Sender<SequencedEnvelope>,
+    next_sequence: Arc<AtomicU64>,
+}
+
+#[derive(Clone)]
+struct SequencedEnvelope {
+    sequence: u64,
+    envelope: Envelope,
 }
 
 impl ControlMailbox {
     fn new() -> (
         Self,
-        watch::Receiver<Option<Envelope>>,
         mpsc::Receiver<Envelope>,
+        watch::Receiver<Option<SequencedEnvelope>>,
+        mpsc::Receiver<SequencedEnvelope>,
     ) {
+        let (initial_tx, initial_rx) = mpsc::channel(1);
         let (state_tx, state_rx) = watch::channel(None);
         let (targeted_tx, targeted_rx) = mpsc::channel(TARGETED_CONTROL_QUEUE_CAPACITY);
         (
             Self {
+                initial_tx,
                 state_tx,
                 targeted_tx,
+                next_sequence: Arc::new(AtomicU64::new(1)),
             },
+            initial_rx,
             state_rx,
             targeted_rx,
         )
     }
 
+    fn enqueue_initial(&self, envelope: Envelope) -> bool {
+        self.initial_tx.try_send(envelope).is_ok()
+    }
+
     fn publish_state(&self, envelope: Envelope) {
-        self.state_tx.send_replace(Some(envelope));
+        self.state_tx.send_replace(Some(self.sequenced(envelope)));
+    }
+
+    fn enqueue_targeted(&self, envelope: Envelope) -> bool {
+        self.targeted_tx.try_send(self.sequenced(envelope)).is_ok()
+    }
+
+    fn sequenced(&self, envelope: Envelope) -> SequencedEnvelope {
+        SequencedEnvelope {
+            sequence: self.next_sequence.fetch_add(1, Ordering::SeqCst),
+            envelope,
+        }
     }
 }
 
@@ -1232,7 +1263,7 @@ impl SharedLayoutHost {
 
             let (writer, reader) = self.transport_open_control(&connection).await?;
             let peer_id = receipt.admitted_peer_id.clone();
-            let (mailbox, state_rx, targeted_rx) = ControlMailbox::new();
+            let (mailbox, initial_rx, state_rx, targeted_rx) = ControlMailbox::new();
             let peer = ControlPeer::pending_reader(mailbox.clone(), connection.clone());
             let reader_abort = peer.reader_abort.clone();
             self.peers
@@ -1244,10 +1275,13 @@ impl SharedLayoutHost {
                 .lock()
                 .map_err(|_| SessionError::PeerTask)?
                 .session_snapshot()?;
-            mailbox.publish_state(coordinator_envelope(
-                self.host.ticket().endpoint_addr().id.as_bytes(),
-                envelope::Body::SessionSnapshot(snapshot),
-            ));
+            mailbox
+                .enqueue_initial(coordinator_envelope(
+                    self.host.ticket().endpoint_addr().id.as_bytes(),
+                    envelope::Body::SessionSnapshot(snapshot),
+                ))
+                .then_some(())
+                .ok_or(SessionError::PeerTask)?;
 
             let reader_task = tokio::spawn(layout_host_reader_task(
                 reader,
@@ -1261,6 +1295,7 @@ impl SharedLayoutHost {
             }
             tokio::spawn(layout_peer_writer_task(
                 writer,
+                initial_rx,
                 state_rx,
                 targeted_rx,
                 receipt.admitted_peer_id.clone(),
@@ -1346,7 +1381,7 @@ fn send_to_peer(
 ) {
     let failed_peer = match peers.lock() {
         Ok(mut peers) => match peers.get(peer_id) {
-            Some(peer) if peer.mailbox.targeted_tx.try_send(envelope).is_ok() => None,
+            Some(peer) if peer.mailbox.enqueue_targeted(envelope) => None,
             Some(_) => peers.remove(peer_id),
             None => None,
         },
@@ -1412,38 +1447,63 @@ pub async fn join_layout(
 
 async fn layout_peer_writer_task<W>(
     mut writer: W,
-    mut state_rx: watch::Receiver<Option<Envelope>>,
-    mut targeted_rx: mpsc::Receiver<Envelope>,
+    mut initial_rx: mpsc::Receiver<Envelope>,
+    mut state_rx: watch::Receiver<Option<SequencedEnvelope>>,
+    mut targeted_rx: mpsc::Receiver<SequencedEnvelope>,
     peer_id: Vec<u8>,
     peers: Arc<Mutex<BTreeMap<Vec<u8>, ControlPeer>>>,
 ) where
     W: ControlFrameSink + 'static,
 {
+    let Some(initial) = initial_rx.recv().await else {
+        remove_control_peer(&peers, &peer_id);
+        return;
+    };
+    if !writer.write_control(&initial).await {
+        remove_control_peer(&peers, &peer_id);
+        return;
+    }
     let mut targeted_open = true;
     let mut state_open = true;
+    let mut pending_targeted = None;
+    let mut pending_state = None;
     loop {
-        let envelope = tokio::select! {
-            biased;
-            changed = state_rx.changed(), if state_open => match changed {
-                Ok(()) => match state_rx.borrow_and_update().clone() {
-                    Some(envelope) => envelope,
-                    None => continue,
-                },
-                Err(_) => {
-                    state_open = false;
-                    continue;
+        if pending_targeted.is_none() {
+            match targeted_rx.try_recv() {
+                Ok(targeted) => pending_targeted = Some(targeted),
+                Err(mpsc::error::TryRecvError::Disconnected) => targeted_open = false,
+                Err(mpsc::error::TryRecvError::Empty) => {}
+            }
+        }
+        if pending_state.is_none() && state_open && state_rx.has_changed().unwrap_or(false) {
+            pending_state = state_rx.borrow_and_update().clone();
+        }
+
+        let next = match (&pending_state, &pending_targeted) {
+            (Some(state), Some(targeted)) if state.sequence < targeted.sequence => {
+                pending_state.take()
+            }
+            (Some(_), Some(_)) | (None, Some(_)) => pending_targeted.take(),
+            (Some(_), None) => pending_state.take(),
+            (None, None) => {
+                tokio::select! {
+                    targeted = targeted_rx.recv(), if targeted_open => match targeted {
+                        Some(targeted) => pending_targeted = Some(targeted),
+                        None => targeted_open = false,
+                    },
+                    changed = state_rx.changed(), if state_open => match changed {
+                        Ok(()) => pending_state = state_rx.borrow_and_update().clone(),
+                        Err(_) => state_open = false,
+                    },
+                    else => return,
                 }
-            },
-            targeted = targeted_rx.recv(), if targeted_open => match targeted {
-                Some(envelope) => envelope,
-                None => {
-                    targeted_open = false;
-                    continue;
-                }
-            },
-            else => return,
+                continue;
+            }
         };
-        if !writer.write_control(&envelope).await {
+        let Some(next) = next else {
+            continue;
+        };
+        if !writer.write_control(&next.envelope).await {
             remove_control_peer(&peers, &peer_id);
             return;
         }
@@ -2004,7 +2064,7 @@ mod control_queue_tests {
     #[tokio::test]
     async fn failed_writer_removes_the_peer_and_aborts_its_reader() {
         let peers = Arc::new(Mutex::new(BTreeMap::new()));
-        let (mailbox, state_rx, targeted_rx) = ControlMailbox::new();
+        let (mailbox, initial_rx, state_rx, targeted_rx) = ControlMailbox::new();
         let reader = tokio::spawn(std::future::pending::<()>());
         peers.lock().unwrap().insert(
             b"slow".to_vec(),
@@ -2017,10 +2077,11 @@ mod control_queue_tests {
                 reason: LayoutRejectReason::Stale as i32,
             }),
         );
-        mailbox.publish_state(commit);
+        assert!(mailbox.enqueue_initial(commit), "initial frame queues");
 
         layout_peer_writer_task(
             FailingWriter,
+            initial_rx,
             state_rx,
             targeted_rx,
             b"slow".to_vec(),
@@ -2031,32 +2092,28 @@ mod control_queue_tests {
         assert!(!peers.lock().unwrap().contains_key(b"slow".as_slice()));
         tokio::task::yield_now().await;
         assert!(reader.is_finished());
-        assert!(
-            mailbox
-                .targeted_tx
-                .send(coordinator_envelope(
-                    b"coordinator",
-                    envelope::Body::LayoutReject(LayoutReject {
-                        request_id: 10,
-                        reason: LayoutRejectReason::Stale as i32,
-                    }),
-                ))
-                .await
-                .is_err()
-        );
+        assert!(!mailbox.enqueue_targeted(coordinator_envelope(
+            b"coordinator",
+            envelope::Body::LayoutReject(LayoutReject {
+                request_id: 10,
+                reason: LayoutRejectReason::Stale as i32,
+            }),
+        )));
     }
 
     #[tokio::test]
     async fn stalled_peer_coalesces_commits_while_a_healthy_peer_receives_the_latest() {
         let peers = Arc::new(Mutex::new(BTreeMap::new()));
-        let (slow_mailbox, slow_state_rx, slow_targeted_rx) = ControlMailbox::new();
+        let (slow_mailbox, slow_initial_rx, slow_state_rx, slow_targeted_rx) =
+            ControlMailbox::new();
         let observed_slow_state = slow_state_rx.clone();
         let slow_reader = tokio::spawn(std::future::pending::<()>());
         peers.lock().unwrap().insert(
             b"slow".to_vec(),
             ControlPeer::new(slow_mailbox, slow_reader.abort_handle(), None),
         );
-        let (healthy_mailbox, healthy_state_rx, healthy_targeted_rx) = ControlMailbox::new();
+        let (healthy_mailbox, healthy_initial_rx, healthy_state_rx, healthy_targeted_rx) =
+            ControlMailbox::new();
         let healthy_reader = tokio::spawn(std::future::pending::<()>());
         peers.lock().unwrap().insert(
             b"healthy".to_vec(),
@@ -2064,11 +2121,32 @@ mod control_queue_tests {
         );
         let (started_tx, started_rx) = oneshot::channel();
         let (release_tx, release_rx) = oneshot::channel();
+        assert!(
+            peers
+                .lock()
+                .unwrap()
+                .get(b"slow".as_slice())
+                .expect("slow peer")
+                .mailbox
+                .enqueue_initial(commit(1)),
+            "slow initial"
+        );
+        assert!(
+            peers
+                .lock()
+                .unwrap()
+                .get(b"healthy".as_slice())
+                .expect("healthy peer")
+                .mailbox
+                .enqueue_initial(commit(1)),
+            "healthy initial"
+        );
         let slow_task = tokio::spawn(layout_peer_writer_task(
             StalledWriter {
                 started: Some(started_tx),
                 release: Some(release_rx),
             },
+            slow_initial_rx,
             slow_state_rx,
             slow_targeted_rx,
             b"slow".to_vec(),
@@ -2077,6 +2155,7 @@ mod control_queue_tests {
         let (healthy_tx, mut healthy_rx) = mpsc::unbounded_channel();
         let healthy_task = tokio::spawn(layout_peer_writer_task(
             RecordingWriter(healthy_tx),
+            healthy_initial_rx,
             healthy_state_rx,
             healthy_targeted_rx,
             b"healthy".to_vec(),
@@ -2090,7 +2169,10 @@ mod control_queue_tests {
         broadcast_envelope(&peers, commit(3));
         broadcast_envelope(&peers, commit(4));
         assert!(matches!(
-            observed_slow_state.borrow().as_ref(),
+            observed_slow_state
+                .borrow()
+                .as_ref()
+                .map(|state| &state.envelope),
             Some(Envelope {
                 body: Some(envelope::Body::LayoutCommit(LayoutCommit {
                     revision: 4,
@@ -2122,7 +2204,7 @@ mod control_queue_tests {
     #[tokio::test]
     async fn targeted_queue_overflow_closes_the_peer_before_it_can_keep_reading() {
         let peers = Arc::new(Mutex::new(BTreeMap::new()));
-        let (mailbox, _state_rx, targeted_rx) = ControlMailbox::new();
+        let (mailbox, _initial_rx, _state_rx, targeted_rx) = ControlMailbox::new();
         let reader = tokio::spawn(std::future::pending::<()>());
         peers.lock().unwrap().insert(
             b"slow".to_vec(),
@@ -2158,18 +2240,105 @@ mod control_queue_tests {
         tokio::task::yield_now().await;
         assert!(reader.is_finished());
         drop(targeted_rx);
-        assert!(
-            mailbox
-                .targeted_tx
-                .send(coordinator_envelope(
-                    b"coordinator",
-                    envelope::Body::LayoutReject(LayoutReject {
-                        request_id: 100,
-                        reason: LayoutRejectReason::Stale as i32,
-                    }),
-                ))
-                .await
-                .is_err()
+        assert!(!mailbox.enqueue_targeted(coordinator_envelope(
+            b"coordinator",
+            envelope::Body::LayoutReject(LayoutReject {
+                request_id: 100,
+                reason: LayoutRejectReason::Stale as i32,
+            }),
+        )));
+    }
+
+    #[tokio::test]
+    async fn initial_snapshot_is_first_when_a_commit_arrives_before_the_writer_starts() {
+        let peers = Arc::new(Mutex::new(BTreeMap::new()));
+        let (mailbox, initial_rx, state_rx, targeted_rx) = ControlMailbox::new();
+        let reader = tokio::spawn(std::future::pending::<()>());
+        peers.lock().unwrap().insert(
+            b"member".to_vec(),
+            ControlPeer::new(mailbox.clone(), reader.abort_handle(), None),
         );
+        let snapshot = coordinator_envelope(
+            b"coordinator",
+            envelope::Body::SessionSnapshot(SessionSnapshot { state: None }),
+        );
+        assert!(
+            mailbox.enqueue_initial(snapshot.clone()),
+            "initial snapshot queues"
+        );
+        mailbox.publish_state(commit(2));
+        let (recorded_tx, mut recorded_rx) = mpsc::unbounded_channel();
+        let writer_task = tokio::spawn(layout_peer_writer_task(
+            RecordingWriter(recorded_tx),
+            initial_rx,
+            state_rx,
+            targeted_rx,
+            b"member".to_vec(),
+            peers.clone(),
+        ));
+
+        assert_eq!(recorded_rx.recv().await, Some(snapshot));
+        assert!(matches!(
+            recorded_rx.recv().await,
+            Some(Envelope {
+                body: Some(envelope::Body::LayoutCommit(LayoutCommit {
+                    revision: 2,
+                    ..
+                })),
+                ..
+            })
+        ));
+        remove_control_peer(&peers, b"member");
+        writer_task.abort();
+    }
+
+    #[tokio::test]
+    async fn targeted_frame_precedes_later_coalesced_state_updates() {
+        let peers = Arc::new(Mutex::new(BTreeMap::new()));
+        let (mailbox, initial_rx, state_rx, targeted_rx) = ControlMailbox::new();
+        let reader = tokio::spawn(std::future::pending::<()>());
+        peers.lock().unwrap().insert(
+            b"member".to_vec(),
+            ControlPeer::new(mailbox.clone(), reader.abort_handle(), None),
+        );
+        assert!(mailbox.enqueue_initial(commit(1)), "initial frame queues");
+        mailbox.publish_state(commit(2));
+        let reject = coordinator_envelope(
+            b"coordinator",
+            envelope::Body::LayoutReject(LayoutReject {
+                request_id: 7,
+                reason: LayoutRejectReason::Stale as i32,
+            }),
+        );
+        assert!(
+            mailbox.enqueue_targeted(reject.clone()),
+            "targeted frame queues"
+        );
+        mailbox.publish_state(commit(3));
+        mailbox.publish_state(commit(4));
+        let (recorded_tx, mut recorded_rx) = mpsc::unbounded_channel();
+        let writer_task = tokio::spawn(layout_peer_writer_task(
+            RecordingWriter(recorded_tx),
+            initial_rx,
+            state_rx,
+            targeted_rx,
+            b"member".to_vec(),
+            peers.clone(),
+        ));
+
+        let _initial = recorded_rx.recv().await.expect("initial output");
+        assert_eq!(recorded_rx.recv().await, Some(reject));
+        assert!(matches!(
+            recorded_rx.recv().await,
+            Some(Envelope {
+                body: Some(envelope::Body::LayoutCommit(LayoutCommit {
+                    revision: 4,
+                    ..
+                })),
+                ..
+            })
+        ));
+        remove_control_peer(&peers, b"member");
+        writer_task.abort();
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -29,8 +29,8 @@ use crate::{
         ControlLease, CreatePane, CreateTab, DeletePane, DeleteTab, Delta, Envelope, Input, Join,
         LayoutCommit, LayoutNode, LayoutReject, LayoutRejectReason, LayoutRequest, LayoutSplit,
         LayoutState, MemberDescriptor, PROTOCOL_VERSION, PaneDescriptor, PaneFailed, PaneReady,
-        PaneReservation, SessionSnapshot, Snapshot, SplitAxis, TabDescriptor, TakeControl, Welcome,
-        envelope,
+        PaneReservation, PaneSubscribe, SessionSnapshot, Snapshot, SplitAxis, TabDescriptor,
+        TakeControl, Welcome, envelope,
     },
     screen::ScreenFrame,
     ticket::{JoinTicket, TicketError},
@@ -647,6 +647,7 @@ fn reject_reason(error: &LayoutError) -> LayoutRejectReason {
     }
 }
 
+#[derive(Clone)]
 pub struct HostPaneChannels {
     pub pane_id: Vec<u8>,
     pub host_peer_id: Vec<u8>,
@@ -751,6 +752,7 @@ pub struct GuestPane {
     pub controls: GuestControlSender,
     transport: Transport,
     connection: Connection,
+    close_transport: bool,
     tasks: Vec<tokio::task::JoinHandle<()>>,
 }
 
@@ -763,6 +765,166 @@ impl GuestPane {
             let _ = task.await;
         }
         self.connection.close(0u8.into(), b"");
+        if self.close_transport {
+            self.transport.close().await;
+        }
+    }
+}
+
+/// Canonical on-stream representation for a layout pane ID.
+pub fn pane_wire_id(pane_id: u64) -> Vec<u8> {
+    pane_id.to_be_bytes().to_vec()
+}
+
+/// Direct pane service for one session member. Its roster is updated from the authoritative
+/// layout state before it accepts subscriptions.
+#[derive(Clone)]
+pub struct PaneServer {
+    transport: Transport,
+    session_id: Vec<u8>,
+    local_peer_id: Vec<u8>,
+    members: Arc<Mutex<BTreeMap<Vec<u8>, EndpointAddr>>>,
+    panes: Arc<Mutex<BTreeMap<u64, HostPaneChannels>>>,
+}
+
+impl PaneServer {
+    pub fn from_host_session(host: &HostSession) -> Self {
+        Self {
+            transport: host.transport.clone(),
+            session_id: host.ticket.session_id().to_vec(),
+            local_peer_id: host.transport.endpoint_id().as_bytes().to_vec(),
+            members: Arc::new(Mutex::new(BTreeMap::new())),
+            panes: Arc::new(Mutex::new(BTreeMap::new())),
+        }
+    }
+
+    pub fn new(transport: Transport, session_id: Vec<u8>) -> Result<Self, SessionError> {
+        if session_id.is_empty() {
+            return Err(SessionError::InvalidPostWelcome);
+        }
+        Ok(Self {
+            local_peer_id: transport.endpoint_id().as_bytes().to_vec(),
+            transport,
+            session_id,
+            members: Arc::new(Mutex::new(BTreeMap::new())),
+            panes: Arc::new(Mutex::new(BTreeMap::new())),
+        })
+    }
+
+    pub fn add_member(
+        &self,
+        peer_id: Vec<u8>,
+        endpoint_addr: EndpointAddr,
+    ) -> Result<(), SessionError> {
+        if peer_id.is_empty() || endpoint_addr.is_empty() || peer_id != endpoint_addr.id.as_bytes()
+        {
+            return Err(SessionError::InvalidPostWelcome);
+        }
+        self.members
+            .lock()
+            .map_err(|_| SessionError::PeerTask)?
+            .insert(peer_id, endpoint_addr);
+        Ok(())
+    }
+
+    pub fn replace_members(
+        &self,
+        members: Vec<(Vec<u8>, EndpointAddr)>,
+    ) -> Result<(), SessionError> {
+        let mut next = BTreeMap::new();
+        for (peer_id, endpoint_addr) in members {
+            if peer_id.is_empty()
+                || endpoint_addr.is_empty()
+                || peer_id != endpoint_addr.id.as_bytes()
+            {
+                return Err(SessionError::InvalidPostWelcome);
+            }
+            next.insert(peer_id, endpoint_addr);
+        }
+        *self.members.lock().map_err(|_| SessionError::PeerTask)? = next;
+        Ok(())
+    }
+
+    pub fn register_pane(
+        &self,
+        descriptor: PaneDescriptor,
+        channels: HostPaneChannels,
+    ) -> Result<(), SessionError> {
+        if descriptor.pane_id == 0
+            || descriptor.host_peer_id != self.local_peer_id
+            || channels.host_peer_id != self.local_peer_id
+            || channels.pane_id != pane_wire_id(descriptor.pane_id)
+        {
+            return Err(SessionError::InvalidPostWelcome);
+        }
+        self.panes
+            .lock()
+            .map_err(|_| SessionError::PeerTask)?
+            .insert(descriptor.pane_id, channels);
+        Ok(())
+    }
+
+    pub fn remove_pane(&self, pane_id: u64) -> Result<Option<HostPaneChannels>, SessionError> {
+        Ok(self
+            .panes
+            .lock()
+            .map_err(|_| SessionError::PeerTask)?
+            .remove(&pane_id))
+    }
+
+    pub async fn accept_one(&self) -> Result<(), SessionError> {
+        let incoming = self.transport.accept_incoming().await?;
+        self.serve_incoming(incoming).await
+    }
+
+    pub async fn serve_incoming(&self, incoming: Incoming) -> Result<(), SessionError> {
+        let connection = timeout(HANDSHAKE_TIMEOUT, incoming)
+            .await
+            .map_err(|_| SessionError::TimedOut("incoming pane connection"))?
+            .map_err(SessionError::Incoming)?;
+        let result = self.serve_connection(&connection).await;
+        if result.is_err() {
+            connection.close(0u8.into(), b"");
+        }
+        result
+    }
+
+    async fn serve_connection(&self, connection: &Connection) -> Result<(), SessionError> {
+        let remote_peer_id = connection.remote_id().as_bytes().to_vec();
+        let (_subscribe_writer, mut subscribe_reader) =
+            self.transport.accept_bi(connection).await?;
+        let envelope = self.transport.read_frame(&mut subscribe_reader).await?;
+        let subscribe = match envelope.body {
+            Some(envelope::Body::PaneSubscribe(subscribe)) => subscribe,
+            _ => return Err(SessionError::InvalidPostWelcome),
+        };
+        if envelope.sender_peer_id != remote_peer_id
+            || subscribe.peer_id != remote_peer_id
+            || subscribe.session_id != self.session_id
+            || !self
+                .members
+                .lock()
+                .map_err(|_| SessionError::PeerTask)?
+                .contains_key(&remote_peer_id)
+        {
+            return Err(SessionError::UnauthenticatedPeer);
+        }
+        let pane = self
+            .panes
+            .lock()
+            .map_err(|_| SessionError::PeerTask)?
+            .get(&subscribe.pane_id)
+            .cloned()
+            .ok_or(SessionError::InvalidPostWelcome)?;
+        if pane.host_peer_id != self.local_peer_id
+            || pane.pane_id != pane_wire_id(subscribe.pane_id)
+        {
+            return Err(SessionError::InvalidPostWelcome);
+        }
+        serve_direct_pane_streams(&self.transport, connection, remote_peer_id, pane).await
+    }
+
+    pub async fn close(&self) {
         self.transport.close().await;
     }
 }
@@ -911,6 +1073,11 @@ impl HostSession {
     pub async fn accept_one_join(&self) -> Result<JoinReceipt, SessionError> {
         let incoming = self.accept_incoming().await?;
         self.handle_incoming(incoming).await
+    }
+
+    /// Compatibility entry point for serving direct layout panes from a coordinator host.
+    pub fn pane_server(&self) -> PaneServer {
+        PaneServer::from_host_session(self)
     }
 
     pub async fn close(&self) {
@@ -1194,6 +1361,12 @@ pub struct SharedLayoutMember {
 }
 
 impl SharedLayoutMember {
+    /// Creates the member-side direct pane service; callers supply the session ID from their
+    /// authenticated join ticket and keep its roster synchronized with layout commits.
+    pub fn pane_server(&self, session_id: Vec<u8>) -> Result<PaneServer, SessionError> {
+        PaneServer::new(self.transport.clone(), session_id)
+    }
+
     pub fn try_request(&self, request: LayoutRequest) -> Result<(), LayoutControlQueueError> {
         self.outbound
             .try_send(LayoutClientMessage::Request(request))
@@ -1768,6 +1941,60 @@ fn join_peer_task(
     result.map_err(|_| SessionError::PeerTask)?
 }
 
+async fn serve_direct_pane_streams(
+    transport: &Transport,
+    connection: &Connection,
+    remote_peer_id: Vec<u8>,
+    pane: HostPaneChannels,
+) -> Result<(), SessionError> {
+    let (screen_writer, _) = transport.open_framed_bi(connection).await?;
+    let screen_task = tokio::spawn(screen_writer_task(
+        screen_writer,
+        pane.screen_rx,
+        pane.pane_id.clone(),
+        pane.host_peer_id.clone(),
+    ));
+    let (lease_writer, _) = match transport.open_framed_bi(connection).await {
+        Ok(streams) => streams,
+        Err(error) => {
+            screen_task.abort();
+            return Err(error.into());
+        }
+    };
+    let lease_task = tokio::spawn(lease_writer_task(
+        pane.host_peer_id.clone(),
+        pane.lease_rx,
+        pane.pane_id.clone(),
+        lease_writer,
+    ));
+    let control_transport = transport.clone();
+    let control_connection = connection.clone();
+    let control_task = tokio::spawn(async move {
+        let (_, control_reader) = control_transport
+            .accept_framed_bi_when_ready(&control_connection)
+            .await?;
+        control_reader_task(
+            control_reader,
+            remote_peer_id,
+            pane.pane_id,
+            pane.control_tx,
+        )
+        .await
+    });
+    let mut screen_task = screen_task;
+    let mut lease_task = lease_task;
+    let mut control_task = control_task;
+    let result = tokio::select! {
+        result = &mut screen_task => join_peer_task(result),
+        result = &mut lease_task => join_peer_task(result),
+        result = &mut control_task => join_peer_task(result),
+    };
+    screen_task.abort();
+    lease_task.abort();
+    control_task.abort();
+    result
+}
+
 async fn screen_writer_task(
     mut writer: crate::transport::FrameWriter,
     mut screen_rx: watch::Receiver<ScreenFrame>,
@@ -1962,6 +2189,7 @@ pub async fn join_pane(
             },
             transport: transport.clone(),
             connection: connection.clone(),
+            close_transport: true,
             tasks,
         })
     }
@@ -1969,6 +2197,93 @@ pub async fn join_pane(
     if result.is_err() {
         connection.close(0u8.into(), b"");
         transport.close().await;
+    }
+    result
+}
+
+/// Subscribe directly to a pane's registered owner. The caller retains ownership of `transport`
+/// so it can keep independent pane connections open to multiple hosts.
+pub async fn subscribe_pane(
+    transport: Transport,
+    session_id: Vec<u8>,
+    host_endpoint: EndpointAddr,
+    descriptor: PaneDescriptor,
+) -> Result<GuestPane, SessionError> {
+    if session_id.is_empty()
+        || descriptor.pane_id == 0
+        || descriptor.host_peer_id != host_endpoint.id.as_bytes()
+    {
+        return Err(SessionError::InvalidPostWelcome);
+    }
+    let connection = transport.connect(host_endpoint.clone()).await?;
+    let result = async {
+        if connection.remote_id() != host_endpoint.id {
+            return Err(SessionError::UnauthenticatedPeer);
+        }
+        let peer_id = transport.endpoint_id().as_bytes().to_vec();
+        let (mut subscribe_writer, _subscribe_reader) = transport.open_bi(&connection).await?;
+        transport
+            .write_frame(
+                &mut subscribe_writer,
+                &Envelope {
+                    version: PROTOCOL_VERSION,
+                    sender_peer_id: peer_id.clone(),
+                    body: Some(envelope::Body::PaneSubscribe(PaneSubscribe {
+                        session_id,
+                        peer_id: peer_id.clone(),
+                        pane_id: descriptor.pane_id,
+                    })),
+                },
+            )
+            .await?;
+        let (_screen_writer, screen_reader) = transport.accept_framed_bi(&connection).await?;
+        let (_lease_writer, lease_reader) = transport.accept_framed_bi(&connection).await?;
+        let (control_writer, _control_reader) = transport.open_framed_bi(&connection).await?;
+        let (events_tx, events) = mpsc::channel(128);
+        let (take_control_tx, take_control_rx) = mpsc::channel(16);
+        let (input_tx, input_rx) = mpsc::channel(256);
+        let pane_id = pane_wire_id(descriptor.pane_id);
+        let host_peer_id = descriptor.host_peer_id;
+        let tasks = vec![
+            tokio::spawn(guest_screen_reader_task(
+                screen_reader,
+                events_tx.clone(),
+                pane_id.clone(),
+                host_peer_id.clone(),
+            )),
+            tokio::spawn(guest_lease_reader_task(
+                lease_reader,
+                events_tx,
+                pane_id.clone(),
+                host_peer_id.clone(),
+            )),
+            tokio::spawn(guest_control_writer_task(
+                control_writer,
+                take_control_rx,
+                input_rx,
+                peer_id.clone(),
+                pane_id.clone(),
+            )),
+        ];
+        Ok(GuestPane {
+            pane_id: pane_id.clone(),
+            host_peer_id,
+            events,
+            controls: GuestControlSender {
+                peer_id,
+                pane_id,
+                take_control_tx,
+                input_tx,
+            },
+            transport: transport.clone(),
+            connection: connection.clone(),
+            close_transport: false,
+            tasks,
+        })
+    }
+    .await;
+    if result.is_err() {
+        connection.close(0u8.into(), b"");
     }
     result
 }

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -13,7 +13,7 @@ use tokio::time::timeout;
 
 use crate::protocol::{Envelope, MAX_FRAME_BYTES, ProtocolError, decode_frame, encode_frame};
 
-pub const ALPN: &[u8] = b"p2pmux/1";
+pub const ALPN: &[u8] = b"p2pmux/2";
 pub const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(5);
 pub const CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
 

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -116,7 +116,14 @@ impl Transport {
     }
 
     pub async fn accept_incoming(&self) -> Result<Incoming, TransportError> {
-        timeout(HANDSHAKE_TIMEOUT, self.endpoint.accept())
+        self.accept_incoming_with_timeout(HANDSHAKE_TIMEOUT).await
+    }
+
+    pub async fn accept_incoming_with_timeout(
+        &self,
+        accept_timeout: Duration,
+    ) -> Result<Incoming, TransportError> {
+        timeout(accept_timeout, self.endpoint.accept())
             .await
             .map_err(|_| TransportError::TimedOut("incoming accept"))?
             .ok_or(TransportError::Closed)

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1,7 +1,7 @@
 //! The fixed-grid local terminal renderer and input loop.
 
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, BTreeSet},
     error::Error,
     io,
     time::{Duration, Instant},
@@ -28,9 +28,19 @@ use ratatui::{
 use crate::{
     layout::{Axis, LayoutError, LayoutSnapshot, Node, PaneId, TabId},
     lease::{IDLE_AFTER, LeaseDecision, LeaseManager, LeaseState},
+    protocol::{
+        CreatePane, CreateTab, DeletePane, DeleteTab, LayoutRequest, PaneDescriptor, PaneFailed,
+        PaneReady, SplitAxis,
+    },
     pty_host::PtyHost,
     screen::{GuestScreen, HostScreen, ScreenFrame},
-    session::{GuestEvent, GuestPane, HostControlEvent},
+    session::{
+        CoordinatorResponse, GuestEvent, GuestPane, HostControlEvent, HostPaneChannels,
+        LayoutControlEvent, LayoutControlQueueError, PaneLayoutReconciler, PaneServer,
+        SharedLayoutHost, SharedLayoutMember, layout_snapshot_from_state, pane_wire_id,
+        subscribe_pane,
+    },
+    transport::Transport,
 };
 
 /// Kept as the module's public marker from the scaffold.
@@ -570,6 +580,922 @@ pub fn render_multi_pane(
         } else if !view.ready {
             frame.render_widget(Paragraph::new("waiting for pane snapshot/lease"), inner);
         }
+    }
+}
+
+/// One fixed-grid PTY owned by this process. Its watch channels are registered with the pane
+/// service before the layout coordinator is told that the pane is ready.
+pub struct SharedLocalPane {
+    pane_id: PaneId,
+    host: PtyHost,
+    screen: HostScreen,
+    lease: LeaseManager,
+    host_peer_id: Vec<u8>,
+    screen_tx: watch::Sender<ScreenFrame>,
+    lease_tx: watch::Sender<LeaseState>,
+    control_tx: mpsc::Sender<HostControlEvent>,
+    control_rx: mpsc::Receiver<HostControlEvent>,
+}
+
+impl SharedLocalPane {
+    pub fn spawn(
+        pane_id: PaneId,
+        grid_rows: u16,
+        grid_cols: u16,
+        host_peer_id: Vec<u8>,
+    ) -> Result<Self, Box<dyn Error>> {
+        let size = PtySize {
+            rows: grid_rows,
+            cols: grid_cols,
+            pixel_width: 0,
+            pixel_height: 0,
+        };
+        let screen = HostScreen::new(grid_rows, grid_cols)?;
+        let (screen_tx, _) = watch::channel(screen.current_frame().clone());
+        let lease = LeaseManager::new(host_peer_id.clone(), Instant::now());
+        let (lease_tx, _) = watch::channel(lease.state().clone());
+        let (control_tx, control_rx) = mpsc::channel(256);
+        Ok(Self {
+            pane_id,
+            host: PtyHost::spawn_default_shell(size)?,
+            screen,
+            lease,
+            host_peer_id,
+            screen_tx,
+            lease_tx,
+            control_tx,
+            control_rx,
+        })
+    }
+
+    pub fn channels(&self) -> HostPaneChannels {
+        HostPaneChannels {
+            pane_id: pane_wire_id(self.pane_id),
+            host_peer_id: self.host_peer_id.clone(),
+            screen_rx: self.screen_tx.subscribe(),
+            lease_rx: self.lease_tx.subscribe(),
+            control_tx: self.control_tx.clone(),
+        }
+    }
+
+    fn view_state(&self) -> PaneViewState {
+        PaneViewState {
+            ready: true,
+            controller_peer_id: Some(self.lease.state().controller_peer_id.clone()),
+            controller_active: !self.lease.state().is_idle_at(Instant::now()),
+        }
+    }
+
+    fn drain(&mut self) -> Result<bool, Box<dyn Error>> {
+        let mut changed = false;
+        while let Ok(event) = self.control_rx.try_recv() {
+            match event {
+                HostControlEvent::Input { peer_id, input } => {
+                    if let LeaseDecision::AcceptInput(bytes) =
+                        self.lease
+                            .input(&peer_id, input.lease_epoch, input.data, Instant::now())
+                    {
+                        self.host.write_input(&bytes)?;
+                    }
+                }
+                HostControlEvent::TakeControl { peer_id, request } => {
+                    let decision = if request.force {
+                        self.lease.force_take_control(
+                            peer_id,
+                            request.known_lease_epoch,
+                            Instant::now(),
+                        )?
+                    } else {
+                        self.lease.take_control(
+                            peer_id,
+                            request.known_lease_epoch,
+                            Instant::now(),
+                        )?
+                    };
+                    if let LeaseDecision::Publish(state) = decision {
+                        self.lease_tx.send_replace(state);
+                        changed = true;
+                    }
+                }
+            }
+        }
+        let started = Instant::now();
+        for _ in 0..64 {
+            if started.elapsed() >= Duration::from_millis(4) {
+                break;
+            }
+            let Some(bytes) = self.host.try_read_output()? else {
+                break;
+            };
+            let frame = self.screen.process_pty(&bytes)?;
+            self.screen_tx.send_replace(frame);
+            changed = true;
+        }
+        Ok(changed)
+    }
+
+    fn take_control(&mut self) -> Result<(), Box<dyn Error>> {
+        if self.lease.state().controller_peer_id != self.host_peer_id
+            && let LeaseDecision::Publish(state) = self.lease.force_take_control(
+                self.host_peer_id.clone(),
+                self.lease.state().epoch,
+                Instant::now(),
+            )?
+        {
+            self.lease_tx.send_replace(state);
+        }
+        Ok(())
+    }
+
+    fn input(&mut self, bytes: Vec<u8>) -> Result<(), Box<dyn Error>> {
+        let epoch = self.lease.state().epoch;
+        let decision = if self.lease.state().controller_peer_id == self.host_peer_id {
+            self.lease
+                .input(&self.host_peer_id, epoch, bytes.clone(), Instant::now())
+        } else {
+            self.lease
+                .take_control(self.host_peer_id.clone(), epoch, Instant::now())?
+        };
+        match decision {
+            LeaseDecision::AcceptInput(bytes) => self.host.write_input(&bytes)?,
+            LeaseDecision::Publish(state) => {
+                self.lease_tx.send_replace(state);
+                self.host.write_input(&bytes)?;
+            }
+            LeaseDecision::RejectStaleInput
+            | LeaseDecision::RejectStaleRequest
+            | LeaseDecision::RejectActiveController => {}
+        }
+        Ok(())
+    }
+
+    fn shutdown(&mut self) -> Result<(), Box<dyn Error>> {
+        self.host.shutdown()
+    }
+}
+
+struct SharedRemotePane {
+    pane: GuestPane,
+    screen: GuestScreen,
+    lease: Option<LeaseState>,
+    last_lease: Instant,
+    pending_control: bool,
+    held_input: Vec<u8>,
+}
+
+impl SharedRemotePane {
+    fn new(pane: GuestPane) -> Self {
+        Self {
+            pane,
+            screen: GuestScreen::new(),
+            lease: None,
+            last_lease: Instant::now(),
+            pending_control: false,
+            held_input: Vec::new(),
+        }
+    }
+
+    fn view_state(&self) -> PaneViewState {
+        PaneViewState {
+            ready: self.screen.screen().is_some() && self.lease.is_some(),
+            controller_peer_id: self
+                .lease
+                .as_ref()
+                .map(|lease| lease.controller_peer_id.clone()),
+            controller_active: self
+                .lease
+                .as_ref()
+                .is_some_and(|lease| !lease.is_idle_at(Instant::now())),
+        }
+    }
+
+    fn drain(&mut self) -> bool {
+        let mut changed = false;
+        loop {
+            match self.pane.events.try_recv() {
+                Ok(GuestEvent::ScreenSnapshot(snapshot)) => {
+                    changed |= self
+                        .screen
+                        .apply_snapshot(snapshot.sequence, &snapshot.screen)
+                        .is_ok();
+                }
+                Ok(GuestEvent::ScreenDelta(delta)) => {
+                    changed |= self
+                        .screen
+                        .apply_delta(delta.base_sequence, delta.sequence, &delta.changes)
+                        .is_ok();
+                }
+                Ok(GuestEvent::InitialLease(lease)) | Ok(GuestEvent::Lease(lease)) => {
+                    self.lease = Some(LeaseState {
+                        controller_peer_id: lease.controller_peer_id,
+                        epoch: lease.lease_epoch,
+                        last_activity: Instant::now(),
+                    });
+                    self.last_lease = Instant::now();
+                    self.pending_control = false;
+                    changed = true;
+                }
+                Ok(GuestEvent::ScreenGap { .. }) => {}
+                Ok(GuestEvent::Disconnected)
+                | Err(tokio::sync::mpsc::error::TryRecvError::Disconnected) => return true,
+                Err(tokio::sync::mpsc::error::TryRecvError::Empty) => break,
+            }
+        }
+        if !self.pending_control
+            && !self.held_input.is_empty()
+            && self
+                .lease
+                .as_ref()
+                .is_some_and(|lease| lease.controller_peer_id == self.pane.controls.peer_id())
+        {
+            let bytes = std::mem::take(&mut self.held_input);
+            if self
+                .pane
+                .controls
+                .try_input(
+                    self.lease.as_ref().expect("checked lease").epoch,
+                    bytes.clone(),
+                )
+                .is_err()
+            {
+                self.held_input = bytes;
+            }
+        }
+        changed
+    }
+
+    fn take_control(&mut self) {
+        if let Some(lease) = self.lease.as_ref()
+            && lease.controller_peer_id != self.pane.controls.peer_id()
+        {
+            let _ = self.pane.controls.try_take_control(lease.epoch, true);
+        }
+    }
+
+    fn input(&mut self, bytes: Vec<u8>) {
+        let Some(lease) = self.lease.as_ref() else {
+            return;
+        };
+        if lease.controller_peer_id == self.pane.controls.peer_id() {
+            if self.held_input.is_empty() {
+                let _ = self.pane.controls.try_input(lease.epoch, bytes);
+            } else {
+                self.held_input.extend_from_slice(&bytes);
+            }
+        } else if self.last_lease.elapsed() >= IDLE_AFTER && !self.pending_control {
+            self.held_input.extend_from_slice(&bytes);
+            self.pending_control = self
+                .pane
+                .controls
+                .try_take_control(lease.epoch, false)
+                .is_ok();
+            if !self.pending_control {
+                self.held_input.clear();
+            }
+        }
+    }
+}
+
+enum SharedControl {
+    Host(SharedLayoutHost),
+    Member(SharedLayoutMember),
+}
+
+impl SharedControl {
+    fn peer_id(&self) -> Vec<u8> {
+        match self {
+            Self::Host(host) => host.ticket().endpoint_addr().id.as_bytes().to_vec(),
+            Self::Member(member) => member.peer_id.clone(),
+        }
+    }
+
+    fn try_request(&self, request: LayoutRequest) -> Result<Option<CoordinatorResponse>, String> {
+        match self {
+            Self::Host(host) => host
+                .handle_local_request(request)
+                .map(Some)
+                .map_err(|error| error.to_string()),
+            Self::Member(member) => member
+                .try_request(request)
+                .map(|()| None)
+                .map_err(layout_queue_message),
+        }
+    }
+
+    fn try_ready(&self, ready: PaneReady) -> Result<Option<CoordinatorResponse>, String> {
+        match self {
+            Self::Host(host) => host
+                .handle_local_ready(ready)
+                .map(Some)
+                .map_err(|error| error.to_string()),
+            Self::Member(member) => member
+                .try_ready(ready)
+                .map(|()| None)
+                .map_err(layout_queue_message),
+        }
+    }
+
+    fn try_failed(&self, failed: PaneFailed) -> Result<(), String> {
+        match self {
+            Self::Host(host) => host
+                .handle_local_failed(failed)
+                .map(|_| ())
+                .map_err(|error| error.to_string()),
+            Self::Member(member) => member.try_failed(failed).map_err(layout_queue_message),
+        }
+    }
+
+    fn try_event(&mut self, current_revision: u64) -> Option<LayoutControlEvent> {
+        match self {
+            // The coordinator is the authority, so it does not receive its own broadcasts. Poll
+            // its tiny in-memory snapshot to observe joins, departures, and member-originated
+            // commits without adding a second internal control stream.
+            Self::Host(host) => host
+                .session_snapshot()
+                .ok()
+                .filter(|snapshot| {
+                    snapshot
+                        .state
+                        .as_ref()
+                        .is_some_and(|state| state.revision > current_revision)
+                })
+                .map(LayoutControlEvent::Snapshot),
+            Self::Member(member) => member.events.try_recv().ok(),
+        }
+    }
+
+    async fn shutdown(self) {
+        match self {
+            Self::Host(host) => host.close().await,
+            Self::Member(member) => member.shutdown().await,
+        }
+    }
+}
+
+fn layout_queue_message(error: LayoutControlQueueError) -> String {
+    match error {
+        LayoutControlQueueError::Full => String::from("layout request queue is busy"),
+        LayoutControlQueueError::Closed => String::from("layout coordinator disconnected"),
+    }
+}
+
+#[derive(Clone, Copy)]
+struct PendingCreate {
+    request_id: u64,
+    base_revision: u64,
+    grid_rows: u16,
+    grid_cols: u16,
+}
+
+/// Blocking terminal runtime for the shared layout. Network tasks keep streams independent while
+/// this loop only drains ready channels and renders the current fixed grids.
+pub struct SharedLayoutRuntime {
+    tui: MultiPaneTui,
+    control: SharedControl,
+    panes: PaneServer,
+    reconciler: PaneLayoutReconciler,
+    transport: Transport,
+    session_id: Vec<u8>,
+    runtime: tokio::runtime::Handle,
+    local: BTreeMap<PaneId, SharedLocalPane>,
+    remote: BTreeMap<PaneId, SharedRemotePane>,
+    pending_subscriptions: BTreeSet<PaneId>,
+    subscription_tx: tokio::sync::mpsc::UnboundedSender<(PaneId, Result<GuestPane, String>)>,
+    subscription_rx: tokio::sync::mpsc::UnboundedReceiver<(PaneId, Result<GuestPane, String>)>,
+    pending_create: Option<PendingCreate>,
+    provisional: BTreeMap<u64, PaneId>,
+    next_request_id: u64,
+    status: String,
+    join_code: Option<String>,
+}
+
+impl SharedLayoutRuntime {
+    pub fn host(
+        host: SharedLayoutHost,
+        panes: PaneServer,
+        snapshot: LayoutSnapshot,
+        initial: SharedLocalPane,
+        join_code: String,
+        runtime: tokio::runtime::Handle,
+    ) -> Result<Self, Box<dyn Error>> {
+        let transport = host.transport();
+        Self::new(
+            SharedControl::Host(host),
+            panes,
+            transport,
+            snapshot,
+            Some(initial),
+            Some(join_code),
+            runtime,
+        )
+    }
+
+    pub fn member(
+        member: SharedLayoutMember,
+        panes: PaneServer,
+        session_id: Vec<u8>,
+        snapshot: LayoutSnapshot,
+        runtime: tokio::runtime::Handle,
+    ) -> Result<Self, Box<dyn Error>> {
+        let transport = member.transport();
+        let mut value = Self::new(
+            SharedControl::Member(member),
+            panes,
+            transport,
+            snapshot,
+            None,
+            None,
+            runtime,
+        )?;
+        value.session_id = session_id;
+        Ok(value)
+    }
+
+    /// Builds a member runtime from the first authoritative snapshot. Applying the state before
+    /// entering raw-terminal mode both establishes the direct-pane admission roster and starts
+    /// nonblocking subscriptions for panes hosted by other members.
+    pub fn member_from_state(
+        member: SharedLayoutMember,
+        panes: PaneServer,
+        session_id: Vec<u8>,
+        state: crate::protocol::LayoutState,
+        runtime: tokio::runtime::Handle,
+    ) -> Result<Self, Box<dyn Error>> {
+        let snapshot = layout_snapshot_from_state(&state)
+            .map_err(|error| io::Error::other(format!("invalid layout state: {error:?}")))?;
+        let mut value = Self::member(member, panes, session_id, snapshot, runtime)?;
+        value.apply_layout_state(&state)?;
+        Ok(value)
+    }
+
+    fn new(
+        control: SharedControl,
+        panes: PaneServer,
+        transport: Transport,
+        snapshot: LayoutSnapshot,
+        initial: Option<SharedLocalPane>,
+        join_code: Option<String>,
+        runtime: tokio::runtime::Handle,
+    ) -> Result<Self, Box<dyn Error>> {
+        let (subscription_tx, subscription_rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut local = BTreeMap::new();
+        if let Some(initial) = initial {
+            local.insert(initial.pane_id, initial);
+        }
+        let session_id = Vec::new();
+        let reconciler = PaneLayoutReconciler::new(panes.clone());
+        let mut value = Self {
+            tui: MultiPaneTui::new(snapshot)
+                .map_err(|error| io::Error::other(format!("invalid layout: {error:?}")))?,
+            control,
+            panes,
+            reconciler,
+            transport,
+            session_id,
+            runtime,
+            local,
+            remote: BTreeMap::new(),
+            pending_subscriptions: BTreeSet::new(),
+            subscription_tx,
+            subscription_rx,
+            pending_create: None,
+            provisional: BTreeMap::new(),
+            next_request_id: 1,
+            status: String::new(),
+            join_code,
+        };
+        value.refresh_local_views();
+        Ok(value)
+    }
+
+    pub fn set_session_id(&mut self, session_id: Vec<u8>) {
+        self.session_id = session_id;
+    }
+
+    pub fn run(mut self) -> Result<(), Box<dyn Error>> {
+        let (cols, rows) = terminal::size()?;
+        let mut guard = TerminalGuard::new();
+        enable_raw_mode()?;
+        guard.raw_mode = true;
+        guard.alternate_screen = true;
+        execute!(io::stdout(), EnterAlternateScreen)?;
+        guard.bracketed_paste = true;
+        execute!(io::stdout(), crossterm::event::EnableBracketedPaste)?;
+        let backend = CrosstermBackend::new(io::stdout());
+        let mut terminal = Terminal::with_options(
+            backend,
+            TerminalOptions {
+                viewport: Viewport::Fixed(Rect::new(0, 0, cols, rows)),
+            },
+        )?;
+        let mut dirty = true;
+        loop {
+            dirty |= self.drain()?;
+            if dirty {
+                let mut screens = BTreeMap::new();
+                for (pane_id, pane) in &self.local {
+                    screens.insert(*pane_id, pane.screen.screen());
+                }
+                for (pane_id, pane) in &self.remote {
+                    if let Some(screen) = pane.screen.screen() {
+                        screens.insert(*pane_id, screen);
+                    }
+                }
+                terminal.draw(|frame| {
+                    let area = frame.area();
+                    render_multi_pane(frame, &self.tui, &screens);
+                    if !self.status.is_empty() && area.height > 0 {
+                        frame.buffer_mut().set_string(
+                            area.x,
+                            area.bottom().saturating_sub(1),
+                            &self.status,
+                            Style::default().fg(Color::Red),
+                        );
+                    }
+                    if let Some(join_code) = &self.join_code
+                        && area.height > 0
+                    {
+                        let text = format!("join: p2pmux join {join_code}");
+                        frame.buffer_mut().set_string(
+                            area.x,
+                            area.bottom().saturating_sub(1),
+                            text,
+                            Style::default().fg(Color::DarkGray),
+                        );
+                    }
+                })?;
+                dirty = false;
+            }
+            if !event::poll(Duration::from_millis(16))? {
+                continue;
+            }
+            match event::read()? {
+                Event::Key(key)
+                    if matches!(key.kind, KeyEventKind::Press | KeyEventKind::Repeat) =>
+                {
+                    match self.tui.handle_key(key, Rect::new(0, 0, cols, rows)) {
+                        KeyHandling::Quit => break,
+                        KeyHandling::TakeControl => self.take_control()?,
+                        KeyHandling::Consumed(intents) => {
+                            for intent in intents {
+                                self.handle_intent(intent)?;
+                            }
+                        }
+                        KeyHandling::Forward => self.forward_key(key)?,
+                    }
+                    dirty = true;
+                }
+                Event::Paste(text) => {
+                    self.forward_paste(&text)?;
+                    dirty = true;
+                }
+                Event::Resize(_, _) => dirty = true,
+                _ => {}
+            }
+        }
+        self.shutdown();
+        Ok(())
+    }
+
+    fn drain(&mut self) -> Result<bool, Box<dyn Error>> {
+        let mut changed = false;
+        while let Some(event) = self.control.try_event(self.tui.snapshot().revision) {
+            self.handle_control_event(event)?;
+            changed = true;
+        }
+        while let Ok((pane_id, result)) = self.subscription_rx.try_recv() {
+            self.pending_subscriptions.remove(&pane_id);
+            match result {
+                Ok(pane) => {
+                    self.remote.insert(pane_id, SharedRemotePane::new(pane));
+                }
+                Err(error) => self.status = format!("pane {pane_id}: {error}"),
+            }
+            changed = true;
+        }
+        for pane in self.local.values_mut() {
+            changed |= pane.drain()?;
+        }
+        for pane in self.remote.values_mut() {
+            changed |= pane.drain();
+        }
+        self.refresh_local_views();
+        Ok(changed)
+    }
+
+    fn refresh_local_views(&mut self) {
+        for (pane_id, pane) in &self.local {
+            self.tui.set_pane_view(*pane_id, pane.view_state());
+        }
+        for (pane_id, pane) in &self.remote {
+            self.tui.set_pane_view(*pane_id, pane.view_state());
+        }
+    }
+
+    fn handle_control_event(&mut self, event: LayoutControlEvent) -> Result<(), Box<dyn Error>> {
+        self.reconciler.apply(&event)?;
+        match event {
+            LayoutControlEvent::Snapshot(snapshot) => {
+                self.apply_layout_state(snapshot.state.as_ref().ok_or("missing layout state")?)?;
+            }
+            LayoutControlEvent::Commit(commit) => {
+                self.apply_layout_state(commit.state.as_ref().ok_or("missing layout state")?)?;
+            }
+            LayoutControlEvent::Reservation(reservation) => self.accept_reservation(reservation)?,
+            LayoutControlEvent::Reject(reject) => self.reject_request(reject.request_id),
+            LayoutControlEvent::Disconnected => {
+                self.status = String::from("layout coordinator disconnected")
+            }
+        }
+        Ok(())
+    }
+
+    fn apply_layout_state(
+        &mut self,
+        state: &crate::protocol::LayoutState,
+    ) -> Result<(), Box<dyn Error>> {
+        let snapshot = layout_snapshot_from_state(state)
+            .map_err(|error| io::Error::other(format!("invalid layout state: {error:?}")))?;
+        let current_ids = snapshot.panes.keys().copied().collect::<BTreeSet<_>>();
+        let local_ids = self.local.keys().copied().collect::<Vec<_>>();
+        for pane_id in local_ids {
+            if !current_ids.contains(&pane_id) {
+                let _ = self.panes.remove_local_pane(pane_id)?;
+                if let Some(mut pane) = self.local.remove(&pane_id) {
+                    pane.shutdown()?;
+                }
+            }
+        }
+        let remote_ids = self.remote.keys().copied().collect::<Vec<_>>();
+        for pane_id in remote_ids {
+            if !current_ids.contains(&pane_id)
+                && let Some(pane) = self.remote.remove(&pane_id)
+            {
+                self.runtime.block_on(pane.pane.shutdown());
+            }
+        }
+        self.tui
+            .apply_snapshot(snapshot.clone())
+            .map_err(|error| io::Error::other(format!("invalid layout state: {error:?}")))?;
+        let me = self.control.peer_id();
+        for pane in state.panes.iter().filter(|pane| pane.host_peer_id != me) {
+            if self.remote.contains_key(&pane.pane_id)
+                || self.pending_subscriptions.contains(&pane.pane_id)
+            {
+                continue;
+            }
+            let endpoint = state
+                .members
+                .iter()
+                .find(|member| member.peer_id == pane.host_peer_id)
+                .and_then(|member| serde_json::from_slice(&member.endpoint_addr).ok());
+            let Some(endpoint) = endpoint else {
+                self.status = format!("pane {} has no usable host address", pane.pane_id);
+                continue;
+            };
+            self.pending_subscriptions.insert(pane.pane_id);
+            let tx = self.subscription_tx.clone();
+            let transport = self.transport.clone();
+            let session_id = self.session_id.clone();
+            let descriptor = pane.clone();
+            let pane_id = pane.pane_id;
+            self.runtime.spawn(async move {
+                let result = subscribe_pane(transport, session_id, endpoint, descriptor)
+                    .await
+                    .map_err(|error| error.to_string());
+                let _ = tx.send((pane_id, result));
+            });
+        }
+        self.refresh_local_views();
+        Ok(())
+    }
+
+    fn handle_intent(&mut self, intent: UiIntent) -> Result<(), Box<dyn Error>> {
+        match intent {
+            UiIntent::CreatePane {
+                target_pane_id,
+                axis,
+                grid_rows,
+                grid_cols,
+            } => {
+                self.begin_create(Some((target_pane_id, axis)), grid_rows, grid_cols)?;
+            }
+            UiIntent::CreateTab {
+                grid_rows,
+                grid_cols,
+            } => {
+                self.begin_create(None, grid_rows, grid_cols)?;
+            }
+            UiIntent::DeletePane { pane_id } => {
+                let request_id = self.next_id();
+                self.send_request(LayoutRequest {
+                    request_id,
+                    base_revision: self.tui.snapshot().revision,
+                    create_pane: None,
+                    delete_pane: Some(DeletePane { pane_id }),
+                    create_tab: None,
+                    delete_tab: None,
+                })?
+            }
+            UiIntent::DeleteTab { tab_id } => {
+                let request_id = self.next_id();
+                self.send_request(LayoutRequest {
+                    request_id,
+                    base_revision: self.tui.snapshot().revision,
+                    create_pane: None,
+                    delete_pane: None,
+                    create_tab: None,
+                    delete_tab: Some(DeleteTab { tab_id }),
+                })?
+            }
+            UiIntent::FocusPane { .. } | UiIntent::SwitchTab { .. } => {}
+        }
+        Ok(())
+    }
+
+    fn begin_create(
+        &mut self,
+        pane: Option<(PaneId, Axis)>,
+        grid_rows: u16,
+        grid_cols: u16,
+    ) -> Result<(), Box<dyn Error>> {
+        if self.pending_create.is_some() {
+            self.status = String::from("waiting for current pane reservation");
+            return Ok(());
+        }
+        let request_id = self.next_id();
+        let base_revision = self.tui.snapshot().revision;
+        self.pending_create = Some(PendingCreate {
+            request_id,
+            base_revision,
+            grid_rows,
+            grid_cols,
+        });
+        self.send_request(LayoutRequest {
+            request_id,
+            base_revision,
+            create_pane: pane.map(|(target_pane_id, axis)| CreatePane {
+                target_pane_id,
+                axis: Some(match axis {
+                    Axis::LeftRight => SplitAxis::LeftRight as i32,
+                    Axis::TopBottom => SplitAxis::TopBottom as i32,
+                }),
+                grid_rows: u32::from(grid_rows),
+                grid_cols: u32::from(grid_cols),
+            }),
+            delete_pane: None,
+            create_tab: pane.is_none().then_some(CreateTab {
+                grid_rows: u32::from(grid_rows),
+                grid_cols: u32::from(grid_cols),
+            }),
+            delete_tab: None,
+        })
+    }
+
+    fn send_request(&mut self, request: LayoutRequest) -> Result<(), Box<dyn Error>> {
+        if let Some(response) = self.control.try_request(request)? {
+            match response {
+                CoordinatorResponse::Reservation(reservation) => {
+                    self.accept_reservation(reservation)?
+                }
+                CoordinatorResponse::Commit(commit) => {
+                    self.handle_control_event(LayoutControlEvent::Commit(commit))?
+                }
+                CoordinatorResponse::Reject(reject) => self.reject_request(reject.request_id),
+            }
+        }
+        Ok(())
+    }
+
+    fn accept_reservation(
+        &mut self,
+        reservation: crate::protocol::PaneReservation,
+    ) -> Result<(), Box<dyn Error>> {
+        let Some(pending) = self.pending_create.take() else {
+            self.status = String::from("unexpected pane reservation");
+            return Ok(());
+        };
+        let host_peer_id = self.control.peer_id();
+        let pane = match SharedLocalPane::spawn(
+            reservation.pane_id,
+            pending.grid_rows,
+            pending.grid_cols,
+            host_peer_id.clone(),
+        ) {
+            Ok(pane) => pane,
+            Err(error) => {
+                let _ = self.control.try_failed(PaneFailed {
+                    reservation_id: reservation.reservation_id,
+                    request_id: pending.request_id,
+                    base_revision: pending.base_revision,
+                });
+                self.status = format!("pane spawn failed: {error}");
+                return Ok(());
+            }
+        };
+        let descriptor = PaneDescriptor {
+            pane_id: reservation.pane_id,
+            host_peer_id,
+            grid_rows: u32::from(pending.grid_rows),
+            grid_cols: u32::from(pending.grid_cols),
+        };
+        if let Err(error) = self.panes.register_local_pane(descriptor, pane.channels()) {
+            let _ = self.control.try_failed(PaneFailed {
+                reservation_id: reservation.reservation_id,
+                request_id: pending.request_id,
+                base_revision: pending.base_revision,
+            });
+            self.status = format!("pane registration failed: {error}");
+            return Ok(());
+        }
+        self.provisional
+            .insert(pending.request_id, reservation.pane_id);
+        self.local.insert(reservation.pane_id, pane);
+        if let Some(tab_id) = reservation.tab_id {
+            self.tui.select_created_tab(tab_id);
+        }
+        match self.control.try_ready(PaneReady {
+            reservation_id: reservation.reservation_id,
+            request_id: pending.request_id,
+            base_revision: pending.base_revision,
+        })? {
+            Some(CoordinatorResponse::Commit(commit)) => {
+                self.handle_control_event(LayoutControlEvent::Commit(commit))?
+            }
+            Some(CoordinatorResponse::Reject(reject)) => self.reject_request(reject.request_id),
+            Some(CoordinatorResponse::Reservation(_)) | None => {}
+        }
+        Ok(())
+    }
+
+    fn reject_request(&mut self, request_id: u64) {
+        self.pending_create = self
+            .pending_create
+            .filter(|pending| pending.request_id != request_id);
+        if let Some(pane_id) = self.provisional.remove(&request_id) {
+            let _ = self.panes.remove_local_pane(pane_id);
+            if let Some(mut pane) = self.local.remove(&pane_id) {
+                let _ = pane.shutdown();
+            }
+        }
+        self.status = format!("layout request {request_id} rejected");
+    }
+
+    fn next_id(&mut self) -> u64 {
+        let id = self.next_request_id;
+        self.next_request_id = self.next_request_id.saturating_add(1).max(1);
+        id
+    }
+
+    fn take_control(&mut self) -> Result<(), Box<dyn Error>> {
+        let pane_id = self.tui.focused_pane();
+        if let Some(pane) = self.local.get_mut(&pane_id) {
+            pane.take_control()?;
+        }
+        if let Some(pane) = self.remote.get_mut(&pane_id) {
+            pane.take_control();
+        }
+        Ok(())
+    }
+
+    fn forward_key(&mut self, key: KeyEvent) -> Result<(), Box<dyn Error>> {
+        let pane_id = self.tui.focused_pane();
+        if let Some(pane) = self.local.get_mut(&pane_id)
+            && let Some(bytes) = encode_key(key, pane.screen.screen())
+        {
+            pane.input(bytes)?;
+        }
+        if let Some(pane) = self.remote.get_mut(&pane_id)
+            && let Some(screen) = pane.screen.screen()
+            && let Some(bytes) = encode_key(key, screen)
+        {
+            pane.input(bytes);
+        }
+        Ok(())
+    }
+
+    fn forward_paste(&mut self, text: &str) -> Result<(), Box<dyn Error>> {
+        let pane_id = self.tui.focused_pane();
+        if let Some(pane) = self.local.get_mut(&pane_id) {
+            pane.input(encode_paste(text, pane.screen.screen().bracketed_paste()))?;
+        }
+        if let Some(pane) = self.remote.get_mut(&pane_id)
+            && let Some(screen) = pane.screen.screen()
+        {
+            pane.input(encode_paste(text, screen.bracketed_paste()));
+        }
+        Ok(())
+    }
+
+    fn shutdown(mut self) {
+        for (_, mut pane) in std::mem::take(&mut self.local) {
+            let _ = self.panes.remove_local_pane(pane.pane_id);
+            let _ = pane.shutdown();
+        }
+        for (_, pane) in std::mem::take(&mut self.remote) {
+            self.runtime.block_on(pane.pane.shutdown());
+        }
+        self.runtime.block_on(self.control.shutdown());
     }
 }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -273,7 +273,7 @@ impl MultiPaneTui {
                 let (grid_rows, grid_cols) = grid_for_pane(rect);
                 Some(UiIntent::CreatePane {
                     target_pane_id: self.focused_pane,
-                    axis: if rect.width >= rect.height {
+                    axis: if rect.width > rect.height {
                         Axis::LeftRight
                     } else {
                         Axis::TopBottom
@@ -442,11 +442,15 @@ fn allocate_node(node: &Node, area: Rect, panes: &mut BTreeMap<PaneId, Rect>) {
     }
 }
 
-fn grid_for_pane(rect: Rect) -> (u16, u16) {
+pub(crate) fn grid_for_pane(rect: Rect) -> (u16, u16) {
     (
         rect.height.saturating_sub(2).max(1),
         rect.width.saturating_sub(2).max(1),
     )
+}
+
+pub(crate) fn initial_root_pane_grid(cols: u16, rows: u16) -> (u16, u16) {
+    grid_for_pane(Rect::new(0, 0, cols, rows.saturating_sub(2)))
 }
 
 fn rect_center(rect: Rect) -> (u32, u32) {
@@ -2390,8 +2394,9 @@ mod tests {
     use super::{
         ChordMode, HostControlEvent, HostPaneChannels, KeyHandling, LayoutControlEvent,
         MultiPaneTui, PaneViewState, RemoteSubscriptionState, SharedLayoutRuntime, SharedLocalPane,
-        UiIntent, VtScreen, encode_key, encode_paste, pane_wire_id, render_guest_screen,
-        render_multi_pane, render_shared_multi_pane, shared_footer_text,
+        UiIntent, VtScreen, encode_key, encode_paste, grid_for_pane, initial_root_pane_grid,
+        pane_wire_id, render_guest_screen, render_multi_pane, render_shared_multi_pane,
+        shared_footer_text,
     };
 
     fn layout(tabs: Vec<Tab>, panes: &[(u64, u16, u16)]) -> LayoutSnapshot {
@@ -2980,6 +2985,54 @@ mod tests {
             KeyHandling::Consumed(vec![UiIntent::FocusPane { pane_id: 2 }])
         );
         assert_eq!(tui.focused_pane(), 2);
+    }
+
+    #[test]
+    fn initial_root_pane_grid_matches_its_bordered_viewport() {
+        let tui = MultiPaneTui::new(layout(
+            vec![Tab {
+                tab_id: 1,
+                root: Node::Leaf { pane_id: 1 },
+            }],
+            &[(1, 1, 1)],
+        ))
+        .expect("valid layout");
+
+        let pane = tui
+            .geometry(Rect::new(0, 0, 80, 24))
+            .panes
+            .get(&1)
+            .copied()
+            .expect("root pane");
+        assert_eq!(grid_for_pane(pane), (20, 78));
+        assert_eq!(initial_root_pane_grid(80, 24), (20, 78));
+    }
+
+    #[test]
+    fn square_pane_create_chord_splits_top_to_bottom() {
+        let mut tui = MultiPaneTui::new(layout(
+            vec![Tab {
+                tab_id: 1,
+                root: Node::Leaf { pane_id: 1 },
+            }],
+            &[(1, 1, 1)],
+        ))
+        .expect("valid layout");
+        let area = Rect::new(0, 0, 12, 14);
+
+        let _ = tui.handle_key(
+            KeyEvent::new(KeyCode::Char('p'), KeyModifiers::CONTROL),
+            area,
+        );
+        assert_eq!(
+            tui.handle_key(KeyEvent::new(KeyCode::Char('n'), KeyModifiers::NONE), area),
+            KeyHandling::Consumed(vec![UiIntent::CreatePane {
+                target_pane_id: 1,
+                axis: Axis::TopBottom,
+                grid_rows: 10,
+                grid_cols: 10,
+            }])
+        );
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -508,6 +508,28 @@ pub fn render_multi_pane(
     tui: &MultiPaneTui,
     screens: &BTreeMap<PaneId, &vt100::Screen>,
 ) {
+    render_shared_multi_pane(frame, tui, screens, "", None);
+}
+
+fn shared_footer_text(status: &str, join_code: Option<&str>) -> String {
+    let controls = "Ctrl+P panes | Ctrl+T tabs | F9 control | F10 quit";
+    match (status.is_empty(), join_code) {
+        (false, Some(join_code)) => {
+            format!("{status} | {controls} | join: p2pmux join {join_code}")
+        }
+        (false, None) => format!("{status} | {controls}"),
+        (true, Some(join_code)) => format!("{controls} | join: p2pmux join {join_code}"),
+        (true, None) => String::from(controls),
+    }
+}
+
+fn render_shared_multi_pane(
+    frame: &mut Frame<'_>,
+    tui: &MultiPaneTui,
+    screens: &BTreeMap<PaneId, &vt100::Screen>,
+    status: &str,
+    join_code: Option<&str>,
+) {
     let geometry = tui.geometry(frame.area());
     let tabs = tui
         .snapshot
@@ -534,7 +556,7 @@ pub fn render_multi_pane(
         frame.buffer_mut().set_string(
             geometry.footer.x,
             geometry.footer.y,
-            "Ctrl+P panes | Ctrl+T tabs | F9 control | F10 quit",
+            shared_footer_text(status, join_code),
             Style::default().fg(Color::DarkGray),
         );
     }
@@ -673,9 +695,21 @@ impl SharedLocalPane {
                             Instant::now(),
                         )?
                     };
-                    if let LeaseDecision::Publish(state) = decision {
-                        self.lease_tx.send_replace(state);
-                        changed = true;
+                    match decision {
+                        LeaseDecision::Publish(state) => {
+                            self.lease_tx.send_replace(state);
+                            changed = true;
+                        }
+                        // A normal request while the holder is active does not change the lease,
+                        // but the requester needs an authoritative re-publication to clear its
+                        // pending claim and try again after the idle timeout.
+                        LeaseDecision::RejectActiveController => {
+                            self.lease_tx.send_replace(self.lease.state().clone());
+                            changed = true;
+                        }
+                        LeaseDecision::AcceptInput(_)
+                        | LeaseDecision::RejectStaleInput
+                        | LeaseDecision::RejectStaleRequest => {}
                     }
                 }
             }
@@ -744,6 +778,13 @@ struct SharedRemotePane {
     held_input: Vec<u8>,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RemotePaneDrain {
+    Unchanged,
+    Changed,
+    Disconnected,
+}
+
 impl SharedRemotePane {
     fn new(pane: GuestPane) -> Self {
         Self {
@@ -770,7 +811,7 @@ impl SharedRemotePane {
         }
     }
 
-    fn drain(&mut self) -> bool {
+    fn drain(&mut self) -> RemotePaneDrain {
         let mut changed = false;
         loop {
             match self.pane.events.try_recv() {
@@ -798,7 +839,9 @@ impl SharedRemotePane {
                 }
                 Ok(GuestEvent::ScreenGap { .. }) => {}
                 Ok(GuestEvent::Disconnected)
-                | Err(tokio::sync::mpsc::error::TryRecvError::Disconnected) => return true,
+                | Err(tokio::sync::mpsc::error::TryRecvError::Disconnected) => {
+                    return RemotePaneDrain::Disconnected;
+                }
                 Err(tokio::sync::mpsc::error::TryRecvError::Empty) => break,
             }
         }
@@ -822,7 +865,11 @@ impl SharedRemotePane {
                 self.held_input = bytes;
             }
         }
-        changed
+        if changed {
+            RemotePaneDrain::Changed
+        } else {
+            RemotePaneDrain::Unchanged
+        }
     }
 
     fn take_control(&mut self) {
@@ -1170,27 +1217,13 @@ impl SharedLayoutRuntime {
                     }
                 }
                 terminal.draw(|frame| {
-                    let area = frame.area();
-                    render_multi_pane(frame, &self.tui, &screens);
-                    if !self.status.is_empty() && area.height > 0 {
-                        frame.buffer_mut().set_string(
-                            area.x,
-                            area.bottom().saturating_sub(1),
-                            &self.status,
-                            Style::default().fg(Color::Red),
-                        );
-                    }
-                    if let Some(join_code) = &self.join_code
-                        && area.height > 0
-                    {
-                        let text = format!("join: p2pmux join {join_code}");
-                        frame.buffer_mut().set_string(
-                            area.x,
-                            area.bottom().saturating_sub(1),
-                            text,
-                            Style::default().fg(Color::DarkGray),
-                        );
-                    }
+                    render_shared_multi_pane(
+                        frame,
+                        &self.tui,
+                        &screens,
+                        &self.status,
+                        self.join_code.as_deref(),
+                    );
                 })?;
                 dirty = false;
             }
@@ -1239,7 +1272,7 @@ impl SharedLayoutRuntime {
                         self.subscriptions.succeeded(pane_id);
                         self.remote.insert(pane_id, SharedRemotePane::new(pane));
                     } else {
-                        self.runtime.block_on(pane.shutdown());
+                        self.spawn_remote_shutdown(pane);
                     }
                 }
                 Err(error) => {
@@ -1253,11 +1286,34 @@ impl SharedLayoutRuntime {
         for pane in self.local.values_mut() {
             changed |= pane.drain()?;
         }
-        for pane in self.remote.values_mut() {
-            changed |= pane.drain();
+        let disconnected = self
+            .remote
+            .iter_mut()
+            .filter_map(|(pane_id, pane)| match pane.drain() {
+                RemotePaneDrain::Unchanged => None,
+                RemotePaneDrain::Changed => {
+                    changed = true;
+                    None
+                }
+                RemotePaneDrain::Disconnected => Some(*pane_id),
+            })
+            .collect::<Vec<_>>();
+        for pane_id in disconnected {
+            if let Some(pane) = self.remote.remove(&pane_id) {
+                self.spawn_remote_shutdown(pane.pane);
+            }
+            if self.remote_descriptors.contains_key(&pane_id) {
+                self.subscriptions.failed(pane_id, self.retry_tick);
+                self.status = format!("pane {pane_id} disconnected; retrying");
+            }
+            changed = true;
         }
         self.refresh_local_views();
         Ok(changed)
+    }
+
+    fn spawn_remote_shutdown(&self, pane: GuestPane) {
+        self.runtime.spawn(async move { pane.shutdown().await });
     }
 
     fn refresh_local_views(&mut self) {
@@ -1294,6 +1350,11 @@ impl SharedLayoutRuntime {
         let snapshot = layout_snapshot_from_state(state)
             .map_err(|error| io::Error::other(format!("invalid layout state: {error:?}")))?;
         let current_ids = snapshot.panes.keys().copied().collect::<BTreeSet<_>>();
+        // A successful authoritative commit is the only point at which a provisional local PTY
+        // becomes a real pane. Forget the request bookkeeping then; rejection handles the other
+        // path and tears the provisional PTY down.
+        self.provisional
+            .retain(|_, pane_id| !current_ids.contains(pane_id));
         let local_ids = self.local.keys().copied().collect::<Vec<_>>();
         for pane_id in local_ids {
             if !current_ids.contains(&pane_id) {
@@ -1308,7 +1369,7 @@ impl SharedLayoutRuntime {
             if !current_ids.contains(&pane_id)
                 && let Some(pane) = self.remote.remove(&pane_id)
             {
-                self.runtime.block_on(pane.pane.shutdown());
+                self.spawn_remote_shutdown(pane.pane);
             }
         }
         self.tui
@@ -2317,7 +2378,7 @@ mod tests {
     };
 
     use crate::layout::{Axis, LayoutSnapshot, Node, Pane, Tab};
-    use crate::lease::LeaseState;
+    use crate::lease::{IDLE_AFTER, LeaseManager, LeaseState};
     use crate::screen::{GuestScreen, HostScreen};
     use crate::{
         protocol::PaneDescriptor,
@@ -2327,9 +2388,10 @@ mod tests {
     use iroh::{Endpoint, RelayMode, endpoint::presets};
 
     use super::{
-        ChordMode, HostPaneChannels, KeyHandling, LayoutControlEvent, MultiPaneTui, PaneViewState,
-        RemoteSubscriptionState, SharedLayoutRuntime, SharedLocalPane, UiIntent, VtScreen,
-        encode_key, encode_paste, pane_wire_id, render_guest_screen, render_multi_pane,
+        ChordMode, HostControlEvent, HostPaneChannels, KeyHandling, LayoutControlEvent,
+        MultiPaneTui, PaneViewState, RemoteSubscriptionState, SharedLayoutRuntime, SharedLocalPane,
+        UiIntent, VtScreen, encode_key, encode_paste, pane_wire_id, render_guest_screen,
+        render_multi_pane, render_shared_multi_pane, shared_footer_text,
     };
 
     fn layout(tabs: Vec<Tab>, panes: &[(u64, u16, u16)]) -> LayoutSnapshot {
@@ -2442,6 +2504,10 @@ mod tests {
             .expect("create intent commits after registering a local pane");
         assert!(runtime.local.contains_key(&2));
         assert!(runtime.panes.has_registered_pane(2).expect("pane registry"));
+        assert!(
+            runtime.provisional.is_empty(),
+            "committed panes clear provisional state"
+        );
         assert_eq!(runtime.tui.snapshot().panes.len(), 2);
 
         runtime
@@ -2473,25 +2539,26 @@ mod tests {
             last_activity: Instant::now(),
         });
         let (control_tx, _control_rx) = mpsc::channel(8);
+        let descriptor = PaneDescriptor {
+            pane_id: 1,
+            host_peer_id: host_id.clone(),
+            grid_rows: 1,
+            grid_cols: 1,
+        };
         host_panes
             .register_local_pane(
-                PaneDescriptor {
-                    pane_id: 1,
-                    host_peer_id: host_id.clone(),
-                    grid_rows: 1,
-                    grid_cols: 1,
-                },
+                descriptor.clone(),
                 HostPaneChannels {
                     pane_id: pane_wire_id(1),
                     host_peer_id: host_id,
-                    screen_rx,
-                    lease_rx,
-                    control_tx,
+                    screen_rx: screen_rx.clone(),
+                    lease_rx: lease_rx.clone(),
+                    control_tx: control_tx.clone(),
                 },
             )
             .expect("host pane");
         let dispatcher = host
-            .incoming_dispatcher(host_panes)
+            .incoming_dispatcher(host_panes.clone())
             .expect("single dispatcher");
         let dispatcher_task = tokio::spawn(async move { dispatcher.accept_loop().await });
 
@@ -2511,7 +2578,7 @@ mod tests {
             member,
             member_panes,
             host.ticket().session_id().to_vec(),
-            state,
+            state.clone(),
             tokio::runtime::Handle::current(),
         )
         .expect("member runtime");
@@ -2526,7 +2593,132 @@ mod tests {
             runtime.remote.contains_key(&1),
             "remote pane attached from snapshot"
         );
+
+        host_panes
+            .remove_local_pane(1)
+            .expect("remove direct pane")
+            .expect("registered pane");
+        for _ in 0..20 {
+            runtime.drain().expect("runtime drain after direct close");
+            if !runtime.remote.contains_key(&1) {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+        assert!(
+            !runtime.remote.contains_key(&1),
+            "a direct stream close removes the stale remote pane"
+        );
+        host_panes
+            .register_local_pane(
+                descriptor,
+                HostPaneChannels {
+                    pane_id: pane_wire_id(1),
+                    host_peer_id: host.ticket().endpoint_addr().id.as_bytes().to_vec(),
+                    screen_rx,
+                    lease_rx,
+                    control_tx,
+                },
+            )
+            .expect("restore direct pane");
+        runtime
+            .apply_layout_state(&state)
+            .expect("authoritative snapshot nudges reconnect");
+        for _ in 0..20 {
+            runtime.drain().expect("runtime drain after restore");
+            if runtime.remote.contains_key(&1) {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+        assert!(
+            runtime.remote.contains_key(&1),
+            "remote pane reconnects after a transient direct close"
+        );
         dispatcher_task.abort();
+    }
+
+    #[test]
+    fn shared_footer_keeps_status_visible_when_a_join_code_is_present() {
+        let footer = shared_footer_text("layout request rejected", Some("TESTCODE"));
+        assert!(footer.starts_with("layout request rejected"));
+        assert!(footer.contains("Ctrl+P panes"));
+        assert!(footer.contains("join: p2pmux join TESTCODE"));
+    }
+
+    #[test]
+    fn shared_renderer_draws_status_before_join_code_in_the_footer() {
+        let snapshot = layout(
+            vec![Tab {
+                tab_id: 1,
+                root: Node::Leaf { pane_id: 1 },
+            }],
+            &[(1, 1, 1)],
+        );
+        let tui = MultiPaneTui::new(snapshot).expect("layout");
+        let mut terminal = Terminal::new(TestBackend::new(160, 5)).expect("terminal");
+        terminal
+            .draw(|frame| {
+                render_shared_multi_pane(
+                    frame,
+                    &tui,
+                    &BTreeMap::new(),
+                    "layout request rejected",
+                    Some("TESTCODE"),
+                );
+            })
+            .expect("draw");
+        let rendered = terminal
+            .backend()
+            .buffer()
+            .content
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+        assert!(rendered.contains("layout request rejected"));
+        assert!(rendered.contains("join: p2pmux join TESTCODE"));
+    }
+
+    #[test]
+    fn rejected_busy_takeover_republishes_lease_and_idle_takeover_succeeds_without_force() {
+        let owner = b"owner".to_vec();
+        let requester = b"guest".to_vec();
+        let mut pane = SharedLocalPane::spawn(99, 1, 1, owner.clone()).expect("local pane");
+        let mut lease_rx = pane.lease_tx.subscribe();
+        pane.control_tx
+            .try_send(HostControlEvent::TakeControl {
+                peer_id: requester.clone(),
+                request: crate::protocol::TakeControl {
+                    pane_id: pane_wire_id(99),
+                    requester_peer_id: requester.clone(),
+                    known_lease_epoch: 1,
+                    force: false,
+                },
+            })
+            .expect("busy takeover event");
+        pane.drain().expect("drain busy takeover");
+        assert!(lease_rx.has_changed().expect("lease watch"));
+        assert_eq!(lease_rx.borrow_and_update().controller_peer_id, owner);
+
+        pane.lease = LeaseManager::with_epoch_for_test(
+            pane.host_peer_id.clone(),
+            1,
+            Instant::now() - IDLE_AFTER,
+        );
+        pane.control_tx
+            .try_send(HostControlEvent::TakeControl {
+                peer_id: requester.clone(),
+                request: crate::protocol::TakeControl {
+                    pane_id: pane_wire_id(99),
+                    requester_peer_id: requester.clone(),
+                    known_lease_epoch: 1,
+                    force: false,
+                },
+            })
+            .expect("idle takeover event");
+        pane.drain().expect("drain idle takeover");
+        assert_eq!(pane.lease.state().controller_peer_id, requester);
+        assert_eq!(pane.lease.state().epoch, 2);
     }
 
     fn split_layout() -> LayoutSnapshot {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -49,7 +49,6 @@ pub enum ChordMode {
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct PaneViewState {
     pub ready: bool,
-    pub host_peer_id: Vec<u8>,
     pub controller_peer_id: Option<Vec<u8>>,
     pub controller_active: bool,
 }
@@ -107,6 +106,7 @@ pub struct MultiPaneTui {
     focused_pane: PaneId,
     chord_mode: ChordMode,
     pane_views: BTreeMap<PaneId, PaneViewState>,
+    pending_created_tab: Option<TabId>,
 }
 
 impl MultiPaneTui {
@@ -116,16 +116,8 @@ impl MultiPaneTui {
         let focused_pane = first_leaf(&snapshot.tabs[0].root).expect("validated layout has a leaf");
         let pane_views = snapshot
             .panes
-            .values()
-            .map(|pane| {
-                (
-                    pane.pane_id,
-                    PaneViewState {
-                        host_peer_id: pane.host_peer_id.clone(),
-                        ..PaneViewState::default()
-                    },
-                )
-            })
+            .keys()
+            .map(|pane_id| (*pane_id, PaneViewState::default()))
             .collect();
         Ok(Self {
             snapshot,
@@ -133,6 +125,7 @@ impl MultiPaneTui {
             focused_pane,
             chord_mode: ChordMode::None,
             pane_views,
+            pending_created_tab: None,
         })
     }
 
@@ -162,6 +155,12 @@ impl MultiPaneTui {
         }
     }
 
+    /// Select a tab only when the coordinator publishes the exact ID reserved for this member.
+    pub fn select_created_tab(&mut self, tab_id: TabId) {
+        self.pending_created_tab = Some(tab_id);
+        self.repair_selection();
+    }
+
     pub fn apply_snapshot(&mut self, snapshot: LayoutSnapshot) -> Result<(), LayoutError> {
         crate::layout::SessionState::validate_snapshot(&snapshot)?;
         let old_views = std::mem::take(&mut self.pane_views);
@@ -169,8 +168,7 @@ impl MultiPaneTui {
             .panes
             .values()
             .map(|pane| {
-                let mut state = old_views.get(&pane.pane_id).cloned().unwrap_or_default();
-                state.host_peer_id = pane.host_peer_id.clone();
+                let state = old_views.get(&pane.pane_id).cloned().unwrap_or_default();
                 (pane.pane_id, state)
             })
             .collect();
@@ -307,7 +305,7 @@ impl MultiPaneTui {
         let geometry = self.geometry(area);
         let source = *geometry.panes.get(&self.focused_pane)?;
         let source_center = rect_center(source);
-        let mut candidates = geometry
+        let candidates = geometry
             .panes
             .iter()
             .filter(|(pane_id, _)| **pane_id != self.focused_pane)
@@ -316,23 +314,12 @@ impl MultiPaneTui {
         if candidates.is_empty() {
             return None;
         }
-        let directed = candidates
+        let pane_id = candidates
             .iter()
             .copied()
             .filter(|(_, rect)| is_in_direction(source_center, rect_center(*rect), direction))
             .min_by_key(|(pane_id, rect)| {
                 direction_distance(source_center, rect_center(*rect), direction, *pane_id)
-            });
-        let pane_id = directed
-            .or_else(|| {
-                candidates.sort_by_key(|(pane_id, rect)| {
-                    let center = rect_center(*rect);
-                    (
-                        source_center.0.abs_diff(center.0) + source_center.1.abs_diff(center.1),
-                        *pane_id,
-                    )
-                });
-                candidates.first().copied()
             })?
             .0;
         self.focused_pane = pane_id;
@@ -365,6 +352,14 @@ impl MultiPaneTui {
     }
 
     fn repair_selection(&mut self) {
+        if let Some(tab_id) = self.pending_created_tab
+            && let Some(tab) = self.snapshot.tabs.iter().find(|tab| tab.tab_id == tab_id)
+        {
+            self.current_tab = tab_id;
+            self.focused_pane = first_leaf(&tab.root).expect("validated layout has a leaf");
+            self.pending_created_tab = None;
+            return;
+        }
         let current_tab = self.current_tab_layout();
         let current_tab = if let Some(tab) = current_tab {
             tab
@@ -545,7 +540,7 @@ pub fn render_multi_pane(
         let title = format!(
             "{} host:{} {lease}",
             if focused { "*" } else { " " },
-            short_peer(&view.host_peer_id)
+            short_peer(&pane.host_peer_id)
         );
         let border_color = if focused {
             Color::Yellow
@@ -558,10 +553,20 @@ pub fn render_multi_pane(
         let inner = block.inner(rect);
         frame.render_widget(block, rect);
         if let Some(screen) = screens.get(&pane_id) {
-            frame.render_widget(
-                VtScreen::new(screen),
-                fixed_grid_viewport(inner, pane.grid_rows, pane.grid_cols),
-            );
+            let viewport = fixed_grid_viewport(inner, pane.grid_rows, pane.grid_cols);
+            frame.render_widget(VtScreen::new(screen), viewport);
+            let (row, col) = screen.cursor_position();
+            if focused
+                && view.ready
+                && !screen.hide_cursor()
+                && row < viewport.height
+                && col < viewport.width
+            {
+                frame.set_cursor_position((
+                    viewport.x.saturating_add(col),
+                    viewport.y.saturating_add(row),
+                ));
+            }
         } else if !view.ready {
             frame.render_widget(Paragraph::new("waiting for pane snapshot/lease"), inner);
         }
@@ -1414,7 +1419,6 @@ mod tests {
             1,
             PaneViewState {
                 ready: true,
-                host_peer_id: b"host".to_vec(),
                 controller_peer_id: Some(b"peer".to_vec()),
                 controller_active: true,
             },
@@ -1430,6 +1434,99 @@ mod tests {
         assert_eq!(buffer[(1, 1)].symbol(), "*");
         assert!(buffer.content.iter().any(|cell| cell.symbol() == "h"));
         assert!(buffer.content.iter().any(|cell| cell.symbol() == "t"));
+    }
+
+    #[test]
+    fn pane_badge_uses_the_snapshot_host_not_mutable_view_state() {
+        let mut tui = MultiPaneTui::new(layout(
+            vec![Tab {
+                tab_id: 1,
+                root: Node::Leaf { pane_id: 1 },
+            }],
+            &[(1, 2, 2)],
+        ))
+        .expect("valid layout");
+        tui.set_pane_view(
+            1,
+            PaneViewState {
+                ready: true,
+                controller_peer_id: None,
+                controller_active: false,
+            },
+        );
+        let mut terminal = Terminal::new(TestBackend::new(40, 6)).expect("test terminal");
+
+        terminal
+            .draw(|frame| render_multi_pane(frame, &tui, &BTreeMap::new()))
+            .expect("render");
+        let title = (0..40)
+            .map(|x| terminal.backend().buffer()[(x, 1)].symbol())
+            .collect::<String>();
+
+        assert!(title.contains("host:686f7374"));
+        assert!(!title.contains("host:66616b65"));
+    }
+
+    #[test]
+    fn focused_ready_pane_maps_its_visible_vt_cursor_into_the_letterboxed_viewport() {
+        let mut parser = vt100::Parser::new(1, 3, 0);
+        parser.process(b"ab");
+        let mut tui = MultiPaneTui::new(layout(
+            vec![Tab {
+                tab_id: 1,
+                root: Node::Leaf { pane_id: 1 },
+            }],
+            &[(1, 1, 3)],
+        ))
+        .expect("valid layout");
+        tui.set_pane_view(
+            1,
+            PaneViewState {
+                ready: true,
+                controller_peer_id: None,
+                controller_active: false,
+            },
+        );
+        let screens = BTreeMap::from([(1, parser.screen())]);
+        let mut terminal = Terminal::new(TestBackend::new(9, 7)).expect("test terminal");
+
+        terminal
+            .draw(|frame| render_multi_pane(frame, &tui, &screens))
+            .expect("render");
+
+        terminal.backend_mut().assert_cursor_position((5, 3));
+    }
+
+    #[test]
+    fn focused_pane_never_draws_a_hidden_or_clipped_vt_cursor() {
+        for sequence in [b"\x1b[?25l".as_slice(), b"abcd".as_slice()] {
+            let mut parser = vt100::Parser::new(1, 5, 0);
+            parser.process(sequence);
+            let mut tui = MultiPaneTui::new(layout(
+                vec![Tab {
+                    tab_id: 1,
+                    root: Node::Leaf { pane_id: 1 },
+                }],
+                &[(1, 1, 3)],
+            ))
+            .expect("valid layout");
+            tui.set_pane_view(
+                1,
+                PaneViewState {
+                    ready: true,
+                    controller_peer_id: None,
+                    controller_active: false,
+                },
+            );
+            let screens = BTreeMap::from([(1, parser.screen())]);
+            let mut terminal = Terminal::new(TestBackend::new(9, 7)).expect("test terminal");
+
+            terminal
+                .draw(|frame| render_multi_pane(frame, &tui, &screens))
+                .expect("render");
+
+            assert!(!terminal.backend().cursor_visible());
+        }
     }
 
     #[test]
@@ -1562,7 +1659,7 @@ mod tests {
     }
 
     #[test]
-    fn pane_focus_uses_nearest_directional_leaf_then_a_stable_fallback() {
+    fn pane_focus_uses_the_nearest_directional_leaf_and_stops_at_edges() {
         let mut tui = MultiPaneTui::new(split_layout()).expect("valid layout");
         let area = Rect::new(0, 0, 80, 24);
         let _ = tui.handle_key(
@@ -1587,8 +1684,98 @@ mod tests {
         );
         assert_eq!(
             tui.handle_key(KeyEvent::new(KeyCode::Right, KeyModifiers::NONE), area),
-            KeyHandling::Consumed(vec![UiIntent::FocusPane { pane_id: 2 }])
+            KeyHandling::Consumed(vec![])
         );
+        assert_eq!(tui.focused_pane(), 3);
+        let _ = tui.handle_key(
+            KeyEvent::new(KeyCode::Char('p'), KeyModifiers::CONTROL),
+            area,
+        );
+        assert_eq!(
+            tui.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE), area),
+            KeyHandling::Consumed(vec![])
+        );
+        assert_eq!(tui.focused_pane(), 3);
+
+        let mut edge_tui = MultiPaneTui::new(split_layout()).expect("valid layout");
+        let _ = edge_tui.handle_key(
+            KeyEvent::new(KeyCode::Char('p'), KeyModifiers::CONTROL),
+            area,
+        );
+        assert_eq!(
+            edge_tui.handle_key(KeyEvent::new(KeyCode::Left, KeyModifiers::NONE), area),
+            KeyHandling::Consumed(vec![])
+        );
+        assert_eq!(edge_tui.focused_pane(), 1);
+
+        let _ = edge_tui.handle_key(
+            KeyEvent::new(KeyCode::Char('p'), KeyModifiers::CONTROL),
+            area,
+        );
+        let _ = edge_tui.handle_key(KeyEvent::new(KeyCode::Right, KeyModifiers::NONE), area);
+        assert_eq!(edge_tui.focused_pane(), 2);
+        for key in [KeyCode::Up, KeyCode::Right] {
+            let _ = edge_tui.handle_key(
+                KeyEvent::new(KeyCode::Char('p'), KeyModifiers::CONTROL),
+                area,
+            );
+            assert_eq!(
+                edge_tui.handle_key(KeyEvent::new(key, KeyModifiers::NONE), area),
+                KeyHandling::Consumed(vec![])
+            );
+            assert_eq!(edge_tui.focused_pane(), 2);
+        }
+    }
+
+    #[test]
+    fn creator_selects_only_its_explicitly_reserved_tab_after_that_tab_commits() {
+        let mut tui = MultiPaneTui::new(layout(
+            vec![Tab {
+                tab_id: 1,
+                root: Node::Leaf { pane_id: 1 },
+            }],
+            &[(1, 2, 2)],
+        ))
+        .expect("valid layout");
+
+        tui.select_created_tab(2);
+        tui.apply_snapshot(layout(
+            vec![
+                Tab {
+                    tab_id: 1,
+                    root: Node::Leaf { pane_id: 1 },
+                },
+                Tab {
+                    tab_id: 3,
+                    root: Node::Leaf { pane_id: 3 },
+                },
+            ],
+            &[(1, 2, 2), (3, 2, 2)],
+        ))
+        .expect("unrelated commit");
+        assert_eq!(tui.current_tab(), 1);
+
+        tui.apply_snapshot(layout(
+            vec![
+                Tab {
+                    tab_id: 1,
+                    root: Node::Leaf { pane_id: 1 },
+                },
+                Tab {
+                    tab_id: 3,
+                    root: Node::Leaf { pane_id: 3 },
+                },
+                Tab {
+                    tab_id: 2,
+                    root: Node::Leaf { pane_id: 2 },
+                },
+            ],
+            &[(1, 2, 2), (2, 2, 2), (3, 2, 2)],
+        ))
+        .expect("targeted tab commit");
+
+        assert_eq!(tui.current_tab(), 2);
+        assert_eq!(tui.focused_pane(), 2);
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -15,6 +15,7 @@ use crossterm::{
         self, EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
     },
 };
+use iroh::EndpointAddr;
 use portable_pty::PtySize;
 use ratatui::{
     Frame, Terminal, TerminalOptions, Viewport,
@@ -947,6 +948,69 @@ struct PendingCreate {
     grid_cols: u16,
 }
 
+/// Pure retry state for direct remote-pane subscriptions. Ticks are supplied by the UI drain
+/// loop, which keeps retry behavior deterministic in tests and prevents a failed connect from
+/// either becoming permanent or spinning a busy loop.
+#[derive(Default)]
+struct RemoteSubscriptionState {
+    in_flight: BTreeSet<PaneId>,
+    retry_at: BTreeMap<PaneId, u64>,
+    failures: BTreeMap<PaneId, u8>,
+}
+
+impl RemoteSubscriptionState {
+    const MAX_BACKOFF_TICKS: u64 = 32;
+
+    fn start(&mut self, pane_id: PaneId, tick: u64) -> bool {
+        if self.in_flight.contains(&pane_id)
+            || self
+                .retry_at
+                .get(&pane_id)
+                .is_some_and(|retry_at| *retry_at > tick)
+        {
+            return false;
+        }
+        self.in_flight.insert(pane_id);
+        true
+    }
+
+    fn succeeded(&mut self, pane_id: PaneId) {
+        self.in_flight.remove(&pane_id);
+        self.retry_at.remove(&pane_id);
+        self.failures.remove(&pane_id);
+    }
+
+    fn failed(&mut self, pane_id: PaneId, tick: u64) {
+        self.in_flight.remove(&pane_id);
+        let failures = self.failures.entry(pane_id).or_default();
+        *failures = failures.saturating_add(1);
+        let delay = 1_u64
+            .checked_shl(u32::from((*failures).saturating_sub(1)))
+            .unwrap_or(Self::MAX_BACKOFF_TICKS)
+            .min(Self::MAX_BACKOFF_TICKS);
+        self.retry_at.insert(pane_id, tick.saturating_add(delay));
+    }
+
+    fn nudge(&mut self) {
+        for retry_at in self.retry_at.values_mut() {
+            *retry_at = 0;
+        }
+    }
+
+    fn retain(&mut self, pane_ids: &BTreeSet<PaneId>) {
+        self.in_flight.retain(|pane_id| pane_ids.contains(pane_id));
+        self.retry_at
+            .retain(|pane_id, _| pane_ids.contains(pane_id));
+        self.failures
+            .retain(|pane_id, _| pane_ids.contains(pane_id));
+    }
+
+    #[cfg(test)]
+    fn next_retry_at(&self, pane_id: PaneId) -> Option<u64> {
+        self.retry_at.get(&pane_id).copied()
+    }
+}
+
 /// Blocking terminal runtime for the shared layout. Network tasks keep streams independent while
 /// this loop only drains ready channels and renders the current fixed grids.
 pub struct SharedLayoutRuntime {
@@ -959,7 +1023,9 @@ pub struct SharedLayoutRuntime {
     runtime: tokio::runtime::Handle,
     local: BTreeMap<PaneId, SharedLocalPane>,
     remote: BTreeMap<PaneId, SharedRemotePane>,
-    pending_subscriptions: BTreeSet<PaneId>,
+    remote_descriptors: BTreeMap<PaneId, (EndpointAddr, PaneDescriptor)>,
+    subscriptions: RemoteSubscriptionState,
+    retry_tick: u64,
     subscription_tx: tokio::sync::mpsc::UnboundedSender<(PaneId, Result<GuestPane, String>)>,
     subscription_rx: tokio::sync::mpsc::UnboundedReceiver<(PaneId, Result<GuestPane, String>)>,
     pending_create: Option<PendingCreate>,
@@ -1055,7 +1121,9 @@ impl SharedLayoutRuntime {
             runtime,
             local,
             remote: BTreeMap::new(),
-            pending_subscriptions: BTreeSet::new(),
+            remote_descriptors: BTreeMap::new(),
+            subscriptions: RemoteSubscriptionState::default(),
+            retry_tick: 0,
             subscription_tx,
             subscription_rx,
             pending_create: None,
@@ -1159,20 +1227,29 @@ impl SharedLayoutRuntime {
 
     fn drain(&mut self) -> Result<bool, Box<dyn Error>> {
         let mut changed = false;
+        self.retry_tick = self.retry_tick.saturating_add(1);
         while let Some(event) = self.control.try_event(self.tui.snapshot().revision) {
             self.handle_control_event(event)?;
             changed = true;
         }
         while let Ok((pane_id, result)) = self.subscription_rx.try_recv() {
-            self.pending_subscriptions.remove(&pane_id);
             match result {
                 Ok(pane) => {
-                    self.remote.insert(pane_id, SharedRemotePane::new(pane));
+                    if self.remote_descriptors.contains_key(&pane_id) {
+                        self.subscriptions.succeeded(pane_id);
+                        self.remote.insert(pane_id, SharedRemotePane::new(pane));
+                    } else {
+                        self.runtime.block_on(pane.shutdown());
+                    }
                 }
-                Err(error) => self.status = format!("pane {pane_id}: {error}"),
+                Err(error) => {
+                    self.subscriptions.failed(pane_id, self.retry_tick);
+                    self.status = format!("pane {pane_id}: {error}; retrying");
+                }
             }
             changed = true;
         }
+        self.start_eligible_subscriptions();
         for pane in self.local.values_mut() {
             changed |= pane.drain()?;
         }
@@ -1238,12 +1315,8 @@ impl SharedLayoutRuntime {
             .apply_snapshot(snapshot.clone())
             .map_err(|error| io::Error::other(format!("invalid layout state: {error:?}")))?;
         let me = self.control.peer_id();
+        self.remote_descriptors.clear();
         for pane in state.panes.iter().filter(|pane| pane.host_peer_id != me) {
-            if self.remote.contains_key(&pane.pane_id)
-                || self.pending_subscriptions.contains(&pane.pane_id)
-            {
-                continue;
-            }
             let endpoint = state
                 .members
                 .iter()
@@ -1253,12 +1326,31 @@ impl SharedLayoutRuntime {
                 self.status = format!("pane {} has no usable host address", pane.pane_id);
                 continue;
             };
-            self.pending_subscriptions.insert(pane.pane_id);
+            self.remote_descriptors
+                .insert(pane.pane_id, (endpoint, pane.clone()));
+        }
+        let remote_ids = self
+            .remote_descriptors
+            .keys()
+            .copied()
+            .collect::<BTreeSet<_>>();
+        self.subscriptions.retain(&remote_ids);
+        self.subscriptions.nudge();
+        self.start_eligible_subscriptions();
+        self.refresh_local_views();
+        Ok(())
+    }
+
+    fn start_eligible_subscriptions(&mut self) {
+        for (pane_id, (endpoint, descriptor)) in self.remote_descriptors.clone() {
+            if self.remote.contains_key(&pane_id)
+                || !self.subscriptions.start(pane_id, self.retry_tick)
+            {
+                continue;
+            }
             let tx = self.subscription_tx.clone();
             let transport = self.transport.clone();
             let session_id = self.session_id.clone();
-            let descriptor = pane.clone();
-            let pane_id = pane.pane_id;
             self.runtime.spawn(async move {
                 let result = subscribe_pane(transport, session_id, endpoint, descriptor)
                     .await
@@ -1266,8 +1358,6 @@ impl SharedLayoutRuntime {
                 let _ = tx.send((pane_id, result));
             });
         }
-        self.refresh_local_views();
-        Ok(())
     }
 
     fn handle_intent(&mut self, intent: UiIntent) -> Result<(), Box<dyn Error>> {
@@ -2211,7 +2301,12 @@ fn short_peer(peer_id: &[u8]) -> String {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
+    use std::{
+        collections::BTreeMap,
+        net::Ipv4Addr,
+        time::{Duration, Instant},
+    };
+    use tokio::sync::{mpsc, watch};
 
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
     use ratatui::{
@@ -2222,11 +2317,19 @@ mod tests {
     };
 
     use crate::layout::{Axis, LayoutSnapshot, Node, Pane, Tab};
+    use crate::lease::LeaseState;
     use crate::screen::{GuestScreen, HostScreen};
+    use crate::{
+        protocol::PaneDescriptor,
+        session::{HostSession, SharedLayoutHost, layout_snapshot_from_state},
+        transport::{ALPN, Transport},
+    };
+    use iroh::{Endpoint, RelayMode, endpoint::presets};
 
     use super::{
-        ChordMode, KeyHandling, MultiPaneTui, PaneViewState, UiIntent, VtScreen, encode_key,
-        encode_paste, render_guest_screen, render_multi_pane,
+        ChordMode, HostPaneChannels, KeyHandling, LayoutControlEvent, MultiPaneTui, PaneViewState,
+        RemoteSubscriptionState, SharedLayoutRuntime, SharedLocalPane, UiIntent, VtScreen,
+        encode_key, encode_paste, pane_wire_id, render_guest_screen, render_multi_pane,
     };
 
     fn layout(tabs: Vec<Tab>, panes: &[(u64, u16, u16)]) -> LayoutSnapshot {
@@ -2252,6 +2355,178 @@ mod tests {
                 })
                 .collect::<BTreeMap<_, _>>(),
         }
+    }
+
+    #[test]
+    fn failed_remote_subscription_retries_with_bounded_backoff_and_commit_nudge() {
+        let mut subscriptions = RemoteSubscriptionState::default();
+        assert!(subscriptions.start(7, 0));
+        subscriptions.failed(7, 0);
+        assert!(!subscriptions.start(7, 0));
+        assert!(subscriptions.start(7, 1));
+        subscriptions.failed(7, 1);
+        assert!(!subscriptions.start(7, 2));
+        assert!(subscriptions.start(7, 3));
+
+        for tick in [3, 7, 15, 31, 63, 95] {
+            subscriptions.failed(7, tick);
+            assert!(
+                subscriptions
+                    .next_retry_at(7)
+                    .is_some_and(|next| next <= tick + 32)
+            );
+        }
+        subscriptions.nudge();
+        assert!(subscriptions.start(7, 95));
+    }
+
+    async fn loopback_transport() -> Transport {
+        let endpoint = Endpoint::builder(presets::Minimal)
+            .relay_mode(RelayMode::Disabled)
+            .clear_ip_transports()
+            .bind_addr((Ipv4Addr::LOCALHOST, 0))
+            .expect("localhost address")
+            .alpns(vec![ALPN.to_vec()])
+            .bind()
+            .await
+            .expect("loopback endpoint");
+        Transport::from_endpoint(endpoint)
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn runtime_create_then_committed_delete_updates_its_local_pane_lifecycle() {
+        let host = SharedLayoutHost::new(
+            HostSession::from_transport(loopback_transport().await).expect("host session"),
+            2,
+            8,
+        )
+        .expect("shared host");
+        let pane_server = host.pane_server();
+        let host_id = host.ticket().endpoint_addr().id.as_bytes().to_vec();
+        let initial = SharedLocalPane::spawn(1, 2, 8, host_id.clone()).expect("initial pty");
+        pane_server
+            .register_local_pane(
+                PaneDescriptor {
+                    pane_id: 1,
+                    host_peer_id: host_id,
+                    grid_rows: 2,
+                    grid_cols: 8,
+                },
+                initial.channels(),
+            )
+            .expect("initial pane registered");
+        let state = host
+            .session_snapshot()
+            .expect("snapshot")
+            .state
+            .expect("layout state");
+        let snapshot = layout_snapshot_from_state(&state).expect("render layout");
+        let mut runtime = SharedLayoutRuntime::host(
+            host,
+            pane_server,
+            snapshot,
+            initial,
+            String::from("TESTCODE"),
+            tokio::runtime::Handle::current(),
+        )
+        .expect("runtime");
+        runtime.set_session_id(b"session".to_vec());
+
+        runtime
+            .handle_intent(UiIntent::CreatePane {
+                target_pane_id: 1,
+                axis: Axis::LeftRight,
+                grid_rows: 2,
+                grid_cols: 8,
+            })
+            .expect("create intent commits after registering a local pane");
+        assert!(runtime.local.contains_key(&2));
+        assert!(runtime.panes.has_registered_pane(2).expect("pane registry"));
+        assert_eq!(runtime.tui.snapshot().panes.len(), 2);
+
+        runtime
+            .handle_intent(UiIntent::DeletePane { pane_id: 2 })
+            .expect("host-owned deletion commits");
+        assert!(!runtime.local.contains_key(&2));
+        assert!(
+            !runtime.panes.has_registered_pane(2).expect("pane registry"),
+            "committed removal revokes the direct-pane service before the PTY is shut down"
+        );
+        assert_eq!(runtime.tui.snapshot().panes.len(), 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn member_runtime_reconciles_snapshot_into_a_direct_remote_pane_attachment() {
+        let host = SharedLayoutHost::new(
+            HostSession::from_transport(loopback_transport().await).expect("host session"),
+            1,
+            1,
+        )
+        .expect("shared host");
+        let host_panes = host.pane_server();
+        let host_id = host.ticket().endpoint_addr().id.as_bytes().to_vec();
+        let screen = HostScreen::new(1, 1).expect("screen");
+        let (_screen_tx, screen_rx) = watch::channel(screen.current_frame().clone());
+        let (_lease_tx, lease_rx) = watch::channel(LeaseState {
+            controller_peer_id: host_id.clone(),
+            epoch: 1,
+            last_activity: Instant::now(),
+        });
+        let (control_tx, _control_rx) = mpsc::channel(8);
+        host_panes
+            .register_local_pane(
+                PaneDescriptor {
+                    pane_id: 1,
+                    host_peer_id: host_id.clone(),
+                    grid_rows: 1,
+                    grid_cols: 1,
+                },
+                HostPaneChannels {
+                    pane_id: pane_wire_id(1),
+                    host_peer_id: host_id,
+                    screen_rx,
+                    lease_rx,
+                    control_tx,
+                },
+            )
+            .expect("host pane");
+        let dispatcher = host
+            .incoming_dispatcher(host_panes)
+            .expect("single dispatcher");
+        let dispatcher_task = tokio::spawn(async move { dispatcher.accept_loop().await });
+
+        let mut member =
+            crate::session::join_layout(loopback_transport().await, host.ticket().clone())
+                .await
+                .expect("member joins");
+        let LayoutControlEvent::Snapshot(snapshot) = member.events.recv().await.expect("snapshot")
+        else {
+            panic!("member must receive snapshot first");
+        };
+        let state = snapshot.state.expect("state");
+        let member_panes = member
+            .pane_server(host.ticket().session_id().to_vec())
+            .expect("member pane server");
+        let mut runtime = SharedLayoutRuntime::member_from_state(
+            member,
+            member_panes,
+            host.ticket().session_id().to_vec(),
+            state,
+            tokio::runtime::Handle::current(),
+        )
+        .expect("member runtime");
+        for _ in 0..20 {
+            runtime.drain().expect("runtime drain");
+            if runtime.remote.contains_key(&1) {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+        assert!(
+            runtime.remote.contains_key(&1),
+            "remote pane attached from snapshot"
+        );
+        dispatcher_task.abort();
     }
 
     fn split_layout() -> LayoutSnapshot {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1,6 +1,7 @@
 //! The fixed-grid local terminal renderer and input loop.
 
 use std::{
+    collections::BTreeMap,
     error::Error,
     io,
     time::{Duration, Instant},
@@ -21,10 +22,11 @@ use ratatui::{
     buffer::Buffer,
     layout::Rect,
     style::{Color, Modifier, Style},
-    widgets::Widget,
+    widgets::{Block, Paragraph, Widget},
 };
 
 use crate::{
+    layout::{Axis, LayoutError, LayoutSnapshot, Node, PaneId, TabId},
     lease::{IDLE_AFTER, LeaseDecision, LeaseManager, LeaseState},
     pty_host::PtyHost,
     screen::{GuestScreen, HostScreen, ScreenFrame},
@@ -33,6 +35,538 @@ use crate::{
 
 /// Kept as the module's public marker from the scaffold.
 pub struct Tui;
+
+/// The in-progress multi-pane command prefix, kept entirely local to one terminal.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum ChordMode {
+    #[default]
+    None,
+    Pane,
+    Tab,
+}
+
+/// Metadata used to draw a pane before its runtime has delivered a screen and lease.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct PaneViewState {
+    pub ready: bool,
+    pub host_peer_id: Vec<u8>,
+    pub controller_peer_id: Option<Vec<u8>>,
+    pub controller_active: bool,
+}
+
+/// User operations emitted by the TUI. Session code owns all resulting mutations and PTYs.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum UiIntent {
+    CreatePane {
+        target_pane_id: PaneId,
+        axis: Axis,
+        grid_rows: u16,
+        grid_cols: u16,
+    },
+    DeletePane {
+        pane_id: PaneId,
+    },
+    CreateTab {
+        grid_rows: u16,
+        grid_cols: u16,
+    },
+    DeleteTab {
+        tab_id: TabId,
+    },
+    FocusPane {
+        pane_id: PaneId,
+    },
+    SwitchTab {
+        tab_id: TabId,
+    },
+}
+
+/// Whether a terminal key belongs to the mux or should later be offered to the focused pane.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum KeyHandling {
+    Forward,
+    Consumed(Vec<UiIntent>),
+    TakeControl,
+    Quit,
+}
+
+/// Rectangles for one rendered terminal frame.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PaneGeometry {
+    pub tab_bar: Rect,
+    pub content: Rect,
+    pub footer: Rect,
+    pub panes: BTreeMap<PaneId, Rect>,
+}
+
+/// Pure local rendering and selection state for a revisioned shared layout.
+#[derive(Clone, Debug)]
+pub struct MultiPaneTui {
+    snapshot: LayoutSnapshot,
+    current_tab: TabId,
+    focused_pane: PaneId,
+    chord_mode: ChordMode,
+    pane_views: BTreeMap<PaneId, PaneViewState>,
+}
+
+impl MultiPaneTui {
+    pub fn new(snapshot: LayoutSnapshot) -> Result<Self, LayoutError> {
+        crate::layout::SessionState::validate_snapshot(&snapshot)?;
+        let current_tab = snapshot.tabs[0].tab_id;
+        let focused_pane = first_leaf(&snapshot.tabs[0].root).expect("validated layout has a leaf");
+        let pane_views = snapshot
+            .panes
+            .values()
+            .map(|pane| {
+                (
+                    pane.pane_id,
+                    PaneViewState {
+                        host_peer_id: pane.host_peer_id.clone(),
+                        ..PaneViewState::default()
+                    },
+                )
+            })
+            .collect();
+        Ok(Self {
+            snapshot,
+            current_tab,
+            focused_pane,
+            chord_mode: ChordMode::None,
+            pane_views,
+        })
+    }
+
+    pub fn snapshot(&self) -> &LayoutSnapshot {
+        &self.snapshot
+    }
+
+    pub fn current_tab(&self) -> TabId {
+        self.current_tab
+    }
+
+    pub fn focused_pane(&self) -> PaneId {
+        self.focused_pane
+    }
+
+    pub fn chord_mode(&self) -> ChordMode {
+        self.chord_mode
+    }
+
+    pub fn pane_view(&self, pane_id: PaneId) -> Option<&PaneViewState> {
+        self.pane_views.get(&pane_id)
+    }
+
+    pub fn set_pane_view(&mut self, pane_id: PaneId, state: PaneViewState) {
+        if self.snapshot.panes.contains_key(&pane_id) {
+            self.pane_views.insert(pane_id, state);
+        }
+    }
+
+    pub fn apply_snapshot(&mut self, snapshot: LayoutSnapshot) -> Result<(), LayoutError> {
+        crate::layout::SessionState::validate_snapshot(&snapshot)?;
+        let old_views = std::mem::take(&mut self.pane_views);
+        self.pane_views = snapshot
+            .panes
+            .values()
+            .map(|pane| {
+                let mut state = old_views.get(&pane.pane_id).cloned().unwrap_or_default();
+                state.host_peer_id = pane.host_peer_id.clone();
+                (pane.pane_id, state)
+            })
+            .collect();
+        self.snapshot = snapshot;
+        self.repair_selection();
+        Ok(())
+    }
+
+    pub fn select_tab(&mut self, tab_id: TabId) -> Result<(), LayoutError> {
+        let tab = self
+            .snapshot
+            .tabs
+            .iter()
+            .find(|tab| tab.tab_id == tab_id)
+            .ok_or(LayoutError::UnknownTab { tab_id })?;
+        self.current_tab = tab_id;
+        self.focused_pane = first_leaf(&tab.root).expect("validated layout has a leaf");
+        Ok(())
+    }
+
+    pub fn geometry(&self, area: Rect) -> PaneGeometry {
+        let tab_bar = Rect::new(area.x, area.y, area.width, area.height.min(1));
+        let footer_height = area.height.saturating_sub(tab_bar.height).min(1);
+        let footer = Rect::new(
+            area.x,
+            area.y
+                .saturating_add(area.height.saturating_sub(footer_height)),
+            area.width,
+            footer_height,
+        );
+        let content = Rect::new(
+            area.x,
+            area.y.saturating_add(tab_bar.height),
+            area.width,
+            area.height.saturating_sub(tab_bar.height + footer_height),
+        );
+        let mut panes = BTreeMap::new();
+        if let Some(tab) = self.current_tab_layout() {
+            allocate_node(&tab.root, content, &mut panes);
+        }
+        PaneGeometry {
+            tab_bar,
+            content,
+            footer,
+            panes,
+        }
+    }
+
+    pub fn handle_key(&mut self, key: KeyEvent, area: Rect) -> KeyHandling {
+        if is_quit(key) {
+            self.chord_mode = ChordMode::None;
+            return KeyHandling::Quit;
+        }
+        if is_take_control(key) {
+            self.chord_mode = ChordMode::None;
+            return KeyHandling::TakeControl;
+        }
+        if key.code == KeyCode::Esc
+            && key.modifiers.is_empty()
+            && self.chord_mode != ChordMode::None
+        {
+            self.chord_mode = ChordMode::None;
+            return KeyHandling::Consumed(vec![]);
+        }
+        if self.chord_mode == ChordMode::None {
+            if key.code == KeyCode::Char('p') && key.modifiers == KeyModifiers::CONTROL {
+                self.chord_mode = ChordMode::Pane;
+                return KeyHandling::Consumed(vec![]);
+            }
+            if key.code == KeyCode::Char('t') && key.modifiers == KeyModifiers::CONTROL {
+                self.chord_mode = ChordMode::Tab;
+                return KeyHandling::Consumed(vec![]);
+            }
+            return KeyHandling::Forward;
+        }
+
+        let chord = self.chord_mode;
+        self.chord_mode = ChordMode::None;
+        let intent = match chord {
+            ChordMode::Pane => self.handle_pane_chord(key, area),
+            ChordMode::Tab => self.handle_tab_chord(key, area),
+            ChordMode::None => None,
+        };
+        KeyHandling::Consumed(intent.into_iter().collect())
+    }
+
+    fn handle_pane_chord(&mut self, key: KeyEvent, area: Rect) -> Option<UiIntent> {
+        match key.code {
+            KeyCode::Char('n') if key.modifiers.is_empty() => {
+                let rect = self.geometry(area).panes.get(&self.focused_pane).copied()?;
+                let (grid_rows, grid_cols) = grid_for_pane(rect);
+                Some(UiIntent::CreatePane {
+                    target_pane_id: self.focused_pane,
+                    axis: if rect.width >= rect.height {
+                        Axis::LeftRight
+                    } else {
+                        Axis::TopBottom
+                    },
+                    grid_rows,
+                    grid_cols,
+                })
+            }
+            KeyCode::Char('x') if key.modifiers.is_empty() => Some(UiIntent::DeletePane {
+                pane_id: self.focused_pane,
+            }),
+            KeyCode::Left | KeyCode::Right | KeyCode::Up | KeyCode::Down
+                if key.modifiers.is_empty() =>
+            {
+                self.move_focus(key.code, area)
+            }
+            _ => None,
+        }
+    }
+
+    fn handle_tab_chord(&mut self, key: KeyEvent, area: Rect) -> Option<UiIntent> {
+        match key.code {
+            KeyCode::Char('n') if key.modifiers.is_empty() => {
+                let (grid_rows, grid_cols) = grid_for_pane(self.geometry(area).content);
+                Some(UiIntent::CreateTab {
+                    grid_rows,
+                    grid_cols,
+                })
+            }
+            KeyCode::Char('x') if key.modifiers.is_empty() => Some(UiIntent::DeleteTab {
+                tab_id: self.current_tab,
+            }),
+            KeyCode::Left if key.modifiers.is_empty() => self.switch_tab(false),
+            KeyCode::Right if key.modifiers.is_empty() => self.switch_tab(true),
+            _ => None,
+        }
+    }
+
+    fn move_focus(&mut self, direction: KeyCode, area: Rect) -> Option<UiIntent> {
+        let geometry = self.geometry(area);
+        let source = *geometry.panes.get(&self.focused_pane)?;
+        let source_center = rect_center(source);
+        let mut candidates = geometry
+            .panes
+            .iter()
+            .filter(|(pane_id, _)| **pane_id != self.focused_pane)
+            .map(|(pane_id, rect)| (*pane_id, *rect))
+            .collect::<Vec<_>>();
+        if candidates.is_empty() {
+            return None;
+        }
+        let directed = candidates
+            .iter()
+            .copied()
+            .filter(|(_, rect)| is_in_direction(source_center, rect_center(*rect), direction))
+            .min_by_key(|(pane_id, rect)| {
+                direction_distance(source_center, rect_center(*rect), direction, *pane_id)
+            });
+        let pane_id = directed
+            .or_else(|| {
+                candidates.sort_by_key(|(pane_id, rect)| {
+                    let center = rect_center(*rect);
+                    (
+                        source_center.0.abs_diff(center.0) + source_center.1.abs_diff(center.1),
+                        *pane_id,
+                    )
+                });
+                candidates.first().copied()
+            })?
+            .0;
+        self.focused_pane = pane_id;
+        Some(UiIntent::FocusPane { pane_id })
+    }
+
+    fn switch_tab(&mut self, forward: bool) -> Option<UiIntent> {
+        let index = self
+            .snapshot
+            .tabs
+            .iter()
+            .position(|tab| tab.tab_id == self.current_tab)?;
+        let len = self.snapshot.tabs.len();
+        let next = if forward {
+            (index + 1) % len
+        } else {
+            (index + len - 1) % len
+        };
+        let tab_id = self.snapshot.tabs[next].tab_id;
+        self.select_tab(tab_id)
+            .expect("tab came from current snapshot");
+        Some(UiIntent::SwitchTab { tab_id })
+    }
+
+    fn current_tab_layout(&self) -> Option<&crate::layout::Tab> {
+        self.snapshot
+            .tabs
+            .iter()
+            .find(|tab| tab.tab_id == self.current_tab)
+    }
+
+    fn repair_selection(&mut self) {
+        let current_tab = self.current_tab_layout();
+        let current_tab = if let Some(tab) = current_tab {
+            tab
+        } else {
+            self.current_tab = self.snapshot.tabs[0].tab_id;
+            &self.snapshot.tabs[0]
+        };
+        if !contains_leaf(&current_tab.root, self.focused_pane) {
+            self.focused_pane = first_leaf(&current_tab.root).expect("validated layout has a leaf");
+        }
+    }
+}
+
+fn first_leaf(node: &Node) -> Option<PaneId> {
+    match node {
+        Node::Leaf { pane_id } => Some(*pane_id),
+        Node::Split { first, .. } => first_leaf(first),
+    }
+}
+
+fn contains_leaf(node: &Node, pane_id: PaneId) -> bool {
+    match node {
+        Node::Leaf { pane_id: candidate } => *candidate == pane_id,
+        Node::Split { first, second, .. } => {
+            contains_leaf(first, pane_id) || contains_leaf(second, pane_id)
+        }
+    }
+}
+
+fn allocate_node(node: &Node, area: Rect, panes: &mut BTreeMap<PaneId, Rect>) {
+    match node {
+        Node::Leaf { pane_id } => {
+            panes.insert(*pane_id, area);
+        }
+        Node::Split {
+            axis,
+            first,
+            second,
+        } => {
+            let (first_area, second_area) = match axis {
+                Axis::LeftRight => {
+                    let first_width = area.width / 2;
+                    (
+                        Rect::new(area.x, area.y, first_width, area.height),
+                        Rect::new(
+                            area.x.saturating_add(first_width),
+                            area.y,
+                            area.width - first_width,
+                            area.height,
+                        ),
+                    )
+                }
+                Axis::TopBottom => {
+                    let first_height = area.height / 2;
+                    (
+                        Rect::new(area.x, area.y, area.width, first_height),
+                        Rect::new(
+                            area.x,
+                            area.y.saturating_add(first_height),
+                            area.width,
+                            area.height - first_height,
+                        ),
+                    )
+                }
+            };
+            allocate_node(first, first_area, panes);
+            allocate_node(second, second_area, panes);
+        }
+    }
+}
+
+fn grid_for_pane(rect: Rect) -> (u16, u16) {
+    (
+        rect.height.saturating_sub(2).max(1),
+        rect.width.saturating_sub(2).max(1),
+    )
+}
+
+fn rect_center(rect: Rect) -> (u32, u32) {
+    (
+        u32::from(rect.x) * 2 + u32::from(rect.width),
+        u32::from(rect.y) * 2 + u32::from(rect.height),
+    )
+}
+
+fn is_in_direction(source: (u32, u32), target: (u32, u32), direction: KeyCode) -> bool {
+    match direction {
+        KeyCode::Left => target.0 < source.0,
+        KeyCode::Right => target.0 > source.0,
+        KeyCode::Up => target.1 < source.1,
+        KeyCode::Down => target.1 > source.1,
+        _ => false,
+    }
+}
+
+fn direction_distance(
+    source: (u32, u32),
+    target: (u32, u32),
+    direction: KeyCode,
+    pane_id: PaneId,
+) -> (u32, u32, u32, PaneId) {
+    match direction {
+        KeyCode::Left | KeyCode::Right => {
+            let primary = source.0.abs_diff(target.0);
+            let secondary = source.1.abs_diff(target.1);
+            (primary + secondary, secondary, primary, pane_id)
+        }
+        KeyCode::Up | KeyCode::Down => {
+            let primary = source.1.abs_diff(target.1);
+            let secondary = source.0.abs_diff(target.0);
+            (primary + secondary, secondary, primary, pane_id)
+        }
+        _ => (u32::MAX, u32::MAX, u32::MAX, pane_id),
+    }
+}
+
+fn fixed_grid_viewport(inner: Rect, rows: u16, cols: u16) -> Rect {
+    let width = inner.width.min(cols);
+    let height = inner.height.min(rows);
+    Rect::new(
+        inner
+            .x
+            .saturating_add(inner.width.saturating_sub(width) / 2),
+        inner
+            .y
+            .saturating_add(inner.height.saturating_sub(height) / 2),
+        width,
+        height,
+    )
+}
+
+/// Renders layout chrome plus any currently available fixed-size VT screens.
+pub fn render_multi_pane(
+    frame: &mut Frame<'_>,
+    tui: &MultiPaneTui,
+    screens: &BTreeMap<PaneId, &vt100::Screen>,
+) {
+    let geometry = tui.geometry(frame.area());
+    let tabs = tui
+        .snapshot
+        .tabs
+        .iter()
+        .map(|tab| {
+            if tab.tab_id == tui.current_tab {
+                format!("[*{}]", tab.tab_id)
+            } else {
+                format!("[{}]", tab.tab_id)
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ");
+    if geometry.tab_bar.width > 0 && geometry.tab_bar.height > 0 {
+        frame.buffer_mut().set_string(
+            geometry.tab_bar.x,
+            geometry.tab_bar.y,
+            tabs,
+            Style::default().fg(Color::Cyan),
+        );
+    }
+    if geometry.footer.width > 0 && geometry.footer.height > 0 {
+        frame.buffer_mut().set_string(
+            geometry.footer.x,
+            geometry.footer.y,
+            "Ctrl+P panes | Ctrl+T tabs | F9 control | F10 quit",
+            Style::default().fg(Color::DarkGray),
+        );
+    }
+
+    for (pane_id, rect) in geometry.panes {
+        let pane = &tui.snapshot.panes[&pane_id];
+        let view = tui.pane_views.get(&pane_id).cloned().unwrap_or_default();
+        let focused = pane_id == tui.focused_pane;
+        let lease = match view.controller_peer_id.as_deref() {
+            Some(peer) if view.controller_active => format!("ctrl:{} typing", short_peer(peer)),
+            Some(peer) => format!("ctrl:{} idle", short_peer(peer)),
+            None => String::from("lease: waiting"),
+        };
+        let title = format!(
+            "{} host:{} {lease}",
+            if focused { "*" } else { " " },
+            short_peer(&view.host_peer_id)
+        );
+        let border_color = if focused {
+            Color::Yellow
+        } else {
+            Color::DarkGray
+        };
+        let block = Block::bordered()
+            .title(title)
+            .border_style(Style::default().fg(border_color));
+        let inner = block.inner(rect);
+        frame.render_widget(block, rect);
+        if let Some(screen) = screens.get(&pane_id) {
+            frame.render_widget(
+                VtScreen::new(screen),
+                fixed_grid_viewport(inner, pane.grid_rows, pane.grid_cols),
+            );
+        } else if !view.ready {
+            frame.render_widget(Paragraph::new("waiting for pane snapshot/lease"), inner);
+        }
+    }
+}
 
 pub struct HostPaneRuntime {
     host: PtyHost,
@@ -746,16 +1280,324 @@ fn short_peer(peer_id: &[u8]) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
     use ratatui::{
         Terminal,
         backend::TestBackend,
+        layout::Rect,
         style::{Color, Modifier},
     };
 
+    use crate::layout::{Axis, LayoutSnapshot, Node, Pane, Tab};
     use crate::screen::{GuestScreen, HostScreen};
 
-    use super::{VtScreen, encode_key, encode_paste, render_guest_screen};
+    use super::{
+        ChordMode, KeyHandling, MultiPaneTui, PaneViewState, UiIntent, VtScreen, encode_key,
+        encode_paste, render_guest_screen, render_multi_pane,
+    };
+
+    fn layout(tabs: Vec<Tab>, panes: &[(u64, u16, u16)]) -> LayoutSnapshot {
+        LayoutSnapshot {
+            revision: 1,
+            members: vec![crate::layout::Member {
+                peer_id: b"host".to_vec(),
+                endpoint_addr: b"endpoint".to_vec(),
+            }],
+            tabs,
+            panes: panes
+                .iter()
+                .map(|(pane_id, rows, cols)| {
+                    (
+                        *pane_id,
+                        Pane {
+                            pane_id: *pane_id,
+                            host_peer_id: b"host".to_vec(),
+                            grid_rows: *rows,
+                            grid_cols: *cols,
+                        },
+                    )
+                })
+                .collect::<BTreeMap<_, _>>(),
+        }
+    }
+
+    fn split_layout() -> LayoutSnapshot {
+        layout(
+            vec![Tab {
+                tab_id: 1,
+                root: Node::Split {
+                    axis: Axis::LeftRight,
+                    first: Box::new(Node::Leaf { pane_id: 1 }),
+                    second: Box::new(Node::Split {
+                        axis: Axis::TopBottom,
+                        first: Box::new(Node::Leaf { pane_id: 2 }),
+                        second: Box::new(Node::Leaf { pane_id: 3 }),
+                    }),
+                },
+            }],
+            &[(1, 4, 10), (2, 4, 10), (3, 4, 10)],
+        )
+    }
+
+    #[test]
+    fn multi_pane_geometry_recursively_splits_the_content_area() {
+        let tui = MultiPaneTui::new(split_layout()).expect("valid layout");
+        let geometry = tui.geometry(Rect::new(0, 0, 80, 24));
+
+        assert_eq!(geometry.tab_bar, Rect::new(0, 0, 80, 1));
+        assert_eq!(geometry.footer, Rect::new(0, 23, 80, 1));
+        assert_eq!(geometry.panes[&1], Rect::new(0, 1, 40, 22));
+        assert_eq!(geometry.panes[&2], Rect::new(40, 1, 40, 11));
+        assert_eq!(geometry.panes[&3], Rect::new(40, 12, 40, 11));
+    }
+
+    #[test]
+    fn tiny_terminal_geometry_stays_in_bounds() {
+        let tui = MultiPaneTui::new(split_layout()).expect("valid layout");
+        let geometry = tui.geometry(Rect::new(u16::MAX, u16::MAX, 1, 1));
+
+        assert_eq!(geometry.tab_bar, Rect::new(u16::MAX, u16::MAX, 1, 1));
+        assert_eq!(geometry.footer, Rect::new(u16::MAX, u16::MAX, 1, 0));
+        assert_eq!(geometry.content, Rect::new(u16::MAX, u16::MAX, 1, 0));
+        assert!(
+            geometry
+                .panes
+                .values()
+                .all(|rect| rect.x == u16::MAX && rect.y == u16::MAX)
+        );
+    }
+
+    #[test]
+    fn snapshot_commit_repairs_removed_tab_and_pane_selection() {
+        let initial = layout(
+            vec![
+                Tab {
+                    tab_id: 1,
+                    root: Node::Leaf { pane_id: 1 },
+                },
+                Tab {
+                    tab_id: 2,
+                    root: Node::Leaf { pane_id: 2 },
+                },
+            ],
+            &[(1, 2, 2), (2, 2, 2)],
+        );
+        let mut tui = MultiPaneTui::new(initial).expect("valid layout");
+        tui.select_tab(2).expect("select second tab");
+
+        tui.apply_snapshot(layout(
+            vec![Tab {
+                tab_id: 1,
+                root: Node::Leaf { pane_id: 1 },
+            }],
+            &[(1, 2, 2)],
+        ))
+        .expect("valid commit");
+
+        assert_eq!(tui.current_tab(), 1);
+        assert_eq!(tui.focused_pane(), 1);
+    }
+
+    #[test]
+    fn chrome_marks_focus_and_reports_host_and_lease() {
+        let mut tui = MultiPaneTui::new(layout(
+            vec![Tab {
+                tab_id: 1,
+                root: Node::Leaf { pane_id: 1 },
+            }],
+            &[(1, 2, 2)],
+        ))
+        .expect("valid layout");
+        tui.set_pane_view(
+            1,
+            PaneViewState {
+                ready: true,
+                host_peer_id: b"host".to_vec(),
+                controller_peer_id: Some(b"peer".to_vec()),
+                controller_active: true,
+            },
+        );
+        let mut terminal = Terminal::new(TestBackend::new(36, 6)).expect("test terminal");
+
+        terminal
+            .draw(|frame| render_multi_pane(frame, &tui, &BTreeMap::new()))
+            .expect("render");
+        let buffer = terminal.backend().buffer();
+
+        assert_eq!(buffer[(0, 1)].symbol(), "┌");
+        assert_eq!(buffer[(1, 1)].symbol(), "*");
+        assert!(buffer.content.iter().any(|cell| cell.symbol() == "h"));
+        assert!(buffer.content.iter().any(|cell| cell.symbol() == "t"));
+    }
+
+    #[test]
+    fn fixed_grid_view_is_centered_and_clipped_inside_pane_chrome() {
+        let mut parser = vt100::Parser::new(1, 5, 0);
+        parser.process(b"abcde");
+        let tui = MultiPaneTui::new(layout(
+            vec![Tab {
+                tab_id: 1,
+                root: Node::Leaf { pane_id: 1 },
+            }],
+            &[(1, 1, 5)],
+        ))
+        .expect("valid layout");
+        let screens = BTreeMap::from([(1, parser.screen())]);
+        let mut terminal = Terminal::new(TestBackend::new(6, 5)).expect("test terminal");
+
+        terminal
+            .draw(|frame| render_multi_pane(frame, &tui, &screens))
+            .expect("render");
+        let buffer = terminal.backend().buffer();
+
+        assert_eq!(buffer[(1, 2)].symbol(), "a");
+        assert_eq!(buffer[(4, 2)].symbol(), "d");
+        assert_eq!(buffer[(5, 2)].symbol(), "│");
+    }
+
+    #[test]
+    fn pane_chord_consumes_commands_and_uses_focused_rect_aspect() {
+        let mut tui = MultiPaneTui::new(split_layout()).expect("valid layout");
+        let area = Rect::new(0, 0, 80, 24);
+
+        assert_eq!(
+            tui.handle_key(
+                KeyEvent::new(KeyCode::Char('p'), KeyModifiers::CONTROL),
+                area,
+            ),
+            KeyHandling::Consumed(vec![])
+        );
+        assert_eq!(tui.chord_mode(), ChordMode::Pane);
+        assert_eq!(
+            tui.handle_key(KeyEvent::new(KeyCode::Char('n'), KeyModifiers::NONE), area),
+            KeyHandling::Consumed(vec![UiIntent::CreatePane {
+                target_pane_id: 1,
+                axis: Axis::LeftRight,
+                grid_rows: 20,
+                grid_cols: 38,
+            }])
+        );
+        assert_eq!(tui.chord_mode(), ChordMode::None);
+
+        let _ = tui.handle_key(
+            KeyEvent::new(KeyCode::Char('p'), KeyModifiers::CONTROL),
+            area,
+        );
+        assert_eq!(
+            tui.handle_key(KeyEvent::new(KeyCode::Right, KeyModifiers::NONE), area),
+            KeyHandling::Consumed(vec![UiIntent::FocusPane { pane_id: 2 }])
+        );
+        assert_eq!(tui.focused_pane(), 2);
+    }
+
+    #[test]
+    fn pane_focus_uses_nearest_directional_leaf_then_a_stable_fallback() {
+        let mut tui = MultiPaneTui::new(split_layout()).expect("valid layout");
+        let area = Rect::new(0, 0, 80, 24);
+        let _ = tui.handle_key(
+            KeyEvent::new(KeyCode::Char('p'), KeyModifiers::CONTROL),
+            area,
+        );
+        assert_eq!(
+            tui.handle_key(KeyEvent::new(KeyCode::Right, KeyModifiers::NONE), area),
+            KeyHandling::Consumed(vec![UiIntent::FocusPane { pane_id: 2 }])
+        );
+        let _ = tui.handle_key(
+            KeyEvent::new(KeyCode::Char('p'), KeyModifiers::CONTROL),
+            area,
+        );
+        assert_eq!(
+            tui.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE), area),
+            KeyHandling::Consumed(vec![UiIntent::FocusPane { pane_id: 3 }])
+        );
+        let _ = tui.handle_key(
+            KeyEvent::new(KeyCode::Char('p'), KeyModifiers::CONTROL),
+            area,
+        );
+        assert_eq!(
+            tui.handle_key(KeyEvent::new(KeyCode::Right, KeyModifiers::NONE), area),
+            KeyHandling::Consumed(vec![UiIntent::FocusPane { pane_id: 2 }])
+        );
+    }
+
+    #[test]
+    fn tab_chord_switches_and_creates_or_deletes_tabs_without_forwarding_keys() {
+        let mut tui = MultiPaneTui::new(layout(
+            vec![
+                Tab {
+                    tab_id: 1,
+                    root: Node::Leaf { pane_id: 1 },
+                },
+                Tab {
+                    tab_id: 2,
+                    root: Node::Leaf { pane_id: 2 },
+                },
+            ],
+            &[(1, 2, 2), (2, 2, 2)],
+        ))
+        .expect("valid layout");
+        let area = Rect::new(0, 0, 12, 8);
+
+        let _ = tui.handle_key(
+            KeyEvent::new(KeyCode::Char('t'), KeyModifiers::CONTROL),
+            area,
+        );
+        assert_eq!(
+            tui.handle_key(KeyEvent::new(KeyCode::Right, KeyModifiers::NONE), area),
+            KeyHandling::Consumed(vec![UiIntent::SwitchTab { tab_id: 2 }])
+        );
+        assert_eq!(
+            tui.handle_key(
+                KeyEvent::new(KeyCode::Char('t'), KeyModifiers::CONTROL),
+                area,
+            ),
+            KeyHandling::Consumed(vec![])
+        );
+        assert_eq!(
+            tui.handle_key(KeyEvent::new(KeyCode::Char('n'), KeyModifiers::NONE), area),
+            KeyHandling::Consumed(vec![UiIntent::CreateTab {
+                grid_rows: 4,
+                grid_cols: 10,
+            }])
+        );
+
+        let _ = tui.handle_key(
+            KeyEvent::new(KeyCode::Char('t'), KeyModifiers::CONTROL),
+            area,
+        );
+        assert_eq!(
+            tui.handle_key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE), area),
+            KeyHandling::Consumed(vec![UiIntent::DeleteTab { tab_id: 2 }])
+        );
+    }
+
+    #[test]
+    fn normal_keys_escape_and_function_keys_are_classified_without_pty_encoding() {
+        let mut tui = MultiPaneTui::new(split_layout()).expect("valid layout");
+        let area = Rect::new(0, 0, 80, 24);
+        assert_eq!(
+            tui.handle_key(KeyEvent::new(KeyCode::Char('z'), KeyModifiers::NONE), area),
+            KeyHandling::Forward
+        );
+        let _ = tui.handle_key(
+            KeyEvent::new(KeyCode::Char('p'), KeyModifiers::CONTROL),
+            area,
+        );
+        assert_eq!(
+            tui.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE), area),
+            KeyHandling::Consumed(vec![])
+        );
+        assert_eq!(
+            tui.handle_key(KeyEvent::new(KeyCode::F(9), KeyModifiers::NONE), area),
+            KeyHandling::TakeControl
+        );
+        assert_eq!(
+            tui.handle_key(KeyEvent::new(KeyCode::F(10), KeyModifiers::NONE), area),
+            KeyHandling::Quit
+        );
+    }
 
     #[test]
     fn remote_renderer_keeps_host_grid_fixed_and_draws_a_footer() {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1493,6 +1493,75 @@ mod tests {
     }
 
     #[test]
+    fn pane_delete_chord_targets_the_focused_pane() {
+        let mut tui = MultiPaneTui::new(split_layout()).expect("valid layout");
+        let area = Rect::new(0, 0, 80, 24);
+        let _ = tui.handle_key(
+            KeyEvent::new(KeyCode::Char('p'), KeyModifiers::CONTROL),
+            area,
+        );
+        let _ = tui.handle_key(KeyEvent::new(KeyCode::Right, KeyModifiers::NONE), area);
+        assert_eq!(tui.focused_pane(), 2);
+
+        let _ = tui.handle_key(
+            KeyEvent::new(KeyCode::Char('p'), KeyModifiers::CONTROL),
+            area,
+        );
+        assert_eq!(
+            tui.handle_key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE), area),
+            KeyHandling::Consumed(vec![UiIntent::DeletePane { pane_id: 2 }])
+        );
+    }
+
+    #[test]
+    fn tall_pane_create_chord_uses_a_top_bottom_split_and_usable_grid() {
+        let mut tui = MultiPaneTui::new(layout(
+            vec![Tab {
+                tab_id: 1,
+                root: Node::Leaf { pane_id: 1 },
+            }],
+            &[(1, 2, 2)],
+        ))
+        .expect("valid layout");
+        let area = Rect::new(0, 0, 20, 40);
+
+        let _ = tui.handle_key(
+            KeyEvent::new(KeyCode::Char('p'), KeyModifiers::CONTROL),
+            area,
+        );
+        assert_eq!(
+            tui.handle_key(KeyEvent::new(KeyCode::Char('n'), KeyModifiers::NONE), area),
+            KeyHandling::Consumed(vec![UiIntent::CreatePane {
+                target_pane_id: 1,
+                axis: Axis::TopBottom,
+                grid_rows: 36,
+                grid_cols: 18,
+            }])
+        );
+    }
+
+    #[test]
+    fn invalid_second_chord_keys_are_consumed_instead_of_forwarded() {
+        let mut tui = MultiPaneTui::new(split_layout()).expect("valid layout");
+        let area = Rect::new(0, 0, 80, 24);
+
+        for prefix in ['p', 't'] {
+            assert_eq!(
+                tui.handle_key(
+                    KeyEvent::new(KeyCode::Char(prefix), KeyModifiers::CONTROL),
+                    area
+                ),
+                KeyHandling::Consumed(vec![])
+            );
+            assert_eq!(
+                tui.handle_key(KeyEvent::new(KeyCode::Char('z'), KeyModifiers::NONE), area),
+                KeyHandling::Consumed(vec![])
+            );
+            assert_eq!(tui.chord_mode(), ChordMode::None);
+        }
+    }
+
+    #[test]
     fn pane_focus_uses_nearest_directional_leaf_then_a_stable_fallback() {
         let mut tui = MultiPaneTui::new(split_layout()).expect("valid layout");
         let area = Rect::new(0, 0, 80, 24);

--- a/tests/layout.rs
+++ b/tests/layout.rs
@@ -1,6 +1,6 @@
 use p2pmux::layout::{
     Axis, LayoutError, LayoutSnapshot, MAX_ENDPOINT_ADDR_BYTES, MAX_MEMBERS, MAX_PANES_PER_TAB,
-    MAX_TABS, Node, ReservationCommit, SessionState,
+    MAX_PEER_ID_BYTES, MAX_TABS, Node, ReservationCommit, SessionState,
 };
 
 const HOST_A: &[u8] = b"host-a";
@@ -65,6 +65,10 @@ fn initial_layout_rejects_zero_sized_grids_and_invalid_endpoint_addresses() {
         SessionState::new(Vec::new(), ADDR_A.to_vec(), 24, 80),
         Err(LayoutError::InvalidPeerId)
     );
+    assert_eq!(
+        SessionState::new(vec![0; MAX_PEER_ID_BYTES + 1], ADDR_A.to_vec(), 24, 80),
+        Err(LayoutError::InvalidPeerId)
+    );
 }
 
 #[test]
@@ -74,6 +78,16 @@ fn member_setup_rejects_empty_peer_ids_without_mutating_the_snapshot() {
 
     assert_eq!(
         state.add_member(state.revision(), Vec::new(), ADDR_B.to_vec()),
+        Err(LayoutError::InvalidPeerId)
+    );
+    assert_eq!(snapshot(&state), before);
+
+    assert_eq!(
+        state.add_member(
+            state.revision(),
+            vec![0; MAX_PEER_ID_BYTES + 1],
+            ADDR_B.to_vec()
+        ),
         Err(LayoutError::InvalidPeerId)
     );
     assert_eq!(snapshot(&state), before);
@@ -508,6 +522,20 @@ fn snapshots_associate_pane_hosts_with_bounded_member_addresses_and_reject_malfo
     zero_pane_id.tabs[0].root = Node::Leaf { pane_id: 0 };
     assert_eq!(
         SessionState::validate_snapshot(&zero_pane_id),
+        Err(LayoutError::InvalidSnapshot)
+    );
+
+    let mut oversized_peer = snapshot(&state);
+    let original_peer = oversized_peer.members[0].peer_id.clone();
+    let replacement_peer = vec![0; MAX_PEER_ID_BYTES + 1];
+    oversized_peer.members[0].peer_id = replacement_peer.clone();
+    for pane in oversized_peer.panes.values_mut() {
+        if pane.host_peer_id == original_peer {
+            pane.host_peer_id = replacement_peer.clone();
+        }
+    }
+    assert_eq!(
+        SessionState::validate_snapshot(&oversized_peer),
         Err(LayoutError::InvalidSnapshot)
     );
 }

--- a/tests/layout.rs
+++ b/tests/layout.rs
@@ -1,0 +1,228 @@
+use p2pmux::layout::{
+    Axis, LayoutError, MAX_MEMBERS, MAX_PANES_PER_TAB, MAX_TABS, Node, SessionState,
+};
+
+const HOST_A: &[u8] = b"host-a";
+const HOST_B: &[u8] = b"host-b";
+
+fn state() -> SessionState {
+    SessionState::new(HOST_A.to_vec(), 24, 80).expect("valid initial layout")
+}
+
+#[test]
+fn initial_state_has_one_tab_and_one_hosted_pane() {
+    let state = state();
+
+    assert_eq!(state.revision, 1);
+    assert_eq!(state.members.len(), 1);
+    assert_eq!(state.tabs.len(), 1);
+    assert_eq!(state.panes.len(), 1);
+    assert_eq!(state.tabs[0].root, Node::Leaf { pane_id: 1 });
+    assert_eq!(state.panes[&1].host_peer_id, HOST_A);
+    assert_eq!(state.panes[&1].grid_rows, 24);
+    assert_eq!(state.panes[&1].grid_cols, 80);
+}
+
+#[test]
+fn creating_panes_uses_the_requested_split_axis() {
+    let mut state = state();
+    let first_revision = state.revision;
+    let right = state
+        .create_pane(HOST_A, first_revision, 1, Axis::LeftRight, 30, 100)
+        .expect("right split");
+
+    assert_eq!(right, 2);
+    assert_eq!(state.revision, first_revision + 1);
+    assert_eq!(
+        state.tabs[0].root,
+        Node::Split {
+            axis: Axis::LeftRight,
+            first: Box::new(Node::Leaf { pane_id: 1 }),
+            second: Box::new(Node::Leaf { pane_id: right }),
+        }
+    );
+
+    let down = state
+        .create_pane(HOST_A, state.revision, right, Axis::TopBottom, 20, 70)
+        .expect("down split");
+    assert!(matches!(
+        &state.tabs[0].root,
+        Node::Split {
+            axis: Axis::LeftRight,
+            second,
+            ..
+        } if matches!(
+            second.as_ref(),
+            Node::Split {
+                axis: Axis::TopBottom,
+                first,
+                second,
+            } if matches!(first.as_ref(), Node::Leaf { pane_id } if *pane_id == right)
+                && matches!(second.as_ref(), Node::Leaf { pane_id } if *pane_id == down)
+        )
+    ));
+}
+
+#[test]
+fn deleting_a_pane_expands_its_sibling() {
+    let mut state = state();
+    let sibling = state
+        .create_pane(HOST_A, state.revision, 1, Axis::LeftRight, 24, 80)
+        .expect("split");
+
+    state
+        .delete_pane(HOST_A, state.revision, sibling)
+        .expect("host can delete pane");
+
+    assert_eq!(state.tabs[0].root, Node::Leaf { pane_id: 1 });
+    assert!(!state.panes.contains_key(&sibling));
+}
+
+#[test]
+fn membership_and_tab_and_pane_limits_are_enforced() {
+    let mut state = state();
+    for member in 1..MAX_MEMBERS {
+        state
+            .add_member(state.revision, format!("member-{member}").into_bytes())
+            .expect("within member limit");
+    }
+    let revision = state.revision;
+    assert_eq!(
+        state.add_member(revision, b"one-too-many".to_vec()),
+        Err(LayoutError::MemberLimit)
+    );
+    assert_eq!(state.revision, revision);
+
+    for _ in 1..MAX_TABS {
+        state
+            .create_tab(HOST_A, state.revision, 24, 80)
+            .expect("within tab limit");
+    }
+    let revision = state.revision;
+    assert_eq!(
+        state.create_tab(HOST_A, revision, 24, 80),
+        Err(LayoutError::TabLimit)
+    );
+    assert_eq!(state.revision, revision);
+
+    let tab_id = state.tabs[0].tab_id;
+    let mut leaves = vec![1];
+    while leaves.len() < MAX_PANES_PER_TAB {
+        let target = leaves.remove(0);
+        let new_pane = state
+            .create_pane(HOST_A, state.revision, target, Axis::LeftRight, 24, 80)
+            .expect("within pane limit");
+        leaves.push(target);
+        leaves.push(new_pane);
+    }
+    assert_eq!(state.pane_ids_in_tab(tab_id).len(), MAX_PANES_PER_TAB);
+    let revision = state.revision;
+    assert_eq!(
+        state.create_pane(HOST_A, revision, leaves[0], Axis::LeftRight, 24, 80),
+        Err(LayoutError::PaneLimit)
+    );
+    assert_eq!(state.revision, revision);
+}
+
+#[test]
+fn splitting_beyond_depth_four_is_rejected() {
+    let mut state = state();
+    let mut leaf = 1;
+    for _ in 0..4 {
+        leaf = state
+            .create_pane(HOST_A, state.revision, leaf, Axis::TopBottom, 24, 80)
+            .expect("within depth limit");
+    }
+
+    let revision = state.revision;
+    assert_eq!(
+        state.create_pane(HOST_A, revision, leaf, Axis::TopBottom, 24, 80),
+        Err(LayoutError::SplitDepthLimit)
+    );
+    assert_eq!(state.revision, revision);
+}
+
+#[test]
+fn only_the_pane_host_can_delete_it() {
+    let mut state = state();
+    state
+        .add_member(state.revision, HOST_B.to_vec())
+        .expect("member B joins");
+    let revision = state.revision;
+
+    assert_eq!(
+        state.delete_pane(HOST_B, revision, 1),
+        Err(LayoutError::NotPaneHost { pane_id: 1 })
+    );
+    assert_eq!(state.revision, revision);
+}
+
+#[test]
+fn deleting_a_tab_requires_ownership_of_every_pane() {
+    let mut state = state();
+    state
+        .add_member(state.revision, HOST_B.to_vec())
+        .expect("member B joins");
+    state
+        .create_pane(HOST_B, state.revision, 1, Axis::LeftRight, 24, 80)
+        .expect("B hosts new pane");
+    let revision = state.revision;
+
+    state
+        .create_tab(HOST_A, state.revision, 24, 80)
+        .expect("a second tab allows deletion");
+    assert_eq!(
+        state.delete_tab(HOST_A, state.revision, 1),
+        Err(LayoutError::NotTabHost { tab_id: 1 })
+    );
+    assert_eq!(state.revision, revision + 1);
+}
+
+#[test]
+fn stale_requests_do_not_change_the_layout() {
+    let mut state = state();
+    let before = state.clone();
+
+    assert_eq!(
+        state.create_pane(HOST_A, 0, 1, Axis::LeftRight, 24, 80),
+        Err(LayoutError::StaleRevision {
+            expected: 1,
+            got: 0,
+        })
+    );
+    assert_eq!(state, before);
+}
+
+#[test]
+fn last_leaf_and_last_tab_cannot_be_deleted() {
+    let mut state = state();
+    let revision = state.revision;
+
+    assert_eq!(
+        state.delete_pane(HOST_A, revision, 1),
+        Err(LayoutError::LastPaneInTab { tab_id: 1 })
+    );
+    assert_eq!(
+        state.delete_tab(HOST_A, revision, 1),
+        Err(LayoutError::LastTab)
+    );
+    assert_eq!(state.revision, revision);
+}
+
+#[test]
+fn pane_ids_are_not_reused_after_deletion() {
+    let mut state = state();
+    let second = state
+        .create_pane(HOST_A, state.revision, 1, Axis::LeftRight, 24, 80)
+        .expect("second pane");
+    state
+        .delete_pane(HOST_A, state.revision, second)
+        .expect("delete second pane");
+
+    assert_eq!(
+        state
+            .create_pane(HOST_A, state.revision, 1, Axis::LeftRight, 24, 80)
+            .expect("third pane"),
+        3
+    );
+}

--- a/tests/layout.rs
+++ b/tests/layout.rs
@@ -226,3 +226,146 @@ fn pane_ids_are_not_reused_after_deletion() {
         3
     );
 }
+
+#[test]
+fn zero_sized_grids_are_rejected_without_mutating_the_state() {
+    let mut state = state();
+    let before = state.clone();
+
+    assert_eq!(
+        state.create_pane(HOST_A, state.revision, 1, Axis::LeftRight, 0, 80),
+        Err(LayoutError::InvalidGrid)
+    );
+    assert_eq!(state, before);
+
+    assert_eq!(
+        state.create_tab(HOST_A, state.revision, 24, 0),
+        Err(LayoutError::InvalidGrid)
+    );
+    assert_eq!(state, before);
+}
+
+#[test]
+fn a_created_tab_has_one_creator_hosted_pane_at_the_requested_grid() {
+    let mut state = state();
+    state
+        .add_member(state.revision, HOST_B.to_vec())
+        .expect("member B joins");
+
+    let tab_id = state
+        .create_tab(HOST_B, state.revision, 33, 111)
+        .expect("B creates a tab");
+    let tab = state
+        .tabs
+        .iter()
+        .find(|tab| tab.tab_id == tab_id)
+        .expect("created tab exists");
+    let Node::Leaf { pane_id } = tab.root else {
+        panic!("a new tab starts with exactly one leaf");
+    };
+    let pane = &state.panes[&pane_id];
+
+    assert_eq!(state.pane_ids_in_tab(tab_id), vec![pane_id]);
+    assert_eq!(pane.host_peer_id, HOST_B);
+    assert_eq!((pane.grid_rows, pane.grid_cols), (33, 111));
+}
+
+#[test]
+fn successful_mutations_advance_the_revision_once() {
+    let mut state = state();
+    let revision = state.revision;
+    state
+        .add_member(revision, HOST_B.to_vec())
+        .expect("member joins");
+    assert_eq!(state.revision, revision + 1);
+
+    let revision = state.revision;
+    let tab_id = state
+        .create_tab(HOST_A, revision, 24, 80)
+        .expect("create tab");
+    assert_eq!(state.revision, revision + 1);
+
+    let pane_id = state
+        .create_pane(HOST_A, state.revision, 1, Axis::LeftRight, 24, 80)
+        .expect("create pane to delete");
+    let revision = state.revision;
+    state
+        .delete_pane(HOST_A, revision, pane_id)
+        .expect("delete pane");
+    assert_eq!(state.revision, revision + 1);
+
+    let revision = state.revision;
+    state
+        .delete_tab(HOST_A, revision, tab_id)
+        .expect("delete all-owned tab");
+    assert_eq!(state.revision, revision + 1);
+}
+
+#[test]
+fn failed_ownership_and_limit_operations_leave_the_entire_state_unchanged() {
+    let mut ownership = state();
+    ownership
+        .add_member(ownership.revision, HOST_B.to_vec())
+        .expect("member B joins");
+    let before = ownership.clone();
+    assert_eq!(
+        ownership.delete_pane(HOST_B, ownership.revision, 1),
+        Err(LayoutError::NotPaneHost { pane_id: 1 })
+    );
+    assert_eq!(ownership, before);
+
+    let mut capped = state();
+    let mut leaves = vec![1];
+    while leaves.len() < MAX_PANES_PER_TAB {
+        let target = leaves.remove(0);
+        let new_pane = capped
+            .create_pane(HOST_A, capped.revision, target, Axis::LeftRight, 24, 80)
+            .expect("within pane limit");
+        leaves.extend([target, new_pane]);
+    }
+    let before = capped.clone();
+    assert_eq!(
+        capped.create_pane(HOST_A, capped.revision, leaves[0], Axis::LeftRight, 24, 80),
+        Err(LayoutError::PaneLimit)
+    );
+    assert_eq!(capped, before);
+}
+
+#[test]
+fn tab_ids_are_not_reused_after_a_tab_is_deleted() {
+    let mut state = state();
+    let first_new_tab = state
+        .create_tab(HOST_A, state.revision, 24, 80)
+        .expect("first new tab");
+    let second_new_tab = state
+        .create_tab(HOST_A, state.revision, 24, 80)
+        .expect("second new tab");
+    state
+        .delete_tab(HOST_A, state.revision, first_new_tab)
+        .expect("delete first new tab");
+
+    assert_eq!(
+        state
+            .create_tab(HOST_A, state.revision, 24, 80)
+            .expect("replacement tab"),
+        second_new_tab + 1
+    );
+}
+
+#[test]
+fn an_owner_can_delete_an_entire_tab_when_every_pane_is_local() {
+    let mut state = state();
+    let tab_id = state
+        .create_tab(HOST_A, state.revision, 24, 80)
+        .expect("second tab");
+    let only_pane = state.pane_ids_in_tab(tab_id)[0];
+    let revision = state.revision;
+
+    state
+        .delete_tab(HOST_A, revision, tab_id)
+        .expect("all-owned tab can be deleted");
+
+    assert_eq!(state.revision, revision + 1);
+    assert_eq!(state.tabs.len(), 1);
+    assert!(!state.panes.contains_key(&only_pane));
+}

--- a/tests/layout.rs
+++ b/tests/layout.rs
@@ -1,64 +1,81 @@
 use p2pmux::layout::{
-    Axis, LayoutError, MAX_MEMBERS, MAX_PANES_PER_TAB, MAX_TABS, Node, SessionState,
+    Axis, LayoutError, LayoutSnapshot, MAX_ENDPOINT_ADDR_BYTES, MAX_MEMBERS, MAX_PANES_PER_TAB,
+    MAX_TABS, Node, ReservationCommit, SessionState,
 };
 
 const HOST_A: &[u8] = b"host-a";
 const HOST_B: &[u8] = b"host-b";
+const ADDR_A: &[u8] = b"addr-a";
+const ADDR_B: &[u8] = b"addr-b";
 
 fn state() -> SessionState {
-    SessionState::new(HOST_A.to_vec(), 24, 80).expect("valid initial layout")
+    SessionState::new(HOST_A.to_vec(), ADDR_A.to_vec(), 24, 80).expect("valid initial layout")
+}
+
+fn snapshot(state: &SessionState) -> LayoutSnapshot {
+    state.snapshot()
+}
+
+fn tab(snapshot: &LayoutSnapshot, tab_id: u64) -> &p2pmux::layout::Tab {
+    snapshot
+        .tabs
+        .iter()
+        .find(|tab| tab.tab_id == tab_id)
+        .expect("tab exists")
 }
 
 #[test]
 fn initial_state_has_one_tab_and_one_hosted_pane() {
     let state = state();
+    let snapshot = snapshot(&state);
 
-    assert_eq!(state.revision, 1);
-    assert_eq!(state.members.len(), 1);
-    assert_eq!(state.tabs.len(), 1);
-    assert_eq!(state.panes.len(), 1);
-    assert_eq!(state.tabs[0].root, Node::Leaf { pane_id: 1 });
-    assert_eq!(state.panes[&1].host_peer_id, HOST_A);
-    assert_eq!(state.panes[&1].grid_rows, 24);
-    assert_eq!(state.panes[&1].grid_cols, 80);
+    assert_eq!(state.revision(), 1);
+    assert_eq!(snapshot.members.len(), 1);
+    assert_eq!(snapshot.tabs.len(), 1);
+    assert_eq!(snapshot.panes.len(), 1);
+    assert_eq!(snapshot.tabs[0].root, Node::Leaf { pane_id: 1 });
+    assert_eq!(snapshot.panes[&1].host_peer_id, HOST_A);
+    assert_eq!(snapshot.members[0].endpoint_addr, ADDR_A);
 }
 
 #[test]
-fn initial_layout_rejects_zero_sized_grids() {
+fn initial_layout_rejects_zero_sized_grids_and_invalid_endpoint_addresses() {
     assert_eq!(
-        SessionState::new(HOST_A.to_vec(), 0, 80),
+        SessionState::new(HOST_A.to_vec(), ADDR_A.to_vec(), 0, 80),
         Err(LayoutError::InvalidGrid)
     );
     assert_eq!(
-        SessionState::new(HOST_A.to_vec(), 24, 0),
+        SessionState::new(HOST_A.to_vec(), ADDR_A.to_vec(), 24, 0),
         Err(LayoutError::InvalidGrid)
+    );
+    assert_eq!(
+        SessionState::new(HOST_A.to_vec(), Vec::new(), 24, 80),
+        Err(LayoutError::InvalidEndpointAddress)
+    );
+    assert_eq!(
+        SessionState::new(
+            HOST_A.to_vec(),
+            vec![0; MAX_ENDPOINT_ADDR_BYTES + 1],
+            24,
+            80
+        ),
+        Err(LayoutError::InvalidEndpointAddress)
     );
 }
 
 #[test]
 fn creating_panes_uses_the_requested_split_axis() {
     let mut state = state();
-    let first_revision = state.revision;
     let right = state
-        .create_pane(HOST_A, first_revision, 1, Axis::LeftRight, 30, 100)
+        .create_pane(HOST_A, state.revision(), 1, Axis::LeftRight, 30, 100)
         .expect("right split");
-
-    assert_eq!(right, 2);
-    assert_eq!(state.revision, first_revision + 1);
-    assert_eq!(
-        state.tabs[0].root,
-        Node::Split {
-            axis: Axis::LeftRight,
-            first: Box::new(Node::Leaf { pane_id: 1 }),
-            second: Box::new(Node::Leaf { pane_id: right }),
-        }
-    );
-
     let down = state
-        .create_pane(HOST_A, state.revision, right, Axis::TopBottom, 20, 70)
+        .create_pane(HOST_A, state.revision(), right, Axis::TopBottom, 20, 70)
         .expect("down split");
+    let root = &snapshot(&state).tabs[0].root;
+
     assert!(matches!(
-        &state.tabs[0].root,
+        root,
         Node::Split {
             axis: Axis::LeftRight,
             second,
@@ -79,122 +96,119 @@ fn creating_panes_uses_the_requested_split_axis() {
 fn deleting_a_pane_expands_its_sibling() {
     let mut state = state();
     let sibling = state
-        .create_pane(HOST_A, state.revision, 1, Axis::LeftRight, 24, 80)
+        .create_pane(HOST_A, state.revision(), 1, Axis::LeftRight, 24, 80)
         .expect("split");
-
     state
-        .delete_pane(HOST_A, state.revision, sibling)
+        .delete_pane(HOST_A, state.revision(), sibling)
         .expect("host can delete pane");
 
-    assert_eq!(state.tabs[0].root, Node::Leaf { pane_id: 1 });
-    assert!(!state.panes.contains_key(&sibling));
+    let snapshot = snapshot(&state);
+    assert_eq!(snapshot.tabs[0].root, Node::Leaf { pane_id: 1 });
+    assert!(!snapshot.panes.contains_key(&sibling));
 }
 
 #[test]
-fn membership_and_tab_and_pane_limits_are_enforced() {
+fn membership_tab_pane_and_depth_limits_are_enforced() {
     let mut state = state();
     for member in 1..MAX_MEMBERS {
         state
-            .add_member(state.revision, format!("member-{member}").into_bytes())
+            .add_member(
+                state.revision(),
+                format!("member-{member}").into_bytes(),
+                format!("addr-{member}").into_bytes(),
+            )
             .expect("within member limit");
     }
-    let revision = state.revision;
+    let before = snapshot(&state);
     assert_eq!(
-        state.add_member(revision, b"one-too-many".to_vec()),
+        state.add_member(
+            state.revision(),
+            b"one-too-many".to_vec(),
+            b"address".to_vec()
+        ),
         Err(LayoutError::MemberLimit)
     );
-    assert_eq!(state.revision, revision);
+    assert_eq!(snapshot(&state), before);
 
     for _ in 1..MAX_TABS {
         state
-            .create_tab(HOST_A, state.revision, 24, 80)
+            .create_tab(HOST_A, state.revision(), 24, 80)
             .expect("within tab limit");
     }
-    let revision = state.revision;
     assert_eq!(
-        state.create_tab(HOST_A, revision, 24, 80),
+        state.create_tab(HOST_A, state.revision(), 24, 80),
         Err(LayoutError::TabLimit)
     );
-    assert_eq!(state.revision, revision);
 
-    let tab_id = state.tabs[0].tab_id;
+    let tab_id = snapshot(&state).tabs[0].tab_id;
     let mut leaves = vec![1];
     while leaves.len() < MAX_PANES_PER_TAB {
         let target = leaves.remove(0);
         let new_pane = state
-            .create_pane(HOST_A, state.revision, target, Axis::LeftRight, 24, 80)
+            .create_pane(HOST_A, state.revision(), target, Axis::LeftRight, 24, 80)
             .expect("within pane limit");
-        leaves.push(target);
-        leaves.push(new_pane);
+        leaves.extend([target, new_pane]);
     }
     assert_eq!(state.pane_ids_in_tab(tab_id).len(), MAX_PANES_PER_TAB);
-    let revision = state.revision;
     assert_eq!(
-        state.create_pane(HOST_A, revision, leaves[0], Axis::LeftRight, 24, 80),
+        state.create_pane(HOST_A, state.revision(), leaves[0], Axis::LeftRight, 24, 80),
         Err(LayoutError::PaneLimit)
     );
-    assert_eq!(state.revision, revision);
-}
 
-#[test]
-fn splitting_beyond_depth_four_is_rejected() {
-    let mut state = state();
+    let mut depth_state =
+        SessionState::new(HOST_A.to_vec(), ADDR_A.to_vec(), 24, 80).expect("valid initial layout");
     let mut leaf = 1;
     for _ in 0..4 {
-        leaf = state
-            .create_pane(HOST_A, state.revision, leaf, Axis::TopBottom, 24, 80)
+        leaf = depth_state
+            .create_pane(
+                HOST_A,
+                depth_state.revision(),
+                leaf,
+                Axis::TopBottom,
+                24,
+                80,
+            )
             .expect("within depth limit");
     }
-
-    let revision = state.revision;
     assert_eq!(
-        state.create_pane(HOST_A, revision, leaf, Axis::TopBottom, 24, 80),
+        depth_state.create_pane(
+            HOST_A,
+            depth_state.revision(),
+            leaf,
+            Axis::TopBottom,
+            24,
+            80
+        ),
         Err(LayoutError::SplitDepthLimit)
     );
-    assert_eq!(state.revision, revision);
 }
 
 #[test]
-fn only_the_pane_host_can_delete_it() {
+fn only_hosts_can_delete_panes_and_mixed_tabs() {
     let mut state = state();
     state
-        .add_member(state.revision, HOST_B.to_vec())
+        .add_member(state.revision(), HOST_B.to_vec(), ADDR_B.to_vec())
         .expect("member B joins");
-    let revision = state.revision;
-
     assert_eq!(
-        state.delete_pane(HOST_B, revision, 1),
+        state.delete_pane(HOST_B, state.revision(), 1),
         Err(LayoutError::NotPaneHost { pane_id: 1 })
     );
-    assert_eq!(state.revision, revision);
-}
-
-#[test]
-fn deleting_a_tab_requires_ownership_of_every_pane() {
-    let mut state = state();
     state
-        .add_member(state.revision, HOST_B.to_vec())
-        .expect("member B joins");
-    state
-        .create_pane(HOST_B, state.revision, 1, Axis::LeftRight, 24, 80)
+        .create_pane(HOST_B, state.revision(), 1, Axis::LeftRight, 24, 80)
         .expect("B hosts new pane");
-    let revision = state.revision;
-
     state
-        .create_tab(HOST_A, state.revision, 24, 80)
-        .expect("a second tab allows deletion");
+        .create_tab(HOST_A, state.revision(), 24, 80)
+        .expect("second tab");
     assert_eq!(
-        state.delete_tab(HOST_A, state.revision, 1),
+        state.delete_tab(HOST_A, state.revision(), 1),
         Err(LayoutError::NotTabHost { tab_id: 1 })
     );
-    assert_eq!(state.revision, revision + 1);
 }
 
 #[test]
-fn stale_requests_do_not_change_the_layout() {
+fn stale_requests_and_failed_grid_operations_do_not_change_the_snapshot() {
     let mut state = state();
-    let before = state.clone();
-
+    let before = snapshot(&state);
     assert_eq!(
         state.create_pane(HOST_A, 0, 1, Axis::LeftRight, 24, 80),
         Err(LayoutError::StaleRevision {
@@ -202,163 +216,59 @@ fn stale_requests_do_not_change_the_layout() {
             got: 0,
         })
     );
-    assert_eq!(state, before);
+    assert_eq!(
+        state.create_tab(HOST_A, state.revision(), 0, 80),
+        Err(LayoutError::InvalidGrid)
+    );
+    assert_eq!(snapshot(&state), before);
+    assert_eq!(state.revision(), before.revision);
 }
 
 #[test]
-fn last_leaf_and_last_tab_cannot_be_deleted() {
+fn last_leaf_and_last_tab_cannot_be_deleted_and_unknown_tab_wins_precedence() {
     let mut state = state();
-    let revision = state.revision;
-
     assert_eq!(
-        state.delete_pane(HOST_A, revision, 1),
+        state.delete_pane(HOST_A, state.revision(), 1),
         Err(LayoutError::LastPaneInTab { tab_id: 1 })
     );
     assert_eq!(
-        state.delete_tab(HOST_A, revision, 1),
+        state.delete_tab(HOST_A, state.revision(), 99),
+        Err(LayoutError::UnknownTab { tab_id: 99 })
+    );
+    assert_eq!(
+        state.delete_tab(HOST_A, state.revision(), 1),
         Err(LayoutError::LastTab)
     );
-    assert_eq!(state.revision, revision);
 }
 
 #[test]
-fn pane_ids_are_not_reused_after_deletion() {
+fn ids_are_not_reused_after_deleted_tabs_or_panes() {
     let mut state = state();
-    let second = state
-        .create_pane(HOST_A, state.revision, 1, Axis::LeftRight, 24, 80)
+    let pane = state
+        .create_pane(HOST_A, state.revision(), 1, Axis::LeftRight, 24, 80)
         .expect("second pane");
     state
-        .delete_pane(HOST_A, state.revision, second)
+        .delete_pane(HOST_A, state.revision(), pane)
         .expect("delete second pane");
-
     assert_eq!(
         state
-            .create_pane(HOST_A, state.revision, 1, Axis::LeftRight, 24, 80)
+            .create_pane(HOST_A, state.revision(), 1, Axis::LeftRight, 24, 80)
             .expect("third pane"),
         3
     );
-}
 
-#[test]
-fn zero_sized_grids_are_rejected_without_mutating_the_state() {
-    let mut state = state();
-    let before = state.clone();
-
-    assert_eq!(
-        state.create_pane(HOST_A, state.revision, 1, Axis::LeftRight, 0, 80),
-        Err(LayoutError::InvalidGrid)
-    );
-    assert_eq!(state, before);
-
-    assert_eq!(
-        state.create_tab(HOST_A, state.revision, 24, 0),
-        Err(LayoutError::InvalidGrid)
-    );
-    assert_eq!(state, before);
-}
-
-#[test]
-fn a_created_tab_has_one_creator_hosted_pane_at_the_requested_grid() {
-    let mut state = state();
-    state
-        .add_member(state.revision, HOST_B.to_vec())
-        .expect("member B joins");
-
-    let tab_id = state
-        .create_tab(HOST_B, state.revision, 33, 111)
-        .expect("B creates a tab");
-    let tab = state
-        .tabs
-        .iter()
-        .find(|tab| tab.tab_id == tab_id)
-        .expect("created tab exists");
-    let Node::Leaf { pane_id } = tab.root else {
-        panic!("a new tab starts with exactly one leaf");
-    };
-    let pane = &state.panes[&pane_id];
-
-    assert_eq!(state.pane_ids_in_tab(tab_id), vec![pane_id]);
-    assert_eq!(pane.host_peer_id, HOST_B);
-    assert_eq!((pane.grid_rows, pane.grid_cols), (33, 111));
-}
-
-#[test]
-fn successful_mutations_advance_the_revision_once() {
-    let mut state = state();
-    let revision = state.revision;
-    state
-        .add_member(revision, HOST_B.to_vec())
-        .expect("member joins");
-    assert_eq!(state.revision, revision + 1);
-
-    let revision = state.revision;
-    let tab_id = state
-        .create_tab(HOST_A, revision, 24, 80)
-        .expect("create tab");
-    assert_eq!(state.revision, revision + 1);
-
-    let pane_id = state
-        .create_pane(HOST_A, state.revision, 1, Axis::LeftRight, 24, 80)
-        .expect("create pane to delete");
-    let revision = state.revision;
-    state
-        .delete_pane(HOST_A, revision, pane_id)
-        .expect("delete pane");
-    assert_eq!(state.revision, revision + 1);
-
-    let revision = state.revision;
-    state
-        .delete_tab(HOST_A, revision, tab_id)
-        .expect("delete all-owned tab");
-    assert_eq!(state.revision, revision + 1);
-}
-
-#[test]
-fn failed_ownership_and_limit_operations_leave_the_entire_state_unchanged() {
-    let mut ownership = state();
-    ownership
-        .add_member(ownership.revision, HOST_B.to_vec())
-        .expect("member B joins");
-    let before = ownership.clone();
-    assert_eq!(
-        ownership.delete_pane(HOST_B, ownership.revision, 1),
-        Err(LayoutError::NotPaneHost { pane_id: 1 })
-    );
-    assert_eq!(ownership, before);
-
-    let mut capped = state();
-    let mut leaves = vec![1];
-    while leaves.len() < MAX_PANES_PER_TAB {
-        let target = leaves.remove(0);
-        let new_pane = capped
-            .create_pane(HOST_A, capped.revision, target, Axis::LeftRight, 24, 80)
-            .expect("within pane limit");
-        leaves.extend([target, new_pane]);
-    }
-    let before = capped.clone();
-    assert_eq!(
-        capped.create_pane(HOST_A, capped.revision, leaves[0], Axis::LeftRight, 24, 80),
-        Err(LayoutError::PaneLimit)
-    );
-    assert_eq!(capped, before);
-}
-
-#[test]
-fn tab_ids_are_not_reused_after_a_tab_is_deleted() {
-    let mut state = state();
     let first_new_tab = state
-        .create_tab(HOST_A, state.revision, 24, 80)
+        .create_tab(HOST_A, state.revision(), 24, 80)
         .expect("first new tab");
     let second_new_tab = state
-        .create_tab(HOST_A, state.revision, 24, 80)
+        .create_tab(HOST_A, state.revision(), 24, 80)
         .expect("second new tab");
     state
-        .delete_tab(HOST_A, state.revision, first_new_tab)
-        .expect("delete first new tab");
-
+        .delete_tab(HOST_A, state.revision(), first_new_tab)
+        .expect("delete first tab");
     assert_eq!(
         state
-            .create_tab(HOST_A, state.revision, 24, 80)
+            .create_tab(HOST_A, state.revision(), 24, 80)
             .expect("replacement tab"),
         second_new_tab + 1
     );
@@ -368,16 +278,199 @@ fn tab_ids_are_not_reused_after_a_tab_is_deleted() {
 fn an_owner_can_delete_an_entire_tab_when_every_pane_is_local() {
     let mut state = state();
     let tab_id = state
-        .create_tab(HOST_A, state.revision, 24, 80)
+        .create_tab(HOST_A, state.revision(), 24, 80)
         .expect("second tab");
     let only_pane = state.pane_ids_in_tab(tab_id)[0];
-    let revision = state.revision;
-
+    let revision = state.revision();
     state
         .delete_tab(HOST_A, revision, tab_id)
         .expect("all-owned tab can be deleted");
 
-    assert_eq!(state.revision, revision + 1);
-    assert_eq!(state.tabs.len(), 1);
-    assert!(!state.panes.contains_key(&only_pane));
+    let snapshot = snapshot(&state);
+    assert_eq!(state.revision(), revision + 1);
+    assert_eq!(snapshot.tabs.len(), 1);
+    assert!(!snapshot.panes.contains_key(&only_pane));
+}
+
+#[test]
+fn successful_visible_mutations_advance_revision_once() {
+    let mut state = state();
+    let revision = state.revision();
+    state
+        .add_member(revision, HOST_B.to_vec(), ADDR_B.to_vec())
+        .expect("member joins");
+    assert_eq!(state.revision(), revision + 1);
+
+    let revision = state.revision();
+    let tab_id = state
+        .create_tab(HOST_A, revision, 24, 80)
+        .expect("create tab");
+    assert_eq!(state.revision(), revision + 1);
+
+    let pane_id = state
+        .create_pane(HOST_A, state.revision(), 1, Axis::LeftRight, 24, 80)
+        .expect("create pane");
+    let revision = state.revision();
+    state
+        .delete_pane(HOST_A, revision, pane_id)
+        .expect("delete pane");
+    assert_eq!(state.revision(), revision + 1);
+
+    let revision = state.revision();
+    state
+        .delete_tab(HOST_A, revision, tab_id)
+        .expect("delete tab");
+    assert_eq!(state.revision(), revision + 1);
+}
+
+#[test]
+fn pane_reservation_is_invisible_until_the_creator_reports_ready() {
+    let mut state = state();
+    state
+        .add_member(state.revision(), HOST_B.to_vec(), ADDR_B.to_vec())
+        .expect("member B joins");
+    let before = snapshot(&state);
+    let reservation = state
+        .reserve_pane(HOST_B, state.revision(), 1, Axis::LeftRight, 30, 100)
+        .expect("reserve B pane");
+
+    assert_eq!(snapshot(&state), before);
+    assert_eq!(state.revision(), before.revision);
+    assert_eq!(
+        state
+            .pane_ready(HOST_B, state.revision(), reservation.reservation_id)
+            .expect("creator reports ready"),
+        ReservationCommit::Pane {
+            pane_id: reservation.pane_id
+        }
+    );
+    let snapshot = snapshot(&state);
+    assert_eq!(snapshot.panes[&reservation.pane_id].host_peer_id, HOST_B);
+    assert_eq!(snapshot.panes[&reservation.pane_id].grid_rows, 30);
+    assert_eq!(state.revision(), before.revision + 1);
+}
+
+#[test]
+fn tab_reservation_commits_its_reserved_tab_and_initial_pane() {
+    let mut state = state();
+    state
+        .add_member(state.revision(), HOST_B.to_vec(), ADDR_B.to_vec())
+        .expect("member B joins");
+    let reservation = state
+        .reserve_tab(HOST_B, state.revision(), 33, 111)
+        .expect("reserve B tab");
+    let tab_id = reservation.tab_id.expect("tab reservation has tab ID");
+
+    assert_eq!(
+        state
+            .pane_ready(HOST_B, state.revision(), reservation.reservation_id)
+            .expect("commit tab"),
+        ReservationCommit::Tab {
+            tab_id,
+            pane_id: reservation.pane_id,
+        }
+    );
+    let snapshot = snapshot(&state);
+    assert_eq!(
+        tab(&snapshot, tab_id).root,
+        Node::Leaf {
+            pane_id: reservation.pane_id
+        }
+    );
+    assert_eq!(snapshot.panes[&reservation.pane_id].host_peer_id, HOST_B);
+}
+
+#[test]
+fn cancelling_or_expiring_a_reservation_keeps_layout_invisible_and_consumes_ids() {
+    let mut state = state();
+    let before = snapshot(&state);
+    let first = state
+        .reserve_pane(HOST_A, state.revision(), 1, Axis::LeftRight, 24, 80)
+        .expect("reserve first pane");
+    state
+        .cancel_reservation(HOST_A, first.reservation_id)
+        .expect("creator cancels");
+    assert_eq!(snapshot(&state), before);
+    assert_eq!(state.revision(), before.revision);
+
+    let second = state
+        .reserve_pane(HOST_A, state.revision(), 1, Axis::LeftRight, 24, 80)
+        .expect("reserve second pane");
+    state
+        .expire_reservation(second.reservation_id)
+        .expect("coordinator expires it");
+    assert_eq!(snapshot(&state), before);
+    let third = state
+        .reserve_pane(HOST_A, state.revision(), 1, Axis::LeftRight, 24, 80)
+        .expect("reserve third pane");
+    assert!(third.pane_id > second.pane_id);
+    state
+        .cancel_reservation(HOST_A, third.reservation_id)
+        .expect("cleanup");
+
+    let tab = state
+        .reserve_tab(HOST_A, state.revision(), 24, 80)
+        .expect("reserve a tab");
+    state
+        .expire_reservation(tab.reservation_id)
+        .expect("expire tab reservation");
+    assert_eq!(snapshot(&state), before);
+}
+
+#[test]
+fn only_the_reservation_creator_can_commit_or_cancel_it() {
+    let mut state = state();
+    state
+        .add_member(state.revision(), HOST_B.to_vec(), ADDR_B.to_vec())
+        .expect("member B joins");
+    let reservation = state
+        .reserve_pane(HOST_B, state.revision(), 1, Axis::LeftRight, 24, 80)
+        .expect("reserve B pane");
+    let before = snapshot(&state);
+
+    assert_eq!(
+        state.pane_ready(HOST_A, state.revision(), reservation.reservation_id),
+        Err(LayoutError::ReservationCreatorMismatch)
+    );
+    assert_eq!(
+        state.cancel_reservation(HOST_A, reservation.reservation_id),
+        Err(LayoutError::ReservationCreatorMismatch)
+    );
+    assert_eq!(snapshot(&state), before);
+    state
+        .cancel_reservation(HOST_B, reservation.reservation_id)
+        .expect("creator can cancel");
+}
+
+#[test]
+fn snapshots_associate_pane_hosts_with_bounded_member_addresses_and_reject_malformed_data() {
+    let mut state = state();
+    state
+        .add_member(state.revision(), HOST_B.to_vec(), ADDR_B.to_vec())
+        .expect("member B joins");
+    state
+        .update_member_endpoint(state.revision(), HOST_B, b"updated-addr-b".to_vec())
+        .expect("member B updates its endpoint");
+    let pane_id = state
+        .create_pane(HOST_B, state.revision(), 1, Axis::LeftRight, 24, 80)
+        .expect("B pane");
+    let snapshot = snapshot(&state);
+    assert_eq!(snapshot.panes[&pane_id].host_peer_id, HOST_B);
+    assert_eq!(
+        snapshot
+            .members
+            .iter()
+            .find(|member| member.peer_id == HOST_B)
+            .expect("B member")
+            .endpoint_addr,
+        b"updated-addr-b"
+    );
+    SessionState::validate_snapshot(&snapshot).expect("valid snapshot");
+
+    let mut malformed = snapshot;
+    malformed.tabs.clear();
+    assert_eq!(
+        SessionState::validate_snapshot(&malformed),
+        Err(LayoutError::InvalidSnapshot)
+    );
 }

--- a/tests/layout.rs
+++ b/tests/layout.rs
@@ -61,6 +61,22 @@ fn initial_layout_rejects_zero_sized_grids_and_invalid_endpoint_addresses() {
         ),
         Err(LayoutError::InvalidEndpointAddress)
     );
+    assert_eq!(
+        SessionState::new(Vec::new(), ADDR_A.to_vec(), 24, 80),
+        Err(LayoutError::InvalidPeerId)
+    );
+}
+
+#[test]
+fn member_setup_rejects_empty_peer_ids_without_mutating_the_snapshot() {
+    let mut state = state();
+    let before = snapshot(&state);
+
+    assert_eq!(
+        state.add_member(state.revision(), Vec::new(), ADDR_B.to_vec()),
+        Err(LayoutError::InvalidPeerId)
+    );
+    assert_eq!(snapshot(&state), before);
 }
 
 #[test]
@@ -454,10 +470,10 @@ fn snapshots_associate_pane_hosts_with_bounded_member_addresses_and_reject_malfo
     let pane_id = state
         .create_pane(HOST_B, state.revision(), 1, Axis::LeftRight, 24, 80)
         .expect("B pane");
-    let snapshot = snapshot(&state);
-    assert_eq!(snapshot.panes[&pane_id].host_peer_id, HOST_B);
+    let valid_snapshot = snapshot(&state);
+    assert_eq!(valid_snapshot.panes[&pane_id].host_peer_id, HOST_B);
     assert_eq!(
-        snapshot
+        valid_snapshot
             .members
             .iter()
             .find(|member| member.peer_id == HOST_B)
@@ -465,12 +481,33 @@ fn snapshots_associate_pane_hosts_with_bounded_member_addresses_and_reject_malfo
             .endpoint_addr,
         b"updated-addr-b"
     );
-    SessionState::validate_snapshot(&snapshot).expect("valid snapshot");
+    SessionState::validate_snapshot(&valid_snapshot).expect("valid snapshot");
 
-    let mut malformed = snapshot;
+    let mut malformed = valid_snapshot;
     malformed.tabs.clear();
     assert_eq!(
         SessionState::validate_snapshot(&malformed),
+        Err(LayoutError::InvalidSnapshot)
+    );
+
+    let mut zero_tab_id = snapshot(&state);
+    zero_tab_id.tabs[0].tab_id = 0;
+    assert_eq!(
+        SessionState::validate_snapshot(&zero_tab_id),
+        Err(LayoutError::InvalidSnapshot)
+    );
+
+    let mut zero_pane_id = snapshot(&state);
+    let pane = zero_pane_id
+        .panes
+        .remove(&pane_id)
+        .expect("pane exists in snapshot");
+    zero_pane_id
+        .panes
+        .insert(0, p2pmux::layout::Pane { pane_id: 0, ..pane });
+    zero_pane_id.tabs[0].root = Node::Leaf { pane_id: 0 };
+    assert_eq!(
+        SessionState::validate_snapshot(&zero_pane_id),
         Err(LayoutError::InvalidSnapshot)
     );
 }

--- a/tests/layout.rs
+++ b/tests/layout.rs
@@ -24,6 +24,18 @@ fn initial_state_has_one_tab_and_one_hosted_pane() {
 }
 
 #[test]
+fn initial_layout_rejects_zero_sized_grids() {
+    assert_eq!(
+        SessionState::new(HOST_A.to_vec(), 0, 80),
+        Err(LayoutError::InvalidGrid)
+    );
+    assert_eq!(
+        SessionState::new(HOST_A.to_vec(), 24, 0),
+        Err(LayoutError::InvalidGrid)
+    );
+}
+
+#[test]
 fn creating_panes_uses_the_requested_split_axis() {
     let mut state = state();
     let first_revision = state.revision;

--- a/tests/layout.rs
+++ b/tests/layout.rs
@@ -16,6 +16,27 @@ fn snapshot(state: &SessionState) -> LayoutSnapshot {
     state.snapshot()
 }
 
+#[test]
+fn removing_a_member_atomically_prunes_its_panes_and_empty_tabs() {
+    let mut state = state();
+    state
+        .add_member(state.revision(), HOST_B.to_vec(), ADDR_B.to_vec())
+        .expect("member B joins");
+    state
+        .create_tab(HOST_B, state.revision(), 24, 80)
+        .expect("B creates a tab");
+
+    state.remove_member(HOST_B).expect("member B departs");
+    let snapshot = snapshot(&state);
+    assert_eq!(snapshot.revision, 4);
+    assert_eq!(snapshot.members.len(), 1);
+    assert_eq!(snapshot.members[0].peer_id, HOST_A);
+    assert_eq!(snapshot.tabs.len(), 1);
+    assert_eq!(snapshot.panes.len(), 1);
+    assert_eq!(snapshot.panes[&1].host_peer_id, HOST_A);
+    SessionState::validate_snapshot(&snapshot).expect("departure leaves a valid snapshot");
+}
+
 fn tab(snapshot: &LayoutSnapshot, tab_id: u64) -> &p2pmux::layout::Tab {
     snapshot
         .tabs

--- a/tests/module_surface.rs
+++ b/tests/module_surface.rs
@@ -17,5 +17,5 @@ fn exposes_the_scaffold_module_boundaries() {
     let _: Option<JoinTicket> = None;
     let _: Option<HostSession> = None;
     let _: Option<Envelope> = None;
-    assert_eq!(PROTOCOL_VERSION, 1);
+    assert_eq!(PROTOCOL_VERSION, 2);
 }

--- a/tests/protocol.rs
+++ b/tests/protocol.rs
@@ -468,6 +468,115 @@ fn layout_messages_reject_invalid_shapes_and_bounds() {
 }
 
 #[test]
+fn layout_grids_must_fit_the_reducer_u16_grid() {
+    let maximum = u32::from(u16::MAX);
+    let oversized = maximum + 1;
+    let state = layout_state(leaf(1));
+    let empty_action = LayoutRequest {
+        request_id: 1,
+        base_revision: 1,
+        create_pane: None,
+        delete_pane: None,
+        create_tab: None,
+        delete_tab: None,
+    };
+
+    for valid in [
+        envelope(envelope::Body::LayoutRequest(LayoutRequest {
+            create_pane: Some(CreatePane {
+                target_pane_id: 1,
+                axis: SplitAxis::LeftRight as i32,
+                grid_rows: maximum,
+                grid_cols: maximum,
+            }),
+            ..empty_action.clone()
+        })),
+        envelope(envelope::Body::LayoutRequest(LayoutRequest {
+            create_tab: Some(CreateTab {
+                grid_rows: maximum,
+                grid_cols: maximum,
+            }),
+            ..empty_action.clone()
+        })),
+        envelope(envelope::Body::SessionSnapshot(SessionSnapshot {
+            state: Some(LayoutState {
+                panes: vec![PaneDescriptor {
+                    grid_rows: maximum,
+                    grid_cols: maximum,
+                    ..state.panes[0].clone()
+                }],
+                ..state.clone()
+            }),
+        })),
+    ] {
+        assert!(
+            encode_frame(&valid).is_ok(),
+            "u16 grid maximum must be valid"
+        );
+    }
+
+    let invalid = [
+        envelope(envelope::Body::LayoutRequest(LayoutRequest {
+            create_pane: Some(CreatePane {
+                target_pane_id: 1,
+                axis: SplitAxis::LeftRight as i32,
+                grid_rows: oversized,
+                grid_cols: 80,
+            }),
+            ..empty_action.clone()
+        })),
+        envelope(envelope::Body::LayoutRequest(LayoutRequest {
+            create_pane: Some(CreatePane {
+                target_pane_id: 1,
+                axis: SplitAxis::LeftRight as i32,
+                grid_rows: 24,
+                grid_cols: oversized,
+            }),
+            ..empty_action.clone()
+        })),
+        envelope(envelope::Body::LayoutRequest(LayoutRequest {
+            create_tab: Some(CreateTab {
+                grid_rows: oversized,
+                grid_cols: 80,
+            }),
+            ..empty_action.clone()
+        })),
+        envelope(envelope::Body::LayoutRequest(LayoutRequest {
+            create_tab: Some(CreateTab {
+                grid_rows: 24,
+                grid_cols: oversized,
+            }),
+            ..empty_action.clone()
+        })),
+        envelope(envelope::Body::SessionSnapshot(SessionSnapshot {
+            state: Some(LayoutState {
+                panes: vec![PaneDescriptor {
+                    grid_rows: oversized,
+                    ..state.panes[0].clone()
+                }],
+                ..state.clone()
+            }),
+        })),
+        envelope(envelope::Body::SessionSnapshot(SessionSnapshot {
+            state: Some(LayoutState {
+                panes: vec![PaneDescriptor {
+                    grid_cols: oversized,
+                    ..state.panes[0].clone()
+                }],
+                ..state
+            }),
+        })),
+    ];
+
+    for invalid in invalid {
+        assert!(
+            encode_frame(&invalid).is_err(),
+            "oversized layout grid must be rejected"
+        );
+    }
+}
+
+#[test]
 fn pane_reservation_rejects_a_zero_present_tab_id() {
     for tab_id in [None, Some(1)] {
         assert!(

--- a/tests/protocol.rs
+++ b/tests/protocol.rs
@@ -35,7 +35,7 @@ fn envelope_exposes_each_v1_body() {
         envelope(envelope::Body::Join(Join {
             session_id: b"session-a".to_vec(),
             peer_id: b"peer-a".to_vec(),
-            endpoint_addr: Vec::new(),
+            endpoint_addr: b"endpoint-a".to_vec(),
         })),
         envelope(envelope::Body::Welcome(Welcome {
             session_id: b"session-a".to_vec(),
@@ -74,7 +74,7 @@ fn envelope_exposes_each_v1_body() {
     ];
 
     let expected_body_shapes: [&[(u32, u8)]; 7] = [
-        &[(1, 2), (2, 2)],
+        &[(1, 2), (2, 2), (3, 2)],
         &[(1, 2), (2, 2), (3, 2)],
         &[(1, 2), (2, 0), (3, 2)],
         &[(1, 2), (2, 2), (3, 0), (4, 0)],
@@ -160,7 +160,7 @@ fn sample_envelopes() -> Vec<Envelope> {
         envelope(envelope::Body::Join(Join {
             session_id: b"session-a".to_vec(),
             peer_id: b"peer-a".to_vec(),
-            endpoint_addr: Vec::new(),
+            endpoint_addr: b"endpoint-a".to_vec(),
         })),
         envelope(envelope::Body::Welcome(Welcome {
             session_id: b"session-a".to_vec(),
@@ -245,7 +245,7 @@ fn v2_envelopes() -> Vec<Envelope> {
             base_revision: 1,
             create_pane: Some(CreatePane {
                 target_pane_id: 1,
-                axis: SplitAxis::LeftRight as i32,
+                axis: Some(SplitAxis::LeftRight as i32),
                 grid_rows: 24,
                 grid_cols: 80,
             }),
@@ -258,7 +258,10 @@ fn v2_envelopes() -> Vec<Envelope> {
             pane_id: 2,
             tab_id: None,
         })),
-        envelope(envelope::Body::PaneReady(PaneReady { reservation_id: 1 })),
+        envelope(envelope::Body::PaneReady(PaneReady {
+            reservation_id: 1,
+            base_revision: 1,
+        })),
         envelope(envelope::Body::LayoutCommit(LayoutCommit {
             revision: 1,
             state: Some(state),
@@ -281,7 +284,7 @@ fn envelope_exposes_each_v2_layout_body_with_stable_tags() {
         &[(1, 2)],
         &[(1, 0), (2, 0), (3, 2)],
         &[(1, 0), (2, 0)],
-        &[(1, 0)],
+        &[(1, 0), (2, 0)],
         &[(1, 0), (2, 2)],
         &[(1, 0), (2, 0)],
         &[(1, 2), (2, 2), (3, 0)],
@@ -328,7 +331,7 @@ fn layout_messages_reject_invalid_shapes_and_bounds() {
     let multiple_actions = LayoutRequest {
         create_pane: Some(CreatePane {
             target_pane_id: 1,
-            axis: SplitAxis::LeftRight as i32,
+            axis: Some(SplitAxis::LeftRight as i32),
             grid_rows: 24,
             grid_cols: 80,
         }),
@@ -351,7 +354,7 @@ fn layout_messages_reject_invalid_shapes_and_bounds() {
             root: Some(LayoutNode {
                 leaf_pane_id: Some(1),
                 split: Some(Box::new(LayoutSplit {
-                    axis: SplitAxis::LeftRight as i32,
+                    axis: Some(SplitAxis::LeftRight as i32),
                     first: Some(leaf(1)),
                     second: Some(leaf(1)),
                 })),
@@ -447,7 +450,10 @@ fn layout_messages_reject_invalid_shapes_and_bounds() {
             pane_id: 1,
             tab_id: None,
         })),
-        envelope(envelope::Body::PaneReady(PaneReady { reservation_id: 0 })),
+        envelope(envelope::Body::PaneReady(PaneReady {
+            reservation_id: 0,
+            base_revision: 1,
+        })),
         envelope(envelope::Body::LayoutReject(LayoutReject {
             request_id: 1,
             reason: 0,
@@ -464,6 +470,101 @@ fn layout_messages_reject_invalid_shapes_and_bounds() {
             encode_frame(&invalid).is_err(),
             "{invalid:?} must be rejected"
         );
+    }
+}
+
+#[test]
+fn join_endpoint_and_pane_ready_revision_are_required() {
+    let empty_join_endpoint = envelope(envelope::Body::Join(Join {
+        session_id: b"session-a".to_vec(),
+        peer_id: b"peer-a".to_vec(),
+        endpoint_addr: Vec::new(),
+    }));
+    let missing_ready_revision = envelope(envelope::Body::PaneReady(PaneReady {
+        reservation_id: 1,
+        base_revision: 0,
+    }));
+
+    for invalid in [empty_join_endpoint, missing_ready_revision] {
+        assert!(
+            encode_frame(&invalid).is_err(),
+            "v2 Join endpoint addresses and PaneReady revisions are required"
+        );
+        let mut raw = Vec::new();
+        invalid
+            .encode_length_delimited(&mut raw)
+            .expect("raw invalid frame should encode");
+        assert!(decode_frame(&raw).is_err());
+    }
+}
+
+#[test]
+fn create_and_split_axes_must_be_explicitly_present_and_valid() {
+    fn create_request(axis: Option<i32>) -> Envelope {
+        envelope(envelope::Body::LayoutRequest(LayoutRequest {
+            request_id: 1,
+            base_revision: 1,
+            create_pane: Some(CreatePane {
+                target_pane_id: 1,
+                axis,
+                grid_rows: 24,
+                grid_cols: 80,
+            }),
+            delete_pane: None,
+            create_tab: None,
+            delete_tab: None,
+        }))
+    }
+
+    fn split_snapshot(axis: Option<i32>) -> Envelope {
+        let state = LayoutState {
+            panes: vec![
+                PaneDescriptor {
+                    pane_id: 1,
+                    host_peer_id: b"peer-a".to_vec(),
+                    grid_rows: 24,
+                    grid_cols: 80,
+                },
+                PaneDescriptor {
+                    pane_id: 2,
+                    host_peer_id: b"peer-a".to_vec(),
+                    grid_rows: 24,
+                    grid_cols: 80,
+                },
+            ],
+            tabs: vec![TabDescriptor {
+                tab_id: 1,
+                root: Some(LayoutNode {
+                    leaf_pane_id: None,
+                    split: Some(Box::new(LayoutSplit {
+                        axis,
+                        first: Some(leaf(1)),
+                        second: Some(leaf(2)),
+                    })),
+                }),
+            }],
+            ..layout_state(leaf(1))
+        };
+        envelope(envelope::Body::SessionSnapshot(SessionSnapshot {
+            state: Some(state),
+        }))
+    }
+
+    for invalid in [
+        create_request(None),
+        create_request(Some(99)),
+        split_snapshot(None),
+        split_snapshot(Some(99)),
+    ] {
+        assert!(
+            encode_frame(&invalid).is_err(),
+            "layout axes must not silently default to LeftRight"
+        );
+        let mut raw = Vec::new();
+        invalid
+            .encode_length_delimited(&mut raw)
+            .expect("raw invalid frame should encode");
+        assert!(decode_frame(&raw).is_err());
     }
 }
 
@@ -485,7 +586,7 @@ fn layout_grids_must_fit_the_reducer_u16_grid() {
         envelope(envelope::Body::LayoutRequest(LayoutRequest {
             create_pane: Some(CreatePane {
                 target_pane_id: 1,
-                axis: SplitAxis::LeftRight as i32,
+                axis: Some(SplitAxis::LeftRight as i32),
                 grid_rows: maximum,
                 grid_cols: maximum,
             }),
@@ -519,7 +620,7 @@ fn layout_grids_must_fit_the_reducer_u16_grid() {
         envelope(envelope::Body::LayoutRequest(LayoutRequest {
             create_pane: Some(CreatePane {
                 target_pane_id: 1,
-                axis: SplitAxis::LeftRight as i32,
+                axis: Some(SplitAxis::LeftRight as i32),
                 grid_rows: oversized,
                 grid_cols: 80,
             }),
@@ -528,7 +629,7 @@ fn layout_grids_must_fit_the_reducer_u16_grid() {
         envelope(envelope::Body::LayoutRequest(LayoutRequest {
             create_pane: Some(CreatePane {
                 target_pane_id: 1,
-                axis: SplitAxis::LeftRight as i32,
+                axis: Some(SplitAxis::LeftRight as i32),
                 grid_rows: 24,
                 grid_cols: oversized,
             }),
@@ -676,7 +777,7 @@ fn layout_state_rejects_empty_duplicate_and_dangling_references() {
             root: Some(LayoutNode {
                 leaf_pane_id: None,
                 split: Some(Box::new(LayoutSplit {
-                    axis: SplitAxis::LeftRight as i32,
+                    axis: Some(SplitAxis::LeftRight as i32),
                     first: Some(leaf(1)),
                     second: Some(leaf(1)),
                 })),
@@ -760,7 +861,7 @@ fn layout_state_wire_shape_includes_all_nested_fields() {
             root: Some(LayoutNode {
                 leaf_pane_id: None,
                 split: Some(Box::new(LayoutSplit {
-                    axis: SplitAxis::TopBottom as i32,
+                    axis: Some(SplitAxis::TopBottom as i32),
                     first: Some(leaf(11)),
                     second: Some(leaf(11)),
                 })),
@@ -821,7 +922,7 @@ fn layout_messages_reject_deep_or_wide_trees_and_oversize_join_endpoint() {
         LayoutNode {
             leaf_pane_id: None,
             split: Some(Box::new(LayoutSplit {
-                axis: SplitAxis::TopBottom as i32,
+                axis: Some(SplitAxis::TopBottom as i32),
                 first: Some(full_tree(depth - 1, next_pane_id)),
                 second: Some(full_tree(depth - 1, next_pane_id)),
             })),

--- a/tests/protocol.rs
+++ b/tests/protocol.rs
@@ -1,8 +1,11 @@
 use p2pmux::protocol::{
-    ControlLease, Delta, Envelope, Input, Join, MAX_DELTA_BYTES, MAX_ENVELOPE_BYTES,
-    MAX_FRAME_BYTES, MAX_INPUT_BYTES, MAX_PANE_ID_BYTES, MAX_PEER_ID_BYTES, MAX_SESSION_ID_BYTES,
-    MAX_SNAPSHOT_BYTES, PROTOCOL_VERSION, ProtocolError, Snapshot, TakeControl, Welcome,
-    decode_frame, encode_frame, envelope,
+    ControlLease, CreatePane, CreateTab, DeletePane, DeleteTab, Delta, Envelope, Input, Join,
+    LayoutCommit, LayoutNode, LayoutReject, LayoutRejectReason, LayoutRequest, LayoutSplit,
+    LayoutState, MAX_DELTA_BYTES, MAX_ENDPOINT_ADDR_BYTES, MAX_ENVELOPE_BYTES, MAX_FRAME_BYTES,
+    MAX_INPUT_BYTES, MAX_PANE_ID_BYTES, MAX_PEER_ID_BYTES, MAX_SESSION_ID_BYTES,
+    MAX_SNAPSHOT_BYTES, MemberDescriptor, PROTOCOL_VERSION, PaneDescriptor, PaneReady,
+    PaneReservation, PaneSubscribe, ProtocolError, SessionSnapshot, Snapshot, SplitAxis,
+    TabDescriptor, TakeControl, Welcome, decode_frame, encode_frame, envelope,
 };
 use prost::Message;
 
@@ -22,11 +25,17 @@ fn envelope(body: envelope::Body) -> Envelope {
 }
 
 #[test]
+fn protocol_version_is_v2() {
+    assert_eq!(PROTOCOL_VERSION, 2);
+}
+
+#[test]
 fn envelope_exposes_each_v1_body() {
     let messages = [
         envelope(envelope::Body::Join(Join {
             session_id: b"session-a".to_vec(),
             peer_id: b"peer-a".to_vec(),
+            endpoint_addr: Vec::new(),
         })),
         envelope(envelope::Body::Welcome(Welcome {
             session_id: b"session-a".to_vec(),
@@ -151,6 +160,7 @@ fn sample_envelopes() -> Vec<Envelope> {
         envelope(envelope::Body::Join(Join {
             session_id: b"session-a".to_vec(),
             peer_id: b"peer-a".to_vec(),
+            endpoint_addr: Vec::new(),
         })),
         envelope(envelope::Body::Welcome(Welcome {
             session_id: b"session-a".to_vec(),
@@ -197,17 +207,337 @@ fn framed_envelopes_round_trip_all_v1_bodies() {
     }
 }
 
+fn leaf(pane_id: u64) -> LayoutNode {
+    LayoutNode {
+        leaf_pane_id: Some(pane_id),
+        split: None,
+    }
+}
+
+fn layout_state(root: LayoutNode) -> LayoutState {
+    LayoutState {
+        revision: 1,
+        members: vec![MemberDescriptor {
+            peer_id: b"peer-a".to_vec(),
+            endpoint_addr: b"endpoint-a".to_vec(),
+        }],
+        panes: vec![PaneDescriptor {
+            pane_id: 1,
+            host_peer_id: b"peer-a".to_vec(),
+            grid_rows: 24,
+            grid_cols: 80,
+        }],
+        tabs: vec![TabDescriptor {
+            tab_id: 1,
+            root: Some(root),
+        }],
+    }
+}
+
+fn v2_envelopes() -> Vec<Envelope> {
+    let state = layout_state(leaf(1));
+    vec![
+        envelope(envelope::Body::SessionSnapshot(SessionSnapshot {
+            state: Some(state.clone()),
+        })),
+        envelope(envelope::Body::LayoutRequest(LayoutRequest {
+            request_id: 1,
+            base_revision: 1,
+            create_pane: Some(CreatePane {
+                target_pane_id: 1,
+                axis: SplitAxis::LeftRight as i32,
+                grid_rows: 24,
+                grid_cols: 80,
+            }),
+            delete_pane: None,
+            create_tab: None,
+            delete_tab: None,
+        })),
+        envelope(envelope::Body::PaneReservation(PaneReservation {
+            reservation_id: 1,
+            pane_id: 2,
+            tab_id: 0,
+        })),
+        envelope(envelope::Body::PaneReady(PaneReady { reservation_id: 1 })),
+        envelope(envelope::Body::LayoutCommit(LayoutCommit {
+            revision: 1,
+            state: Some(state),
+        })),
+        envelope(envelope::Body::LayoutReject(LayoutReject {
+            request_id: 1,
+            reason: LayoutRejectReason::NotHost as i32,
+        })),
+        envelope(envelope::Body::PaneSubscribe(PaneSubscribe {
+            session_id: b"session-a".to_vec(),
+            peer_id: b"peer-a".to_vec(),
+            pane_id: 1,
+        })),
+    ]
+}
+
+#[test]
+fn envelope_exposes_each_v2_layout_body_with_stable_tags() {
+    let expected_body_shapes: [&[(u32, u8)]; 7] = [
+        &[(1, 2)],
+        &[(1, 0), (2, 0), (3, 2)],
+        &[(1, 0), (2, 0)],
+        &[(1, 0)],
+        &[(1, 0), (2, 2)],
+        &[(1, 0), (2, 0)],
+        &[(1, 2), (2, 2), (3, 0)],
+    ];
+
+    for ((message, expected_body_field), expected_body_shape) in v2_envelopes()
+        .into_iter()
+        .zip(17..=23)
+        .zip(expected_body_shapes)
+    {
+        let wire = message.encode_to_vec();
+        let envelope_fields = parse_fields(&wire);
+        assert_eq!(
+            field_shape(&envelope_fields),
+            vec![(1, 0), (2, 2), (expected_body_field, 2)],
+        );
+        assert_eq!(
+            field_shape(&parse_fields(&envelope_fields[2].value)),
+            expected_body_shape,
+        );
+        assert_eq!(Envelope::decode(wire.as_slice()).unwrap(), message);
+    }
+}
+
+#[test]
+fn framed_envelopes_round_trip_all_v2_layout_bodies() {
+    for original in v2_envelopes() {
+        let frame = encode_frame(&original).expect("valid layout envelope encodes");
+        assert_eq!(decode_frame(&frame).expect("valid frame decodes"), original);
+    }
+}
+
+#[test]
+fn layout_messages_reject_invalid_shapes_and_bounds() {
+    let state = layout_state(leaf(1));
+    let empty_action = LayoutRequest {
+        request_id: 1,
+        base_revision: 1,
+        create_pane: None,
+        delete_pane: None,
+        create_tab: None,
+        delete_tab: None,
+    };
+    let multiple_actions = LayoutRequest {
+        create_pane: Some(CreatePane {
+            target_pane_id: 1,
+            axis: SplitAxis::LeftRight as i32,
+            grid_rows: 24,
+            grid_cols: 80,
+        }),
+        delete_pane: Some(DeletePane { pane_id: 1 }),
+        ..empty_action.clone()
+    };
+    let empty_node = LayoutState {
+        tabs: vec![TabDescriptor {
+            tab_id: 1,
+            root: Some(LayoutNode {
+                leaf_pane_id: None,
+                split: None,
+            }),
+        }],
+        ..state.clone()
+    };
+    let multiple_nodes = LayoutState {
+        tabs: vec![TabDescriptor {
+            tab_id: 1,
+            root: Some(LayoutNode {
+                leaf_pane_id: Some(1),
+                split: Some(Box::new(LayoutSplit {
+                    axis: SplitAxis::LeftRight as i32,
+                    first: Some(leaf(1)),
+                    second: Some(leaf(1)),
+                })),
+            }),
+        }],
+        ..state.clone()
+    };
+    let too_many_members = LayoutState {
+        members: (0..9)
+            .map(|index| MemberDescriptor {
+                peer_id: format!("peer-{index}").into_bytes(),
+                endpoint_addr: b"endpoint".to_vec(),
+            })
+            .collect(),
+        ..state.clone()
+    };
+    let too_many_panes = LayoutState {
+        panes: (1..=73)
+            .map(|pane_id| PaneDescriptor {
+                pane_id,
+                host_peer_id: b"peer-a".to_vec(),
+                grid_rows: 24,
+                grid_cols: 80,
+            })
+            .collect(),
+        ..state.clone()
+    };
+    let too_many_tabs = LayoutState {
+        tabs: (1..=10)
+            .map(|tab_id| TabDescriptor {
+                tab_id,
+                root: Some(leaf(1)),
+            })
+            .collect(),
+        ..state.clone()
+    };
+    let zero_pane_grid = LayoutState {
+        panes: vec![PaneDescriptor {
+            pane_id: 1,
+            host_peer_id: b"peer-a".to_vec(),
+            grid_rows: 0,
+            grid_cols: 80,
+        }],
+        ..state.clone()
+    };
+    let invalid_grid = LayoutRequest {
+        create_tab: Some(CreateTab {
+            grid_rows: 0,
+            grid_cols: 80,
+        }),
+        ..empty_action.clone()
+    };
+    let invalid_delete = LayoutRequest {
+        delete_tab: Some(DeleteTab { tab_id: 0 }),
+        ..empty_action.clone()
+    };
+    let invalid_commit = LayoutCommit {
+        revision: 2,
+        state: Some(state.clone()),
+    };
+
+    let cases = vec![
+        envelope(envelope::Body::LayoutRequest(LayoutRequest {
+            request_id: 0,
+            base_revision: 1,
+            ..multiple_actions.clone()
+        })),
+        envelope(envelope::Body::LayoutRequest(empty_action)),
+        envelope(envelope::Body::LayoutRequest(multiple_actions)),
+        envelope(envelope::Body::LayoutRequest(invalid_grid)),
+        envelope(envelope::Body::LayoutRequest(invalid_delete)),
+        envelope(envelope::Body::SessionSnapshot(SessionSnapshot {
+            state: Some(empty_node),
+        })),
+        envelope(envelope::Body::SessionSnapshot(SessionSnapshot {
+            state: Some(multiple_nodes),
+        })),
+        envelope(envelope::Body::SessionSnapshot(SessionSnapshot {
+            state: Some(too_many_members),
+        })),
+        envelope(envelope::Body::SessionSnapshot(SessionSnapshot {
+            state: Some(too_many_panes),
+        })),
+        envelope(envelope::Body::SessionSnapshot(SessionSnapshot {
+            state: Some(too_many_tabs),
+        })),
+        envelope(envelope::Body::SessionSnapshot(SessionSnapshot {
+            state: Some(zero_pane_grid),
+        })),
+        envelope(envelope::Body::LayoutCommit(invalid_commit)),
+        envelope(envelope::Body::PaneReservation(PaneReservation {
+            reservation_id: 0,
+            pane_id: 1,
+            tab_id: 0,
+        })),
+        envelope(envelope::Body::PaneReady(PaneReady { reservation_id: 0 })),
+        envelope(envelope::Body::LayoutReject(LayoutReject {
+            request_id: 1,
+            reason: 0,
+        })),
+        envelope(envelope::Body::PaneSubscribe(PaneSubscribe {
+            session_id: Vec::new(),
+            peer_id: b"peer-a".to_vec(),
+            pane_id: 1,
+        })),
+    ];
+
+    for invalid in cases {
+        assert!(
+            encode_frame(&invalid).is_err(),
+            "{invalid:?} must be rejected"
+        );
+    }
+}
+
+#[test]
+fn layout_messages_reject_deep_or_wide_trees_and_oversize_join_endpoint() {
+    fn full_tree(depth: usize, next_pane_id: &mut u64) -> LayoutNode {
+        if depth == 0 {
+            let pane_id = *next_pane_id;
+            *next_pane_id += 1;
+            return leaf(pane_id);
+        }
+        LayoutNode {
+            leaf_pane_id: None,
+            split: Some(Box::new(LayoutSplit {
+                axis: SplitAxis::TopBottom as i32,
+                first: Some(full_tree(depth - 1, next_pane_id)),
+                second: Some(full_tree(depth - 1, next_pane_id)),
+            })),
+        }
+    }
+
+    let mut next_pane_id = 1;
+    let wide_tree = full_tree(4, &mut next_pane_id);
+    let mut next_pane_id = 1;
+    let deep_tree = full_tree(5, &mut next_pane_id);
+    let too_wide = LayoutState {
+        tabs: vec![TabDescriptor {
+            tab_id: 1,
+            root: Some(wide_tree),
+        }],
+        ..layout_state(leaf(1))
+    };
+    let too_deep = LayoutState {
+        tabs: vec![TabDescriptor {
+            tab_id: 1,
+            root: Some(deep_tree),
+        }],
+        ..layout_state(leaf(1))
+    };
+    let oversized_endpoint = envelope(envelope::Body::Join(Join {
+        session_id: b"session-a".to_vec(),
+        peer_id: b"peer-a".to_vec(),
+        endpoint_addr: vec![0; MAX_ENDPOINT_ADDR_BYTES + 1],
+    }));
+
+    for invalid in [
+        envelope(envelope::Body::SessionSnapshot(SessionSnapshot {
+            state: Some(too_wide),
+        })),
+        envelope(envelope::Body::SessionSnapshot(SessionSnapshot {
+            state: Some(too_deep),
+        })),
+        oversized_endpoint,
+    ] {
+        assert!(
+            encode_frame(&invalid).is_err(),
+            "{invalid:?} must be rejected"
+        );
+    }
+}
+
 #[test]
 fn decoder_rejects_unsupported_version() {
-    let mut wrong = sample_envelopes().remove(0);
-    wrong.version = PROTOCOL_VERSION + 1;
-    let mut frame = Vec::new();
-    wrong.encode_length_delimited(&mut frame).unwrap();
+    for version in [1, PROTOCOL_VERSION + 1] {
+        let mut wrong = sample_envelopes().remove(0);
+        wrong.version = version;
+        let mut frame = Vec::new();
+        wrong.encode_length_delimited(&mut frame).unwrap();
 
-    assert!(matches!(
-        decode_frame(&frame),
-        Err(ProtocolError::UnsupportedVersion(v)) if v == PROTOCOL_VERSION + 1
-    ));
+        assert!(matches!(
+            decode_frame(&frame),
+            Err(ProtocolError::UnsupportedVersion(v)) if v == version
+        ));
+    }
 }
 
 #[test]
@@ -332,6 +662,7 @@ fn decoder_rejects_missing_fields_and_invalid_sequences() {
     let empty_id = envelope(envelope::Body::Join(Join {
         session_id: Vec::new(),
         peer_id: b"peer-a".to_vec(),
+        endpoint_addr: Vec::new(),
     }));
     let mut empty_id_frame = Vec::new();
     empty_id
@@ -446,6 +777,7 @@ fn encode_frame_rejects_invalid_envelopes() {
             envelope(envelope::Body::Join(Join {
                 session_id: vec![0; MAX_SESSION_ID_BYTES + 1],
                 peer_id: b"peer-a".to_vec(),
+                endpoint_addr: Vec::new(),
             })),
         ),
         (
@@ -453,6 +785,7 @@ fn encode_frame_rejects_invalid_envelopes() {
             envelope(envelope::Body::Join(Join {
                 session_id: b"session-a".to_vec(),
                 peer_id: vec![0; MAX_PEER_ID_BYTES + 1],
+                endpoint_addr: Vec::new(),
             })),
         ),
         (

--- a/tests/protocol.rs
+++ b/tests/protocol.rs
@@ -256,7 +256,7 @@ fn v2_envelopes() -> Vec<Envelope> {
         envelope(envelope::Body::PaneReservation(PaneReservation {
             reservation_id: 1,
             pane_id: 2,
-            tab_id: 0,
+            tab_id: None,
         })),
         envelope(envelope::Body::PaneReady(PaneReady { reservation_id: 1 })),
         envelope(envelope::Body::LayoutCommit(LayoutCommit {
@@ -445,7 +445,7 @@ fn layout_messages_reject_invalid_shapes_and_bounds() {
         envelope(envelope::Body::PaneReservation(PaneReservation {
             reservation_id: 0,
             pane_id: 1,
-            tab_id: 0,
+            tab_id: None,
         })),
         envelope(envelope::Body::PaneReady(PaneReady { reservation_id: 0 })),
         envelope(envelope::Body::LayoutReject(LayoutReject {
@@ -465,6 +465,240 @@ fn layout_messages_reject_invalid_shapes_and_bounds() {
             "{invalid:?} must be rejected"
         );
     }
+}
+
+#[test]
+fn pane_reservation_rejects_a_zero_present_tab_id() {
+    for tab_id in [None, Some(1)] {
+        assert!(
+            encode_frame(&envelope(envelope::Body::PaneReservation(
+                PaneReservation {
+                    reservation_id: 1,
+                    pane_id: 2,
+                    tab_id,
+                }
+            )))
+            .is_ok(),
+            "an absent or nonzero reservation tab ID must be accepted"
+        );
+    }
+
+    let reservation = envelope(envelope::Body::PaneReservation(PaneReservation {
+        reservation_id: 1,
+        pane_id: 2,
+        tab_id: Some(0),
+    }));
+
+    assert!(
+        encode_frame(&reservation).is_err(),
+        "a present reservation tab ID must be nonzero"
+    );
+}
+
+#[test]
+fn layout_state_rejects_empty_duplicate_and_dangling_references() {
+    let state = layout_state(leaf(1));
+    let zero_revision = LayoutState {
+        revision: 0,
+        ..state.clone()
+    };
+    let empty_members = LayoutState {
+        members: Vec::new(),
+        ..state.clone()
+    };
+    let empty_panes = LayoutState {
+        panes: Vec::new(),
+        ..state.clone()
+    };
+    let empty_tabs = LayoutState {
+        tabs: Vec::new(),
+        ..state.clone()
+    };
+    let duplicate_members = LayoutState {
+        members: vec![state.members[0].clone(), state.members[0].clone()],
+        ..state.clone()
+    };
+    let empty_member_id = LayoutState {
+        members: vec![MemberDescriptor {
+            peer_id: Vec::new(),
+            ..state.members[0].clone()
+        }],
+        ..state.clone()
+    };
+    let empty_member_endpoint = LayoutState {
+        members: vec![MemberDescriptor {
+            endpoint_addr: Vec::new(),
+            ..state.members[0].clone()
+        }],
+        ..state.clone()
+    };
+    let duplicate_tabs = LayoutState {
+        tabs: vec![state.tabs[0].clone(), state.tabs[0].clone()],
+        ..state.clone()
+    };
+    let duplicate_panes = LayoutState {
+        panes: vec![state.panes[0].clone(), state.panes[0].clone()],
+        ..state.clone()
+    };
+    let zero_pane_id = LayoutState {
+        panes: vec![PaneDescriptor {
+            pane_id: 0,
+            ..state.panes[0].clone()
+        }],
+        ..state.clone()
+    };
+    let zero_tab_id = LayoutState {
+        tabs: vec![TabDescriptor {
+            tab_id: 0,
+            ..state.tabs[0].clone()
+        }],
+        ..state.clone()
+    };
+    let unknown_host = LayoutState {
+        panes: vec![PaneDescriptor {
+            host_peer_id: b"peer-b".to_vec(),
+            ..state.panes[0].clone()
+        }],
+        ..state.clone()
+    };
+    let duplicate_leaves = LayoutState {
+        tabs: vec![TabDescriptor {
+            tab_id: 1,
+            root: Some(LayoutNode {
+                leaf_pane_id: None,
+                split: Some(Box::new(LayoutSplit {
+                    axis: SplitAxis::LeftRight as i32,
+                    first: Some(leaf(1)),
+                    second: Some(leaf(1)),
+                })),
+            }),
+        }],
+        ..state.clone()
+    };
+    let unknown_leaf = LayoutState {
+        tabs: vec![TabDescriptor {
+            tab_id: 1,
+            root: Some(leaf(2)),
+        }],
+        ..state.clone()
+    };
+    let zero_leaf = LayoutState {
+        tabs: vec![TabDescriptor {
+            tab_id: 1,
+            root: Some(leaf(0)),
+        }],
+        ..state.clone()
+    };
+    let unreferenced_pane = LayoutState {
+        panes: vec![
+            state.panes[0].clone(),
+            PaneDescriptor {
+                pane_id: 2,
+                host_peer_id: b"peer-a".to_vec(),
+                grid_rows: 24,
+                grid_cols: 80,
+            },
+        ],
+        ..state
+    };
+
+    for invalid in [
+        zero_revision,
+        empty_members,
+        empty_panes,
+        empty_tabs,
+        duplicate_members,
+        empty_member_id,
+        empty_member_endpoint,
+        duplicate_tabs,
+        duplicate_panes,
+        zero_pane_id,
+        zero_tab_id,
+        unknown_host,
+        duplicate_leaves,
+        unknown_leaf,
+        zero_leaf,
+        unreferenced_pane,
+    ] {
+        assert!(
+            encode_frame(&envelope(envelope::Body::SessionSnapshot(
+                SessionSnapshot {
+                    state: Some(invalid),
+                }
+            )))
+            .is_err(),
+            "inconsistent layout state must be rejected"
+        );
+    }
+}
+
+#[test]
+fn layout_state_wire_shape_includes_all_nested_fields() {
+    let state = LayoutState {
+        revision: 7,
+        members: vec![MemberDescriptor {
+            peer_id: b"peer-a".to_vec(),
+            endpoint_addr: b"endpoint-a".to_vec(),
+        }],
+        panes: vec![PaneDescriptor {
+            pane_id: 11,
+            host_peer_id: b"peer-a".to_vec(),
+            grid_rows: 24,
+            grid_cols: 80,
+        }],
+        tabs: vec![TabDescriptor {
+            tab_id: 13,
+            root: Some(LayoutNode {
+                leaf_pane_id: None,
+                split: Some(Box::new(LayoutSplit {
+                    axis: SplitAxis::TopBottom as i32,
+                    first: Some(leaf(11)),
+                    second: Some(leaf(11)),
+                })),
+            }),
+        }],
+    };
+    let state_fields = parse_fields(&state.encode_to_vec());
+    assert_eq!(
+        field_shape(&state_fields),
+        vec![(1, 0), (2, 2), (3, 2), (4, 2)]
+    );
+    assert_eq!(
+        field_shape(&parse_fields(&state_fields[1].value)),
+        vec![(1, 2), (2, 2)]
+    );
+    assert_eq!(
+        field_shape(&parse_fields(&state_fields[2].value)),
+        vec![(1, 0), (2, 2), (3, 0), (4, 0)]
+    );
+    let tab_fields = parse_fields(&state_fields[3].value);
+    assert_eq!(field_shape(&tab_fields), vec![(1, 0), (2, 2)]);
+    let node_fields = parse_fields(&tab_fields[1].value);
+    assert_eq!(field_shape(&node_fields), vec![(2, 2)]);
+    let split_fields = parse_fields(&node_fields[0].value);
+    assert_eq!(field_shape(&split_fields), vec![(1, 0), (2, 2), (3, 2)]);
+    assert_eq!(
+        field_shape(&parse_fields(&split_fields[1].value)),
+        vec![(1, 0)]
+    );
+    assert_eq!(
+        field_shape(&parse_fields(&split_fields[2].value)),
+        vec![(1, 0)]
+    );
+}
+
+#[test]
+fn join_wire_shape_encodes_a_present_endpoint_address() {
+    let join = Join {
+        session_id: b"session-a".to_vec(),
+        peer_id: b"peer-a".to_vec(),
+        endpoint_addr: b"endpoint-a".to_vec(),
+    };
+
+    assert_eq!(
+        field_shape(&parse_fields(&join.encode_to_vec())),
+        vec![(1, 2), (2, 2), (3, 2)]
+    );
 }
 
 #[test]

--- a/tests/protocol.rs
+++ b/tests/protocol.rs
@@ -3,7 +3,7 @@ use p2pmux::protocol::{
     LayoutCommit, LayoutNode, LayoutReject, LayoutRejectReason, LayoutRequest, LayoutSplit,
     LayoutState, MAX_DELTA_BYTES, MAX_ENDPOINT_ADDR_BYTES, MAX_ENVELOPE_BYTES, MAX_FRAME_BYTES,
     MAX_INPUT_BYTES, MAX_PANE_ID_BYTES, MAX_PEER_ID_BYTES, MAX_SESSION_ID_BYTES,
-    MAX_SNAPSHOT_BYTES, MemberDescriptor, PROTOCOL_VERSION, PaneDescriptor, PaneReady,
+    MAX_SNAPSHOT_BYTES, MemberDescriptor, PROTOCOL_VERSION, PaneDescriptor, PaneFailed, PaneReady,
     PaneReservation, PaneSubscribe, ProtocolError, SessionSnapshot, Snapshot, SplitAxis,
     TabDescriptor, TakeControl, Welcome, decode_frame, encode_frame, envelope,
 };
@@ -261,6 +261,7 @@ fn v2_envelopes() -> Vec<Envelope> {
         envelope(envelope::Body::PaneReady(PaneReady {
             reservation_id: 1,
             base_revision: 1,
+            request_id: 1,
         })),
         envelope(envelope::Body::LayoutCommit(LayoutCommit {
             revision: 1,
@@ -275,24 +276,30 @@ fn v2_envelopes() -> Vec<Envelope> {
             peer_id: b"peer-a".to_vec(),
             pane_id: 1,
         })),
+        envelope(envelope::Body::PaneFailed(PaneFailed {
+            reservation_id: 1,
+            request_id: 1,
+            base_revision: 1,
+        })),
     ]
 }
 
 #[test]
 fn envelope_exposes_each_v2_layout_body_with_stable_tags() {
-    let expected_body_shapes: [&[(u32, u8)]; 7] = [
+    let expected_body_shapes: [&[(u32, u8)]; 8] = [
         &[(1, 2)],
         &[(1, 0), (2, 0), (3, 2)],
         &[(1, 0), (2, 0)],
-        &[(1, 0), (2, 0)],
+        &[(1, 0), (2, 0), (3, 0)],
         &[(1, 0), (2, 2)],
         &[(1, 0), (2, 0)],
         &[(1, 2), (2, 2), (3, 0)],
+        &[(1, 0), (2, 0), (3, 0)],
     ];
 
     for ((message, expected_body_field), expected_body_shape) in v2_envelopes()
         .into_iter()
-        .zip(17..=23)
+        .zip(17..=24)
         .zip(expected_body_shapes)
     {
         let wire = message.encode_to_vec();
@@ -453,6 +460,7 @@ fn layout_messages_reject_invalid_shapes_and_bounds() {
         envelope(envelope::Body::PaneReady(PaneReady {
             reservation_id: 0,
             base_revision: 1,
+            request_id: 1,
         })),
         envelope(envelope::Body::LayoutReject(LayoutReject {
             request_id: 1,
@@ -474,7 +482,7 @@ fn layout_messages_reject_invalid_shapes_and_bounds() {
 }
 
 #[test]
-fn join_endpoint_and_pane_ready_revision_are_required() {
+fn join_endpoint_and_reservation_lifecycle_identifiers_are_required() {
     let empty_join_endpoint = envelope(envelope::Body::Join(Join {
         session_id: b"session-a".to_vec(),
         peer_id: b"peer-a".to_vec(),
@@ -483,9 +491,25 @@ fn join_endpoint_and_pane_ready_revision_are_required() {
     let missing_ready_revision = envelope(envelope::Body::PaneReady(PaneReady {
         reservation_id: 1,
         base_revision: 0,
+        request_id: 1,
+    }));
+    let missing_ready_request = envelope(envelope::Body::PaneReady(PaneReady {
+        reservation_id: 1,
+        base_revision: 1,
+        request_id: 0,
+    }));
+    let missing_failed_request = envelope(envelope::Body::PaneFailed(PaneFailed {
+        reservation_id: 1,
+        request_id: 0,
+        base_revision: 1,
     }));
 
-    for invalid in [empty_join_endpoint, missing_ready_revision] {
+    for invalid in [
+        empty_join_endpoint,
+        missing_ready_revision,
+        missing_ready_request,
+        missing_failed_request,
+    ] {
         assert!(
             encode_frame(&invalid).is_err(),
             "v2 Join endpoint addresses and PaneReady revisions are required"

--- a/tests/session_handshake.rs
+++ b/tests/session_handshake.rs
@@ -2,7 +2,8 @@ use std::{net::Ipv4Addr, str::FromStr, time::Duration};
 
 use iroh::{Endpoint, RelayMode, endpoint::presets};
 use p2pmux::{
-    session::{HostSession, join_once},
+    protocol::{Envelope, Join, PROTOCOL_VERSION, envelope},
+    session::{HostSession, SessionError, join_once},
     ticket::JoinTicket,
     transport::{ALPN, Transport},
 };
@@ -21,6 +22,43 @@ async fn loopback_transport() -> Transport {
         .await
         .expect("loopback endpoint should bind");
     Transport::from_endpoint(endpoint)
+}
+
+async fn rejected_raw_join_endpoint(host: &HostSession, endpoint_addr: Vec<u8>) -> SessionError {
+    let host_task = {
+        let host = host.clone();
+        tokio::spawn(async move { host.accept_one_join().await })
+    };
+    let guest = loopback_transport().await;
+    let guest_id = guest.endpoint_id().as_bytes().to_vec();
+    let connection = guest
+        .connect(host.ticket().endpoint_addr().clone())
+        .await
+        .expect("connect");
+    let (mut send, _recv) = guest.open_bi(&connection).await.expect("open Join stream");
+    guest
+        .write_frame(
+            &mut send,
+            &Envelope {
+                version: PROTOCOL_VERSION,
+                sender_peer_id: guest_id.clone(),
+                body: Some(envelope::Body::Join(Join {
+                    session_id: host.ticket().session_id().to_vec(),
+                    peer_id: guest_id,
+                    endpoint_addr,
+                })),
+            },
+        )
+        .await
+        .expect("write raw Join");
+    let error = timeout(TEST_TIMEOUT, host_task)
+        .await
+        .expect("host should reject Join")
+        .expect("host task should complete")
+        .expect_err("Join endpoint must be rejected");
+    connection.close(0u8.into(), b"");
+    guest.close().await;
+    error
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -76,6 +114,24 @@ async fn the_same_ticket_admits_two_joiners_in_separate_handshakes() {
         first_host_receipt.admitted_peer_id,
         second_host_receipt.admitted_peer_id
     );
+
+    host.close().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn host_rejects_malformed_or_mismatched_join_endpoint_addresses() {
+    let host = HostSession::from_transport(loopback_transport().await).expect("host");
+
+    for endpoint_addr in [
+        b"not an endpoint address".to_vec(),
+        serde_json::to_vec(host.ticket().endpoint_addr())
+            .expect("endpoint address should serialize"),
+    ] {
+        assert!(matches!(
+            rejected_raw_join_endpoint(&host, endpoint_addr).await,
+            SessionError::InvalidJoinEndpointAddress
+        ));
+    }
 
     host.close().await;
 }

--- a/tests/session_handshake.rs
+++ b/tests/session_handshake.rs
@@ -108,6 +108,14 @@ async fn the_same_ticket_admits_two_joiners_in_separate_handshakes() {
     assert_eq!(second_receipt.session_id, session_id);
     assert_eq!(first_host_receipt.admitted_peer_id, first_id);
     assert_eq!(second_host_receipt.admitted_peer_id, second_id);
+    assert_eq!(
+        first_host_receipt.endpoint_addr.id.as_bytes().as_slice(),
+        first_host_receipt.admitted_peer_id
+    );
+    assert_eq!(
+        second_host_receipt.endpoint_addr.id.as_bytes().as_slice(),
+        second_host_receipt.admitted_peer_id
+    );
     assert_eq!(first_receipt.coordinator_peer_id, coordinator);
     assert_eq!(second_receipt.coordinator_peer_id, coordinator);
     assert_ne!(

--- a/tests/session_layout.rs
+++ b/tests/session_layout.rs
@@ -1,0 +1,328 @@
+use p2pmux::{
+    protocol::{
+        CreatePane, CreateTab, DeletePane, DeleteTab, LayoutCommit, LayoutRejectReason,
+        LayoutRequest, PaneReady, SplitAxis,
+    },
+    session::{CoordinatorResponse, LayoutCoordinator},
+};
+
+const HOST_A: &[u8] = b"host-a";
+const HOST_B: &[u8] = b"host-b";
+const ADDR_A: &[u8] = b"endpoint-a";
+const ADDR_B: &[u8] = b"endpoint-b";
+
+fn coordinator() -> LayoutCoordinator {
+    LayoutCoordinator::new(HOST_A.to_vec(), ADDR_A.to_vec(), 24, 80).expect("valid coordinator")
+}
+
+fn request(request_id: u64, base_revision: u64) -> LayoutRequest {
+    LayoutRequest {
+        request_id,
+        base_revision,
+        create_pane: None,
+        delete_pane: None,
+        create_tab: None,
+        delete_tab: None,
+    }
+}
+
+fn commit(response: CoordinatorResponse) -> LayoutCommit {
+    match response {
+        CoordinatorResponse::Commit(commit) => commit,
+        other => panic!("expected commit, got {other:?}"),
+    }
+}
+
+fn reject(response: CoordinatorResponse) -> p2pmux::protocol::LayoutReject {
+    match response {
+        CoordinatorResponse::Reject(reject) => reject,
+        other => panic!("expected rejection, got {other:?}"),
+    }
+}
+
+#[test]
+fn initial_snapshot_faithfully_converts_the_authoritative_layout() {
+    let coordinator = coordinator();
+    let snapshot = coordinator.session_snapshot().expect("snapshot converts");
+    let state = snapshot.state.expect("state present");
+
+    assert_eq!(state.revision, 1);
+    assert_eq!(state.members.len(), 1);
+    assert_eq!(state.members[0].peer_id, HOST_A);
+    assert_eq!(state.members[0].endpoint_addr, ADDR_A);
+    assert_eq!(state.panes.len(), 1);
+    assert_eq!(state.panes[0].pane_id, 1);
+    assert_eq!(state.panes[0].host_peer_id, HOST_A);
+    assert_eq!(
+        (state.panes[0].grid_rows, state.panes[0].grid_cols),
+        (24, 80)
+    );
+    assert_eq!(state.tabs.len(), 1);
+    assert_eq!(state.tabs[0].tab_id, 1);
+    assert_eq!(state.tabs[0].root.as_ref().unwrap().leaf_pane_id, Some(1));
+}
+
+#[test]
+fn admission_advances_revision_and_publishes_the_member_endpoint() {
+    let mut coordinator = coordinator();
+    let commit = coordinator
+        .admit(HOST_B.to_vec(), ADDR_B.to_vec())
+        .expect("guest is admitted");
+
+    assert_eq!(commit.revision, 2);
+    let state = commit.state.expect("state present");
+    assert!(
+        state
+            .members
+            .iter()
+            .any(|member| member.peer_id == HOST_B && member.endpoint_addr == ADDR_B)
+    );
+}
+
+#[test]
+fn pane_creation_is_hidden_until_its_creator_marks_the_reservation_ready() {
+    let mut coordinator = coordinator();
+    let mut create = request(10, 1);
+    create.create_pane = Some(CreatePane {
+        target_pane_id: 1,
+        axis: Some(SplitAxis::LeftRight as i32),
+        grid_rows: 30,
+        grid_cols: 100,
+    });
+
+    let reservation = match coordinator.handle_request(HOST_A, create) {
+        CoordinatorResponse::Reservation(reservation) => reservation,
+        other => panic!("expected reservation, got {other:?}"),
+    };
+    assert_eq!(
+        coordinator
+            .session_snapshot()
+            .unwrap()
+            .state
+            .unwrap()
+            .panes
+            .len(),
+        1
+    );
+
+    let commit = commit(coordinator.handle_pane_ready(
+        HOST_A,
+        PaneReady {
+            reservation_id: reservation.reservation_id,
+            base_revision: 1,
+        },
+    ));
+    let state = commit.state.expect("state present");
+    assert_eq!(commit.revision, 2);
+    assert!(
+        state
+            .panes
+            .iter()
+            .any(|pane| pane.pane_id == reservation.pane_id)
+    );
+}
+
+#[test]
+fn admitted_guest_hosts_its_own_pane_after_ready() {
+    let mut coordinator = coordinator();
+    coordinator.admit(HOST_B.to_vec(), ADDR_B.to_vec()).unwrap();
+    let mut create = request(11, 2);
+    create.create_pane = Some(CreatePane {
+        target_pane_id: 1,
+        axis: Some(SplitAxis::TopBottom as i32),
+        grid_rows: 31,
+        grid_cols: 101,
+    });
+    let reservation = match coordinator.handle_request(HOST_B, create) {
+        CoordinatorResponse::Reservation(reservation) => reservation,
+        other => panic!("expected reservation, got {other:?}"),
+    };
+
+    let commit = commit(coordinator.handle_pane_ready(
+        HOST_B,
+        PaneReady {
+            reservation_id: reservation.reservation_id,
+            base_revision: 2,
+        },
+    ));
+    let state = commit.state.unwrap();
+    let pane = state
+        .panes
+        .iter()
+        .find(|pane| pane.pane_id == reservation.pane_id)
+        .expect("reserved pane committed");
+    assert_eq!(pane.host_peer_id, HOST_B);
+    assert_eq!((pane.grid_rows, pane.grid_cols), (31, 101));
+}
+
+#[test]
+fn stale_request_is_rejected_without_a_layout_change() {
+    let mut coordinator = coordinator();
+    let mut create = request(12, 99);
+    create.create_tab = Some(CreateTab {
+        grid_rows: 24,
+        grid_cols: 80,
+    });
+
+    let rejection = reject(coordinator.handle_request(HOST_A, create));
+    assert_eq!(rejection.reason, LayoutRejectReason::Stale as i32);
+    let state = coordinator.session_snapshot().unwrap().state.unwrap();
+    assert_eq!(state.revision, 1);
+    assert_eq!(state.tabs.len(), 1);
+}
+
+#[test]
+fn foreign_pane_deletion_is_rejected() {
+    let mut coordinator = coordinator();
+    coordinator.admit(HOST_B.to_vec(), ADDR_B.to_vec()).unwrap();
+    let mut delete = request(13, 2);
+    delete.delete_pane = Some(DeletePane { pane_id: 1 });
+
+    let rejection = reject(coordinator.handle_request(HOST_B, delete));
+    assert_eq!(rejection.reason, LayoutRejectReason::NotHost as i32);
+    assert_eq!(
+        coordinator
+            .session_snapshot()
+            .unwrap()
+            .state
+            .unwrap()
+            .revision,
+        2
+    );
+}
+
+#[test]
+fn mixed_host_tab_deletion_is_rejected() {
+    let mut coordinator = coordinator();
+    coordinator.admit(HOST_B.to_vec(), ADDR_B.to_vec()).unwrap();
+    let mut create = request(14, 2);
+    create.create_pane = Some(CreatePane {
+        target_pane_id: 1,
+        axis: Some(SplitAxis::LeftRight as i32),
+        grid_rows: 24,
+        grid_cols: 80,
+    });
+    let reservation = match coordinator.handle_request(HOST_B, create) {
+        CoordinatorResponse::Reservation(reservation) => reservation,
+        other => panic!("expected reservation, got {other:?}"),
+    };
+    commit(coordinator.handle_pane_ready(
+        HOST_B,
+        PaneReady {
+            reservation_id: reservation.reservation_id,
+            base_revision: 2,
+        },
+    ));
+    let mut create_tab = request(15, 3);
+    create_tab.create_tab = Some(CreateTab {
+        grid_rows: 24,
+        grid_cols: 80,
+    });
+    let reservation = match coordinator.handle_request(HOST_A, create_tab) {
+        CoordinatorResponse::Reservation(reservation) => reservation,
+        other => panic!("expected reservation, got {other:?}"),
+    };
+    commit(coordinator.handle_pane_ready(
+        HOST_A,
+        PaneReady {
+            reservation_id: reservation.reservation_id,
+            base_revision: 3,
+        },
+    ));
+    let mut delete = request(16, 4);
+    delete.delete_tab = Some(DeleteTab { tab_id: 1 });
+
+    let rejection = reject(coordinator.handle_request(HOST_A, delete));
+    assert_eq!(rejection.reason, LayoutRejectReason::MixedTab as i32);
+}
+
+#[test]
+fn limits_are_rejected_without_creating_visible_layout() {
+    let mut coordinator = coordinator();
+    let mut revision = 1;
+    for request_id in 16..24 {
+        let mut create = request(request_id, revision);
+        create.create_tab = Some(CreateTab {
+            grid_rows: 24,
+            grid_cols: 80,
+        });
+        let reservation = match coordinator.handle_request(HOST_A, create) {
+            CoordinatorResponse::Reservation(reservation) => reservation,
+            other => panic!("expected reservation, got {other:?}"),
+        };
+        commit(coordinator.handle_pane_ready(
+            HOST_A,
+            PaneReady {
+                reservation_id: reservation.reservation_id,
+                base_revision: revision,
+            },
+        ));
+        revision += 1;
+    }
+    let mut one_too_many = request(24, revision);
+    one_too_many.create_tab = Some(CreateTab {
+        grid_rows: 24,
+        grid_cols: 80,
+    });
+
+    let rejection = reject(coordinator.handle_request(HOST_A, one_too_many));
+    assert_eq!(rejection.reason, LayoutRejectReason::Limit as i32);
+    assert_eq!(
+        coordinator
+            .session_snapshot()
+            .unwrap()
+            .state
+            .unwrap()
+            .tabs
+            .len(),
+        9
+    );
+}
+
+#[test]
+fn wrong_creator_and_ready_revision_are_rejected_with_the_original_request_id() {
+    let mut coordinator = coordinator();
+    coordinator.admit(HOST_B.to_vec(), ADDR_B.to_vec()).unwrap();
+    let mut create = request(18, 2);
+    create.create_tab = Some(CreateTab {
+        grid_rows: 24,
+        grid_cols: 80,
+    });
+    let reservation = match coordinator.handle_request(HOST_A, create) {
+        CoordinatorResponse::Reservation(reservation) => reservation,
+        other => panic!("expected reservation, got {other:?}"),
+    };
+
+    let wrong_creator = reject(coordinator.handle_pane_ready(
+        HOST_B,
+        PaneReady {
+            reservation_id: reservation.reservation_id,
+            base_revision: 2,
+        },
+    ));
+    assert_eq!(wrong_creator.request_id, 18);
+    assert_eq!(
+        wrong_creator.reason,
+        LayoutRejectReason::ReservationFailure as i32
+    );
+
+    let stale_ready = reject(coordinator.handle_pane_ready(
+        HOST_A,
+        PaneReady {
+            reservation_id: reservation.reservation_id,
+            base_revision: 1,
+        },
+    ));
+    assert_eq!(stale_ready.request_id, 18);
+    assert_eq!(stale_ready.reason, LayoutRejectReason::Stale as i32);
+    assert_eq!(
+        coordinator
+            .session_snapshot()
+            .unwrap()
+            .state
+            .unwrap()
+            .tabs
+            .len(),
+        1
+    );
+}

--- a/tests/session_layout.rs
+++ b/tests/session_layout.rs
@@ -1,18 +1,36 @@
+use iroh::{EndpointAddr, SecretKey};
 use p2pmux::{
     protocol::{
         CreatePane, CreateTab, DeletePane, DeleteTab, LayoutCommit, LayoutRejectReason,
-        LayoutRequest, PaneReady, SplitAxis,
+        LayoutRequest, PaneFailed, PaneReady, SplitAxis,
     },
-    session::{CoordinatorResponse, LayoutCoordinator},
+    session::{CoordinatorError, CoordinatorResponse, LayoutCoordinator},
+};
+use std::{
+    net::SocketAddr,
+    time::{Duration, Instant},
 };
 
-const HOST_A: &[u8] = b"host-a";
-const HOST_B: &[u8] = b"host-b";
-const ADDR_A: &[u8] = b"endpoint-a";
-const ADDR_B: &[u8] = b"endpoint-b";
+fn endpoint(seed: u8, port: u16) -> EndpointAddr {
+    EndpointAddr::new(SecretKey::from_bytes(&[seed; 32]).public())
+        .with_ip_addr(SocketAddr::from(([127, 0, 0, 1], port)))
+}
+
+fn host_a() -> Vec<u8> {
+    endpoint(1, 4101).id.as_bytes().to_vec()
+}
+fn host_b() -> Vec<u8> {
+    endpoint(2, 4102).id.as_bytes().to_vec()
+}
+fn addr_a() -> EndpointAddr {
+    endpoint(1, 4101)
+}
+fn addr_b() -> EndpointAddr {
+    endpoint(2, 4102)
+}
 
 fn coordinator() -> LayoutCoordinator {
-    LayoutCoordinator::new(HOST_A.to_vec(), ADDR_A.to_vec(), 24, 80).expect("valid coordinator")
+    LayoutCoordinator::new(host_a(), addr_a(), 24, 80).expect("valid coordinator")
 }
 
 fn request(request_id: u64, base_revision: u64) -> LayoutRequest {
@@ -48,11 +66,14 @@ fn initial_snapshot_faithfully_converts_the_authoritative_layout() {
 
     assert_eq!(state.revision, 1);
     assert_eq!(state.members.len(), 1);
-    assert_eq!(state.members[0].peer_id, HOST_A);
-    assert_eq!(state.members[0].endpoint_addr, ADDR_A);
+    assert_eq!(state.members[0].peer_id, host_a());
+    assert_eq!(
+        state.members[0].endpoint_addr,
+        serde_json::to_vec(&addr_a()).unwrap()
+    );
     assert_eq!(state.panes.len(), 1);
     assert_eq!(state.panes[0].pane_id, 1);
-    assert_eq!(state.panes[0].host_peer_id, HOST_A);
+    assert_eq!(state.panes[0].host_peer_id, host_a());
     assert_eq!(
         (state.panes[0].grid_rows, state.panes[0].grid_cols),
         (24, 80)
@@ -66,17 +87,13 @@ fn initial_snapshot_faithfully_converts_the_authoritative_layout() {
 fn admission_advances_revision_and_publishes_the_member_endpoint() {
     let mut coordinator = coordinator();
     let commit = coordinator
-        .admit(HOST_B.to_vec(), ADDR_B.to_vec())
+        .admit(host_b(), addr_b())
         .expect("guest is admitted");
 
-    assert_eq!(commit.revision, 2);
-    let state = commit.state.expect("state present");
-    assert!(
-        state
-            .members
-            .iter()
-            .any(|member| member.peer_id == HOST_B && member.endpoint_addr == ADDR_B)
-    );
+    assert_eq!(commit.commit.revision, 2);
+    let state = commit.commit.state.expect("state present");
+    assert!(state.members.iter().any(|member| member.peer_id == host_b()
+        && member.endpoint_addr == serde_json::to_vec(&addr_b()).unwrap()));
 }
 
 #[test]
@@ -90,7 +107,7 @@ fn pane_creation_is_hidden_until_its_creator_marks_the_reservation_ready() {
         grid_cols: 100,
     });
 
-    let reservation = match coordinator.handle_request(HOST_A, create) {
+    let reservation = match coordinator.handle_request(&host_a(), create) {
         CoordinatorResponse::Reservation(reservation) => reservation,
         other => panic!("expected reservation, got {other:?}"),
     };
@@ -106,10 +123,11 @@ fn pane_creation_is_hidden_until_its_creator_marks_the_reservation_ready() {
     );
 
     let commit = commit(coordinator.handle_pane_ready(
-        HOST_A,
+        &host_a(),
         PaneReady {
             reservation_id: reservation.reservation_id,
             base_revision: 1,
+            request_id: 10,
         },
     ));
     let state = commit.state.expect("state present");
@@ -132,31 +150,50 @@ fn ready_cannot_commit_a_reservation_after_membership_advances_its_revision() {
         grid_rows: 30,
         grid_cols: 100,
     });
-    let reservation = match coordinator.handle_request(HOST_A, create) {
+    let reservation = match coordinator.handle_request(&host_a(), create) {
         CoordinatorResponse::Reservation(reservation) => reservation,
         other => panic!("expected reservation, got {other:?}"),
     };
-    coordinator.admit(HOST_B.to_vec(), ADDR_B.to_vec()).unwrap();
+    let membership = coordinator.admit(host_b(), addr_b()).unwrap();
+    let invalidation = membership
+        .invalidated_reservation
+        .expect("reservation invalidated");
+    assert_eq!(invalidation.peer_id, host_a());
+    assert_eq!(invalidation.reject.request_id, 101);
+    assert_eq!(invalidation.reject.reason, LayoutRejectReason::Stale as i32);
 
     let rejection = reject(coordinator.handle_pane_ready(
-        HOST_A,
+        &host_a(),
         PaneReady {
             reservation_id: reservation.reservation_id,
             base_revision: 2,
+            request_id: 101,
         },
     ));
     assert_eq!(rejection.request_id, 101);
-    assert_eq!(rejection.reason, LayoutRejectReason::Stale as i32);
+    assert_eq!(
+        rejection.reason,
+        LayoutRejectReason::ReservationFailure as i32
+    );
     let state = coordinator.session_snapshot().unwrap().state.unwrap();
     assert_eq!(state.revision, 2);
     assert_eq!(state.tabs.len(), 1);
     assert_eq!(state.panes.len(), 1);
+    let mut next = request(102, 2);
+    next.create_tab = Some(CreateTab {
+        grid_rows: 24,
+        grid_cols: 80,
+    });
+    assert!(matches!(
+        coordinator.handle_request(&host_a(), next),
+        CoordinatorResponse::Reservation(_)
+    ));
 }
 
 #[test]
 fn admitted_guest_hosts_its_own_pane_after_ready() {
     let mut coordinator = coordinator();
-    coordinator.admit(HOST_B.to_vec(), ADDR_B.to_vec()).unwrap();
+    coordinator.admit(host_b(), addr_b()).unwrap();
     let mut create = request(11, 2);
     create.create_pane = Some(CreatePane {
         target_pane_id: 1,
@@ -164,16 +201,17 @@ fn admitted_guest_hosts_its_own_pane_after_ready() {
         grid_rows: 31,
         grid_cols: 101,
     });
-    let reservation = match coordinator.handle_request(HOST_B, create) {
+    let reservation = match coordinator.handle_request(&host_b(), create) {
         CoordinatorResponse::Reservation(reservation) => reservation,
         other => panic!("expected reservation, got {other:?}"),
     };
 
     let commit = commit(coordinator.handle_pane_ready(
-        HOST_B,
+        &host_b(),
         PaneReady {
             reservation_id: reservation.reservation_id,
             base_revision: 2,
+            request_id: 11,
         },
     ));
     let state = commit.state.unwrap();
@@ -182,7 +220,7 @@ fn admitted_guest_hosts_its_own_pane_after_ready() {
         .iter()
         .find(|pane| pane.pane_id == reservation.pane_id)
         .expect("reserved pane committed");
-    assert_eq!(pane.host_peer_id, HOST_B);
+    assert_eq!(pane.host_peer_id, host_b());
     assert_eq!((pane.grid_rows, pane.grid_cols), (31, 101));
 }
 
@@ -195,7 +233,7 @@ fn stale_request_is_rejected_without_a_layout_change() {
         grid_cols: 80,
     });
 
-    let rejection = reject(coordinator.handle_request(HOST_A, create));
+    let rejection = reject(coordinator.handle_request(&host_a(), create));
     assert_eq!(rejection.reason, LayoutRejectReason::Stale as i32);
     let state = coordinator.session_snapshot().unwrap().state.unwrap();
     assert_eq!(state.revision, 1);
@@ -205,11 +243,11 @@ fn stale_request_is_rejected_without_a_layout_change() {
 #[test]
 fn foreign_pane_deletion_is_rejected() {
     let mut coordinator = coordinator();
-    coordinator.admit(HOST_B.to_vec(), ADDR_B.to_vec()).unwrap();
+    coordinator.admit(host_b(), addr_b()).unwrap();
     let mut delete = request(13, 2);
     delete.delete_pane = Some(DeletePane { pane_id: 1 });
 
-    let rejection = reject(coordinator.handle_request(HOST_B, delete));
+    let rejection = reject(coordinator.handle_request(&host_b(), delete));
     assert_eq!(rejection.reason, LayoutRejectReason::NotHost as i32);
     assert_eq!(
         coordinator
@@ -225,7 +263,7 @@ fn foreign_pane_deletion_is_rejected() {
 #[test]
 fn mixed_host_tab_deletion_is_rejected() {
     let mut coordinator = coordinator();
-    coordinator.admit(HOST_B.to_vec(), ADDR_B.to_vec()).unwrap();
+    coordinator.admit(host_b(), addr_b()).unwrap();
     let mut create = request(14, 2);
     create.create_pane = Some(CreatePane {
         target_pane_id: 1,
@@ -233,15 +271,16 @@ fn mixed_host_tab_deletion_is_rejected() {
         grid_rows: 24,
         grid_cols: 80,
     });
-    let reservation = match coordinator.handle_request(HOST_B, create) {
+    let reservation = match coordinator.handle_request(&host_b(), create) {
         CoordinatorResponse::Reservation(reservation) => reservation,
         other => panic!("expected reservation, got {other:?}"),
     };
     commit(coordinator.handle_pane_ready(
-        HOST_B,
+        &host_b(),
         PaneReady {
             reservation_id: reservation.reservation_id,
             base_revision: 2,
+            request_id: 14,
         },
     ));
     let mut create_tab = request(15, 3);
@@ -249,21 +288,22 @@ fn mixed_host_tab_deletion_is_rejected() {
         grid_rows: 24,
         grid_cols: 80,
     });
-    let reservation = match coordinator.handle_request(HOST_A, create_tab) {
+    let reservation = match coordinator.handle_request(&host_a(), create_tab) {
         CoordinatorResponse::Reservation(reservation) => reservation,
         other => panic!("expected reservation, got {other:?}"),
     };
     commit(coordinator.handle_pane_ready(
-        HOST_A,
+        &host_a(),
         PaneReady {
             reservation_id: reservation.reservation_id,
             base_revision: 3,
+            request_id: 15,
         },
     ));
     let mut delete = request(16, 4);
     delete.delete_tab = Some(DeleteTab { tab_id: 1 });
 
-    let rejection = reject(coordinator.handle_request(HOST_A, delete));
+    let rejection = reject(coordinator.handle_request(&host_a(), delete));
     assert_eq!(rejection.reason, LayoutRejectReason::MixedTab as i32);
 }
 
@@ -277,15 +317,16 @@ fn limits_are_rejected_without_creating_visible_layout() {
             grid_rows: 24,
             grid_cols: 80,
         });
-        let reservation = match coordinator.handle_request(HOST_A, create) {
+        let reservation = match coordinator.handle_request(&host_a(), create) {
             CoordinatorResponse::Reservation(reservation) => reservation,
             other => panic!("expected reservation, got {other:?}"),
         };
         commit(coordinator.handle_pane_ready(
-            HOST_A,
+            &host_a(),
             PaneReady {
                 reservation_id: reservation.reservation_id,
                 base_revision: revision,
+                request_id,
             },
         ));
         revision += 1;
@@ -296,7 +337,7 @@ fn limits_are_rejected_without_creating_visible_layout() {
         grid_cols: 80,
     });
 
-    let rejection = reject(coordinator.handle_request(HOST_A, one_too_many));
+    let rejection = reject(coordinator.handle_request(&host_a(), one_too_many));
     assert_eq!(rejection.reason, LayoutRejectReason::Limit as i32);
     assert_eq!(
         coordinator
@@ -313,22 +354,23 @@ fn limits_are_rejected_without_creating_visible_layout() {
 #[test]
 fn wrong_creator_and_ready_revision_are_rejected_with_the_original_request_id() {
     let mut coordinator = coordinator();
-    coordinator.admit(HOST_B.to_vec(), ADDR_B.to_vec()).unwrap();
+    coordinator.admit(host_b(), addr_b()).unwrap();
     let mut create = request(18, 2);
     create.create_tab = Some(CreateTab {
         grid_rows: 24,
         grid_cols: 80,
     });
-    let reservation = match coordinator.handle_request(HOST_A, create) {
+    let reservation = match coordinator.handle_request(&host_a(), create) {
         CoordinatorResponse::Reservation(reservation) => reservation,
         other => panic!("expected reservation, got {other:?}"),
     };
 
     let wrong_creator = reject(coordinator.handle_pane_ready(
-        HOST_B,
+        &host_b(),
         PaneReady {
             reservation_id: reservation.reservation_id,
             base_revision: 2,
+            request_id: 18,
         },
     ));
     assert_eq!(wrong_creator.request_id, 18);
@@ -338,10 +380,11 @@ fn wrong_creator_and_ready_revision_are_rejected_with_the_original_request_id() 
     );
 
     let stale_ready = reject(coordinator.handle_pane_ready(
-        HOST_A,
+        &host_a(),
         PaneReady {
             reservation_id: reservation.reservation_id,
             base_revision: 1,
+            request_id: 18,
         },
     ));
     assert_eq!(stale_ready.request_id, 18);
@@ -355,5 +398,137 @@ fn wrong_creator_and_ready_revision_are_rejected_with_the_original_request_id() 
             .tabs
             .len(),
         1
+    );
+}
+
+#[test]
+fn reservation_expiry_is_deterministic_and_unwedges_new_requests() {
+    let now = Instant::now();
+    let mut coordinator = LayoutCoordinator::with_reservation_timeout(
+        host_a(),
+        addr_a(),
+        24,
+        80,
+        Duration::from_secs(5),
+        now,
+    )
+    .unwrap();
+    let mut create = request(201, 1);
+    create.create_tab = Some(CreateTab {
+        grid_rows: 24,
+        grid_cols: 80,
+    });
+    match coordinator.handle_request_at(&host_a(), create, now) {
+        CoordinatorResponse::Reservation(reservation) => reservation,
+        other => panic!("expected reservation, got {other:?}"),
+    };
+    assert!(
+        coordinator
+            .expire_reservation_at(now + Duration::from_secs(4))
+            .unwrap()
+            .is_none()
+    );
+    let expired = coordinator
+        .expire_reservation_at(now + Duration::from_secs(5))
+        .unwrap()
+        .unwrap();
+    assert_eq!(expired.peer_id, host_a());
+    assert_eq!(expired.reject.request_id, 201);
+    assert_eq!(
+        expired.reject.reason,
+        LayoutRejectReason::ReservationFailure as i32
+    );
+    let mut next = request(202, 1);
+    next.create_tab = Some(CreateTab {
+        grid_rows: 24,
+        grid_cols: 80,
+    });
+    assert!(matches!(
+        coordinator.handle_request_at(&host_a(), next, now),
+        CoordinatorResponse::Reservation(_)
+    ));
+}
+
+#[test]
+fn pane_failure_clears_its_creator_reservation_immediately() {
+    let mut coordinator = coordinator();
+    let mut create = request(203, 1);
+    create.create_tab = Some(CreateTab {
+        grid_rows: 24,
+        grid_cols: 80,
+    });
+    let reservation = match coordinator.handle_request(&host_a(), create) {
+        CoordinatorResponse::Reservation(reservation) => reservation,
+        other => panic!("expected reservation, got {other:?}"),
+    };
+    let failed = coordinator.handle_pane_failed(
+        &host_a(),
+        PaneFailed {
+            reservation_id: reservation.reservation_id,
+            request_id: 203,
+            base_revision: 1,
+        },
+    );
+    assert_eq!(failed.peer_id, host_a());
+    assert_eq!(failed.reject.request_id, 203);
+    let mut next = request(204, 1);
+    next.create_tab = Some(CreateTab {
+        grid_rows: 24,
+        grid_cols: 80,
+    });
+    assert!(matches!(
+        coordinator.handle_request(&host_a(), next),
+        CoordinatorResponse::Reservation(_)
+    ));
+}
+
+#[test]
+fn endpoints_and_ready_request_ids_must_match_authenticated_reservations() {
+    assert!(matches!(
+        LayoutCoordinator::new(host_a(), addr_b(), 24, 80),
+        Err(CoordinatorError::EndpointIdentityMismatch)
+    ));
+    assert!(matches!(
+        LayoutCoordinator::new(
+            host_a(),
+            EndpointAddr::new(SecretKey::from_bytes(&[1; 32]).public()),
+            24,
+            80
+        ),
+        Err(CoordinatorError::InvalidEndpointAddress)
+    ));
+    let mut coordinator = coordinator();
+    assert!(matches!(
+        coordinator.admit(host_b(), addr_a()),
+        Err(CoordinatorError::EndpointIdentityMismatch)
+    ));
+    assert!(matches!(
+        coordinator.admit(
+            host_b(),
+            EndpointAddr::new(SecretKey::from_bytes(&[2; 32]).public())
+        ),
+        Err(CoordinatorError::InvalidEndpointAddress)
+    ));
+    let mut create = request(205, 1);
+    create.create_tab = Some(CreateTab {
+        grid_rows: 24,
+        grid_cols: 80,
+    });
+    let reservation = match coordinator.handle_request(&host_a(), create) {
+        CoordinatorResponse::Reservation(reservation) => reservation,
+        other => panic!("expected reservation, got {other:?}"),
+    };
+    let rejected = reject(coordinator.handle_pane_ready(
+        &host_a(),
+        PaneReady {
+            reservation_id: reservation.reservation_id,
+            base_revision: 1,
+            request_id: 206,
+        },
+    ));
+    assert_eq!(rejected.request_id, 206);
+    assert_eq!(
+        rejected.reason,
+        LayoutRejectReason::ReservationFailure as i32
     );
 }

--- a/tests/session_layout.rs
+++ b/tests/session_layout.rs
@@ -123,6 +123,37 @@ fn pane_creation_is_hidden_until_its_creator_marks_the_reservation_ready() {
 }
 
 #[test]
+fn ready_cannot_commit_a_reservation_after_membership_advances_its_revision() {
+    let mut coordinator = coordinator();
+    let mut create = request(101, 1);
+    create.create_pane = Some(CreatePane {
+        target_pane_id: 1,
+        axis: Some(SplitAxis::LeftRight as i32),
+        grid_rows: 30,
+        grid_cols: 100,
+    });
+    let reservation = match coordinator.handle_request(HOST_A, create) {
+        CoordinatorResponse::Reservation(reservation) => reservation,
+        other => panic!("expected reservation, got {other:?}"),
+    };
+    coordinator.admit(HOST_B.to_vec(), ADDR_B.to_vec()).unwrap();
+
+    let rejection = reject(coordinator.handle_pane_ready(
+        HOST_A,
+        PaneReady {
+            reservation_id: reservation.reservation_id,
+            base_revision: 2,
+        },
+    ));
+    assert_eq!(rejection.request_id, 101);
+    assert_eq!(rejection.reason, LayoutRejectReason::Stale as i32);
+    let state = coordinator.session_snapshot().unwrap().state.unwrap();
+    assert_eq!(state.revision, 2);
+    assert_eq!(state.tabs.len(), 1);
+    assert_eq!(state.panes.len(), 1);
+}
+
+#[test]
 fn admitted_guest_hosts_its_own_pane_after_ready() {
     let mut coordinator = coordinator();
     coordinator.admit(HOST_B.to_vec(), ADDR_B.to_vec()).unwrap();

--- a/tests/session_layout_control.rs
+++ b/tests/session_layout_control.rs
@@ -98,17 +98,11 @@ async fn joining_member_receives_a_snapshot_and_existing_members_receive_admissi
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn incoming_dispatcher_routes_layout_join_and_direct_pane_subscription_on_one_endpoint() {
+async fn late_joiner_subscribes_after_snapshot_without_preloaded_host_roster() {
     let host = HostSession::from_transport(loopback_transport().await).expect("host");
     let coordinator = SharedLayoutHost::new(host, 24, 80).expect("shared host");
     let guest = loopback_transport().await;
     let pane_server = coordinator.pane_server();
-    pane_server
-        .add_member(
-            guest.endpoint_id().as_bytes().to_vec(),
-            guest.endpoint_addr(),
-        )
-        .expect("preload direct-pane roster");
     let host_id = coordinator.ticket().endpoint_addr().id.as_bytes().to_vec();
     let descriptor = PaneDescriptor {
         pane_id: 201,
@@ -141,21 +135,21 @@ async fn incoming_dispatcher_routes_layout_join_and_direct_pane_subscription_on_
         .expect("matching dispatcher services");
     let dispatcher_task = tokio::spawn(async move { dispatcher.accept_loop().await });
 
-    let (member, pane) = tokio::join!(
-        join_layout(guest.clone(), coordinator.ticket().clone()),
-        subscribe_pane(
-            guest.clone(),
-            coordinator.ticket().session_id().to_vec(),
-            coordinator.ticket().endpoint_addr().clone(),
-            descriptor,
-        )
-    );
-    let mut member = member.expect("layout join");
-    let mut pane = pane.expect("pane subscription");
+    let mut member = join_layout(guest.clone(), coordinator.ticket().clone())
+        .await
+        .expect("layout join");
     assert!(matches!(
         next_event(&mut member).await,
         LayoutControlEvent::Snapshot(_)
     ));
+    let mut pane = subscribe_pane(
+        guest.clone(),
+        coordinator.ticket().session_id().to_vec(),
+        coordinator.ticket().endpoint_addr().clone(),
+        descriptor,
+    )
+    .await
+    .expect("pane subscription after authoritative snapshot");
     let mut saw_snapshot = false;
     let mut saw_lease = false;
     for _ in 0..2 {

--- a/tests/session_layout_control.rs
+++ b/tests/session_layout_control.rs
@@ -1,0 +1,251 @@
+use std::{net::Ipv4Addr, time::Duration};
+
+use iroh::{Endpoint, RelayMode, endpoint::presets};
+use p2pmux::{
+    protocol::{CreatePane, DeletePane, LayoutRejectReason, LayoutRequest, PaneReady, SplitAxis},
+    session::{HostSession, LayoutControlEvent, SharedLayoutHost, join_layout},
+    transport::{ALPN, Transport},
+};
+use tokio::time::timeout;
+
+const TEST_TIMEOUT: Duration = Duration::from_secs(5);
+
+async fn loopback_transport() -> Transport {
+    let endpoint = Endpoint::builder(presets::Minimal)
+        .relay_mode(RelayMode::Disabled)
+        .clear_ip_transports()
+        .bind_addr((Ipv4Addr::LOCALHOST, 0))
+        .expect("localhost address")
+        .alpns(vec![ALPN.to_vec()])
+        .bind()
+        .await
+        .expect("loopback endpoint");
+    Transport::from_endpoint(endpoint)
+}
+
+async fn next_event(member: &mut p2pmux::session::SharedLayoutMember) -> LayoutControlEvent {
+    timeout(TEST_TIMEOUT, member.events.recv())
+        .await
+        .expect("control event should arrive")
+        .expect("control stream should remain open")
+}
+
+fn create_request(request_id: u64, base_revision: u64) -> LayoutRequest {
+    LayoutRequest {
+        request_id,
+        base_revision,
+        create_pane: Some(CreatePane {
+            target_pane_id: 1,
+            axis: Some(SplitAxis::LeftRight as i32),
+            grid_rows: 24,
+            grid_cols: 80,
+        }),
+        delete_pane: None,
+        create_tab: None,
+        delete_tab: None,
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn joining_member_receives_a_snapshot_and_existing_members_receive_admission_commit() {
+    let host = HostSession::from_transport(loopback_transport().await).expect("host");
+    let coordinator = SharedLayoutHost::new(host, 24, 80).expect("shared host");
+
+    let accept_first = {
+        let coordinator = coordinator.clone();
+        tokio::spawn(async move { coordinator.accept_one_member().await })
+    };
+    let mut first = join_layout(loopback_transport().await, coordinator.ticket().clone())
+        .await
+        .expect("first joins");
+    accept_first
+        .await
+        .expect("accept task")
+        .expect("accept first");
+    assert!(
+        matches!(next_event(&mut first).await, LayoutControlEvent::Snapshot(snapshot) if snapshot.state.as_ref().is_some_and(|state| state.revision == 2))
+    );
+
+    let accept_second = {
+        let coordinator = coordinator.clone();
+        tokio::spawn(async move { coordinator.accept_one_member().await })
+    };
+    let mut second = join_layout(loopback_transport().await, coordinator.ticket().clone())
+        .await
+        .expect("second joins");
+    accept_second
+        .await
+        .expect("accept task")
+        .expect("accept second");
+    assert!(
+        matches!(next_event(&mut first).await, LayoutControlEvent::Commit(commit) if commit.revision == 3)
+    );
+    assert!(
+        matches!(next_event(&mut second).await, LayoutControlEvent::Snapshot(snapshot) if snapshot.state.as_ref().is_some_and(|state| state.revision == 3))
+    );
+
+    first.shutdown().await;
+    second.shutdown().await;
+    coordinator.close().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn reservation_is_targeted_and_ready_broadcasts_the_commit() {
+    let host = HostSession::from_transport(loopback_transport().await).expect("host");
+    let coordinator = SharedLayoutHost::new(host, 24, 80).expect("shared host");
+    let accept_first = {
+        let coordinator = coordinator.clone();
+        tokio::spawn(async move { coordinator.accept_one_member().await })
+    };
+    let mut first = join_layout(loopback_transport().await, coordinator.ticket().clone())
+        .await
+        .expect("first");
+    accept_first.await.unwrap().unwrap();
+    let _ = next_event(&mut first).await;
+    let accept_second = {
+        let coordinator = coordinator.clone();
+        tokio::spawn(async move { coordinator.accept_one_member().await })
+    };
+    let mut second = join_layout(loopback_transport().await, coordinator.ticket().clone())
+        .await
+        .expect("second");
+    accept_second.await.unwrap().unwrap();
+    let _ = next_event(&mut first).await;
+    let _ = next_event(&mut second).await;
+
+    second
+        .try_request(create_request(7, 3))
+        .expect("queue request");
+    let reservation = match next_event(&mut second).await {
+        LayoutControlEvent::Reservation(reservation) => reservation,
+        event => panic!("expected reservation, got {event:?}"),
+    };
+    assert!(
+        timeout(Duration::from_millis(150), first.events.recv())
+            .await
+            .is_err(),
+        "reservation must be targeted"
+    );
+    second
+        .try_ready(PaneReady {
+            reservation_id: reservation.reservation_id,
+            base_revision: 3,
+            request_id: 7,
+        })
+        .expect("queue ready");
+    assert!(
+        matches!(next_event(&mut first).await, LayoutControlEvent::Commit(commit) if commit.revision == 4)
+    );
+    assert!(
+        matches!(next_event(&mut second).await, LayoutControlEvent::Commit(commit) if commit.revision == 4)
+    );
+
+    second
+        .try_request(LayoutRequest {
+            request_id: 8,
+            base_revision: 4,
+            create_pane: None,
+            delete_pane: Some(DeletePane {
+                pane_id: reservation.pane_id,
+            }),
+            create_tab: None,
+            delete_tab: None,
+        })
+        .expect("queue deletion");
+    assert!(
+        matches!(next_event(&mut first).await, LayoutControlEvent::Commit(commit) if commit.revision == 5)
+    );
+    assert!(
+        matches!(next_event(&mut second).await, LayoutControlEvent::Commit(commit) if commit.revision == 5)
+    );
+
+    first
+        .try_request(LayoutRequest {
+            request_id: 9,
+            base_revision: 5,
+            create_pane: None,
+            delete_pane: Some(DeletePane { pane_id: 1 }),
+            create_tab: None,
+            delete_tab: None,
+        })
+        .expect("queue foreign deletion");
+    assert!(matches!(
+        next_event(&mut first).await,
+        LayoutControlEvent::Reject(reject)
+            if reject.request_id == 9 && reject.reason == LayoutRejectReason::NotHost as i32
+    ));
+
+    first.shutdown().await;
+    second.shutdown().await;
+    coordinator.close().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn stale_requests_are_rejected_only_for_the_requester() {
+    let host = HostSession::from_transport(loopback_transport().await).expect("host");
+    let coordinator = SharedLayoutHost::new(host, 24, 80).expect("shared host");
+    let accept = {
+        let coordinator = coordinator.clone();
+        tokio::spawn(async move { coordinator.accept_one_member().await })
+    };
+    let mut member = join_layout(loopback_transport().await, coordinator.ticket().clone())
+        .await
+        .expect("member");
+    accept.await.unwrap().unwrap();
+    let _ = next_event(&mut member).await;
+
+    member
+        .try_request(create_request(8, 1))
+        .expect("queue request");
+    assert!(
+        matches!(next_event(&mut member).await, LayoutControlEvent::Reject(reject) if reject.request_id == 8 && reject.reason == LayoutRejectReason::Stale as i32)
+    );
+    member.shutdown().await;
+    coordinator.close().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn admission_invalidates_a_member_reservation_and_notifies_its_creator() {
+    let host = HostSession::from_transport(loopback_transport().await).expect("host");
+    let coordinator = SharedLayoutHost::new(host, 24, 80).expect("shared host");
+    let accept_first = {
+        let coordinator = coordinator.clone();
+        tokio::spawn(async move { coordinator.accept_one_member().await })
+    };
+    let mut first = join_layout(loopback_transport().await, coordinator.ticket().clone())
+        .await
+        .expect("first");
+    accept_first.await.unwrap().unwrap();
+    let _ = next_event(&mut first).await;
+    first
+        .try_request(create_request(10, 2))
+        .expect("queue reservation request");
+    assert!(matches!(
+        next_event(&mut first).await,
+        LayoutControlEvent::Reservation(_)
+    ));
+
+    let accept_second = {
+        let coordinator = coordinator.clone();
+        tokio::spawn(async move { coordinator.accept_one_member().await })
+    };
+    let mut second = join_layout(loopback_transport().await, coordinator.ticket().clone())
+        .await
+        .expect("second");
+    accept_second.await.unwrap().unwrap();
+    assert!(
+        matches!(next_event(&mut first).await, LayoutControlEvent::Commit(commit) if commit.revision == 3)
+    );
+    assert!(matches!(
+        next_event(&mut first).await,
+        LayoutControlEvent::Reject(reject)
+            if reject.request_id == 10 && reject.reason == LayoutRejectReason::Stale as i32
+    ));
+    assert!(
+        matches!(next_event(&mut second).await, LayoutControlEvent::Snapshot(snapshot) if snapshot.state.as_ref().is_some_and(|state| state.revision == 3))
+    );
+
+    first.shutdown().await;
+    second.shutdown().await;
+    coordinator.close().await;
+}

--- a/tests/session_layout_control.rs
+++ b/tests/session_layout_control.rs
@@ -2,7 +2,10 @@ use std::{net::Ipv4Addr, time::Duration};
 
 use iroh::{Endpoint, RelayMode, endpoint::presets};
 use p2pmux::{
-    protocol::{CreatePane, DeletePane, LayoutRejectReason, LayoutRequest, PaneReady, SplitAxis},
+    protocol::{
+        CreatePane, CreateTab, DeletePane, DeleteTab, Envelope, Join, LayoutRejectReason,
+        LayoutRequest, PROTOCOL_VERSION, PaneReady, SplitAxis, envelope,
+    },
     session::{HostSession, LayoutControlEvent, SharedLayoutHost, join_layout},
     transport::{ALPN, Transport},
 };
@@ -83,6 +86,175 @@ async fn joining_member_receives_a_snapshot_and_existing_members_receive_admissi
     assert!(
         matches!(next_event(&mut second).await, LayoutControlEvent::Snapshot(snapshot) if snapshot.state.as_ref().is_some_and(|state| state.revision == 3))
     );
+
+    first.shutdown().await;
+    second.shutdown().await;
+    coordinator.close().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn forged_post_welcome_sender_is_rejected_without_a_layout_mutation() {
+    let host = HostSession::from_transport(loopback_transport().await).expect("host");
+    let coordinator = SharedLayoutHost::new(host, 24, 80).expect("shared host");
+    let accept_first = {
+        let coordinator = coordinator.clone();
+        tokio::spawn(async move { coordinator.accept_one_member().await })
+    };
+    let raw = loopback_transport().await;
+    let raw_id = raw.endpoint_id().as_bytes().to_vec();
+    let connection = raw
+        .connect(coordinator.ticket().endpoint_addr().clone())
+        .await
+        .expect("connect");
+    let (mut handshake_send, mut handshake_recv) = raw.open_bi(&connection).await.expect("join");
+    raw.write_frame(
+        &mut handshake_send,
+        &Envelope {
+            version: PROTOCOL_VERSION,
+            sender_peer_id: raw_id.clone(),
+            body: Some(envelope::Body::Join(Join {
+                session_id: coordinator.ticket().session_id().to_vec(),
+                peer_id: raw_id.clone(),
+                endpoint_addr: serde_json::to_vec(&raw.endpoint_addr()).expect("endpoint"),
+            })),
+        },
+    )
+    .await
+    .expect("send Join");
+    let _welcome = raw.read_frame(&mut handshake_recv).await.expect("welcome");
+    let (mut writer, mut reader) = raw
+        .accept_framed_bi(&connection)
+        .await
+        .expect("control stream");
+    assert!(matches!(
+        reader.read_next().await.expect("snapshot read"),
+        Some(Envelope {
+            body: Some(envelope::Body::SessionSnapshot(_)),
+            ..
+        })
+    ));
+    accept_first.await.unwrap().unwrap();
+
+    writer
+        .write_next(&Envelope {
+            version: PROTOCOL_VERSION,
+            sender_peer_id: b"forged-peer".to_vec(),
+            body: Some(envelope::Body::LayoutRequest(LayoutRequest {
+                request_id: 77,
+                base_revision: 2,
+                create_pane: None,
+                delete_pane: None,
+                create_tab: Some(CreateTab {
+                    grid_rows: 24,
+                    grid_cols: 80,
+                }),
+                delete_tab: None,
+            })),
+        })
+        .await
+        .expect("write forged request");
+    let forged_outcome = timeout(TEST_TIMEOUT, reader.read_next()).await;
+    assert!(
+        matches!(forged_outcome, Ok(Ok(None)) | Ok(Err(_))),
+        "forged outcome: {forged_outcome:?}; the coordinator must close a forged control stream without replying"
+    );
+
+    let accept_second = {
+        let coordinator = coordinator.clone();
+        tokio::spawn(async move { coordinator.accept_one_member().await })
+    };
+    let mut second = join_layout(loopback_transport().await, coordinator.ticket().clone())
+        .await
+        .expect("second joins");
+    accept_second.await.unwrap().unwrap();
+    assert!(matches!(
+        next_event(&mut second).await,
+        LayoutControlEvent::Snapshot(snapshot)
+            if snapshot.state.as_ref().is_some_and(|state| state.revision == 3 && state.tabs.len() == 1 && state.panes.len() == 1)
+    ));
+
+    connection.close(0u8.into(), b"");
+    raw.close().await;
+    second.shutdown().await;
+    coordinator.close().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn deleting_a_member_owned_tab_broadcasts_the_full_commit() {
+    let host = HostSession::from_transport(loopback_transport().await).expect("host");
+    let coordinator = SharedLayoutHost::new(host, 24, 80).expect("shared host");
+    let accept_first = {
+        let coordinator = coordinator.clone();
+        tokio::spawn(async move { coordinator.accept_one_member().await })
+    };
+    let mut first = join_layout(loopback_transport().await, coordinator.ticket().clone())
+        .await
+        .expect("first");
+    accept_first.await.unwrap().unwrap();
+    let _ = next_event(&mut first).await;
+    let accept_second = {
+        let coordinator = coordinator.clone();
+        tokio::spawn(async move { coordinator.accept_one_member().await })
+    };
+    let mut second = join_layout(loopback_transport().await, coordinator.ticket().clone())
+        .await
+        .expect("second");
+    accept_second.await.unwrap().unwrap();
+    let _ = next_event(&mut first).await;
+    let _ = next_event(&mut second).await;
+
+    second
+        .try_request(LayoutRequest {
+            request_id: 12,
+            base_revision: 3,
+            create_pane: None,
+            delete_pane: None,
+            create_tab: Some(CreateTab {
+                grid_rows: 24,
+                grid_cols: 80,
+            }),
+            delete_tab: None,
+        })
+        .expect("queue tab request");
+    let reservation = match next_event(&mut second).await {
+        LayoutControlEvent::Reservation(reservation) => reservation,
+        event => panic!("expected tab reservation, got {event:?}"),
+    };
+    second
+        .try_ready(PaneReady {
+            reservation_id: reservation.reservation_id,
+            base_revision: 3,
+            request_id: 12,
+        })
+        .expect("ready tab");
+    let commit = match next_event(&mut first).await {
+        LayoutControlEvent::Commit(commit) => commit,
+        event => panic!("expected tab commit, got {event:?}"),
+    };
+    assert_eq!(commit.revision, 4);
+    assert_eq!(commit.state.as_ref().expect("state").tabs.len(), 2);
+    let _ = next_event(&mut second).await;
+
+    second
+        .try_request(LayoutRequest {
+            request_id: 13,
+            base_revision: 4,
+            create_pane: None,
+            delete_pane: None,
+            create_tab: None,
+            delete_tab: Some(DeleteTab {
+                tab_id: reservation.tab_id.expect("tab reservation"),
+            }),
+        })
+        .expect("queue tab delete");
+    for member in [&mut first, &mut second] {
+        let commit = match next_event(member).await {
+            LayoutControlEvent::Commit(commit) => commit,
+            event => panic!("expected delete commit, got {event:?}"),
+        };
+        assert_eq!(commit.revision, 5);
+        assert_eq!(commit.state.expect("full state").tabs.len(), 1);
+    }
 
     first.shutdown().await;
     second.shutdown().await;

--- a/tests/session_layout_control.rs
+++ b/tests/session_layout_control.rs
@@ -10,7 +10,7 @@ use p2pmux::{
     screen::HostScreen,
     session::{
         GuestEvent, HostPaneChannels, HostSession, LayoutControlEvent, SharedLayoutHost,
-        join_layout, pane_wire_id, subscribe_pane,
+        join_layout, layout_snapshot_from_state, pane_wire_id, subscribe_pane,
     },
     transport::{ALPN, Transport},
 };
@@ -29,6 +29,38 @@ async fn loopback_transport() -> Transport {
         .await
         .expect("loopback endpoint");
     Transport::from_endpoint(endpoint)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn control_snapshot_converts_to_a_renderable_local_layout() {
+    let host = HostSession::from_transport(loopback_transport().await).expect("host");
+    let coordinator = SharedLayoutHost::new(host, 24, 80).expect("shared host");
+    let accept = {
+        let coordinator = coordinator.clone();
+        tokio::spawn(async move { coordinator.accept_one_member().await })
+    };
+    let mut member = join_layout(loopback_transport().await, coordinator.ticket().clone())
+        .await
+        .expect("member joins");
+    accept.await.expect("accept task").expect("accept member");
+
+    let LayoutControlEvent::Snapshot(snapshot) = next_event(&mut member).await else {
+        panic!("first layout event must be a snapshot");
+    };
+    let layout = layout_snapshot_from_state(snapshot.state.as_ref().expect("state"))
+        .expect("wire layout is renderable");
+    assert_eq!(layout.revision, 2);
+    assert_eq!(layout.tabs.len(), 1);
+    assert_eq!(layout.panes.len(), 1);
+    assert!(
+        layout
+            .panes
+            .get(&1)
+            .is_some_and(|pane| pane.grid_rows == 24 && pane.grid_cols == 80)
+    );
+
+    member.shutdown().await;
+    coordinator.close().await;
 }
 
 async fn next_event(member: &mut p2pmux::session::SharedLayoutMember) -> LayoutControlEvent {

--- a/tests/session_layout_control.rs
+++ b/tests/session_layout_control.rs
@@ -484,6 +484,83 @@ async fn simultaneous_member_requests_publish_only_monotonic_commits() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn closing_after_welcome_rolls_back_admission_before_control_setup() {
+    let host = HostSession::from_transport(loopback_transport().await).expect("host");
+    let coordinator = SharedLayoutHost::new(host, 24, 80).expect("shared host");
+    let accept_first = {
+        let coordinator = coordinator.clone();
+        tokio::spawn(async move { coordinator.accept_one_member().await })
+    };
+    let mut first = join_layout(loopback_transport().await, coordinator.ticket().clone())
+        .await
+        .expect("first joins");
+    accept_first.await.unwrap().unwrap();
+    let _ = next_event(&mut first).await;
+
+    let accept_raw = {
+        let coordinator = coordinator.clone();
+        tokio::spawn(async move { coordinator.accept_one_member().await })
+    };
+    let raw = loopback_transport().await;
+    let raw_id = raw.endpoint_id().as_bytes().to_vec();
+    let connection = raw
+        .connect(coordinator.ticket().endpoint_addr().clone())
+        .await
+        .expect("connect");
+    let (mut send, mut recv) = raw.open_bi(&connection).await.expect("handshake");
+    raw.write_frame(
+        &mut send,
+        &Envelope {
+            version: PROTOCOL_VERSION,
+            sender_peer_id: raw_id.clone(),
+            body: Some(envelope::Body::Join(Join {
+                session_id: coordinator.ticket().session_id().to_vec(),
+                peer_id: raw_id,
+                endpoint_addr: serde_json::to_vec(&raw.endpoint_addr()).expect("endpoint"),
+            })),
+        },
+    )
+    .await
+    .expect("Join");
+    let _ = raw.read_frame(&mut recv).await.expect("Welcome");
+    connection.close(0u8.into(), b"");
+    raw.close().await;
+    let _ = accept_raw.await.unwrap();
+    assert!(matches!(
+        next_event(&mut first).await,
+        LayoutControlEvent::Commit(commit) if commit.revision == 3
+    ));
+    let rollback = match next_event(&mut first).await {
+        LayoutControlEvent::Commit(commit) => commit,
+        event => panic!("expected rollback commit, got {event:?}"),
+    };
+    assert_eq!(rollback.revision, 4);
+    assert_eq!(rollback.state.expect("state").members.len(), 2);
+
+    let accept_second = {
+        let coordinator = coordinator.clone();
+        tokio::spawn(async move { coordinator.accept_one_member().await })
+    };
+    let mut second = join_layout(loopback_transport().await, coordinator.ticket().clone())
+        .await
+        .expect("second joins after rollback");
+    accept_second.await.unwrap().unwrap();
+    assert!(matches!(
+        next_event(&mut first).await,
+        LayoutControlEvent::Commit(commit) if commit.revision == 5
+    ));
+    assert!(matches!(
+        next_event(&mut second).await,
+        LayoutControlEvent::Snapshot(snapshot)
+            if snapshot.state.as_ref().is_some_and(|state| state.revision == 5 && state.members.len() == 3)
+    ));
+
+    first.shutdown().await;
+    second.shutdown().await;
+    coordinator.close().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn admission_invalidates_a_member_reservation_and_notifies_its_creator() {
     let host = HostSession::from_transport(loopback_transport().await).expect("host");
     let coordinator = SharedLayoutHost::new(host, 24, 80).expect("shared host");

--- a/tests/session_layout_control.rs
+++ b/tests/session_layout_control.rs
@@ -416,6 +416,74 @@ async fn expired_reservation_rejects_its_creator_and_unblocks_the_next_request()
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn simultaneous_member_requests_publish_only_monotonic_commits() {
+    let host = HostSession::from_transport(loopback_transport().await).expect("host");
+    let coordinator = SharedLayoutHost::new(host, 24, 80).expect("shared host");
+    let accept_first = {
+        let coordinator = coordinator.clone();
+        tokio::spawn(async move { coordinator.accept_one_member().await })
+    };
+    let mut first = join_layout(loopback_transport().await, coordinator.ticket().clone())
+        .await
+        .expect("first");
+    accept_first.await.unwrap().unwrap();
+    let _ = next_event(&mut first).await;
+    let accept_second = {
+        let coordinator = coordinator.clone();
+        tokio::spawn(async move { coordinator.accept_one_member().await })
+    };
+    let mut second = join_layout(loopback_transport().await, coordinator.ticket().clone())
+        .await
+        .expect("second");
+    accept_second.await.unwrap().unwrap();
+    let _ = next_event(&mut first).await;
+    let _ = next_event(&mut second).await;
+
+    first
+        .try_request(create_request(31, 3))
+        .expect("first request");
+    second
+        .try_request(create_request(32, 3))
+        .expect("second request");
+    let first_result = next_event(&mut first).await;
+    let second_result = next_event(&mut second).await;
+    let reservation = match (first_result, second_result) {
+        (LayoutControlEvent::Reservation(reservation), LayoutControlEvent::Reject(_)) => {
+            first
+                .try_ready(PaneReady {
+                    reservation_id: reservation.reservation_id,
+                    base_revision: 3,
+                    request_id: 31,
+                })
+                .expect("first ready");
+            reservation
+        }
+        (LayoutControlEvent::Reject(_), LayoutControlEvent::Reservation(reservation)) => {
+            second
+                .try_ready(PaneReady {
+                    reservation_id: reservation.reservation_id,
+                    base_revision: 3,
+                    request_id: 32,
+                })
+                .expect("second ready");
+            reservation
+        }
+        events => panic!("expected one reservation and one reject, got {events:?}"),
+    };
+    assert_ne!(reservation.reservation_id, 0);
+    for member in [&mut first, &mut second] {
+        assert!(matches!(
+            next_event(member).await,
+            LayoutControlEvent::Commit(commit) if commit.revision == 4
+        ));
+    }
+
+    first.shutdown().await;
+    second.shutdown().await;
+    coordinator.close().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn admission_invalidates_a_member_reservation_and_notifies_its_creator() {
     let host = HostSession::from_transport(loopback_transport().await).expect("host");
     let coordinator = SharedLayoutHost::new(host, 24, 80).expect("shared host");

--- a/tests/session_layout_control.rs
+++ b/tests/session_layout_control.rs
@@ -170,7 +170,7 @@ async fn forged_post_welcome_sender_is_rejected_without_a_layout_mutation() {
     assert!(matches!(
         next_event(&mut second).await,
         LayoutControlEvent::Snapshot(snapshot)
-            if snapshot.state.as_ref().is_some_and(|state| state.revision == 3 && state.tabs.len() == 1 && state.panes.len() == 1)
+            if snapshot.state.as_ref().is_some_and(|state| state.revision == 4 && state.tabs.len() == 1 && state.panes.len() == 1)
     ));
 
     connection.close(0u8.into(), b"");
@@ -372,6 +372,45 @@ async fn stale_requests_are_rejected_only_for_the_requester() {
     assert!(
         matches!(next_event(&mut member).await, LayoutControlEvent::Reject(reject) if reject.request_id == 8 && reject.reason == LayoutRejectReason::Stale as i32)
     );
+    member.shutdown().await;
+    coordinator.close().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn expired_reservation_rejects_its_creator_and_unblocks_the_next_request() {
+    let host = HostSession::from_transport(loopback_transport().await).expect("host");
+    let coordinator = SharedLayoutHost::with_reservation_timeout(host, 24, 80, Duration::ZERO)
+        .expect("shared host");
+    let accept = {
+        let coordinator = coordinator.clone();
+        tokio::spawn(async move { coordinator.accept_one_member().await })
+    };
+    let mut member = join_layout(loopback_transport().await, coordinator.ticket().clone())
+        .await
+        .expect("member joins");
+    accept.await.unwrap().unwrap();
+    let _ = next_event(&mut member).await;
+
+    member
+        .try_request(create_request(21, 2))
+        .expect("queue creation");
+    assert!(matches!(
+        next_event(&mut member).await,
+        LayoutControlEvent::Reservation(_)
+    ));
+    assert!(matches!(
+        next_event(&mut member).await,
+        LayoutControlEvent::Reject(reject)
+            if reject.request_id == 21 && reject.reason == LayoutRejectReason::ReservationFailure as i32
+    ));
+    member
+        .try_request(create_request(22, 2))
+        .expect("reservation expiry unblocks a new request");
+    assert!(matches!(
+        next_event(&mut member).await,
+        LayoutControlEvent::Reservation(_)
+    ));
+
     member.shutdown().await;
     coordinator.close().await;
 }

--- a/tests/session_layout_control.rs
+++ b/tests/session_layout_control.rs
@@ -174,6 +174,115 @@ async fn late_joiner_subscribes_after_snapshot_without_preloaded_host_roster() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn departed_member_loses_direct_pane_access_while_healthy_member_receives_departure_commit() {
+    let host = HostSession::from_transport(loopback_transport().await).expect("host");
+    let coordinator = SharedLayoutHost::new(host, 24, 80).expect("shared host");
+    let pane_server = coordinator.pane_server();
+    let host_id = coordinator.ticket().endpoint_addr().id.as_bytes().to_vec();
+    let descriptor = PaneDescriptor {
+        pane_id: 211,
+        host_peer_id: host_id.clone(),
+        grid_rows: 1,
+        grid_cols: 1,
+    };
+    let screen = HostScreen::new(1, 1).expect("screen");
+    let (_screen_tx, screen_rx) = tokio::sync::watch::channel(screen.current_frame().clone());
+    let (_lease_tx, lease_rx) = tokio::sync::watch::channel(LeaseState {
+        controller_peer_id: host_id.clone(),
+        epoch: 1,
+        last_activity: std::time::Instant::now(),
+    });
+    let (control_tx, mut control_rx) = tokio::sync::mpsc::channel(1);
+    pane_server
+        .register_pane(
+            descriptor.clone(),
+            HostPaneChannels {
+                pane_id: pane_wire_id(211),
+                host_peer_id: host_id,
+                screen_rx,
+                lease_rx,
+                control_tx,
+            },
+        )
+        .expect("register pane");
+    let dispatcher = coordinator
+        .incoming_dispatcher(pane_server)
+        .expect("dispatcher");
+    let dispatcher_task = tokio::spawn(async move { dispatcher.accept_loop().await });
+    let departed_transport = loopback_transport().await;
+    let healthy_transport = loopback_transport().await;
+    let mut departed = join_layout(departed_transport.clone(), coordinator.ticket().clone())
+        .await
+        .expect("departed joins");
+    assert!(matches!(
+        next_event(&mut departed).await,
+        LayoutControlEvent::Snapshot(_)
+    ));
+    let mut healthy = join_layout(healthy_transport.clone(), coordinator.ticket().clone())
+        .await
+        .expect("healthy joins");
+    assert!(matches!(
+        next_event(&mut healthy).await,
+        LayoutControlEvent::Snapshot(_)
+    ));
+    let mut pane = subscribe_pane(
+        departed_transport.clone(),
+        coordinator.ticket().session_id().to_vec(),
+        coordinator.ticket().endpoint_addr().clone(),
+        descriptor.clone(),
+    )
+    .await
+    .expect("direct subscribe");
+    for _ in 0..2 {
+        let _ = timeout(TEST_TIMEOUT, pane.events.recv())
+            .await
+            .expect("initial pane event");
+    }
+    departed.disconnect_control();
+    assert!(
+        matches!(next_event(&mut healthy).await, LayoutControlEvent::Commit(commit) if commit.state.as_ref().is_some_and(|state| !state.members.iter().any(|member| member.peer_id == departed.peer_id)))
+    );
+    let mut disconnected = false;
+    for _ in 0..2 {
+        if matches!(
+            timeout(TEST_TIMEOUT, pane.events.recv())
+                .await
+                .expect("disconnect event"),
+            Some(GuestEvent::Disconnected)
+        ) {
+            disconnected = true;
+            break;
+        }
+    }
+    assert!(disconnected, "departure must close the direct pane stream");
+    let _ = pane.controls.try_input(1, b"late".to_vec());
+    assert!(
+        !matches!(
+            timeout(Duration::from_millis(100), control_rx.recv()).await,
+            Ok(Some(_))
+        ),
+        "departure must block late input"
+    );
+    assert!(
+        subscribe_pane(
+            departed_transport.clone(),
+            coordinator.ticket().session_id().to_vec(),
+            coordinator.ticket().endpoint_addr().clone(),
+            descriptor
+        )
+        .await
+        .is_err(),
+        "departed peer cannot resubscribe"
+    );
+    pane.shutdown().await;
+    departed_transport.close().await;
+    healthy.shutdown().await;
+    dispatcher_task.abort();
+    let _ = dispatcher_task.await;
+    coordinator.close().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn forged_post_welcome_sender_is_rejected_without_a_layout_mutation() {
     let host = HostSession::from_transport(loopback_transport().await).expect("host");
     let coordinator = SharedLayoutHost::new(host, 24, 80).expect("shared host");

--- a/tests/session_layout_control.rs
+++ b/tests/session_layout_control.rs
@@ -2,11 +2,16 @@ use std::{net::Ipv4Addr, time::Duration};
 
 use iroh::{Endpoint, RelayMode, endpoint::presets};
 use p2pmux::{
+    lease::LeaseState,
     protocol::{
         CreatePane, CreateTab, DeletePane, DeleteTab, Envelope, Join, LayoutRejectReason,
-        LayoutRequest, PROTOCOL_VERSION, PaneReady, SplitAxis, envelope,
+        LayoutRequest, PROTOCOL_VERSION, PaneDescriptor, PaneReady, SplitAxis, envelope,
     },
-    session::{HostSession, LayoutControlEvent, SharedLayoutHost, join_layout},
+    screen::HostScreen,
+    session::{
+        GuestEvent, HostPaneChannels, HostSession, LayoutControlEvent, SharedLayoutHost,
+        join_layout, pane_wire_id, subscribe_pane,
+    },
     transport::{ALPN, Transport},
 };
 use tokio::time::timeout;
@@ -89,6 +94,88 @@ async fn joining_member_receives_a_snapshot_and_existing_members_receive_admissi
 
     first.shutdown().await;
     second.shutdown().await;
+    coordinator.close().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn incoming_dispatcher_routes_layout_join_and_direct_pane_subscription_on_one_endpoint() {
+    let host = HostSession::from_transport(loopback_transport().await).expect("host");
+    let coordinator = SharedLayoutHost::new(host, 24, 80).expect("shared host");
+    let guest = loopback_transport().await;
+    let pane_server = coordinator.pane_server();
+    pane_server
+        .add_member(
+            guest.endpoint_id().as_bytes().to_vec(),
+            guest.endpoint_addr(),
+        )
+        .expect("preload direct-pane roster");
+    let host_id = coordinator.ticket().endpoint_addr().id.as_bytes().to_vec();
+    let descriptor = PaneDescriptor {
+        pane_id: 201,
+        host_peer_id: host_id.clone(),
+        grid_rows: 1,
+        grid_cols: 1,
+    };
+    let screen = HostScreen::new(1, 1).expect("screen");
+    let (_screen_tx, screen_rx) = tokio::sync::watch::channel(screen.current_frame().clone());
+    let (_lease_tx, lease_rx) = tokio::sync::watch::channel(LeaseState {
+        controller_peer_id: host_id.clone(),
+        epoch: 9,
+        last_activity: std::time::Instant::now(),
+    });
+    let (control_tx, _control_rx) = tokio::sync::mpsc::channel(8);
+    pane_server
+        .register_pane(
+            descriptor.clone(),
+            HostPaneChannels {
+                pane_id: pane_wire_id(201),
+                host_peer_id: host_id,
+                screen_rx,
+                lease_rx,
+                control_tx,
+            },
+        )
+        .expect("register local pane");
+    let dispatcher = coordinator
+        .incoming_dispatcher(pane_server)
+        .expect("matching dispatcher services");
+    let dispatcher_task = tokio::spawn(async move { dispatcher.accept_loop().await });
+
+    let (member, pane) = tokio::join!(
+        join_layout(guest.clone(), coordinator.ticket().clone()),
+        subscribe_pane(
+            guest.clone(),
+            coordinator.ticket().session_id().to_vec(),
+            coordinator.ticket().endpoint_addr().clone(),
+            descriptor,
+        )
+    );
+    let mut member = member.expect("layout join");
+    let mut pane = pane.expect("pane subscription");
+    assert!(matches!(
+        next_event(&mut member).await,
+        LayoutControlEvent::Snapshot(_)
+    ));
+    let mut saw_snapshot = false;
+    let mut saw_lease = false;
+    for _ in 0..2 {
+        match timeout(TEST_TIMEOUT, pane.events.recv())
+            .await
+            .expect("pane event")
+        {
+            Some(GuestEvent::ScreenSnapshot(_)) => saw_snapshot = true,
+            Some(GuestEvent::Lease(lease)) if lease.lease_epoch == 9 => saw_lease = true,
+            other => panic!("unexpected pane event: {other:?}"),
+        }
+    }
+    assert!(
+        saw_snapshot && saw_lease,
+        "direct pane remains independent of layout control"
+    );
+    pane.shutdown().await;
+    member.shutdown().await;
+    dispatcher_task.abort();
+    let _ = dispatcher_task.await;
     coordinator.close().await;
 }
 

--- a/tests/session_stream.rs
+++ b/tests/session_stream.rs
@@ -3,9 +3,15 @@ use std::{net::Ipv4Addr, time::Duration};
 use iroh::{Endpoint, RelayMode, endpoint::presets};
 use p2pmux::{
     lease::LeaseState,
-    protocol::{ControlLease, Envelope, Join, PROTOCOL_VERSION, Snapshot, envelope},
+    protocol::{
+        ControlLease, Envelope, Input, Join, PROTOCOL_VERSION, PaneDescriptor, PaneSubscribe,
+        Snapshot, envelope,
+    },
     screen::HostScreen,
-    session::{DEFAULT_PANE_ID, GuestEvent, HostPaneChannels, HostSession, join_pane},
+    session::{
+        DEFAULT_PANE_ID, GuestEvent, HostPaneChannels, HostSession, PaneServer, join_pane,
+        pane_wire_id, subscribe_pane,
+    },
     transport::{ALPN, Transport},
 };
 use tokio::time::{sleep, timeout};
@@ -73,6 +79,447 @@ async fn join_pane_delivers_snapshot_then_delta_in_order() {
     );
     pane.shutdown().await;
     let _ = timeout(TEST_TIMEOUT, host_task).await;
+    host.close().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn direct_subscription_streams_a_registered_non_default_pane_without_synthetic_lease() {
+    let host = HostSession::from_transport(loopback_transport().await).expect("host");
+    let guest = loopback_transport().await;
+    let host_id = host.ticket().endpoint_addr().id.as_bytes().to_vec();
+    let pane_id = 42;
+    let descriptor = PaneDescriptor {
+        pane_id,
+        host_peer_id: host_id.clone(),
+        grid_rows: 1,
+        grid_cols: 3,
+    };
+    let mut screen = HostScreen::new(1, 3).expect("screen");
+    let (screen_tx, screen_rx) = tokio::sync::watch::channel(screen.current_frame().clone());
+    let (_lease_tx, lease_rx) = tokio::sync::watch::channel(LeaseState {
+        controller_peer_id: host_id.clone(),
+        epoch: 7,
+        last_activity: std::time::Instant::now(),
+    });
+    let (control_tx, _control_rx) = tokio::sync::mpsc::channel(8);
+    let server = host.pane_server();
+    server
+        .add_member(
+            guest.endpoint_id().as_bytes().to_vec(),
+            guest.endpoint_addr(),
+        )
+        .expect("admit guest");
+    server
+        .register_pane(
+            descriptor.clone(),
+            HostPaneChannels {
+                pane_id: pane_wire_id(pane_id),
+                host_peer_id: host_id,
+                screen_rx,
+                lease_rx,
+                control_tx,
+            },
+        )
+        .expect("register pane");
+    let server_task = {
+        let server = server.clone();
+        tokio::spawn(async move { server.accept_one().await })
+    };
+
+    let mut pane = subscribe_pane(
+        guest.clone(),
+        host.ticket().session_id().to_vec(),
+        host.ticket().endpoint_addr().clone(),
+        descriptor,
+    )
+    .await
+    .expect("subscribe");
+    assert_eq!(pane.pane_id, pane_wire_id(pane_id));
+    // The first two events can arrive in either stream order, but they must describe this pane.
+    let mut saw_snapshot = false;
+    let mut saw_lease = false;
+    for _ in 0..4 {
+        match timeout(TEST_TIMEOUT, pane.events.recv())
+            .await
+            .expect("event timeout")
+        {
+            Some(GuestEvent::ScreenSnapshot(snapshot)) => {
+                assert_eq!(snapshot.pane_id, pane_wire_id(pane_id));
+                saw_snapshot = true;
+            }
+            Some(GuestEvent::Lease(lease)) => {
+                assert_eq!(lease.pane_id, pane_wire_id(pane_id));
+                assert_eq!(lease.lease_epoch, 7);
+                saw_lease = true;
+            }
+            Some(GuestEvent::InitialLease(_)) => {
+                panic!("direct subscriptions must not synthesize a lease")
+            }
+            Some(GuestEvent::Disconnected) => panic!("direct pane disconnected before its lease"),
+            other => panic!("unexpected direct pane event: {other:?}"),
+        }
+        if saw_snapshot && saw_lease {
+            break;
+        }
+    }
+    assert!(
+        saw_snapshot && saw_lease,
+        "host must send snapshot and actual lease"
+    );
+    screen_tx.send_replace(screen.process_pty(b"abc").expect("screen update"));
+    loop {
+        if matches!(timeout(TEST_TIMEOUT, pane.events.recv()).await.expect("delta timeout"), Some(GuestEvent::ScreenDelta(delta)) if delta.sequence == 2)
+        {
+            break;
+        }
+    }
+    pane.shutdown().await;
+    timeout(TEST_TIMEOUT, server_task)
+        .await
+        .expect("server task")
+        .expect("server join")
+        .expect("serve pane");
+    guest.close().await;
+    host.close().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn one_viewer_subscribes_to_panes_owned_by_two_different_hosts() {
+    let first_host = loopback_transport().await;
+    let second_host = loopback_transport().await;
+    let viewer = loopback_transport().await;
+    let session_id = b"shared-session".to_vec();
+    let first_id = first_host.endpoint_id().as_bytes().to_vec();
+    let second_id = second_host.endpoint_id().as_bytes().to_vec();
+    let viewer_id = viewer.endpoint_id().as_bytes().to_vec();
+    let first_server =
+        PaneServer::new(first_host.clone(), session_id.clone()).expect("first server");
+    let second_server =
+        PaneServer::new(second_host.clone(), session_id.clone()).expect("second server");
+    first_server
+        .add_member(viewer_id.clone(), viewer.endpoint_addr())
+        .expect("admit viewer to first host");
+    second_server
+        .add_member(viewer_id, viewer.endpoint_addr())
+        .expect("admit viewer to second host");
+
+    let first_descriptor = PaneDescriptor {
+        pane_id: 11,
+        host_peer_id: first_id.clone(),
+        grid_rows: 1,
+        grid_cols: 1,
+    };
+    let second_descriptor = PaneDescriptor {
+        pane_id: 12,
+        host_peer_id: second_id.clone(),
+        grid_rows: 1,
+        grid_cols: 1,
+    };
+    let first_screen = HostScreen::new(1, 1).expect("first screen");
+    let second_screen = HostScreen::new(1, 1).expect("second screen");
+    let (_first_screen_tx, first_screen_rx) =
+        tokio::sync::watch::channel(first_screen.current_frame().clone());
+    let (_second_screen_tx, second_screen_rx) =
+        tokio::sync::watch::channel(second_screen.current_frame().clone());
+    let (_first_lease_tx, first_lease_rx) = tokio::sync::watch::channel(LeaseState {
+        controller_peer_id: first_id.clone(),
+        epoch: 3,
+        last_activity: std::time::Instant::now(),
+    });
+    let (_second_lease_tx, second_lease_rx) = tokio::sync::watch::channel(LeaseState {
+        controller_peer_id: second_id.clone(),
+        epoch: 4,
+        last_activity: std::time::Instant::now(),
+    });
+    let (first_control_tx, _first_control_rx) = tokio::sync::mpsc::channel(8);
+    let (second_control_tx, _second_control_rx) = tokio::sync::mpsc::channel(8);
+    first_server
+        .register_pane(
+            first_descriptor.clone(),
+            HostPaneChannels {
+                pane_id: pane_wire_id(11),
+                host_peer_id: first_id.clone(),
+                screen_rx: first_screen_rx,
+                lease_rx: first_lease_rx,
+                control_tx: first_control_tx,
+            },
+        )
+        .expect("register first pane");
+    second_server
+        .register_pane(
+            second_descriptor.clone(),
+            HostPaneChannels {
+                pane_id: pane_wire_id(12),
+                host_peer_id: second_id.clone(),
+                screen_rx: second_screen_rx,
+                lease_rx: second_lease_rx,
+                control_tx: second_control_tx,
+            },
+        )
+        .expect("register second pane");
+    let first_task = {
+        let server = first_server.clone();
+        tokio::spawn(async move { server.accept_one().await })
+    };
+    let second_task = {
+        let server = second_server.clone();
+        tokio::spawn(async move { server.accept_one().await })
+    };
+
+    let mut first_pane = subscribe_pane(
+        viewer.clone(),
+        session_id.clone(),
+        first_host.endpoint_addr(),
+        first_descriptor,
+    )
+    .await
+    .expect("subscribe first pane");
+    let mut second_pane = subscribe_pane(
+        viewer.clone(),
+        session_id,
+        second_host.endpoint_addr(),
+        second_descriptor,
+    )
+    .await
+    .expect("subscribe second pane");
+    assert_eq!(first_pane.host_peer_id, first_id);
+    assert_eq!(second_pane.host_peer_id, second_id);
+    for pane in [&mut first_pane, &mut second_pane] {
+        let mut saw_snapshot = false;
+        let mut saw_lease = false;
+        for _ in 0..2 {
+            match timeout(TEST_TIMEOUT, pane.events.recv())
+                .await
+                .expect("pane event")
+            {
+                Some(GuestEvent::ScreenSnapshot(_)) => saw_snapshot = true,
+                Some(GuestEvent::Lease(_)) => saw_lease = true,
+                other => panic!("unexpected pane event: {other:?}"),
+            }
+        }
+        assert!(
+            saw_snapshot && saw_lease,
+            "each host serves its own pane streams"
+        );
+    }
+    first_pane.shutdown().await;
+    second_pane.shutdown().await;
+    timeout(TEST_TIMEOUT, first_task)
+        .await
+        .expect("first server task")
+        .expect("first task join")
+        .expect("first serve");
+    timeout(TEST_TIMEOUT, second_task)
+        .await
+        .expect("second server task")
+        .expect("second task join")
+        .expect("second serve");
+    viewer.close().await;
+    first_host.close().await;
+    second_host.close().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn direct_subscriptions_reject_unknown_nonmember_and_mismatched_hosts() {
+    let host = loopback_transport().await;
+    let member = loopback_transport().await;
+    let outsider = loopback_transport().await;
+    let server = PaneServer::new(host.clone(), b"shared-session".to_vec()).expect("server");
+    let host_id = host.endpoint_id().as_bytes().to_vec();
+    server
+        .add_member(
+            member.endpoint_id().as_bytes().to_vec(),
+            member.endpoint_addr(),
+        )
+        .expect("member");
+    let unknown = PaneDescriptor {
+        pane_id: 91,
+        host_peer_id: host_id.clone(),
+        grid_rows: 1,
+        grid_cols: 1,
+    };
+    let unknown_task = {
+        let server = server.clone();
+        tokio::spawn(async move { server.accept_one().await })
+    };
+    assert!(
+        subscribe_pane(
+            member.clone(),
+            b"shared-session".to_vec(),
+            host.endpoint_addr(),
+            unknown
+        )
+        .await
+        .is_err()
+    );
+    assert!(
+        timeout(TEST_TIMEOUT, unknown_task)
+            .await
+            .expect("unknown task")
+            .expect("unknown join")
+            .is_err()
+    );
+
+    let screen = HostScreen::new(1, 1).expect("screen");
+    let (_screen_tx, screen_rx) = tokio::sync::watch::channel(screen.current_frame().clone());
+    let (_lease_tx, lease_rx) = tokio::sync::watch::channel(LeaseState {
+        controller_peer_id: host_id.clone(),
+        epoch: 1,
+        last_activity: std::time::Instant::now(),
+    });
+    let (control_tx, _control_rx) = tokio::sync::mpsc::channel(1);
+    let registered = PaneDescriptor {
+        pane_id: 92,
+        host_peer_id: host_id.clone(),
+        grid_rows: 1,
+        grid_cols: 1,
+    };
+    server
+        .register_pane(
+            registered.clone(),
+            HostPaneChannels {
+                pane_id: pane_wire_id(92),
+                host_peer_id: host_id.clone(),
+                screen_rx,
+                lease_rx,
+                control_tx,
+            },
+        )
+        .expect("register");
+    let outsider_task = {
+        let server = server.clone();
+        tokio::spawn(async move { server.accept_one().await })
+    };
+    assert!(
+        subscribe_pane(
+            outsider.clone(),
+            b"shared-session".to_vec(),
+            host.endpoint_addr(),
+            registered.clone()
+        )
+        .await
+        .is_err()
+    );
+    assert!(
+        timeout(TEST_TIMEOUT, outsider_task)
+            .await
+            .expect("outsider task")
+            .expect("outsider join")
+            .is_err()
+    );
+
+    let mismatched = PaneDescriptor {
+        host_peer_id: outsider.endpoint_id().as_bytes().to_vec(),
+        ..registered
+    };
+    assert!(
+        subscribe_pane(
+            member.clone(),
+            b"shared-session".to_vec(),
+            host.endpoint_addr(),
+            mismatched
+        )
+        .await
+        .is_err()
+    );
+    member.close().await;
+    outsider.close().await;
+    host.close().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn rejected_direct_subscriber_cannot_inject_control_into_a_registered_pane() {
+    let host = loopback_transport().await;
+    let attacker = loopback_transport().await;
+    let server = PaneServer::new(host.clone(), b"shared-session".to_vec()).expect("server");
+    let host_id = host.endpoint_id().as_bytes().to_vec();
+    server
+        .add_member(
+            attacker.endpoint_id().as_bytes().to_vec(),
+            attacker.endpoint_addr(),
+        )
+        .expect("member");
+    let screen = HostScreen::new(1, 1).expect("screen");
+    let (_screen_tx, screen_rx) = tokio::sync::watch::channel(screen.current_frame().clone());
+    let (_lease_tx, lease_rx) = tokio::sync::watch::channel(LeaseState {
+        controller_peer_id: host_id.clone(),
+        epoch: 1,
+        last_activity: std::time::Instant::now(),
+    });
+    let (control_tx, mut control_rx) = tokio::sync::mpsc::channel(1);
+    server
+        .register_pane(
+            PaneDescriptor {
+                pane_id: 101,
+                host_peer_id: host_id.clone(),
+                grid_rows: 1,
+                grid_cols: 1,
+            },
+            HostPaneChannels {
+                pane_id: pane_wire_id(101),
+                host_peer_id: host_id,
+                screen_rx,
+                lease_rx,
+                control_tx,
+            },
+        )
+        .expect("register");
+    let server_task = {
+        let server = server.clone();
+        tokio::spawn(async move { server.accept_one().await })
+    };
+    let connection = attacker
+        .connect(host.endpoint_addr())
+        .await
+        .expect("connect");
+    let attacker_id = attacker.endpoint_id().as_bytes().to_vec();
+    let (mut subscribe_writer, _subscribe_reader) = attacker
+        .open_bi(&connection)
+        .await
+        .expect("subscribe stream");
+    attacker
+        .write_frame(
+            &mut subscribe_writer,
+            &Envelope {
+                version: PROTOCOL_VERSION,
+                sender_peer_id: attacker_id.clone(),
+                body: Some(envelope::Body::PaneSubscribe(PaneSubscribe {
+                    session_id: b"shared-session".to_vec(),
+                    peer_id: attacker_id.clone(),
+                    pane_id: 102,
+                })),
+            },
+        )
+        .await
+        .expect("send rejected subscription");
+    if let Ok((mut control_writer, _)) = attacker.open_framed_bi(&connection).await {
+        let _ = control_writer
+            .write_next(&Envelope {
+                version: PROTOCOL_VERSION,
+                sender_peer_id: attacker_id,
+                body: Some(envelope::Body::Input(Input {
+                    pane_id: pane_wire_id(101),
+                    lease_epoch: 1,
+                    data: b"bad".to_vec(),
+                })),
+            })
+            .await;
+    }
+    assert!(
+        timeout(TEST_TIMEOUT, server_task)
+            .await
+            .expect("server task")
+            .expect("server join")
+            .is_err()
+    );
+    assert!(
+        timeout(Duration::from_millis(100), control_rx.recv())
+            .await
+            .is_err(),
+        "unregistered subscription must not reach pane control"
+    );
+    connection.close(0u8.into(), b"");
+    attacker.close().await;
     host.close().await;
 }
 

--- a/tests/session_stream.rs
+++ b/tests/session_stream.rs
@@ -616,6 +616,167 @@ async fn pane_server_accept_loop_serves_two_viewers_without_waiting_for_the_firs
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pane_server_retries_an_idle_accept_timeout_before_serving_a_later_connection() {
+    let host = loopback_transport().await;
+    let viewer = loopback_transport().await;
+    let server = PaneServer::new(host.clone(), b"shared-session".to_vec()).expect("server");
+    let host_id = host.endpoint_id().as_bytes().to_vec();
+    server
+        .add_member(
+            viewer.endpoint_id().as_bytes().to_vec(),
+            viewer.endpoint_addr(),
+        )
+        .expect("member");
+    let screen = HostScreen::new(1, 1).expect("screen");
+    let (_screen_tx, screen_rx) = tokio::sync::watch::channel(screen.current_frame().clone());
+    let (_lease_tx, lease_rx) = tokio::sync::watch::channel(LeaseState {
+        controller_peer_id: host_id.clone(),
+        epoch: 1,
+        last_activity: std::time::Instant::now(),
+    });
+    let (control_tx, _control_rx) = tokio::sync::mpsc::channel(1);
+    let descriptor = PaneDescriptor {
+        pane_id: 161,
+        host_peer_id: host_id.clone(),
+        grid_rows: 1,
+        grid_cols: 1,
+    };
+    server
+        .register_pane(
+            descriptor.clone(),
+            HostPaneChannels {
+                pane_id: pane_wire_id(161),
+                host_peer_id: host_id,
+                screen_rx,
+                lease_rx,
+                control_tx,
+            },
+        )
+        .expect("register");
+    let loop_task = {
+        let server = server.clone();
+        tokio::spawn(async move {
+            server
+                .accept_loop_with_timeout(Duration::from_millis(10))
+                .await
+        })
+    };
+    sleep(Duration::from_millis(30)).await;
+    let mut pane = subscribe_pane(
+        viewer.clone(),
+        b"shared-session".to_vec(),
+        host.endpoint_addr(),
+        descriptor,
+    )
+    .await
+    .expect("subscription after idle timeout");
+    let mut saw_lease = false;
+    for _ in 0..2 {
+        if matches!(
+            timeout(TEST_TIMEOUT, pane.events.recv())
+                .await
+                .expect("event"),
+            Some(GuestEvent::Lease(_))
+        ) {
+            saw_lease = true;
+        }
+    }
+    assert!(saw_lease);
+    pane.shutdown().await;
+    loop_task.abort();
+    let _ = loop_task.await;
+    viewer.close().await;
+    host.close().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn removing_a_pane_disconnects_subscribers_and_blocks_later_control_delivery() {
+    let host = loopback_transport().await;
+    let viewer = loopback_transport().await;
+    let server = PaneServer::new(host.clone(), b"shared-session".to_vec()).expect("server");
+    let host_id = host.endpoint_id().as_bytes().to_vec();
+    server
+        .add_member(
+            viewer.endpoint_id().as_bytes().to_vec(),
+            viewer.endpoint_addr(),
+        )
+        .expect("member");
+    let screen = HostScreen::new(1, 1).expect("screen");
+    let (_screen_tx, screen_rx) = tokio::sync::watch::channel(screen.current_frame().clone());
+    let (_lease_tx, lease_rx) = tokio::sync::watch::channel(LeaseState {
+        controller_peer_id: host_id.clone(),
+        epoch: 1,
+        last_activity: std::time::Instant::now(),
+    });
+    let (control_tx, mut control_rx) = tokio::sync::mpsc::channel(1);
+    let descriptor = PaneDescriptor {
+        pane_id: 171,
+        host_peer_id: host_id.clone(),
+        grid_rows: 1,
+        grid_cols: 1,
+    };
+    server
+        .register_pane(
+            descriptor.clone(),
+            HostPaneChannels {
+                pane_id: pane_wire_id(171),
+                host_peer_id: host_id,
+                screen_rx,
+                lease_rx,
+                control_tx,
+            },
+        )
+        .expect("register");
+    let loop_task = {
+        let server = server.clone();
+        tokio::spawn(async move { server.accept_loop().await })
+    };
+    let mut pane = subscribe_pane(
+        viewer.clone(),
+        b"shared-session".to_vec(),
+        host.endpoint_addr(),
+        descriptor,
+    )
+    .await
+    .expect("subscribe");
+    for _ in 0..2 {
+        let _ = timeout(TEST_TIMEOUT, pane.events.recv())
+            .await
+            .expect("initial event");
+    }
+    assert!(server.remove_pane(171).expect("remove").is_some());
+    let mut disconnected = false;
+    for _ in 0..2 {
+        if matches!(
+            timeout(TEST_TIMEOUT, pane.events.recv())
+                .await
+                .expect("disconnect event"),
+            Some(GuestEvent::Disconnected)
+        ) {
+            disconnected = true;
+            break;
+        }
+    }
+    assert!(
+        disconnected,
+        "removed pane must close existing subscriptions"
+    );
+    let _ = pane.controls.try_input(1, b"late".to_vec());
+    assert!(
+        !matches!(
+            timeout(Duration::from_millis(100), control_rx.recv()).await,
+            Ok(Some(_))
+        ),
+        "removed pane must not receive late input"
+    );
+    pane.shutdown().await;
+    loop_task.abort();
+    let _ = loop_task.await;
+    viewer.close().await;
+    host.close().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn post_welcome_screen_stream_starts_with_a_snapshot_then_sends_delta() {
     let host = HostSession::from_transport(loopback_transport().await).expect("host");
     let guest = loopback_transport().await;

--- a/tests/session_stream.rs
+++ b/tests/session_stream.rs
@@ -524,6 +524,98 @@ async fn rejected_direct_subscriber_cannot_inject_control_into_a_registered_pane
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pane_server_accept_loop_serves_two_viewers_without_waiting_for_the_first() {
+    let host = loopback_transport().await;
+    let first_viewer = loopback_transport().await;
+    let second_viewer = loopback_transport().await;
+    let server = PaneServer::new(host.clone(), b"shared-session".to_vec()).expect("server");
+    let host_id = host.endpoint_id().as_bytes().to_vec();
+    server
+        .add_member(
+            first_viewer.endpoint_id().as_bytes().to_vec(),
+            first_viewer.endpoint_addr(),
+        )
+        .expect("first member");
+    server
+        .add_member(
+            second_viewer.endpoint_id().as_bytes().to_vec(),
+            second_viewer.endpoint_addr(),
+        )
+        .expect("second member");
+    let screen = HostScreen::new(1, 1).expect("screen");
+    let (_screen_tx, screen_rx) = tokio::sync::watch::channel(screen.current_frame().clone());
+    let (_lease_tx, lease_rx) = tokio::sync::watch::channel(LeaseState {
+        controller_peer_id: host_id.clone(),
+        epoch: 5,
+        last_activity: std::time::Instant::now(),
+    });
+    let (control_tx, _control_rx) = tokio::sync::mpsc::channel(8);
+    let descriptor = PaneDescriptor {
+        pane_id: 151,
+        host_peer_id: host_id.clone(),
+        grid_rows: 1,
+        grid_cols: 1,
+    };
+    server
+        .register_pane(
+            descriptor.clone(),
+            HostPaneChannels {
+                pane_id: pane_wire_id(151),
+                host_peer_id: host_id,
+                screen_rx,
+                lease_rx,
+                control_tx,
+            },
+        )
+        .expect("register pane");
+    let accept_loop = {
+        let server = server.clone();
+        tokio::spawn(async move { server.accept_loop().await })
+    };
+    let (first, second) = tokio::join!(
+        subscribe_pane(
+            first_viewer.clone(),
+            b"shared-session".to_vec(),
+            host.endpoint_addr(),
+            descriptor.clone()
+        ),
+        subscribe_pane(
+            second_viewer.clone(),
+            b"shared-session".to_vec(),
+            host.endpoint_addr(),
+            descriptor
+        )
+    );
+    let mut first = first.expect("first subscription");
+    let mut second = second.expect("second subscription");
+    for pane in [&mut first, &mut second] {
+        let mut saw_snapshot = false;
+        let mut saw_lease = false;
+        for _ in 0..2 {
+            match timeout(TEST_TIMEOUT, pane.events.recv())
+                .await
+                .expect("pane event")
+            {
+                Some(GuestEvent::ScreenSnapshot(_)) => saw_snapshot = true,
+                Some(GuestEvent::Lease(lease)) if lease.lease_epoch == 5 => saw_lease = true,
+                other => panic!("unexpected pane event: {other:?}"),
+            }
+        }
+        assert!(
+            saw_snapshot && saw_lease,
+            "each viewer gets independent streams"
+        );
+    }
+    first.shutdown().await;
+    second.shutdown().await;
+    accept_loop.abort();
+    let _ = accept_loop.await;
+    first_viewer.close().await;
+    second_viewer.close().await;
+    host.close().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn post_welcome_screen_stream_starts_with_a_snapshot_then_sends_delta() {
     let host = HostSession::from_transport(loopback_transport().await).expect("host");
     let guest = loopback_transport().await;

--- a/tests/session_stream.rs
+++ b/tests/session_stream.rs
@@ -25,6 +25,10 @@ async fn loopback_transport() -> Transport {
     Transport::from_endpoint(endpoint)
 }
 
+fn encoded_endpoint_addr(transport: &Transport) -> Vec<u8> {
+    serde_json::to_vec(&transport.endpoint_addr()).expect("endpoint address should serialize")
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn join_pane_delivers_snapshot_then_delta_in_order() {
     let host = HostSession::from_transport(loopback_transport().await).expect("host");
@@ -107,6 +111,7 @@ async fn post_welcome_screen_stream_starts_with_a_snapshot_then_sends_delta() {
         .await
         .expect("connect");
     let guest_id = guest.endpoint_id().as_bytes().to_vec();
+    let guest_endpoint_addr = encoded_endpoint_addr(&guest);
     let (mut handshake_send, mut handshake_recv) =
         guest.open_bi(&connection).await.expect("handshake");
     guest
@@ -118,7 +123,7 @@ async fn post_welcome_screen_stream_starts_with_a_snapshot_then_sends_delta() {
                 body: Some(envelope::Body::Join(Join {
                     session_id: host.ticket().session_id().to_vec(),
                     peer_id: guest_id.clone(),
-                    endpoint_addr: Vec::new(),
+                    endpoint_addr: guest_endpoint_addr,
                 })),
             },
         )
@@ -192,6 +197,7 @@ async fn host_keeps_a_silent_spectator_connected_after_control_stream_setup_wind
         .await
         .expect("connect");
     let guest_id = guest.endpoint_id().as_bytes().to_vec();
+    let guest_endpoint_addr = encoded_endpoint_addr(&guest);
     let (mut handshake_send, mut handshake_recv) =
         guest.open_bi(&connection).await.expect("handshake");
     guest
@@ -203,7 +209,7 @@ async fn host_keeps_a_silent_spectator_connected_after_control_stream_setup_wind
                 body: Some(envelope::Body::Join(Join {
                     session_id: host.ticket().session_id().to_vec(),
                     peer_id: guest_id,
-                    endpoint_addr: Vec::new(),
+                    endpoint_addr: guest_endpoint_addr,
                 })),
             },
         )

--- a/tests/session_stream.rs
+++ b/tests/session_stream.rs
@@ -118,6 +118,7 @@ async fn post_welcome_screen_stream_starts_with_a_snapshot_then_sends_delta() {
                 body: Some(envelope::Body::Join(Join {
                     session_id: host.ticket().session_id().to_vec(),
                     peer_id: guest_id.clone(),
+                    endpoint_addr: Vec::new(),
                 })),
             },
         )
@@ -202,6 +203,7 @@ async fn host_keeps_a_silent_spectator_connected_after_control_stream_setup_wind
                 body: Some(envelope::Body::Join(Join {
                     session_id: host.ticket().session_id().to_vec(),
                     peer_id: guest_id,
+                    endpoint_addr: Vec::new(),
                 })),
             },
         )

--- a/tests/transport.rs
+++ b/tests/transport.rs
@@ -6,6 +6,11 @@ use tokio::time::timeout;
 
 const TEST_TIMEOUT: Duration = Duration::from_secs(5);
 
+#[test]
+fn transport_uses_v2_alpn() {
+    assert_eq!(ALPN, b"p2pmux/2");
+}
+
 async fn loopback_endpoint() -> Endpoint {
     Endpoint::builder(presets::Minimal)
         .relay_mode(RelayMode::Disabled)


### PR DESCRIPTION
## Summary
- add authoritative shared layout coordination, reservations, persistent control, and direct per-pane streams
- add multi-pane and tab TUI with host-owned deletion rules, fixed-grid rendering, and late-join bootstrap
- document the Spike 3 workflow and add layout, protocol, session, stream, and UI coverage

## Validation
- cargo fmt --check
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings
- Manual localhost host, guest, and late-join acceptance: pane/tab creation, ownership rejections, delete, and clean F10 exit