### PR TITLE
UX: sticky chords, tab chrome, mouse focus, display names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2451,6 +2451,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "toml",
  "vt100",
 ]
 
@@ -2724,7 +2725,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.25.13+spec-1.1.0",
 ]
 
 [[package]]
@@ -3205,6 +3206,15 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -3705,6 +3715,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3715,14 +3746,28 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -3731,8 +3776,14 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.4",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -4418,6 +4469,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,5 @@ prost = "0.14"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "time", "sync"] }
+toml = "0.8"
 vt100 = "0.16"

--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ Terminal 1: cargo run -- create
 Terminal 2: cargo run -- join <printed 10-character code>
 ```
 
+Set a peer-visible display name once with `p2pmux config set name pelazas`; inspect it with
+`p2pmux config get name`. It is stored in `$XDG_CONFIG_HOME/p2pmux/config.toml` (or
+`~/.config/p2pmux/config.toml`). `create` and `join` accept `--name <name>` to override and save
+the value for that run and future sessions.
+
 `create` prints `Join with: p2pmux join <CODE>`, waits for Enter so you can copy it, then
 enters the shared-layout TUI. The same code stays in the footer. `join` first receives the
 authoritative layout, then attaches directly to every remote pane.

--- a/README.md
+++ b/README.md
@@ -76,14 +76,16 @@ Only one peer controls each pane at a time: after about eight seconds of idle ti
 can type to hop in. Active typing is protected, so there is no forced takeover. Ctrl+Q exits only
 the local p2pmux view; F9 and F10 continue through to the focused PTY.
 
-Shared-layout commands are local mux chords and never reach a PTY:
+Shared-layout commands are sticky local mux modes and never reach a PTY. `Ctrl+P` or `Ctrl+T`
+enters its mode; use the listed command repeatedly, press `Esc` to cancel, or type any normal key
+to leave the mode and send that key to the focused PTY.
 
 - `Ctrl+P`, then `N` — split the focused pane. The new fixed-grid PTY runs on the requester’s Mac.
 - `Ctrl+P`, then `X` — delete the focused pane. Only that pane’s host may delete it.
 - `Ctrl+P`, then arrows — move focus.
 - `Ctrl+T`, then `N` — create a tab with a local PTY on the requester’s Mac.
 - `Ctrl+T`, then `X` — delete the current tab only when the requester hosts every pane in it.
-- `Ctrl+T`, then left/right — switch tabs; `Esc` cancels a chord.
+- `Ctrl+T`, then left/right — switch tabs.
 
 The final pane in a tab must be removed by deleting its tab; the final tab cannot be deleted.
 Nested 50/50 splits are part of Spike 3 (depth 4, at most 8 panes per tab, at most 9 tabs). Each

--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ Shared-layout commands are sticky local mux modes and never reach a PTY. `Ctrl+P
 enters its mode; use the listed command repeatedly, press `Esc` to cancel, or type any normal key
 to leave the mode and send that key to the focused PTY.
 
+Clicking a pane focuses it locally without taking control or sending input. When p2pmux runs
+inside Zellij, Zellij may swallow mouse events; try Zellij with mouse mode disabled or a locked
+passthrough configuration.
+
 - `Ctrl+P`, then `N` — split the focused pane. The new fixed-grid PTY runs on the requester’s Mac.
 - `Ctrl+P`, then `X` — delete the focused pane. Only that pane’s host may delete it.
 - `Ctrl+P`, then arrows — move focus.

--- a/docs/superpowers/plans/2026-07-25-sticky-chords-tabs-names.md
+++ b/docs/superpowers/plans/2026-07-25-sticky-chords-tabs-names.md
@@ -1,0 +1,217 @@
+# Sticky Chords, Tabs Chrome, and Display Names Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship sticky pane/tab chords with contextual footers, mouse focus, `Tab #N` active highlighting, and persistent peer-visible display names.
+
+**Architecture:** Keep layout/session authority unchanged. TUI owns sticky chord state, mouse hit-testing, and chrome. New `config` module loads/saves `display_name`. Protocol/layout `Member` carries optional/required display name for roster chrome; cryptographic peer id remains identity.
+
+**Tech Stack:** Rust 2024, clap, ratatui/crossterm (mouse), toml + serde for config, existing prost layout protocol.
+
+**Spec:** `docs/superpowers/specs/2026-07-25-sticky-chords-tabs-names-design.md`
+
+---
+
+## File map
+
+| File | Responsibility |
+|------|----------------|
+| `src/config.rs` (new) | Load/save `~/.config/p2pmux/config.toml`, validate names |
+| `src/lib.rs` | Export `config` module |
+| `src/cli.rs` | `config` subcommands; `--name`; resolve name on create/join |
+| `src/layout.rs` | `Member.display_name` |
+| `src/protocol.rs` | `MemberDescriptor.display_name` (+ Join field if admission needs it) |
+| `src/session.rs` | Plumb names through admission/snapshots |
+| `src/tui.rs` | Sticky chords, footers, tab chrome, mouse focus, name chrome |
+| `tests/*` | Focused coverage per task |
+| `README.md` | Document new UX + config + Zellij mouse note |
+
+---
+
+### Task 1: Spec already on branch — verify and commit docs if needed
+
+**Files:**
+- `docs/superpowers/specs/2026-07-25-sticky-chords-tabs-names-design.md`
+- `docs/superpowers/plans/2026-07-25-sticky-chords-tabs-names.md`
+
+- [ ] Ensure both files exist on the feature branch
+- [ ] Commit if not already committed:
+
+```bash
+git add docs/superpowers/specs/2026-07-25-sticky-chords-tabs-names-design.md docs/superpowers/plans/2026-07-25-sticky-chords-tabs-names.md
+git commit -m "$(cat <<'EOF'
+docs: specify sticky chords, tab chrome, and display names
+
+EOF
+)"
+```
+
+---
+
+### Task 2: Sticky chord modes + contextual footer
+
+**Files:**
+- Modify: `src/tui.rs` (`handle_key`, footer helpers, tests)
+- Modify: `README.md` chord docs
+
+- [ ] **Step 1: Write failing tests** for:
+  - pane mode stays across two Right arrows
+  - Esc clears mode without forwarding
+  - a normal char while in pane mode clears mode and is returned/forwarded once
+  - footer text switches for Pane / Tab / Normal
+
+- [ ] **Step 2: Run tests — expect FAIL**
+
+```bash
+cargo test --lib sticky_ -- --nocapture
+cargo test --lib footer_ -- --nocapture
+```
+
+- [ ] **Step 3: Implement** sticky mode (do **not** clear `chord_mode` before handling chord keys; only clear on Esc / quit / forward / mode switch). Update `shared_footer_text` / render path to use mode-specific help.
+
+- [ ] **Step 4: Tests PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tui.rs README.md
+git commit -m "$(cat <<'EOF'
+feat: keep pane and tab chords sticky with contextual help
+
+EOF
+)"
+```
+
+---
+
+### Task 3: Tab labels + active highlight
+
+**Files:**
+- Modify: `src/tui.rs` tab bar rendering + tests
+
+- [ ] **Step 1: Failing tests** asserting labels `Tab #1`… and active tab uses red bg + white fg (TestBackend / buffer cell inspection)
+
+- [ ] **Step 2: Implement** ordinal labels from `tabs` order; style active vs inactive
+
+- [ ] **Step 3: Tests PASS + commit**
+
+```bash
+git add src/tui.rs
+git commit -m "$(cat <<'EOF'
+feat: label tabs and highlight the active tab
+
+EOF
+)"
+```
+
+---
+
+### Task 4: Mouse click focuses pane
+
+**Files:**
+- Modify: `src/tui.rs` (hit test helper + event loop mouse enable)
+- Tests: hit-test unit tests
+
+- [ ] **Step 1: Failing test** — given geometry panes, click coordinate maps to correct `pane_id`; miss maps to None
+
+- [ ] **Step 2: Implement** `pane_at(x,y)`, enable mouse capture in shared-layout loops, on left click set `focused_pane` (no lease/input). Keep chord mode.
+
+- [ ] **Step 3: README note** about Zellij mouse
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/tui.rs README.md
+git commit -m "$(cat <<'EOF'
+feat: focus panes with mouse clicks
+
+EOF
+)"
+```
+
+---
+
+### Task 5: Local display-name config + CLI
+
+**Files:**
+- Create: `src/config.rs`
+- Modify: `src/lib.rs`, `src/cli.rs`
+- Create/modify: `tests/config.rs` or unit tests in `config.rs`
+
+- [ ] **Step 1: Failing tests** for validate/save/load round-trip; reject empty/long/control
+
+- [ ] **Step 2: Implement** config path (`dirs` crate or `XDG_CONFIG_HOME`/`HOME`), toml serde, `p2pmux config set|get name`
+
+- [ ] **Step 3: Wire create/join** to resolve name: `--name` > config > TTY prompt > non-interactive error
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/config.rs src/lib.rs src/cli.rs Cargo.toml tests README.md
+git commit -m "$(cat <<'EOF'
+feat: add persistent display name config
+
+EOF
+)"
+```
+
+---
+
+### Task 6: Share display names in layout/protocol/chrome
+
+**Files:**
+- Modify: `src/layout.rs`, `src/protocol.rs`, `src/session.rs`, `src/tui.rs`
+- Modify: related tests (`tests/layout.rs`, `tests/protocol.rs`, `tests/session_*`)
+
+- [ ] **Step 1: Extend** `Member` / `MemberDescriptor` with `display_name: String` (validate length on decode)
+- [ ] **Step 2: Plumb** name from create/join admission into coordinator roster and snapshots
+- [ ] **Step 3: Chrome helper** `format_member_label(name, peer_id, roster)` with duplicate disambiguation `name · aabbccdd`
+- [ ] **Step 4: Replace** `short_peer`-only host/controller chrome with labels
+- [ ] **Step 5: Update tests**; full `cargo fmt`, `clippy --all-targets --all-features -- -D warnings`, `cargo test`
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/layout.rs src/protocol.rs src/session.rs src/tui.rs tests README.md docs
+git commit -m "$(cat <<'EOF'
+feat: advertise display names in the shared roster
+
+EOF
+)"
+```
+
+---
+
+### Task 7: Push and open PR
+
+- [ ] Push branch to origin
+- [ ] Open PR against `main` with summary + test plan covering sticky chords, footer, tabs, mouse, config, roster names
+- [ ] Ensure CI green or fix follow-ups with additional commits
+
+**PR title:** `UX: sticky chords, tab chrome, mouse focus, display names`
+
+**PR body sketch:**
+
+```markdown
+## Summary
+- sticky Ctrl+P/Ctrl+T modes with contextual footer help
+- Tab #N labels with red active highlight
+- mouse click focuses panes
+- persistent display names via config + roster
+
+## Test plan
+- [ ] cargo fmt/clippy/test
+- [ ] sticky pane focus with repeated arrows
+- [ ] contextual footers
+- [ ] config set name + create/join chrome
+- [ ] duplicate name disambiguation
+- [ ] mouse focus (outside Zellij)
+```
+
+---
+
+## Success criteria
+
+- Spec behaviors implemented
+- One commit per task (2–6) plus docs commit
+- PR opened from the feature worktree branch
+- CI quality gates pass

--- a/docs/superpowers/specs/2026-07-25-sticky-chords-tabs-names-design.md
+++ b/docs/superpowers/specs/2026-07-25-sticky-chords-tabs-names-design.md
@@ -1,0 +1,125 @@
+# Sticky Chords, Contextual Footer, Tab Chrome, and Display Names
+
+## Goal
+
+Improve local mux UX after Spike 3 + shared control UI:
+
+1. Sticky `Ctrl+P` / `Ctrl+T` chord modes with repeatable navigation
+2. Contextual footer help for normal / pane / tab modes
+3. Mouse click to change local pane focus
+4. Human tab labels with active-tab highlight (`Tab #N`, red + white)
+5. Persistent display names shared to peers (config + first-run prompt)
+
+## Non-goals
+
+- Changing outer-mux leader keys (`Ctrl+G` remap) in this change
+- Interactive prompts during `brew install` (caveat text only, later)
+- Mid-session rename chord
+- Custom tab titles typed by users (use ordinal `Tab #1` … for now)
+- Mouse claiming control or injecting input
+- Guaranteeing mouse works when nested under Zellij (document workaround)
+
+## Interaction model
+
+### Sticky chords
+
+- `Ctrl+P` enters **pane mode** and stays there until exit.
+- In pane mode:
+  - arrows move focus repeatedly without re-pressing `Ctrl+P`
+  - `N` creates a pane (existing rules)
+  - `X` deletes focused pane (host-only rules unchanged)
+- `Ctrl+T` enters **tab mode** and stays until exit.
+- In tab mode:
+  - `←` / `→` switch tabs repeatedly
+  - `N` creates a tab
+  - `X` deletes current tab (all-host rule unchanged)
+- Exit chord mode on:
+  - `Esc` (consume; do not forward)
+  - `Ctrl+Q` (quit still wins; clear mode)
+  - any key that would otherwise forward to the focused PTY (printable / paste / etc.)
+- When exiting because of a forwarding keystroke: leave mode, then forward **that same keystroke exactly once** to the focused pane’s normal input path (idle-claim rules still apply).
+- Entering the other chord prefix while already in a mode switches modes (`Ctrl+T` while in pane mode → tab mode).
+
+### Contextual footer
+
+Three footers (join code still appendable for coordinator as today):
+
+| Mode | Footer text |
+|------|-------------|
+| Normal | `Ctrl+P panes \| Ctrl+T tabs \| type to claim idle \| active typing is protected \| Ctrl+Q quit` |
+| Pane | `arrows move focus \| N new pane \| X delete pane \| Esc cancel` |
+| Tab | `←/→ switch tab \| N new tab \| X delete tab \| Esc cancel` |
+
+Status prefixes (rejection / waiting) still win left side when present; mode help replaces the controls segment.
+
+### Mouse focus
+
+- Enable mouse capture in the shared-layout TUI event loop.
+- Left-click inside a pane’s content/chrome rectangle → set local `focused_pane` to that pane.
+- Click does **not** take control, claim lease, or send input.
+- Clicking while in pane/tab mode may keep the mode (navigation convenience) or leave it; prefer **keep mode** so click + arrows still work.
+- Click on tab bar: optional MVP stretch — if easy, click `Tab #N` switches tab; otherwise keyboard-only tabs are fine for this PR.
+- Document: under Zellij, mouse may be swallowed; try `zellij` with mouse mode off / locked passthrough.
+
+### Tab chrome
+
+- Label tabs by session ordinal: `Tab #1`, `Tab #2`, … following the order of `snapshot.tabs` (stable left-to-right).
+- Active tab (matches `current_tab`): background `Color::Rgb(220, 50, 47)` (or close red), foreground white, bold if easy.
+- Inactive tabs: default/dark-gray foreground, no fill (or subtle dark fill).
+- Flat highlight is enough; Powerline chevrons are optional and not required.
+
+### Display names
+
+**Storage**
+
+- File: `$XDG_CONFIG_HOME/p2pmux/config.toml` (default `~/.config/p2pmux/config.toml`)
+- Field: `display_name = "pelazas"`
+- Validation: trimmed, non-empty, max 32 Unicode scalars, no control characters.
+
+**CLI**
+
+- `p2pmux config set name <name>`
+- `p2pmux config get name`
+- Optional: `p2pmux config path` prints resolved config path (nice-to-have).
+
+**Session entry**
+
+- On `create` / `join`: load config name.
+- If missing and stdin is a TTY: prompt once  
+  `Choose a display name (visible to session peers):`  
+  validate, save to config, continue.
+- If missing and non-interactive: error with exact remediation  
+  `missing display name; run: p2pmux config set name <name>`
+- `--name <name>` on `create`/`join` overrides for this process and updates the saved config.
+
+**Protocol / roster**
+
+- Add optional `display_name` string to membership descriptors used in layout state / admission (`Member` / `MemberDescriptor` and Join if needed so the coordinator stores the joiner’s chosen name).
+- Names are labels only — never auth. Peer id remains the identity.
+- Chrome uses display names for host badge and controller text.
+- Duplicate names allowed. When two visible members share the same display name (case-sensitive compare after trim), render  
+  `{name} · {short_fingerprint}`  
+  where fingerprint is the existing 4-byte hex `short_peer` (or equivalent stable short id). Unique names render as `{name}` only.
+
+**Brew (later, not this PR)**
+
+- Formula caveat only: point at `p2pmux config set name`. No interactive brew install step.
+
+## Testing
+
+- Unit: sticky mode stays across multiple arrows; Esc clears; forwarding keystroke exits and is queued once.
+- Unit: footer strings for each mode.
+- Unit/render: active tab style and `Tab #N` labels.
+- Unit: config round-trip + validation rejects empty/too-long/control chars.
+- Protocol/layout: member display_name round-trips in snapshots; duplicate disambiguation helper.
+- Mouse: unit-test hit-testing pane rect → pane id (no full interactive mouse required in CI).
+- `cargo fmt`, `clippy -D warnings`, `cargo test`.
+
+## Manual acceptance
+
+1. `p2pmux config set name pelazas` then create/join — chrome shows name.
+2. Sticky: `Ctrl+P`, right, right focuses across panes; type `h` exits mode and types `h` if lease allows.
+3. Footer swaps in pane/tab modes.
+4. Tabs show `Tab #1`… with red active highlight.
+5. Second member with same name shows disambiguated chrome.
+6. Click pane focuses (outside Zellij or with Zellij mouse passthrough).

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,7 +2,7 @@
 
 use std::{
     error::Error,
-    io::{self, Write},
+    io::{self, IsTerminal, Write},
     str::FromStr,
 };
 
@@ -33,9 +33,27 @@ enum Command {
     /// Start one local interactive shell (Spike 1).
     Local,
     /// Create a shared session with a reusable join ticket.
-    Create,
+    Create {
+        #[arg(long)]
+        name: Option<String>,
+    },
     /// Join a remote fixed-grid shared pane using a reusable shared-session ticket.
-    Join { ticket: String },
+    Join {
+        ticket: String,
+        #[arg(long)]
+        name: Option<String>,
+    },
+    /// Read or write local configuration.
+    Config {
+        #[command(subcommand)]
+        command: ConfigCommand,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+enum ConfigCommand {
+    Set { key: String, value: String },
+    Get { key: String },
 }
 
 const TRUST_WARNING: &str = "TRUST WARNING: This is a fully trusted shared-shell session. Anyone with the join ticket can see every pane and may obtain interactive control of available terminals (run commands, see output, touch files reachable to that macOS user).
@@ -63,12 +81,26 @@ pub async fn parse_and_run() -> Result<(), Box<dyn Error>> {
 async fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
     match cli.command {
         Command::Local => crate::tui::run_local(),
-        Command::Create => {
+        Command::Config { command } => match command {
+            ConfigCommand::Set { key, value } if key == "name" => {
+                crate::config::save(&value)?;
+                Ok(())
+            }
+            ConfigCommand::Get { key } if key == "name" => {
+                if let Some(name) = crate::config::load()? {
+                    println!("{name}");
+                }
+                Ok(())
+            }
+            _ => Err(CliError("config key must be name").into()),
+        },
+        Command::Create { name } => {
             {
                 let mut stdout = io::stdout().lock();
                 writeln!(stdout, "{TRUST_WARNING}\n")?;
                 stdout.flush()?;
             }
+            let _display_name = resolve_display_name(name)?;
             let (cols, rows) = crossterm::terminal::size()?;
             let (shell_rows, shell_cols) = crate::tui::initial_root_pane_grid(cols, rows);
             let host = SharedLayoutHost::new(HostSession::create().await?, shell_rows, shell_cols)?;
@@ -138,13 +170,14 @@ async fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
             result.map_err(io::Error::other)?;
             Ok(())
         }
-        Command::Join { ticket } => {
+        Command::Join { ticket, name } => {
             {
                 let mut stdout = io::stdout().lock();
                 writeln!(stdout, "{TRUST_WARNING}\n")?;
                 stdout.flush()?;
             }
             let ticket = resolve_join_ticket(&ticket)?;
+            let _display_name = resolve_display_name(name)?;
             let transport = Transport::bind().await?;
             let mut member = join_layout(transport, ticket.clone()).await?;
             let state = match member.events.recv().await {
@@ -183,6 +216,26 @@ async fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
     }
 }
 
+fn resolve_display_name(override_name: Option<String>) -> Result<String, Box<dyn Error>> {
+    if let Some(name) = override_name {
+        return Ok(crate::config::save(&name)?);
+    }
+    if let Some(name) = crate::config::load()? {
+        return Ok(name);
+    }
+    if !io::stdin().is_terminal() {
+        return Err(CliError("missing display name; run: p2pmux config set name <name>").into());
+    }
+    {
+        let mut stdout = io::stdout().lock();
+        write!(stdout, "Choose a display name (visible to session peers): ")?;
+        stdout.flush()?;
+    }
+    let mut name = String::new();
+    io::stdin().read_line(&mut name)?;
+    Ok(crate::config::save(&name)?)
+}
+
 fn resolve_join_ticket(input: &str) -> Result<JoinTicket, CliError> {
     if input.starts_with(TICKET_PREFIX) {
         return JoinTicket::from_str(input).map_err(|_| CliError("invalid ticket format"));
@@ -207,10 +260,10 @@ mod tests {
     fn create_releases_stdout_before_starting_the_host_tui() {
         let source = include_str!("cli.rs");
         let create_arm = source
-            .split_once("Command::Create => {")
+            .split_once("Command::Create { name } => {")
             .expect("create arm")
             .1
-            .split_once("Command::Join { ticket } => {")
+            .split_once("Command::Join { ticket, name } => {")
             .expect("join arm")
             .0;
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -11,7 +11,8 @@ use clap::{Parser, Subcommand};
 use crate::{
     rendezvous::{LocalRendezvous, RendezvousError},
     session::{
-        HostSession, LayoutControlEvent, SharedLayoutHost, join_layout, layout_snapshot_from_state,
+        HostSession, LayoutControlEvent, SharedLayoutHost, join_layout_with_display_name,
+        layout_snapshot_from_state,
     },
     ticket::{JoinTicket, TICKET_PREFIX},
     transport::Transport,
@@ -100,10 +101,15 @@ async fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
                 writeln!(stdout, "{TRUST_WARNING}\n")?;
                 stdout.flush()?;
             }
-            let _display_name = resolve_display_name(name)?;
+            let display_name = resolve_display_name(name)?;
             let (cols, rows) = crossterm::terminal::size()?;
             let (shell_rows, shell_cols) = crate::tui::initial_root_pane_grid(cols, rows);
-            let host = SharedLayoutHost::new(HostSession::create().await?, shell_rows, shell_cols)?;
+            let host = SharedLayoutHost::with_display_name(
+                HostSession::create().await?,
+                display_name,
+                shell_rows,
+                shell_cols,
+            )?;
             let host_peer_id = host.ticket().endpoint_addr().id.as_bytes().to_vec();
             let initial = crate::tui::SharedLocalPane::spawn(
                 1,
@@ -177,9 +183,10 @@ async fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
                 stdout.flush()?;
             }
             let ticket = resolve_join_ticket(&ticket)?;
-            let _display_name = resolve_display_name(name)?;
+            let display_name = resolve_display_name(name)?;
             let transport = Transport::bind().await?;
-            let mut member = join_layout(transport, ticket.clone()).await?;
+            let mut member =
+                join_layout_with_display_name(transport, ticket.clone(), display_name).await?;
             let state = match member.events.recv().await {
                 Some(LayoutControlEvent::Snapshot(snapshot)) => {
                     snapshot.state.ok_or("missing layout snapshot")?

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,99 @@
+use std::{
+    env, fmt, fs, io,
+    path::{Path, PathBuf},
+};
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug)]
+pub enum ConfigError {
+    MissingHome,
+    InvalidName(&'static str),
+    Io(io::Error),
+    Parse(toml::de::Error),
+    Serialize(toml::ser::Error),
+}
+
+impl fmt::Display for ConfigError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingHome => f.write_str("could not resolve config directory"),
+            Self::InvalidName(message) => f.write_str(message),
+            Self::Io(error) => error.fmt(f),
+            Self::Parse(error) => error.fmt(f),
+            Self::Serialize(error) => error.fmt(f),
+        }
+    }
+}
+
+impl std::error::Error for ConfigError {}
+
+impl From<io::Error> for ConfigError {
+    fn from(error: io::Error) -> Self {
+        Self::Io(error)
+    }
+}
+
+#[derive(Debug, Default, Deserialize, Serialize)]
+struct ConfigFile {
+    display_name: Option<String>,
+}
+
+pub fn config_path() -> Result<PathBuf, ConfigError> {
+    let base = env::var_os("XDG_CONFIG_HOME")
+        .map(PathBuf::from)
+        .or_else(|| env::var_os("HOME").map(|home| PathBuf::from(home).join(".config")))
+        .ok_or(ConfigError::MissingHome)?;
+    Ok(base.join("p2pmux").join("config.toml"))
+}
+
+pub fn validate_display_name(name: &str) -> Result<String, ConfigError> {
+    let name = name.trim();
+    if name.is_empty() {
+        return Err(ConfigError::InvalidName("display name must not be empty"));
+    }
+    if name.chars().count() > 32 {
+        return Err(ConfigError::InvalidName(
+            "display name must be at most 32 characters",
+        ));
+    }
+    if name.chars().any(char::is_control) {
+        return Err(ConfigError::InvalidName(
+            "display name must not contain control characters",
+        ));
+    }
+    Ok(name.to_owned())
+}
+
+pub fn load_from(path: &Path) -> Result<Option<String>, ConfigError> {
+    let text = match fs::read_to_string(path) {
+        Ok(text) => text,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error.into()),
+    };
+    let config: ConfigFile = toml::from_str(&text).map_err(ConfigError::Parse)?;
+    config
+        .display_name
+        .map(|name| validate_display_name(&name))
+        .transpose()
+}
+
+pub fn save_to(path: &Path, name: &str) -> Result<String, ConfigError> {
+    let display_name = validate_display_name(name)?;
+    let config = ConfigFile {
+        display_name: Some(display_name.clone()),
+    };
+    let text = toml::to_string_pretty(&config).map_err(ConfigError::Serialize)?;
+    let parent = path.parent().ok_or(ConfigError::MissingHome)?;
+    fs::create_dir_all(parent)?;
+    fs::write(path, text)?;
+    Ok(display_name)
+}
+
+pub fn load() -> Result<Option<String>, ConfigError> {
+    load_from(&config_path()?)
+}
+
+pub fn save(name: &str) -> Result<String, ConfigError> {
+    save_to(&config_path()?, name)
+}

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -35,6 +35,7 @@ pub enum Node {
 pub struct Member {
     pub peer_id: Vec<u8>,
     pub endpoint_addr: Vec<u8>,
+    pub display_name: String,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -124,6 +125,7 @@ pub enum LayoutError {
     NotMember,
     InvalidPeerId,
     InvalidEndpointAddress,
+    InvalidDisplayName,
     TabLimit,
     PaneLimit,
     SplitDepthLimit,
@@ -149,9 +151,26 @@ impl SessionState {
         grid_rows: u16,
         grid_cols: u16,
     ) -> Result<Self, LayoutError> {
+        Self::new_with_display_name(
+            initial_host,
+            endpoint_addr,
+            String::new(),
+            grid_rows,
+            grid_cols,
+        )
+    }
+
+    pub fn new_with_display_name(
+        initial_host: Vec<u8>,
+        endpoint_addr: Vec<u8>,
+        display_name: String,
+        grid_rows: u16,
+        grid_cols: u16,
+    ) -> Result<Self, LayoutError> {
         validate_grid(grid_rows, grid_cols)?;
         validate_peer_id(&initial_host)?;
         validate_endpoint_addr(&endpoint_addr)?;
+        validate_display_name(&display_name)?;
         let initial_pane = Pane {
             pane_id: 1,
             host_peer_id: initial_host.clone(),
@@ -165,6 +184,7 @@ impl SessionState {
             members: vec![Member {
                 peer_id: initial_host,
                 endpoint_addr,
+                display_name,
             }],
             tabs: vec![Tab {
                 tab_id: 1,
@@ -221,6 +241,7 @@ impl SessionState {
             if validate_peer_id(&member.peer_id).is_err()
                 || !peer_ids.insert(&member.peer_id)
                 || validate_endpoint_addr(&member.endpoint_addr).is_err()
+                || validate_display_name(&member.display_name).is_err()
             {
                 return Err(LayoutError::InvalidSnapshot);
             }
@@ -261,9 +282,20 @@ impl SessionState {
         peer_id: Vec<u8>,
         endpoint_addr: Vec<u8>,
     ) -> Result<Option<InvalidatedReservation>, LayoutError> {
+        self.add_member_with_display_name(base_revision, peer_id, endpoint_addr, String::new())
+    }
+
+    pub fn add_member_with_display_name(
+        &mut self,
+        base_revision: u64,
+        peer_id: Vec<u8>,
+        endpoint_addr: Vec<u8>,
+        display_name: String,
+    ) -> Result<Option<InvalidatedReservation>, LayoutError> {
         self.check_mutation(base_revision)?;
         validate_peer_id(&peer_id)?;
         validate_endpoint_addr(&endpoint_addr)?;
+        validate_display_name(&display_name)?;
         if self.members.iter().any(|member| member.peer_id == peer_id) {
             return Err(LayoutError::AlreadyMember);
         }
@@ -273,6 +305,7 @@ impl SessionState {
         self.members.push(Member {
             peer_id,
             endpoint_addr,
+            display_name,
         });
         self.advance_revision();
         Ok(self.invalidate_reservation())
@@ -849,6 +882,13 @@ fn validate_grid(grid_rows: u16, grid_cols: u16) -> Result<(), LayoutError> {
     (grid_rows > 0 && grid_cols > 0)
         .then_some(())
         .ok_or(LayoutError::InvalidGrid)
+}
+
+fn validate_display_name(display_name: &str) -> Result<(), LayoutError> {
+    if display_name.chars().count() > 32 || display_name.chars().any(char::is_control) {
+        return Err(LayoutError::InvalidDisplayName);
+    }
+    Ok(())
 }
 
 fn validate_endpoint_addr(endpoint_addr: &[u8]) -> Result<(), LayoutError> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![forbid(unsafe_code)]
 
 pub mod cli;
+pub mod config;
 pub mod layout;
 pub mod lease;
 pub mod protocol;

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -157,6 +157,8 @@ pub struct Join {
     pub peer_id: Vec<u8>,
     #[prost(bytes = "vec", tag = "3")]
     pub endpoint_addr: Vec<u8>,
+    #[prost(string, tag = "4")]
+    pub display_name: String,
 }
 
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -249,6 +251,8 @@ pub struct MemberDescriptor {
     pub peer_id: Vec<u8>,
     #[prost(bytes = "vec", tag = "2")]
     pub endpoint_addr: Vec<u8>,
+    #[prost(string, tag = "3")]
+    pub display_name: String,
 }
 
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/src/session.rs
+++ b/src/session.rs
@@ -121,9 +121,26 @@ impl LayoutCoordinator {
         grid_rows: u16,
         grid_cols: u16,
     ) -> Result<Self, CoordinatorError> {
-        Self::with_reservation_timeout(
+        Self::new_with_display_name(
             coordinator_peer_id,
             endpoint_addr,
+            String::new(),
+            grid_rows,
+            grid_cols,
+        )
+    }
+
+    pub fn new_with_display_name(
+        coordinator_peer_id: Vec<u8>,
+        endpoint_addr: EndpointAddr,
+        display_name: String,
+        grid_rows: u16,
+        grid_cols: u16,
+    ) -> Result<Self, CoordinatorError> {
+        Self::with_reservation_timeout_and_display_name(
+            coordinator_peer_id,
+            endpoint_addr,
+            display_name,
             grid_rows,
             grid_cols,
             DEFAULT_RESERVATION_TIMEOUT,
@@ -137,11 +154,37 @@ impl LayoutCoordinator {
         grid_rows: u16,
         grid_cols: u16,
         reservation_timeout: Duration,
+        now: Instant,
+    ) -> Result<Self, CoordinatorError> {
+        Self::with_reservation_timeout_and_display_name(
+            coordinator_peer_id,
+            endpoint_addr,
+            String::new(),
+            grid_rows,
+            grid_cols,
+            reservation_timeout,
+            now,
+        )
+    }
+
+    pub fn with_reservation_timeout_and_display_name(
+        coordinator_peer_id: Vec<u8>,
+        endpoint_addr: EndpointAddr,
+        display_name: String,
+        grid_rows: u16,
+        grid_cols: u16,
+        reservation_timeout: Duration,
         _now: Instant,
     ) -> Result<Self, CoordinatorError> {
         let endpoint_addr = serialized_endpoint(&coordinator_peer_id, endpoint_addr)?;
         Ok(Self {
-            state: SessionState::new(coordinator_peer_id, endpoint_addr, grid_rows, grid_cols)?,
+            state: SessionState::new_with_display_name(
+                coordinator_peer_id,
+                endpoint_addr,
+                display_name,
+                grid_rows,
+                grid_cols,
+            )?,
             reservations: BTreeMap::new(),
             reservation_timeout,
         })
@@ -158,10 +201,22 @@ impl LayoutCoordinator {
         peer_id: Vec<u8>,
         endpoint_addr: EndpointAddr,
     ) -> Result<MembershipChange, CoordinatorError> {
+        self.admit_with_display_name(peer_id, endpoint_addr, String::new())
+    }
+
+    pub fn admit_with_display_name(
+        &mut self,
+        peer_id: Vec<u8>,
+        endpoint_addr: EndpointAddr,
+        display_name: String,
+    ) -> Result<MembershipChange, CoordinatorError> {
         let endpoint_addr = serialized_endpoint(&peer_id, endpoint_addr)?;
-        let invalidated = self
-            .state
-            .add_member(self.state.revision(), peer_id, endpoint_addr)?;
+        let invalidated = self.state.add_member_with_display_name(
+            self.state.revision(),
+            peer_id,
+            endpoint_addr,
+            display_name,
+        )?;
         self.membership_change(invalidated)
     }
 
@@ -563,6 +618,7 @@ fn protocol_layout_state(snapshot: LayoutSnapshot) -> LayoutState {
             .map(|member| MemberDescriptor {
                 peer_id: member.peer_id,
                 endpoint_addr: member.endpoint_addr,
+                display_name: member.display_name,
             })
             .collect(),
         panes: snapshot
@@ -597,6 +653,7 @@ pub fn layout_snapshot_from_state(state: &LayoutState) -> Result<LayoutSnapshot,
         .map(|member| Member {
             peer_id: member.peer_id.clone(),
             endpoint_addr: member.endpoint_addr.clone(),
+            display_name: member.display_name.clone(),
         })
         .collect();
     let panes = state
@@ -708,6 +765,7 @@ fn reject_reason(error: &LayoutError) -> LayoutRejectReason {
         | LayoutError::ReservationInvalid => LayoutRejectReason::ReservationFailure,
         LayoutError::InvalidPeerId
         | LayoutError::InvalidEndpointAddress
+        | LayoutError::InvalidDisplayName
         | LayoutError::InvalidGrid
         | LayoutError::AlreadyMember
         | LayoutError::InvalidSnapshot => LayoutRejectReason::Malformed,
@@ -1207,6 +1265,7 @@ pub struct JoinReceipt {
     pub admitted_peer_id: Vec<u8>,
     pub coordinator_peer_id: Vec<u8>,
     pub endpoint_addr: EndpointAddr,
+    pub display_name: String,
 }
 
 #[derive(Debug)]
@@ -1446,6 +1505,7 @@ impl HostSession {
             admitted_peer_id: remote_id.as_bytes().to_vec(),
             coordinator_peer_id: coordinator.as_bytes().to_vec(),
             endpoint_addr,
+            display_name: join.display_name,
         };
         self.transport
             .write_frame(
@@ -1710,7 +1770,22 @@ impl Drop for SharedLayoutMember {
 
 impl SharedLayoutHost {
     pub fn new(host: HostSession, grid_rows: u16, grid_cols: u16) -> Result<Self, SessionError> {
-        Self::with_reservation_timeout(host, grid_rows, grid_cols, DEFAULT_RESERVATION_TIMEOUT)
+        Self::with_display_name(host, String::new(), grid_rows, grid_cols)
+    }
+
+    pub fn with_display_name(
+        host: HostSession,
+        display_name: String,
+        grid_rows: u16,
+        grid_cols: u16,
+    ) -> Result<Self, SessionError> {
+        Self::with_reservation_timeout_and_display_name(
+            host,
+            display_name,
+            grid_rows,
+            grid_cols,
+            DEFAULT_RESERVATION_TIMEOUT,
+        )
     }
 
     pub fn with_reservation_timeout(
@@ -1719,11 +1794,28 @@ impl SharedLayoutHost {
         grid_cols: u16,
         reservation_timeout: Duration,
     ) -> Result<Self, SessionError> {
+        Self::with_reservation_timeout_and_display_name(
+            host,
+            String::new(),
+            grid_rows,
+            grid_cols,
+            reservation_timeout,
+        )
+    }
+
+    pub fn with_reservation_timeout_and_display_name(
+        host: HostSession,
+        display_name: String,
+        grid_rows: u16,
+        grid_cols: u16,
+        reservation_timeout: Duration,
+    ) -> Result<Self, SessionError> {
         let pane_server = host.pane_server();
         let coordinator_peer_id = host.ticket().endpoint_addr().id.as_bytes().to_vec();
-        let coordinator = LayoutCoordinator::with_reservation_timeout(
+        let coordinator = LayoutCoordinator::with_reservation_timeout_and_display_name(
             coordinator_peer_id,
             host.ticket().endpoint_addr().clone(),
+            display_name,
             grid_rows,
             grid_cols,
             reservation_timeout,
@@ -1870,9 +1962,10 @@ impl SharedLayoutHost {
                     .coordinator
                     .lock()
                     .map_err(|_| SessionError::PeerTask)?;
-                let membership = coordinator_guard.admit(
+                let membership = coordinator_guard.admit_with_display_name(
                     receipt.admitted_peer_id.clone(),
                     receipt.endpoint_addr.clone(),
+                    receipt.display_name.clone(),
                 )?;
 
                 let state = membership
@@ -2203,9 +2296,19 @@ pub async fn join_layout(
     transport: Transport,
     ticket: JoinTicket,
 ) -> Result<SharedLayoutMember, SessionError> {
+    join_layout_with_display_name(transport, ticket, String::new()).await
+}
+
+pub async fn join_layout_with_display_name(
+    transport: Transport,
+    ticket: JoinTicket,
+    display_name: String,
+) -> Result<SharedLayoutMember, SessionError> {
     let connection = transport.connect(ticket.endpoint_addr().clone()).await?;
     let result = async {
-        let receipt = join_handshake(&transport, &connection, &ticket).await?;
+        let receipt =
+            join_handshake_with_display_name(&transport, &connection, &ticket, display_name)
+                .await?;
         let (writer, reader) = transport.accept_framed_bi(&connection).await?;
         let (events_tx, events) = mpsc::channel(128);
         let (outbound, outbound_rx) = mpsc::channel(64);
@@ -2868,6 +2971,15 @@ async fn join_handshake(
     connection: &Connection,
     ticket: &JoinTicket,
 ) -> Result<JoinReceipt, SessionError> {
+    join_handshake_with_display_name(transport, connection, ticket, String::new()).await
+}
+
+async fn join_handshake_with_display_name(
+    transport: &Transport,
+    connection: &Connection,
+    ticket: &JoinTicket,
+    display_name: String,
+) -> Result<JoinReceipt, SessionError> {
     let client_id = transport.endpoint_id();
     if connection.remote_id() != ticket.endpoint_addr().id {
         return Err(SessionError::UnauthenticatedPeer);
@@ -2884,6 +2996,7 @@ async fn join_handshake(
                     peer_id: client_id.as_bytes().to_vec(),
                     endpoint_addr: serde_json::to_vec(&transport.endpoint_addr())
                         .expect("endpoint address should serialize"),
+                    display_name,
                 })),
             },
         )
@@ -2900,6 +3013,7 @@ async fn join_handshake(
         admitted_peer_id: welcome.admitted_peer_id,
         coordinator_peer_id: welcome.coordinator_peer_id,
         endpoint_addr: ticket.endpoint_addr().clone(),
+        display_name: String::new(),
     })
 }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -160,6 +160,10 @@ impl MultiPaneTui {
         self.chord_mode
     }
 
+    fn exit_chord_mode(&mut self) {
+        self.chord_mode = ChordMode::None;
+    }
+
     pub fn pane_view(&self, pane_id: PaneId) -> Option<&PaneViewState> {
         self.pane_views.get(&pane_id)
     }
@@ -1309,6 +1313,7 @@ impl SharedLayoutRuntime {
                     dirty = true;
                 }
                 Event::Paste(text) => {
+                    self.tui.exit_chord_mode();
                     self.forward_paste(&text)?;
                     dirty = true;
                 }
@@ -3121,6 +3126,20 @@ mod tests {
             tui.handle_key(KeyEvent::new(KeyCode::Char('z'), KeyModifiers::NONE), area),
             KeyHandling::Forward
         );
+        assert_eq!(tui.chord_mode(), ChordMode::None);
+    }
+
+    #[test]
+    fn paste_exits_sticky_chord_mode_before_forwarding() {
+        let mut tui = MultiPaneTui::new(split_layout()).expect("valid layout");
+        let area = Rect::new(0, 0, 80, 24);
+        let _ = tui.handle_key(
+            KeyEvent::new(KeyCode::Char('p'), KeyModifiers::CONTROL),
+            area,
+        );
+
+        tui.exit_chord_mode();
+
         assert_eq!(tui.chord_mode(), ChordMode::None);
     }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -9,7 +9,10 @@ use std::{
 use tokio::sync::{mpsc, watch};
 
 use crossterm::{
-    event::{self, DisableBracketedPaste, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers},
+    event::{
+        self, DisableBracketedPaste, DisableMouseCapture, EnableMouseCapture, Event, KeyCode,
+        KeyEvent, KeyEventKind, KeyModifiers, MouseButton, MouseEventKind,
+    },
     execute,
     terminal::{
         self, EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
@@ -203,6 +206,17 @@ impl MultiPaneTui {
         self.current_tab = tab_id;
         self.focused_pane = first_leaf(&tab.root).expect("validated layout has a leaf");
         Ok(())
+    }
+
+    fn focus_pane_at(&mut self, column: u16, row: u16, area: Rect) -> bool {
+        let Some(pane_id) = pane_at(&self.geometry(area).panes, column, row) else {
+            return false;
+        };
+        if self.focused_pane == pane_id {
+            return false;
+        }
+        self.focused_pane = pane_id;
+        true
     }
 
     pub fn geometry(&self, area: Rect) -> PaneGeometry {
@@ -424,6 +438,16 @@ fn first_leaf(node: &Node) -> Option<PaneId> {
         Node::Leaf { pane_id } => Some(*pane_id),
         Node::Split { first, .. } => first_leaf(first),
     }
+}
+
+fn pane_at(panes: &BTreeMap<PaneId, Rect>, column: u16, row: u16) -> Option<PaneId> {
+    panes.iter().find_map(|(pane_id, rect)| {
+        let inside = u32::from(column) >= u32::from(rect.x)
+            && u32::from(column) < u32::from(rect.x) + u32::from(rect.width)
+            && u32::from(row) >= u32::from(rect.y)
+            && u32::from(row) < u32::from(rect.y) + u32::from(rect.height);
+        inside.then_some(*pane_id)
+    })
 }
 
 fn contains_leaf(node: &Node, pane_id: PaneId) -> bool {
@@ -1227,6 +1251,8 @@ impl SharedLayoutRuntime {
         execute!(io::stdout(), EnterAlternateScreen)?;
         guard.bracketed_paste = true;
         execute!(io::stdout(), crossterm::event::EnableBracketedPaste)?;
+        guard.mouse_capture = true;
+        execute!(io::stdout(), EnableMouseCapture)?;
         let backend = CrosstermBackend::new(io::stdout());
         let mut terminal = Terminal::with_options(
             backend,
@@ -1279,6 +1305,15 @@ impl SharedLayoutRuntime {
                 Event::Paste(text) => {
                     self.forward_paste(&text)?;
                     dirty = true;
+                }
+                Event::Mouse(mouse)
+                    if matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left)) =>
+                {
+                    dirty |= self.tui.focus_pane_at(
+                        mouse.column,
+                        mouse.row,
+                        Rect::new(0, 0, cols, rows),
+                    );
                 }
                 Event::Resize(_, _) => dirty = true,
                 _ => {}
@@ -1906,6 +1941,7 @@ struct TerminalGuard {
     raw_mode: bool,
     alternate_screen: bool,
     bracketed_paste: bool,
+    mouse_capture: bool,
 }
 
 impl TerminalGuard {
@@ -1914,6 +1950,7 @@ impl TerminalGuard {
             raw_mode: false,
             alternate_screen: false,
             bracketed_paste: false,
+            mouse_capture: false,
         }
     }
 }
@@ -1923,6 +1960,9 @@ impl Drop for TerminalGuard {
         let mut stdout = io::stdout();
         if self.bracketed_paste {
             let _ = execute!(stdout, DisableBracketedPaste);
+        }
+        if self.mouse_capture {
+            let _ = execute!(stdout, DisableMouseCapture);
         }
         if self.alternate_screen {
             let _ = execute!(stdout, crossterm::cursor::Show, LeaveAlternateScreen);
@@ -2757,6 +2797,22 @@ mod tests {
         assert_eq!(geometry.panes[&1], Rect::new(0, 1, 40, 22));
         assert_eq!(geometry.panes[&2], Rect::new(40, 1, 40, 11));
         assert_eq!(geometry.panes[&3], Rect::new(40, 12, 40, 11));
+    }
+
+    #[test]
+    fn mouse_hit_testing_focuses_the_clicked_pane_and_ignores_misses() {
+        let mut tui = MultiPaneTui::new(split_layout()).expect("valid layout");
+        let area = Rect::new(0, 0, 80, 24);
+        let _ = tui.handle_key(
+            KeyEvent::new(KeyCode::Char('p'), KeyModifiers::CONTROL),
+            area,
+        );
+
+        assert!(tui.focus_pane_at(60, 17, area));
+        assert_eq!(tui.focused_pane(), 3);
+        assert_eq!(tui.chord_mode(), ChordMode::Pane);
+        assert!(!tui.focus_pane_at(10, 0, area));
+        assert_eq!(tui.focused_pane(), 3);
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -258,13 +258,25 @@ impl MultiPaneTui {
         }
 
         let chord = self.chord_mode;
-        self.chord_mode = ChordMode::None;
+        if key.code == KeyCode::Char('p') && key.modifiers == KeyModifiers::CONTROL {
+            self.chord_mode = ChordMode::Pane;
+            return KeyHandling::Consumed(vec![]);
+        }
+        if key.code == KeyCode::Char('t') && key.modifiers == KeyModifiers::CONTROL {
+            self.chord_mode = ChordMode::Tab;
+            return KeyHandling::Consumed(vec![]);
+        }
         let intent = match chord {
             ChordMode::Pane => self.handle_pane_chord(key, area),
             ChordMode::Tab => self.handle_tab_chord(key, area),
             ChordMode::None => None,
         };
-        KeyHandling::Consumed(intent.into_iter().collect())
+        if intent.is_some() || is_chord_command(chord, key) {
+            KeyHandling::Consumed(intent.into_iter().collect())
+        } else {
+            self.chord_mode = ChordMode::None;
+            KeyHandling::Forward
+        }
     }
 
     fn handle_pane_chord(&mut self, key: KeyEvent, area: Rect) -> Option<UiIntent> {
@@ -382,6 +394,28 @@ impl MultiPaneTui {
         if !contains_leaf(&current_tab.root, self.focused_pane) {
             self.focused_pane = first_leaf(&current_tab.root).expect("validated layout has a leaf");
         }
+    }
+}
+
+fn is_chord_command(mode: ChordMode, key: KeyEvent) -> bool {
+    if !key.modifiers.is_empty() {
+        return false;
+    }
+    match mode {
+        ChordMode::Pane => matches!(
+            key.code,
+            KeyCode::Char('n')
+                | KeyCode::Char('x')
+                | KeyCode::Left
+                | KeyCode::Right
+                | KeyCode::Up
+                | KeyCode::Down
+        ),
+        ChordMode::Tab => matches!(
+            key.code,
+            KeyCode::Char('n') | KeyCode::Char('x') | KeyCode::Left | KeyCode::Right
+        ),
+        ChordMode::None => false,
     }
 }
 
@@ -516,8 +550,14 @@ pub fn render_multi_pane(
     render_shared_multi_pane(frame, tui, screens, "", None);
 }
 
-fn shared_footer_text(status: &str, join_code: Option<&str>) -> String {
-    let controls = format!("Ctrl+P panes | Ctrl+T tabs | {CONTROL_HELP}");
+fn shared_footer_text(status: &str, join_code: Option<&str>, chord_mode: ChordMode) -> String {
+    let controls = match chord_mode {
+        ChordMode::None => format!("Ctrl+P panes | Ctrl+T tabs | {CONTROL_HELP}"),
+        ChordMode::Pane => {
+            String::from("arrows move focus | N new pane | X delete pane | Esc cancel")
+        }
+        ChordMode::Tab => String::from("←/→ switch tab | N new tab | X delete tab | Esc cancel"),
+    };
     match (status.is_empty(), join_code) {
         (false, Some(join_code)) => {
             format!("{status} | {controls} | join: p2pmux join {join_code}")
@@ -561,7 +601,7 @@ fn render_shared_multi_pane(
         frame.buffer_mut().set_string(
             geometry.footer.x,
             geometry.footer.y,
-            shared_footer_text(status, join_code),
+            shared_footer_text(status, join_code, tui.chord_mode),
             Style::default().fg(Color::DarkGray),
         );
     }
@@ -2576,7 +2616,8 @@ mod tests {
 
     #[test]
     fn shared_footer_keeps_status_visible_when_a_join_code_is_present() {
-        let footer = shared_footer_text("layout request rejected", Some("TESTCODE"));
+        let footer =
+            shared_footer_text("layout request rejected", Some("TESTCODE"), ChordMode::None);
         assert!(footer.starts_with("layout request rejected"));
         assert!(footer.contains("Ctrl+P panes"));
         assert!(footer.contains(CONTROL_HELP));
@@ -2932,7 +2973,7 @@ mod tests {
                 grid_cols: 38,
             }])
         );
-        assert_eq!(tui.chord_mode(), ChordMode::None);
+        assert_eq!(tui.chord_mode(), ChordMode::Pane);
 
         let _ = tui.handle_key(
             KeyEvent::new(KeyCode::Char('p'), KeyModifiers::CONTROL),
@@ -2943,6 +2984,99 @@ mod tests {
             KeyHandling::Consumed(vec![UiIntent::FocusPane { pane_id: 2 }])
         );
         assert_eq!(tui.focused_pane(), 2);
+    }
+
+    #[test]
+    fn sticky_pane_mode_moves_focus_across_multiple_arrows() {
+        let mut tui = MultiPaneTui::new(split_layout()).expect("valid layout");
+        let area = Rect::new(0, 0, 80, 24);
+
+        let _ = tui.handle_key(
+            KeyEvent::new(KeyCode::Char('p'), KeyModifiers::CONTROL),
+            area,
+        );
+        assert_eq!(
+            tui.handle_key(KeyEvent::new(KeyCode::Right, KeyModifiers::NONE), area),
+            KeyHandling::Consumed(vec![UiIntent::FocusPane { pane_id: 2 }])
+        );
+        assert_eq!(tui.chord_mode(), ChordMode::Pane);
+        assert_eq!(
+            tui.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE), area),
+            KeyHandling::Consumed(vec![UiIntent::FocusPane { pane_id: 3 }])
+        );
+        assert_eq!(tui.chord_mode(), ChordMode::Pane);
+    }
+
+    #[test]
+    fn escape_clears_sticky_chord_mode_without_forwarding() {
+        let mut tui = MultiPaneTui::new(split_layout()).expect("valid layout");
+        let area = Rect::new(0, 0, 80, 24);
+
+        let _ = tui.handle_key(
+            KeyEvent::new(KeyCode::Char('p'), KeyModifiers::CONTROL),
+            area,
+        );
+        assert_eq!(
+            tui.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE), area),
+            KeyHandling::Consumed(vec![])
+        );
+        assert_eq!(tui.chord_mode(), ChordMode::None);
+    }
+
+    #[test]
+    fn forwarding_key_exits_sticky_pane_mode_once() {
+        let mut tui = MultiPaneTui::new(split_layout()).expect("valid layout");
+        let area = Rect::new(0, 0, 80, 24);
+
+        let _ = tui.handle_key(
+            KeyEvent::new(KeyCode::Char('p'), KeyModifiers::CONTROL),
+            area,
+        );
+        assert_eq!(
+            tui.handle_key(KeyEvent::new(KeyCode::Char('z'), KeyModifiers::NONE), area),
+            KeyHandling::Forward
+        );
+        assert_eq!(tui.chord_mode(), ChordMode::None);
+    }
+
+    #[test]
+    fn shared_footer_uses_help_for_each_chord_mode() {
+        let mut tui = MultiPaneTui::new(layout(
+            vec![Tab {
+                tab_id: 1,
+                root: Node::Leaf { pane_id: 1 },
+            }],
+            &[(1, 2, 2)],
+        ))
+        .expect("valid layout");
+        let mut terminal = Terminal::new(TestBackend::new(120, 4)).expect("test terminal");
+
+        for (mode, expected) in [
+            (
+                ChordMode::None,
+                "Ctrl+P panes | Ctrl+T tabs | type to claim idle | active typing is protected | Ctrl+Q quit",
+            ),
+            (
+                ChordMode::Pane,
+                "arrows move focus | N new pane | X delete pane | Esc cancel",
+            ),
+            (
+                ChordMode::Tab,
+                "←/→ switch tab | N new tab | X delete tab | Esc cancel",
+            ),
+        ] {
+            tui.chord_mode = mode;
+            terminal
+                .draw(|frame| render_multi_pane(frame, &tui, &BTreeMap::new()))
+                .expect("render");
+            let footer = (0..120)
+                .map(|x| terminal.backend().buffer()[(x, 3)].symbol())
+                .collect::<String>();
+            assert!(
+                footer.starts_with(expected),
+                "mode: {mode:?}, footer: {footer}"
+            );
+        }
     }
 
     #[test]
@@ -3042,7 +3176,7 @@ mod tests {
     }
 
     #[test]
-    fn invalid_second_chord_keys_are_consumed_instead_of_forwarded() {
+    fn forwarding_keys_exit_a_chord_mode_and_are_forwarded() {
         let mut tui = MultiPaneTui::new(split_layout()).expect("valid layout");
         let area = Rect::new(0, 0, 80, 24);
 
@@ -3056,7 +3190,7 @@ mod tests {
             );
             assert_eq!(
                 tui.handle_key(KeyEvent::new(KeyCode::Char('z'), KeyModifiers::NONE), area),
-                KeyHandling::Consumed(vec![])
+                KeyHandling::Forward
             );
             assert_eq!(tui.chord_mode(), ChordMode::None);
         }
@@ -3231,6 +3365,44 @@ mod tests {
             tui.handle_key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE), area),
             KeyHandling::Consumed(vec![UiIntent::DeleteTab { tab_id: 2 }])
         );
+    }
+
+    #[test]
+    fn sticky_tab_mode_switches_tabs_repeatedly() {
+        let mut tui = MultiPaneTui::new(layout(
+            vec![
+                Tab {
+                    tab_id: 1,
+                    root: Node::Leaf { pane_id: 1 },
+                },
+                Tab {
+                    tab_id: 2,
+                    root: Node::Leaf { pane_id: 2 },
+                },
+                Tab {
+                    tab_id: 3,
+                    root: Node::Leaf { pane_id: 3 },
+                },
+            ],
+            &[(1, 2, 2), (2, 2, 2), (3, 2, 2)],
+        ))
+        .expect("valid layout");
+        let area = Rect::new(0, 0, 12, 8);
+
+        let _ = tui.handle_key(
+            KeyEvent::new(KeyCode::Char('t'), KeyModifiers::CONTROL),
+            area,
+        );
+        assert_eq!(
+            tui.handle_key(KeyEvent::new(KeyCode::Right, KeyModifiers::NONE), area),
+            KeyHandling::Consumed(vec![UiIntent::SwitchTab { tab_id: 2 }])
+        );
+        assert_eq!(tui.chord_mode(), ChordMode::Tab);
+        assert_eq!(
+            tui.handle_key(KeyEvent::new(KeyCode::Right, KeyModifiers::NONE), area),
+            KeyHandling::Consumed(vec![UiIntent::SwitchTab { tab_id: 3 }])
+        );
+        assert_eq!(tui.chord_mode(), ChordMode::Tab);
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -640,15 +640,21 @@ fn render_shared_multi_pane(
         let focused = pane_id == tui.focused_pane;
         let lease = match view.controller_peer_id.as_deref() {
             Some(peer) if view.controller_active => {
-                format!("ctrl:{} this user is typing", short_peer(peer))
+                format!(
+                    "ctrl:{} this user is typing",
+                    member_label(peer, &tui.snapshot.members)
+                )
             }
-            Some(peer) => format!("ctrl:{} this user has control", short_peer(peer)),
+            Some(peer) => format!(
+                "ctrl:{} this user has control",
+                member_label(peer, &tui.snapshot.members)
+            ),
             None => String::from("lease: waiting"),
         };
         let title = format!(
             "{} host:{} {lease}",
             if focused { "*" } else { " " },
-            short_peer(&pane.host_peer_id)
+            member_label(&pane.host_peer_id, &tui.snapshot.members)
         );
         let border_color = match view.controller_peer_id.as_ref() {
             Some(_) if view.controller_active => Color::Rgb(255, 69, 0),
@@ -2379,6 +2385,24 @@ fn short_peer(peer_id: &[u8]) -> String {
         .collect()
 }
 
+fn member_label(peer_id: &[u8], members: &[crate::layout::Member]) -> String {
+    let Some(member) = members.iter().find(|member| member.peer_id == peer_id) else {
+        return short_peer(peer_id);
+    };
+    if member.display_name.is_empty() {
+        return short_peer(peer_id);
+    }
+    let duplicates = members
+        .iter()
+        .filter(|candidate| candidate.display_name == member.display_name)
+        .count();
+    if duplicates > 1 {
+        format!("{} · {}", member.display_name, short_peer(peer_id))
+    } else {
+        member.display_name.clone()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::{
@@ -2410,7 +2434,7 @@ mod tests {
         CONTROL_HELP, ChordMode, HostControlEvent, HostPaneChannels, KeyHandling,
         LayoutControlEvent, MultiPaneTui, PaneViewState, RemoteSubscriptionState,
         SharedLayoutRuntime, SharedLocalPane, UiIntent, VtScreen, encode_key, encode_paste,
-        grid_for_pane, initial_root_pane_grid, pane_wire_id, render_guest_screen,
+        grid_for_pane, initial_root_pane_grid, member_label, pane_wire_id, render_guest_screen,
         render_multi_pane, render_shared_multi_pane, shared_footer_text,
     };
 
@@ -2420,6 +2444,7 @@ mod tests {
             members: vec![crate::layout::Member {
                 peer_id: b"host".to_vec(),
                 endpoint_addr: b"endpoint".to_vec(),
+                display_name: String::new(),
             }],
             tabs,
             panes: panes
@@ -3167,6 +3192,33 @@ mod tests {
         assert!(tab_bar.contains("Tab #2"));
         assert_eq!(buffer[(0, 0)].fg, Color::White);
         assert_eq!(buffer[(0, 0)].bg, Color::Rgb(220, 50, 47));
+    }
+
+    #[test]
+    fn member_labels_disambiguate_duplicate_display_names() {
+        let members = vec![
+            crate::layout::Member {
+                peer_id: vec![0xaa, 0xbb, 0xcc, 0xdd],
+                endpoint_addr: vec![1],
+                display_name: "sam".into(),
+            },
+            crate::layout::Member {
+                peer_id: vec![0x11, 0x22, 0x33, 0x44],
+                endpoint_addr: vec![2],
+                display_name: "sam".into(),
+            },
+            crate::layout::Member {
+                peer_id: vec![0x55, 0x66, 0x77, 0x88],
+                endpoint_addr: vec![3],
+                display_name: "pat".into(),
+            },
+        ];
+
+        assert_eq!(
+            member_label(&members[0].peer_id, &members),
+            "sam · aabbccdd"
+        );
+        assert_eq!(member_label(&members[2].peer_id, &members), "pat");
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -576,26 +576,30 @@ fn render_shared_multi_pane(
     join_code: Option<&str>,
 ) {
     let geometry = tui.geometry(frame.area());
-    let tabs = tui
-        .snapshot
-        .tabs
-        .iter()
-        .map(|tab| {
-            if tab.tab_id == tui.current_tab {
-                format!("[*{}]", tab.tab_id)
-            } else {
-                format!("[{}]", tab.tab_id)
-            }
-        })
-        .collect::<Vec<_>>()
-        .join(" ");
     if geometry.tab_bar.width > 0 && geometry.tab_bar.height > 0 {
-        frame.buffer_mut().set_string(
-            geometry.tab_bar.x,
-            geometry.tab_bar.y,
-            tabs,
-            Style::default().fg(Color::Cyan),
-        );
+        let mut x = geometry.tab_bar.x;
+        for (index, tab) in tui.snapshot.tabs.iter().enumerate() {
+            if index > 0 {
+                frame
+                    .buffer_mut()
+                    .set_string(x, geometry.tab_bar.y, " ", Style::default());
+                x = x.saturating_add(1);
+            }
+            let active = tab.tab_id == tui.current_tab;
+            let style = if active {
+                Style::default()
+                    .fg(Color::White)
+                    .bg(Color::Rgb(220, 50, 47))
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(Color::DarkGray)
+            };
+            let label = format!("Tab #{}", index + 1);
+            frame
+                .buffer_mut()
+                .set_string(x, geometry.tab_bar.y, &label, style);
+            x = x.saturating_add(label.len() as u16);
+        }
     }
     if geometry.footer.width > 0 && geometry.footer.height > 0 {
         frame.buffer_mut().set_string(
@@ -3077,6 +3081,36 @@ mod tests {
                 "mode: {mode:?}, footer: {footer}"
             );
         }
+    }
+
+    #[test]
+    fn tab_bar_uses_ordinal_labels_and_highlights_the_active_tab() {
+        let tui = MultiPaneTui::new(layout(
+            vec![
+                Tab {
+                    tab_id: 10,
+                    root: Node::Leaf { pane_id: 1 },
+                },
+                Tab {
+                    tab_id: 20,
+                    root: Node::Leaf { pane_id: 2 },
+                },
+            ],
+            &[(1, 2, 2), (2, 2, 2)],
+        ))
+        .expect("valid layout");
+        let mut terminal = Terminal::new(TestBackend::new(32, 4)).expect("test terminal");
+
+        terminal
+            .draw(|frame| render_multi_pane(frame, &tui, &BTreeMap::new()))
+            .expect("render");
+        let buffer = terminal.backend().buffer();
+        let tab_bar = (0..32).map(|x| buffer[(x, 0)].symbol()).collect::<String>();
+
+        assert!(tab_bar.contains("Tab #1"));
+        assert!(tab_bar.contains("Tab #2"));
+        assert_eq!(buffer[(0, 0)].fg, Color::White);
+        assert_eq!(buffer[(0, 0)].bg, Color::Rgb(220, 50, 47));
     }
 
     #[test]

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -1,0 +1,27 @@
+use std::path::PathBuf;
+
+use p2pmux::config::{load_from, save_to, validate_display_name};
+
+fn temp_config_path() -> PathBuf {
+    std::env::temp_dir()
+        .join(format!("p2pmux-config-test-{}", std::process::id()))
+        .join("config.toml")
+}
+
+#[test]
+fn display_name_config_round_trips() {
+    let path = temp_config_path();
+    save_to(&path, "  pelazas  ").expect("save config");
+    assert_eq!(
+        load_from(&path).expect("load config"),
+        Some("pelazas".into())
+    );
+    let _ = std::fs::remove_dir_all(path.parent().expect("temp parent"));
+}
+
+#[test]
+fn display_name_validation_rejects_empty_long_and_control_values() {
+    assert!(validate_display_name("  ").is_err());
+    assert!(validate_display_name(&"x".repeat(33)).is_err());
+    assert!(validate_display_name("bad\nname").is_err());
+}

--- a/tests/protocol.rs
+++ b/tests/protocol.rs
@@ -36,6 +36,7 @@ fn envelope_exposes_each_v1_body() {
             session_id: b"session-a".to_vec(),
             peer_id: b"peer-a".to_vec(),
             endpoint_addr: b"endpoint-a".to_vec(),
+            display_name: String::new(),
         })),
         envelope(envelope::Body::Welcome(Welcome {
             session_id: b"session-a".to_vec(),
@@ -160,6 +161,7 @@ fn sample_envelopes() -> Vec<Envelope> {
             session_id: b"session-a".to_vec(),
             peer_id: b"peer-a".to_vec(),
             endpoint_addr: b"endpoint-a".to_vec(),
+            display_name: String::new(),
         })),
         envelope(envelope::Body::Welcome(Welcome {
             session_id: b"session-a".to_vec(),
@@ -218,6 +220,7 @@ fn layout_state(root: LayoutNode) -> LayoutState {
         members: vec![MemberDescriptor {
             peer_id: b"peer-a".to_vec(),
             endpoint_addr: b"endpoint-a".to_vec(),
+            display_name: String::new(),
         }],
         panes: vec![PaneDescriptor {
             pane_id: 1,
@@ -372,6 +375,7 @@ fn layout_messages_reject_invalid_shapes_and_bounds() {
             .map(|index| MemberDescriptor {
                 peer_id: format!("peer-{index}").into_bytes(),
                 endpoint_addr: b"endpoint".to_vec(),
+                display_name: String::new(),
             })
             .collect(),
         ..state.clone()
@@ -485,6 +489,7 @@ fn join_endpoint_and_reservation_lifecycle_identifiers_are_required() {
         session_id: b"session-a".to_vec(),
         peer_id: b"peer-a".to_vec(),
         endpoint_addr: Vec::new(),
+        display_name: String::new(),
     }));
     let missing_ready_revision = envelope(envelope::Body::PaneReady(PaneReady {
         reservation_id: 1,
@@ -871,6 +876,7 @@ fn layout_state_wire_shape_includes_all_nested_fields() {
         members: vec![MemberDescriptor {
             peer_id: b"peer-a".to_vec(),
             endpoint_addr: b"endpoint-a".to_vec(),
+            display_name: String::new(),
         }],
         panes: vec![PaneDescriptor {
             pane_id: 11,
@@ -925,6 +931,7 @@ fn join_wire_shape_encodes_a_present_endpoint_address() {
         session_id: b"session-a".to_vec(),
         peer_id: b"peer-a".to_vec(),
         endpoint_addr: b"endpoint-a".to_vec(),
+        display_name: String::new(),
     };
 
     assert_eq!(
@@ -973,6 +980,7 @@ fn layout_messages_reject_deep_or_wide_trees_and_oversize_join_endpoint() {
         session_id: b"session-a".to_vec(),
         peer_id: b"peer-a".to_vec(),
         endpoint_addr: vec![0; MAX_ENDPOINT_ADDR_BYTES + 1],
+        display_name: String::new(),
     }));
 
     for invalid in [
@@ -1129,6 +1137,7 @@ fn decoder_rejects_missing_fields_and_invalid_sequences() {
         session_id: Vec::new(),
         peer_id: b"peer-a".to_vec(),
         endpoint_addr: Vec::new(),
+        display_name: String::new(),
     }));
     let mut empty_id_frame = Vec::new();
     empty_id
@@ -1244,6 +1253,7 @@ fn encode_frame_rejects_invalid_envelopes() {
                 session_id: vec![0; MAX_SESSION_ID_BYTES + 1],
                 peer_id: b"peer-a".to_vec(),
                 endpoint_addr: Vec::new(),
+                display_name: String::new(),
             })),
         ),
         (
@@ -1252,6 +1262,7 @@ fn encode_frame_rejects_invalid_envelopes() {
                 session_id: b"session-a".to_vec(),
                 peer_id: vec![0; MAX_PEER_ID_BYTES + 1],
                 endpoint_addr: Vec::new(),
+                display_name: String::new(),
             })),
         ),
         (

--- a/tests/session_handshake.rs
+++ b/tests/session_handshake.rs
@@ -46,6 +46,7 @@ async fn rejected_raw_join_endpoint(host: &HostSession, endpoint_addr: Vec<u8>) 
                     session_id: host.ticket().session_id().to_vec(),
                     peer_id: guest_id,
                     endpoint_addr,
+                    display_name: String::new(),
                 })),
             },
         )

--- a/tests/session_layout_control.rs
+++ b/tests/session_layout_control.rs
@@ -338,6 +338,7 @@ async fn forged_post_welcome_sender_is_rejected_without_a_layout_mutation() {
                 session_id: coordinator.ticket().session_id().to_vec(),
                 peer_id: raw_id.clone(),
                 endpoint_addr: serde_json::to_vec(&raw.endpoint_addr()).expect("endpoint"),
+                display_name: String::new(),
             })),
         },
     )
@@ -739,6 +740,7 @@ async fn closing_after_welcome_rolls_back_admission_before_control_setup() {
                 session_id: coordinator.ticket().session_id().to_vec(),
                 peer_id: raw_id,
                 endpoint_addr: serde_json::to_vec(&raw.endpoint_addr()).expect("endpoint"),
+                display_name: String::new(),
             })),
         },
     )

--- a/tests/session_stream.rs
+++ b/tests/session_stream.rs
@@ -833,6 +833,7 @@ async fn post_welcome_screen_stream_starts_with_a_snapshot_then_sends_delta() {
                     session_id: host.ticket().session_id().to_vec(),
                     peer_id: guest_id.clone(),
                     endpoint_addr: guest_endpoint_addr,
+                    display_name: String::new(),
                 })),
             },
         )
@@ -919,6 +920,7 @@ async fn host_keeps_a_silent_spectator_connected_after_control_stream_setup_wind
                     session_id: host.ticket().session_id().to_vec(),
                     peer_id: guest_id,
                     endpoint_addr: guest_endpoint_addr,
+                    display_name: String::new(),
                 })),
             },
         )


### PR DESCRIPTION
## Summary
- sticky Ctrl+P/Ctrl+T modes with contextual footer help
- Tab #N labels with red active highlight
- mouse click focuses panes
- persistent display names via config + shared roster

## Test plan
- [x] cargo fmt --check
- [x] cargo clippy --all-targets --all-features -- -D warnings
- [x] cargo test
- [x] sticky pane/tab focus with repeated arrows and forwarding exits
- [x] contextual footers and tab chrome
- [x] config validation and round-trip
- [x] duplicate name disambiguation
- [x] mouse pane hit testing (manual Zellij passthrough caveat documented)