### PR TITLE
UX: free-pane control, pane titles, tab clicks, footer chrome

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,12 @@ Short join codes resolve through a restrictive local cache on the same Mac, so t
 dogfooding only; they work while the corresponding `create` process is alive and are removed when
 it exits. Long `p2pmux-v1:` tickets remain accepted for backwards compatibility.
 
-Only one peer controls each pane at a time: after about eight seconds of idle time another member
-can type to hop in. Active typing is protected, so there is no forced takeover. Ctrl+Q exits only
-the local p2pmux view; F9 and F10 continue through to the focused PTY.
+Only one peer controls a pane while they are actively typing. After about eight seconds without
+activity, the host clears the controller and the pane becomes free. The next member's ordinary key
+claims the free pane and is delivered as its first input; active typing is protected, so there is
+no forced takeover. A pane's host owns its PTY, not its control lease: newly created split and tab
+panes start free. Ctrl+Q exits only the local p2pmux view; F9 and F10 continue through to the
+focused PTY.
 
 Shared-layout commands are sticky local mux modes and never reach a PTY. `Ctrl+P` or `Ctrl+T`
 enters its mode; use the listed command repeatedly, press `Esc` to cancel, or type any normal key
@@ -98,9 +101,12 @@ passthrough configuration.
 
 The final pane in a tab must be removed by deleting its tab; the final tab cannot be deleted.
 Nested 50/50 splits are part of Spike 3 (depth 4, at most 8 panes per tab, at most 9 tabs). Each
-pane reports whether its controller is actively typing or merely retains idle control, and every
-member sees the same footer: `Ctrl+P panes | Ctrl+T tabs | type to claim when free | active typing is
-protected | Ctrl+Q quit`.
+pane title shows `Pane #N  host: <name>  control: free|<name>|…`; free focused panes use a white
+border and actively controlled panes use red-orange. Click tab labels to switch tabs without
+claiming control or sending input. The dark contextual footer uses red key accents: normal mode is
+`Ctrl+ <p> PANE   <t> TAB   <q> QUIT    type to claim when free`; pane mode is
+`Pane  <←↓↑→> FOCUS   <n> NEW   <x> CLOSE   <Esc> BACK`; tab mode is
+`Tab  <←→> SWITCH   <n> NEW   <x> CLOSE   <Esc> BACK`.
 
 Slow viewers may receive coalesced screen deltas and then a fresh snapshot to recover. Resizing an
 outer terminal crops or letterboxes the immutable host grid; it never resizes the host PTY.

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ passthrough configuration.
 The final pane in a tab must be removed by deleting its tab; the final tab cannot be deleted.
 Nested 50/50 splits are part of Spike 3 (depth 4, at most 8 panes per tab, at most 9 tabs). Each
 pane reports whether its controller is actively typing or merely retains idle control, and every
-member sees the same footer: `Ctrl+P panes | Ctrl+T tabs | type to claim idle | active typing is
+member sees the same footer: `Ctrl+P panes | Ctrl+T tabs | type to claim when free | active typing is
 protected | Ctrl+Q quit`.
 
 Slow viewers may receive coalesced screen deltas and then a fresh snapshot to recover. Resizing an

--- a/docs/MVP_DESIGN.md
+++ b/docs/MVP_DESIGN.md
@@ -29,7 +29,9 @@ Brew-installable macOS terminal mux: each pane’s process runs on its host’s 
   fixed-grid PTY runs on that requester’s Mac. Only a pane’s host may delete that pane. A tab may
   be deleted only by a member that hosts every pane in it. There is no close confirmation in this
   spike; stale requests are rejected rather than replayed.
-- **Input:** one controller per pane; **idle → hop in and type, no approval**; if controller is **actively typing**, explicit **Take control** required.
+- **Input:** a pane has a controller only while that peer is actively typing. After about eight
+  seconds idle, the host clears the controller and the pane is free; the next ordinary key claims
+  it and is delivered as the first input. Active typing is protected; there is no forced takeover.
 - **Later-spike disconnect behavior:** 5-minute unavailable placeholders and coordinator failover
   are MVP goals, not implemented by Spike 3.
 - **Layout:** nested binary 50/50; **depth ≤ 4**; **≤ 8 panes/tab**; max **9 tabs**.
@@ -40,8 +42,12 @@ Brew-installable macOS terminal mux: each pane’s process runs on its host’s 
 
 1. You `create` → reusable join ticket → first shell on your Mac. You start as coordinator.
 2. Others `join <ticket>` (up to 8). Everyone sees the same tabs/panes.
-3. Shells run on whoever **hosts** that pane’s Mac. Others watch; when idle they hop in and type; active typing is protected until the controller becomes idle.
-4. Any member can split an available pane or create a tab; the requester hosts the new PTY. Only the host can delete a pane. A member can delete a tab only when it owns every pane in that tab.
+3. Shells run on whoever **hosts** that pane’s Mac. Others watch; an idle pane is free for the
+   next member's ordinary key to claim and deliver. Active typing is protected until the host clears
+   the controller after the idle timeout.
+4. Any member can split an available pane or create a tab; the requester hosts the new PTY, but is
+   not its controller and the new pane starts free. Only the host can delete a pane. A member can
+   delete a tab only when it owns every pane in that tab.
 5. Spike 3 is localhost layout/control work. Disconnect grace and coordinator failover remain later spikes.
 
 ## 4. Architecture
@@ -77,10 +83,11 @@ If coordinator disconnects:
 
 ### Input control
 
-- `controller` + idle(~8s)/typing; focus ≠ control.
-- Idle: another member may take over by hopping in / typing — **no approval**.
-- Typing: explicit **Take control** (visible handoff).
-- Control serialized so two streams never hit one PTY.
+- `controller` exists only during active typing; focus ≠ control.
+- After ~8 seconds idle, the host publishes an empty controller and a new lease epoch: the pane is
+  free. The next ordinary input claims it and carries its first key.
+- Active typing rejects other ordinary input; no forced takeover exists.
+- Claims are serialized so two streams never hit one PTY.
 
 ### Spike 3 layout and deletion
 
@@ -102,7 +109,12 @@ the local view; F9 and F10 reach the focused PTY. Pane grids never resize.
 
 ## 5. UI / presence
 
-Tabs + nested splits as above. Tab bar: who is on which tab. Pane: host badge, focus, **controller/driver**, idle vs typing cue. Direct | relayed indicator.
+Tabs + nested splits as above. Tab labels are clickable for local tab switching. Each pane title is
+`Pane #N  host: <name>  control: free|<name>|…`; a focused free pane has a white border, an
+actively controlled pane a red-orange border, and an unbootstrapped lease a yellow focused border.
+The dark contextual footer uses red key accents: normal mode shows
+`Ctrl+ <p> PANE   <t> TAB   <q> QUIT    type to claim when free`; pane and tab modes show their
+focus/switch, new, close, and back commands. Direct | relayed indicator.
 
 ## 6. Wire sketch
 
@@ -129,8 +141,8 @@ See [SPIKE_PLAN.md](./SPIKE_PLAN.md).
 ## 10. MVP success criteria
 
 Two (then more) Macs join via reusable ticket; shared layout; both host panes; anyone can split
-available panes; pane hosts delete their own panes; all-host tabs can be deleted; idle hop-in
-typing; Take control when busy; presence; locality of processes; encrypted P2P/relay; ≈ SSH feel;
+available panes; pane hosts delete their own panes; all-host tabs can be deleted; free-pane first-
+key claims and protected active typing; presence; locality of processes; encrypted P2P/relay; ≈ SSH feel;
 disconnect grace works; coordinator leave does not kill whole session.
 
 ## Caveat (honest)

--- a/docs/PRODUCT.md
+++ b/docs/PRODUCT.md
@@ -10,7 +10,7 @@ The multiplexer is a **shared control surface, not a shared computer**.
 - Every user in a session can create their own panes and tabs.
 - Each pane is backed by a local PTY on that user’s machine.
 - Processes in that pane (shell, Docker, Claude Code, etc.) run on the owner’s hardware, with their PATH, env, API keys, and subscriptions.
-- Other users can attach as guests: see live output, and work on that pane (via take-control — see MVP design).
+- Other users can attach as guests: see live output, then claim a free pane with ordinary input.
 - The same person is host of their panes and guest on everyone else’s. Host/guest is **per pane**, not per person.
 
 Example: Pelazas starts Claude Code in his pane (his subscription). Tis hops into that pane and prompts to do a code change. Pelazas never sees Tis’ keys; nothing runs on Tis’ machine for that pane. A code change has been made on Pelazas’ machine. At the same time, Tis can host panes that Pelazas guests into.
@@ -36,7 +36,7 @@ Example: Pelazas starts Claude Code in his pane (his subscription). Tis hops int
 - Create a session; peers join P2P.
 - Open tabs and split panes like a modern mux (Zellij-style).
 - Create a pane → it runs locally on you.
-- Click/hop into a teammate’s pane → live view + input via take-control rules.
+- Click a teammate’s pane to focus it locally; type to claim it once it is free.
 - Presence indicators show who is active where.
 - If a host disconnects or sleeps their machine, their panes become unavailable for a grace period; guests cannot keep a host pane alive without the host machine.
 

--- a/docs/superpowers/plans/2026-07-25-free-pane-chrome.md
+++ b/docs/superpowers/plans/2026-07-25-free-pane-chrome.md
@@ -1,0 +1,123 @@
+# Free-pane control and chrome Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make idle panes free (no retained controller), retitle pane chrome, white free borders, clickable tabs, and Zellij-inspired contextual footers.
+
+**Architecture:** Extend `LeaseManager` to clear controller on idle and publish empty-controller leases. TUI chrome/footer/mouse hit-testing consume the new states. Keep host-owned PTY and display-name roster unchanged.
+
+**Tech Stack:** Existing Rust / ratatui / crossterm / prost lease path.
+
+**Spec:** `docs/superpowers/specs/2026-07-25-free-pane-chrome-design.md`
+
+---
+
+### Task 1: Commit spec + plan
+
+- [ ] Ensure spec and this plan are on the branch; commit:
+
+```bash
+git add docs/superpowers/specs/2026-07-25-free-pane-chrome-design.md docs/superpowers/plans/2026-07-25-free-pane-chrome.md
+git commit -m "$(cat <<'EOF'
+docs: specify free-pane control and chrome polish
+
+EOF
+)"
+```
+
+---
+
+### Task 2: Free-pane lease semantics
+
+**Files:** `src/lease.rs`, `tests/lease.rs`, session/TUI lease publish paths as needed
+
+- [ ] Allow empty `controller_peer_id` meaning free
+- [ ] On idle timeout path used by host loops: clear controller, bump epoch, publish
+- [ ] Input on free pane claims for sender and accepts data
+- [ ] Input while another peer actively controls → reject
+- [ ] Tests for clear-on-idle, free claim, active reject
+- [ ] Commit:
+
+```bash
+git commit -m "$(cat <<'EOF'
+feat: clear pane control when idle so panes go free
+
+EOF
+)"
+```
+
+---
+
+### Task 3: Pane titles + white free borders
+
+**Files:** `src/tui.rs`, docs/README as needed
+
+- [ ] Title `Pane #N  host: …  control: free|name|…`
+- [ ] Focused free border white; typing red-orange; remove brown idle style
+- [ ] Tests for title helper / border color selection
+- [ ] Commit:
+
+```bash
+git commit -m "$(cat <<'EOF'
+feat: name panes and use white borders when free
+
+EOF
+)"
+```
+
+---
+
+### Task 4: Clickable tabs
+
+**Files:** `src/tui.rs`
+
+- [ ] Track tab label hit rects; mouse click switches tab
+- [ ] Unit test hit-test
+- [ ] Commit:
+
+```bash
+git commit -m "$(cat <<'EOF'
+feat: switch tabs with mouse clicks
+
+EOF
+)"
+```
+
+---
+
+### Task 5: Footer restyle
+
+**Files:** `src/tui.rs`, `README.md`
+
+- [ ] Implement normal / pane / tab footers per spec with accent key styling
+- [ ] Update help copy: “type to claim when free”
+- [ ] Tests for mode footer content
+- [ ] Commit:
+
+```bash
+git commit -m "$(cat <<'EOF'
+feat: restyle contextual footer help
+
+EOF
+)"
+```
+
+---
+
+### Task 6: Docs alignment + verify + PR
+
+- [ ] Align README / design snippets that still describe idle retained control
+- [ ] `cargo fmt`, `clippy --all-targets --all-features -- -D warnings`, `cargo test`
+- [ ] Push and open PR:
+
+**Title:** `UX: free-pane control, pane titles, tab clicks, footer chrome`
+
+**Body:** Summary + test plan for free lease, titles, borders, tab click, footer.
+
+---
+
+## Success criteria
+
+- Idle panes publish free (empty controller)
+- Chrome/borders/footer/tabs match spec
+- One commit per task; PR open; CI green

--- a/docs/superpowers/specs/2026-07-25-free-pane-chrome-design.md
+++ b/docs/superpowers/specs/2026-07-25-free-pane-chrome-design.md
@@ -1,0 +1,113 @@
+# Free-pane control, pane titles, tab clicks, and footer chrome
+
+## Goal
+
+Polish shared-layout UX after sticky chords / display names:
+
+1. Control means **actively typing only**; idle panes are **free**
+2. Pane titles: `Pane #N  host: <name>  control: …`
+3. Click tab labels to switch tabs
+4. Non-typing focused border is white (no brown idle-owner state)
+5. Zellij-inspired contextual footer with accent keys
+
+## Non-goals
+
+- Changing idle timeout duration (keep ~8s)
+- Forced takeover / F9
+- Custom user-typed pane or tab titles
+- Perfect mouse under Zellij (document caveat)
+- Brew onboarding changes
+
+## Control model
+
+### Semantics
+
+- A pane has a controller **only while that peer is actively typing** (activity within `IDLE_AFTER`).
+- When idle timeout elapses, the pane host **clears** the controller and publishes a new lease epoch with empty `controller_peer_id`.
+- A free pane accepts the next member’s input: claim + deliver the first keystroke (same buffering rules as today’s idle claim).
+- Concurrent claims on a free pane: host `LeaseManager` serializes; one Publish winner; losers clear buffered input.
+- Active typing still rejects other members’ input.
+
+### Wire / lease
+
+- `ControlLease.controller_peer_id` may be empty ⇒ free.
+- Clearing on idle bumps `lease_epoch` and republishes to watchers (same path as today’s lease publish).
+- Guests: empty controller ⇒ free chrome; do not show a retained owner.
+- Remove UI copy about “has control” while idle; remove brown idle-owner border state.
+
+### Initial pane state
+
+- Newly created panes start **free** until someone types into them.
+- Creator is still the **host** (PTY owner); host ≠ controller.
+
+## Pane chrome
+
+Ordinal `N` is 1-based among panes visible on the **current tab** (stable traversal order of that tab’s leaves).
+
+Title format:
+
+```text
+Pane #1  host: pelazas  control: free
+Pane #2  host: tis  control: pelazas
+Pane #3  host: pelazas  control: …
+```
+
+| State | `control:` value | Border (focused) | Border (unfocused) |
+|-------|------------------|------------------|--------------------|
+| Free | `free` | White | Dark gray |
+| Typing | display name (disambiguated if needed) | Red-orange `Rgb(255,69,0)` | same red-orange or slightly dim |
+| Waiting for lease bootstrap | `…` | Yellow or white | Dark gray |
+
+Drop brown `Rgb(140,91,68)` idle-owner styling.
+
+## Tab click
+
+- Hit-test clicks against rendered tab label rectangles.
+- Left-click on `Tab #N` → local `SwitchTab` / set current tab (same as keyboard).
+- Does not affect leases or input.
+- Pane-mode / tab-mode sticky chords may remain active across the click.
+
+## Footer design
+
+Dark footer. Muted labels. Accent red on the key glyph inside `<…>` (or equivalent). Spaced groups — fewer than Zellij.
+
+**Normal**
+
+```text
+Ctrl+ <p> PANE   <t> TAB   <q> QUIT    type to claim when free
+```
+
+**Pane mode**
+
+```text
+Pane  <←↓↑→> FOCUS   <n> NEW   <x> CLOSE   <Esc> BACK
+```
+
+**Tab mode**
+
+```text
+Tab   <←→> SWITCH   <n> NEW   <x> CLOSE   <Esc> BACK
+```
+
+Coordinator join code remains a quiet right-side / truncated suffix when present. Status prefixes (rejection, etc.) still take left priority when set.
+
+## Docs
+
+Update README + shared-control / MVP snippets that still say idle retained control or brown “has control” chrome.
+
+## Testing
+
+- Lease: idle clear publishes empty controller + new epoch; free pane accepts first input; active rejects others.
+- Chrome: title strings; border colors for free vs typing.
+- Tab click hit-test.
+- Footer mode strings / render accents (unit-level).
+- `cargo fmt`, `clippy -D warnings`, `cargo test`.
+
+## Manual acceptance
+
+1. Type in a pane → red border + `control: <you>`.
+2. Wait ~8s → white focused border + `control: free`.
+3. Other member types one char → they become controller; char delivered.
+4. Pane titles show `Pane #N` + host name.
+5. Click tabs to switch.
+6. Footer matches mode styling.

--- a/docs/superpowers/specs/2026-07-25-free-pane-chrome-design.md
+++ b/docs/superpowers/specs/2026-07-25-free-pane-chrome-design.md
@@ -7,7 +7,7 @@ Polish shared-layout UX after sticky chords / display names:
 1. Control means **actively typing only**; idle panes are **free**
 2. Pane titles: `Pane #N  host: <name>  control: …`
 3. Click tab labels to switch tabs
-4. Non-typing focused border is white (no brown idle-owner state)
+4. A focused free pane has a white border
 5. Zellij-inspired contextual footer with accent keys
 
 ## Non-goals
@@ -33,7 +33,7 @@ Polish shared-layout UX after sticky chords / display names:
 - `ControlLease.controller_peer_id` may be empty ⇒ free.
 - Clearing on idle bumps `lease_epoch` and republishes to watchers (same path as today’s lease publish).
 - Guests: empty controller ⇒ free chrome; do not show a retained owner.
-- Remove UI copy about “has control” while idle; remove brown idle-owner border state.
+- Free panes show `control: free`.
 
 ### Initial pane state
 
@@ -58,7 +58,7 @@ Pane #3  host: pelazas  control: …
 | Typing | display name (disambiguated if needed) | Red-orange `Rgb(255,69,0)` | same red-orange or slightly dim |
 | Waiting for lease bootstrap | `…` | Yellow or white | Dark gray |
 
-Drop brown `Rgb(140,91,68)` idle-owner styling.
+Free panes use the colors in the table.
 
 ## Tab click
 
@@ -93,7 +93,7 @@ Coordinator join code remains a quiet right-side / truncated suffix when present
 
 ## Docs
 
-Update README + shared-control / MVP snippets that still say idle retained control or brown “has control” chrome.
+Keep README, shared-control, and MVP snippets aligned with free panes and the current chrome.
 
 ## Testing
 

--- a/docs/superpowers/specs/2026-07-25-shared-control-ui-design.md
+++ b/docs/superpowers/specs/2026-07-25-shared-control-ui-design.md
@@ -8,11 +8,11 @@ internet, presence, disconnect-grace, and failover work must not be implied as c
 
 ## Interaction model
 
-One controller leases each pane. A member gains control by ordinary input when the current
-controller has been idle for the existing eight-second timeout; the claiming input is buffered
-until the host accepts the lease claim. Active typing is protected: no UI or wire-level forced
-takeover exists. Ctrl+Q exits only the local p2pmux view; F9 and F10 pass through to the focused
-PTY.
+A pane has a controller only while that peer is actively typing. After the existing eight-second
+timeout, the host clears the controller, advances the lease epoch, and publishes the pane as free.
+The next member's ordinary input claims the free pane; its first key is buffered until the host
+accepts the claim, then delivered. Active typing is protected: no UI or wire-level forced takeover
+exists. Ctrl+Q exits only the local p2pmux view; F9 and F10 pass through to the focused PTY.
 
 The local mux consumes its commands before any focused PTY receives them:
 
@@ -20,40 +20,44 @@ The local mux consumes its commands before any focused PTY receives them:
 - `Ctrl+T`, then `N` creates a tab; `X` requests tab deletion; left/right switch tabs.
 - `Esc` cancels a pending chord.
 
-The new PTY for a split or tab runs on the requester’s Mac with a fixed creation grid. A pane’s
-host alone may delete it. A tab deletion succeeds only when the requester hosts every pane in
-that tab. The last pane in a tab is removed by deleting the tab; the final tab cannot be deleted.
-All splits are nested 50/50 (depth 4; up to 8 panes/tab and 9 tabs).
+The new PTY for a split or tab runs on the requester’s Mac with a fixed creation grid. Its creator
+is the pane host, not its controller; new panes start free. A pane’s host alone may delete it. A
+tab deletion succeeds only when the requester hosts every pane in that tab. The last pane in a tab
+is removed by deleting the tab; the final tab cannot be deleted. All splits are nested 50/50 (depth
+4; up to 8 panes/tab and 9 tabs).
 
-The pane host's existing `LeaseManager` remains authoritative. It serializes
-concurrent idle claims; the first accepted claim advances the lease epoch and
-the other claimant receives the published current lease, clears its buffered
-input, and remains a spectator. Stale claim and input epochs are rejected by the
-same manager. Every accepted input republishes the current lease, so remote members use receipt
-time as their activity clock. A guest waits for its first host-published lease rather than
-synthesizing an initial one. This change does not make the timeout configurable.
+The pane host's `LeaseManager` remains authoritative. It serializes concurrent free-pane claims;
+the first accepted claim advances the lease epoch and the other claimant receives the published
+current lease, clears its buffered input, and remains a spectator. Stale claim and input epochs are
+rejected by the same manager. Every accepted input republishes the current lease, so remote members
+use receipt time as their activity clock. A guest waits for its first host-published lease rather
+than synthesizing an initial one. This change does not make the timeout configurable.
 
 ## Shared help and permissions
 
-Every member renders the same tab bar, focused-pane chrome, host badge, and controller state.
-The footer communicates `Ctrl+P panes | Ctrl+T tabs | type to claim idle | active typing is
-protected | Ctrl+Q quit`; the coordinator may append its join code. Focus never grants control.
-The UI shows reservation, rejection, and waiting-for-snapshot/lease status without blocking pane
-drain or layout control.
+Every member renders the same tab bar, focused-pane chrome, host badge, and controller state. Tab
+labels are clickable to switch tabs locally; a click never claims control or sends input. The dark
+contextual footer uses red key accents: normal mode shows
+`Ctrl+ <p> PANE   <t> TAB   <q> QUIT    type to claim when free`; pane mode shows
+`Pane  <←↓↑→> FOCUS   <n> NEW   <x> CLOSE   <Esc> BACK`; tab mode shows
+`Tab  <←→> SWITCH   <n> NEW   <x> CLOSE   <Esc> BACK`. The coordinator may append its join code.
+Focus never grants control. The UI shows reservation, rejection, and waiting-for-snapshot/lease
+status without blocking pane drain or layout control.
 
 ## Control-pane chrome
 
-Every controlled pane has a distinct border: vivid red-orange and `this user is typing` while its
-controller is active, muted gray-orange and `this user has control` once idle. Before
-screen/lease bootstrap, the leaf remains in the authoritative layout with a compact waiting state.
-Remote screen data is letterboxed or clipped inside its leaf; no client resizes the host PTY.
+Each pane title is `Pane #N  host: <name>  control: free|<name>|…`. A focused free pane has a white
+border and an actively controlled pane a vivid red-orange border; unfocused free or waiting panes
+are dark gray, while a focused pane waiting for its first lease is yellow. Before screen/lease
+bootstrap, the leaf remains in the authoritative layout with a compact waiting state. Remote screen
+data is letterboxed or clipped inside its leaf; no client resizes the host PTY.
 
 ## Testing
 
 Cover chord consumption, focus, fixed-grid geometry, lease transitions, coordinator request /
 reservation / ready / commit lifecycle, host-only deletion, all-host tab deletion, and remote
-subscription retry after a transient failure. Also cover Ctrl+Q, F9/F10 PTY forwarding, active /
-idle chrome, host lease publication after accepted input, and waiting for the first lease. Run the
-full Cargo suite and strict clippy. Finally run `p2pmux create` in one terminal and `p2pmux join
-<ticket>` in another, exercising split, pane delete, tab create/delete, idle handoff, active-input
-protection, and Ctrl+Q on both processes.
+subscription retry after a transient failure. Also cover Ctrl+Q, F9/F10 PTY forwarding, free-pane
+and active-typing chrome, host clearing control on idle, first-key claims, and waiting for the first
+lease. Run the full Cargo suite and strict clippy. Finally run `p2pmux create` in one terminal and
+`p2pmux join <ticket>` in another, exercising split, pane delete, tab create/delete, idle clearing,
+free-pane first-key claims, active-input protection, and Ctrl+Q on both processes.

--- a/docs/superpowers/specs/2026-07-25-sticky-chords-tabs-names-design.md
+++ b/docs/superpowers/specs/2026-07-25-sticky-chords-tabs-names-design.md
@@ -46,9 +46,9 @@ Three footers (join code still appendable for coordinator as today):
 
 | Mode | Footer text |
 |------|-------------|
-| Normal | `Ctrl+P panes \| Ctrl+T tabs \| type to claim idle \| active typing is protected \| Ctrl+Q quit` |
-| Pane | `arrows move focus \| N new pane \| X delete pane \| Esc cancel` |
-| Tab | `←/→ switch tab \| N new tab \| X delete tab \| Esc cancel` |
+| Normal | `Ctrl+ <p> PANE   <t> TAB   <q> QUIT    type to claim when free` |
+| Pane | `Pane  <←↓↑→> FOCUS   <n> NEW   <x> CLOSE   <Esc> BACK` |
+| Tab | `Tab  <←→> SWITCH   <n> NEW   <x> CLOSE   <Esc> BACK` |
 
 Status prefixes (rejection / waiting) still win left side when present; mode help replaces the controls segment.
 
@@ -58,7 +58,7 @@ Status prefixes (rejection / waiting) still win left side when present; mode hel
 - Left-click inside a pane’s content/chrome rectangle → set local `focused_pane` to that pane.
 - Click does **not** take control, claim lease, or send input.
 - Clicking while in pane/tab mode may keep the mode (navigation convenience) or leave it; prefer **keep mode** so click + arrows still work.
-- Click on tab bar: optional MVP stretch — if easy, click `Tab #N` switches tab; otherwise keyboard-only tabs are fine for this PR.
+- Click on a tab label: switch to that tab locally. It does not claim a lease or send input.
 - Document: under Zellij, mouse may be swallowed; try `zellij` with mouse mode off / locked passthrough.
 
 ### Tab chrome

--- a/src/lease.rs
+++ b/src/lease.rs
@@ -69,10 +69,11 @@ impl LeaseManager {
         if data.is_empty() || epoch != self.state.epoch {
             return LeaseDecision::RejectStaleInput;
         }
-        if !self.state.controller_peer_id.is_empty() && self.state.is_idle_at(now) {
-            if self.change_controller(Vec::new(), now).is_err() {
-                return LeaseDecision::RejectStaleInput;
-            }
+        if !self.state.controller_peer_id.is_empty()
+            && self.state.is_idle_at(now)
+            && self.change_controller(Vec::new(), now).is_err()
+        {
+            return LeaseDecision::RejectStaleInput;
         }
         if self.state.controller_peer_id.is_empty() {
             if self.change_controller(sender.to_vec(), now).is_err() {

--- a/src/lease.rs
+++ b/src/lease.rs
@@ -69,6 +69,11 @@ impl LeaseManager {
         if data.is_empty() || epoch != self.state.epoch {
             return LeaseDecision::RejectStaleInput;
         }
+        if !self.state.controller_peer_id.is_empty() && self.state.is_idle_at(now) {
+            if self.change_controller(Vec::new(), now).is_err() {
+                return LeaseDecision::RejectStaleInput;
+            }
+        }
         if self.state.controller_peer_id.is_empty() {
             if self.change_controller(sender.to_vec(), now).is_err() {
                 return LeaseDecision::RejectStaleInput;

--- a/src/lease.rs
+++ b/src/lease.rs
@@ -13,7 +13,8 @@ pub struct LeaseState {
 
 impl LeaseState {
     pub fn is_idle_at(&self, now: Instant) -> bool {
-        now.saturating_duration_since(self.last_activity) >= IDLE_AFTER
+        self.controller_peer_id.is_empty()
+            || now.saturating_duration_since(self.last_activity) >= IDLE_AFTER
     }
 }
 
@@ -65,11 +66,28 @@ impl LeaseManager {
         data: Vec<u8>,
         now: Instant,
     ) -> LeaseDecision {
-        if data.is_empty() || sender != self.state.controller_peer_id || epoch != self.state.epoch {
+        if data.is_empty() || epoch != self.state.epoch {
+            return LeaseDecision::RejectStaleInput;
+        }
+        if self.state.controller_peer_id.is_empty() {
+            if self.change_controller(sender.to_vec(), now).is_err() {
+                return LeaseDecision::RejectStaleInput;
+            }
+        } else if sender != self.state.controller_peer_id {
             return LeaseDecision::RejectStaleInput;
         }
         self.state.last_activity = now;
         LeaseDecision::AcceptInput(data)
+    }
+
+    pub fn clear_if_idle(&mut self, now: Instant) -> Result<Option<LeaseState>, LeaseError> {
+        if self.state.controller_peer_id.is_empty() || !self.state.is_idle_at(now) {
+            return Ok(None);
+        }
+        match self.change_controller(Vec::new(), now)? {
+            LeaseDecision::Publish(state) => Ok(Some(state)),
+            _ => unreachable!("changing controller always publishes"),
+        }
     }
 
     pub fn take_control(
@@ -83,6 +101,9 @@ impl LeaseManager {
         }
         if self.state.epoch == u64::MAX {
             return Err(LeaseError::EpochExhausted);
+        }
+        if self.state.controller_peer_id.is_empty() {
+            return self.change_controller(sender, now);
         }
         if !self.state.is_idle_at(now) {
             return Ok(LeaseDecision::RejectActiveController);

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -591,9 +591,9 @@ fn validate_envelope(envelope: &Envelope) -> Result<(), ProtocolError> {
                 &control_lease.pane_id,
                 MAX_PANE_ID_BYTES,
             )?;
-            validate_id(
+            validate_field_size(
                 "control_lease.controller_peer_id",
-                &control_lease.controller_peer_id,
+                control_lease.controller_peer_id.len(),
                 MAX_PEER_ID_BYTES,
             )?;
             if control_lease.lease_epoch == 0 {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -852,6 +852,22 @@ enum RemotePaneDrain {
     Disconnected,
 }
 
+fn lease_allows_held_input(controller_peer_id: &[u8], peer_id: &[u8]) -> bool {
+    controller_peer_id.is_empty() || controller_peer_id == peer_id
+}
+
+fn reconcile_remote_control_attempt(
+    pending_control: &mut bool,
+    held_input: &mut Vec<u8>,
+    controller_peer_id: &[u8],
+    peer_id: &[u8],
+) {
+    *pending_control = false;
+    if !lease_allows_held_input(controller_peer_id, peer_id) {
+        held_input.clear();
+    }
+}
+
 impl SharedRemotePane {
     fn new(pane: GuestPane) -> Self {
         Self {
@@ -880,6 +896,7 @@ impl SharedRemotePane {
 
     fn drain(&mut self) -> RemotePaneDrain {
         let mut changed = false;
+        let mut received_lease = false;
         loop {
             match self.pane.events.try_recv() {
                 Ok(GuestEvent::ScreenSnapshot(snapshot)) => {
@@ -895,21 +912,14 @@ impl SharedRemotePane {
                         .is_ok();
                 }
                 Ok(GuestEvent::Lease(lease)) => {
-                    let controls_this_pane =
-                        lease.controller_peer_id == self.pane.controls.peer_id();
-                    let pane_is_free = lease.controller_peer_id.is_empty();
+                    received_lease = true;
                     self.lease = Some(LeaseState {
                         controller_peer_id: lease.controller_peer_id,
                         epoch: lease.lease_epoch,
                         last_activity: Instant::now(),
                     });
                     self.last_lease = Instant::now();
-                    if self.pending_control {
-                        self.pending_control = false;
-                        if !controls_this_pane && !pane_is_free {
-                            self.held_input.clear();
-                        }
-                    }
+                    self.pending_control = false;
                     changed = true;
                 }
                 Ok(GuestEvent::ScreenGap { .. }) => {}
@@ -920,11 +930,18 @@ impl SharedRemotePane {
                 Err(tokio::sync::mpsc::error::TryRecvError::Empty) => break,
             }
         }
+        if received_lease && let Some(lease) = self.lease.as_ref() {
+            reconcile_remote_control_attempt(
+                &mut self.pending_control,
+                &mut self.held_input,
+                &lease.controller_peer_id,
+                self.pane.controls.peer_id(),
+            );
+        }
         if !self.pending_control
             && !self.held_input.is_empty()
             && self.lease.as_ref().is_some_and(|lease| {
-                lease.controller_peer_id == self.pane.controls.peer_id()
-                    || lease.controller_peer_id.is_empty()
+                lease_allows_held_input(&lease.controller_peer_id, self.pane.controls.peer_id())
             })
         {
             let bytes = std::mem::take(&mut self.held_input);
@@ -2228,12 +2245,12 @@ pub fn run_guest(mut pane: GuestPane) -> Result<(), Box<dyn Error>> {
     let mut footer = String::from("controller: waiting spectator");
     let mut lease = None;
     let mut last_lease = Instant::now();
-    let mut received_host_lease = false;
     let mut pending_control = false;
     let mut held_input = Vec::new();
     let mut dirty = true;
 
     loop {
+        let mut received_lease = false;
         loop {
             match pane.events.try_recv() {
                 Ok(GuestEvent::ScreenSnapshot(snapshot)) => {
@@ -2254,22 +2271,13 @@ pub fn run_guest(mut pane: GuestPane) -> Result<(), Box<dyn Error>> {
                 }
                 Ok(GuestEvent::ScreenGap { .. }) => {}
                 Ok(GuestEvent::Lease(state)) => {
-                    let already_received_host_lease = received_host_lease;
-                    received_host_lease = true;
+                    received_lease = true;
                     footer = format!(
                         "controller: {} typing",
                         short_peer(&state.controller_peer_id)
                     );
                     last_lease = Instant::now();
-                    if pending_control && state.controller_peer_id == pane.controls.peer_id() {
-                        pending_control = false;
-                    } else if pending_control
-                        && already_received_host_lease
-                        && !state.controller_peer_id.is_empty()
-                    {
-                        pending_control = false;
-                        held_input.clear();
-                    }
+                    pending_control = false;
                     lease = Some(state);
                     dirty = true;
                 }
@@ -2285,11 +2293,19 @@ pub fn run_guest(mut pane: GuestPane) -> Result<(), Box<dyn Error>> {
             }
         }
 
+        if received_lease && let Some(state) = lease.as_ref() {
+            reconcile_remote_control_attempt(
+                &mut pending_control,
+                &mut held_input,
+                &state.controller_peer_id,
+                pane.controls.peer_id(),
+            );
+        }
+
         if !pending_control
             && !held_input.is_empty()
             && let Some(state) = lease.as_ref()
-            && (state.controller_peer_id == pane.controls.peer_id()
-                || state.controller_peer_id.is_empty())
+            && lease_allows_held_input(&state.controller_peer_id, pane.controls.peer_id())
         {
             let bytes = std::mem::take(&mut held_input);
             if pane
@@ -2405,6 +2421,7 @@ mod tests {
     use std::{
         collections::BTreeMap,
         net::Ipv4Addr,
+        thread,
         time::{Duration, Instant},
     };
     use tokio::sync::{mpsc, watch};
@@ -2431,8 +2448,9 @@ mod tests {
         CONTROL_HELP, ChordMode, HostControlEvent, HostPaneChannels, KeyHandling,
         LayoutControlEvent, MultiPaneTui, PaneViewState, RemoteSubscriptionState,
         SharedLayoutRuntime, SharedLocalPane, UiIntent, VtScreen, encode_key, encode_paste,
-        grid_for_pane, initial_root_pane_grid, member_label, pane_wire_id, render_guest_screen,
-        render_multi_pane, render_shared_multi_pane, shared_footer_text,
+        grid_for_pane, initial_root_pane_grid, lease_allows_held_input, member_label, pane_wire_id,
+        reconcile_remote_control_attempt, render_guest_screen, render_multi_pane,
+        render_shared_multi_pane, shared_footer_text,
     };
 
     fn layout(tabs: Vec<Tab>, panes: &[(u64, u16, u16)]) -> LayoutSnapshot {
@@ -2810,14 +2828,55 @@ mod tests {
     fn local_input_crossing_the_idle_timeout_reclaims_and_delivers_it() {
         let host_id = b"host".to_vec();
         let mut pane = SharedLocalPane::spawn(99, 1, 1, host_id.clone()).expect("local pane");
+        let mut lease_rx = pane.lease_tx.subscribe();
         pane.lease =
             LeaseManager::with_epoch_for_test(b"remote".to_vec(), 1, Instant::now() - IDLE_AFTER);
 
-        pane.input(b"first".to_vec())
+        pane.input(b"printf boundary-input-delivered\\n".to_vec())
             .expect("first input at idle boundary");
 
         assert_eq!(pane.lease.state().controller_peer_id, host_id);
         assert_eq!(pane.lease.state().epoch, 3);
+        assert!(lease_rx.has_changed().expect("lease watch"));
+        let lease = lease_rx.borrow_and_update().clone();
+        assert_eq!(lease.controller_peer_id, b"host");
+        assert_eq!(lease.epoch, 3);
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        let mut output = Vec::new();
+        while Instant::now() < deadline {
+            while let Some(bytes) = pane.host.try_read_output().expect("PTY reader") {
+                output.extend(bytes);
+            }
+            if String::from_utf8_lossy(&output).contains("boundary-input-delivered") {
+                pane.shutdown().expect("shutdown local pane");
+                return;
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+        pane.shutdown().expect("shutdown local pane");
+        panic!(
+            "first input was not delivered to the PTY: {:?}",
+            String::from_utf8_lossy(&output)
+        );
+    }
+
+    #[test]
+    fn remote_held_input_follows_the_final_lease_owner() {
+        let peer = b"requester";
+        let mut pending_control = true;
+        let mut held_input = b"first".to_vec();
+
+        assert!(lease_allows_held_input(b"", peer));
+        reconcile_remote_control_attempt(&mut pending_control, &mut held_input, b"", peer);
+        assert!(!pending_control, "free leases release the retry gate");
+        assert_eq!(held_input, b"first", "free leases retain queued input");
+
+        reconcile_remote_control_attempt(&mut pending_control, &mut held_input, b"other", peer);
+        assert!(
+            held_input.is_empty(),
+            "a later controller wins and discards stale input"
+        );
     }
 
     fn split_layout() -> LayoutSnapshot {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -108,6 +108,7 @@ pub enum KeyHandling {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PaneGeometry {
     pub tab_bar: Rect,
+    pub tab_labels: BTreeMap<TabId, Rect>,
     pub content: Rect,
     pub footer: Rect,
     pub panes: BTreeMap<PaneId, Rect>,
@@ -223,6 +224,17 @@ impl MultiPaneTui {
         true
     }
 
+    fn switch_tab_at(&mut self, column: u16, row: u16, area: Rect) -> Option<UiIntent> {
+        let tab_id = self
+            .geometry(area)
+            .tab_labels
+            .iter()
+            .find_map(|(tab_id, rect)| rect_contains(*rect, column, row).then_some(*tab_id))?;
+        self.select_tab(tab_id)
+            .expect("tab came from current snapshot");
+        Some(UiIntent::SwitchTab { tab_id })
+    }
+
     pub fn geometry(&self, area: Rect) -> PaneGeometry {
         let tab_bar = Rect::new(area.x, area.y, area.width, area.height.min(1));
         let footer_height = area.height.saturating_sub(tab_bar.height).min(1);
@@ -245,10 +257,31 @@ impl MultiPaneTui {
         }
         PaneGeometry {
             tab_bar,
+            tab_labels: self.tab_label_rects(tab_bar),
             content,
             footer,
             panes,
         }
+    }
+
+    fn tab_label_rects(&self, tab_bar: Rect) -> BTreeMap<TabId, Rect> {
+        let mut x = tab_bar.x;
+        let right = tab_bar.x.saturating_add(tab_bar.width);
+        self.snapshot
+            .tabs
+            .iter()
+            .enumerate()
+            .map(|(index, tab)| {
+                if index > 0 {
+                    x = x.saturating_add(1);
+                }
+                let label_width = format!("Tab #{}", index + 1).len() as u16;
+                let width = right.saturating_sub(x).min(label_width);
+                let rect = Rect::new(x, tab_bar.y, width, tab_bar.height);
+                x = x.saturating_add(label_width);
+                (tab.tab_id, rect)
+            })
+            .collect()
     }
 
     pub fn handle_key(&mut self, key: KeyEvent, area: Rect) -> KeyHandling {
@@ -456,13 +489,16 @@ fn visible_leaf_panes(node: &Node) -> Vec<PaneId> {
 }
 
 fn pane_at(panes: &BTreeMap<PaneId, Rect>, column: u16, row: u16) -> Option<PaneId> {
-    panes.iter().find_map(|(pane_id, rect)| {
-        let inside = u32::from(column) >= u32::from(rect.x)
-            && u32::from(column) < u32::from(rect.x) + u32::from(rect.width)
-            && u32::from(row) >= u32::from(rect.y)
-            && u32::from(row) < u32::from(rect.y) + u32::from(rect.height);
-        inside.then_some(*pane_id)
-    })
+    panes
+        .iter()
+        .find_map(|(pane_id, rect)| rect_contains(*rect, column, row).then_some(*pane_id))
+}
+
+fn rect_contains(rect: Rect, column: u16, row: u16) -> bool {
+    u32::from(column) >= u32::from(rect.x)
+        && u32::from(column) < u32::from(rect.x) + u32::from(rect.width)
+        && u32::from(row) >= u32::from(rect.y)
+        && u32::from(row) < u32::from(rect.y) + u32::from(rect.height)
 }
 
 fn pane_title(
@@ -664,9 +700,16 @@ fn render_shared_multi_pane(
                 Style::default().fg(Color::DarkGray)
             };
             let label = format!("Tab #{}", index + 1);
-            frame
-                .buffer_mut()
-                .set_string(x, geometry.tab_bar.y, &label, style);
+            let label_rect = geometry.tab_labels[&tab.tab_id];
+            if label_rect.width == 0 {
+                continue;
+            }
+            frame.buffer_mut().set_string(
+                label_rect.x,
+                label_rect.y,
+                &label[..usize::from(label_rect.width)],
+                style,
+            );
             x = x.saturating_add(label.len() as u16);
         }
     }
@@ -1372,11 +1415,13 @@ impl SharedLayoutRuntime {
                 Event::Mouse(mouse)
                     if matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left)) =>
                 {
-                    dirty |= self.tui.focus_pane_at(
-                        mouse.column,
-                        mouse.row,
-                        Rect::new(0, 0, cols, rows),
-                    );
+                    let area = Rect::new(0, 0, cols, rows);
+                    if let Some(intent) = self.tui.switch_tab_at(mouse.column, mouse.row, area) {
+                        self.handle_intent(intent)?;
+                        dirty = true;
+                    } else {
+                        dirty |= self.tui.focus_pane_at(mouse.column, mouse.row, area);
+                    }
                 }
                 Event::Resize(_, _) => dirty = true,
                 _ => {}
@@ -3058,6 +3103,39 @@ mod tests {
         assert_eq!(tui.chord_mode(), ChordMode::Pane);
         assert!(!tui.focus_pane_at(10, 0, area));
         assert_eq!(tui.focused_pane(), 3);
+    }
+
+    #[test]
+    fn tab_hit_testing_switches_the_clicked_rendered_label_without_exiting_tab_mode() {
+        let mut tui = MultiPaneTui::new(layout(
+            vec![
+                Tab {
+                    tab_id: 1,
+                    root: Node::Leaf { pane_id: 1 },
+                },
+                Tab {
+                    tab_id: 2,
+                    root: Node::Leaf { pane_id: 2 },
+                },
+            ],
+            &[(1, 2, 2), (2, 2, 2)],
+        ))
+        .expect("valid layout");
+        let area = Rect::new(0, 0, 20, 8);
+
+        let _ = tui.handle_key(
+            KeyEvent::new(KeyCode::Char('t'), KeyModifiers::CONTROL),
+            area,
+        );
+
+        assert_eq!(
+            tui.switch_tab_at(8, 0, area),
+            Some(UiIntent::SwitchTab { tab_id: 2 })
+        );
+        assert_eq!(tui.current_tab(), 2);
+        assert_eq!(tui.focused_pane(), 2);
+        assert_eq!(tui.chord_mode(), ChordMode::Tab);
+        assert_eq!(tui.switch_tab_at(6, 0, area), None);
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -757,6 +757,10 @@ impl SharedLocalPane {
 
     fn drain(&mut self) -> Result<bool, Box<dyn Error>> {
         let mut changed = false;
+        if let Some(state) = self.lease.clear_if_idle(Instant::now())? {
+            self.lease_tx.send_replace(state);
+            changed = true;
+        }
         while let Ok(event) = self.control_rx.try_recv() {
             match event {
                 HostControlEvent::Input { peer_id, input } => {
@@ -811,22 +815,15 @@ impl SharedLocalPane {
 
     fn input(&mut self, bytes: Vec<u8>) -> Result<(), Box<dyn Error>> {
         let epoch = self.lease.state().epoch;
-        let decision = if self.lease.state().controller_peer_id == self.host_peer_id {
-            self.lease
-                .input(&self.host_peer_id, epoch, bytes.clone(), Instant::now())
-        } else {
-            self.lease
-                .take_control(self.host_peer_id.clone(), epoch, Instant::now())?
-        };
+        let decision = self
+            .lease
+            .input(&self.host_peer_id, epoch, bytes, Instant::now());
         match decision {
             LeaseDecision::AcceptInput(bytes) => {
                 self.host.write_input(&bytes)?;
                 self.lease_tx.send_replace(self.lease.state().clone());
             }
-            LeaseDecision::Publish(state) => {
-                self.lease_tx.send_replace(state);
-                self.host.write_input(&bytes)?;
-            }
+            LeaseDecision::Publish(_) => {}
             LeaseDecision::RejectStaleInput
             | LeaseDecision::RejectStaleRequest
             | LeaseDecision::RejectActiveController => {}
@@ -959,6 +956,8 @@ impl SharedRemotePane {
             } else {
                 self.held_input.extend_from_slice(&bytes);
             }
+        } else if lease.controller_peer_id.is_empty() {
+            let _ = self.pane.controls.try_input(lease.epoch, bytes);
         } else if self.last_lease.elapsed() >= IDLE_AFTER && !self.pending_control {
             self.held_input.extend_from_slice(&bytes);
             self.pending_control = self.pane.controls.try_take_control(lease.epoch).is_ok();
@@ -2087,6 +2086,9 @@ pub fn run_host(mut runtime: HostPaneRuntime) -> Result<(), Box<dyn Error>> {
     let footer = format!("{CONTROL_HELP} | join: p2pmux join {}", runtime.join_code);
     let mut dirty = true;
     loop {
+        if let Some(state) = runtime.lease.clear_if_idle(Instant::now())? {
+            runtime.lease_tx.send_replace(state);
+        }
         while let Ok(event) = runtime.control_rx.try_recv() {
             match event {
                 HostControlEvent::Input { peer_id, input } => match runtime.lease.input(
@@ -2163,25 +2165,15 @@ pub fn run_host(mut runtime: HostPaneRuntime) -> Result<(), Box<dyn Error>> {
                 if let Some(bytes) = encode_key(key, runtime.screen.screen()) {
                     let now = Instant::now();
                     let epoch = runtime.lease.state().epoch;
-                    let decision =
-                        if runtime.lease.state().controller_peer_id == runtime.host_peer_id {
-                            runtime
-                                .lease
-                                .input(&runtime.host_peer_id, epoch, bytes.clone(), now)
-                        } else {
-                            runtime
-                                .lease
-                                .take_control(runtime.host_peer_id.clone(), epoch, now)?
-                        };
+                    let decision = runtime
+                        .lease
+                        .input(&runtime.host_peer_id, epoch, bytes, now);
                     match decision {
                         LeaseDecision::AcceptInput(bytes) => {
                             runtime.host.write_input(&bytes)?;
                             runtime.lease_tx.send_replace(runtime.lease.state().clone());
                         }
-                        LeaseDecision::Publish(state) => {
-                            runtime.lease_tx.send_replace(state);
-                            runtime.host.write_input(&bytes)?;
-                        }
+                        LeaseDecision::Publish(_) => {}
                         LeaseDecision::RejectStaleInput
                         | LeaseDecision::RejectStaleRequest
                         | LeaseDecision::RejectActiveController => {}
@@ -2192,24 +2184,15 @@ pub fn run_host(mut runtime: HostPaneRuntime) -> Result<(), Box<dyn Error>> {
                 let bytes = encode_paste(&text, runtime.screen.screen().bracketed_paste());
                 let now = Instant::now();
                 let epoch = runtime.lease.state().epoch;
-                let decision = if runtime.lease.state().controller_peer_id == runtime.host_peer_id {
-                    runtime
-                        .lease
-                        .input(&runtime.host_peer_id, epoch, bytes.clone(), now)
-                } else {
-                    runtime
-                        .lease
-                        .take_control(runtime.host_peer_id.clone(), epoch, now)?
-                };
+                let decision = runtime
+                    .lease
+                    .input(&runtime.host_peer_id, epoch, bytes, now);
                 match decision {
                     LeaseDecision::AcceptInput(bytes) => {
                         runtime.host.write_input(&bytes)?;
                         runtime.lease_tx.send_replace(runtime.lease.state().clone());
                     }
-                    LeaseDecision::Publish(state) => {
-                        runtime.lease_tx.send_replace(state);
-                        runtime.host.write_input(&bytes)?;
-                    }
+                    LeaseDecision::Publish(_) => {}
                     LeaseDecision::RejectStaleInput
                     | LeaseDecision::RejectStaleRequest
                     | LeaseDecision::RejectActiveController => {}
@@ -2342,6 +2325,8 @@ pub fn run_guest(mut pane: GuestPane) -> Result<(), Box<dyn Error>> {
                         } else {
                             held_input.extend_from_slice(&bytes);
                         }
+                    } else if state.controller_peer_id.is_empty() {
+                        let _ = pane.controls.try_input(state.lease_epoch, bytes);
                     } else if last_lease.elapsed() >= IDLE_AFTER {
                         held_input.extend_from_slice(&bytes);
                         if !pending_control {
@@ -2363,6 +2348,8 @@ pub fn run_guest(mut pane: GuestPane) -> Result<(), Box<dyn Error>> {
                         } else {
                             held_input.extend_from_slice(&bytes);
                         }
+                    } else if state.controller_peer_id.is_empty() {
+                        let _ = pane.controls.try_input(state.lease_epoch, bytes);
                     } else if last_lease.elapsed() >= IDLE_AFTER {
                         held_input.extend_from_slice(&bytes);
                         if !pending_control {
@@ -2790,13 +2777,28 @@ mod tests {
                 request: crate::protocol::TakeControl {
                     pane_id: pane_wire_id(99),
                     requester_peer_id: requester.clone(),
-                    known_lease_epoch: 1,
+                    known_lease_epoch: 2,
                 },
             })
             .expect("idle takeover event");
         pane.drain().expect("drain idle takeover");
         assert_eq!(pane.lease.state().controller_peer_id, requester);
-        assert_eq!(pane.lease.state().epoch, 2);
+        assert_eq!(pane.lease.state().epoch, 3);
+    }
+
+    #[test]
+    fn idle_controller_is_cleared_and_published_to_watchers() {
+        let host_id = b"host".to_vec();
+        let mut pane = SharedLocalPane::spawn(99, 1, 1, host_id.clone()).expect("local pane");
+        let mut lease_rx = pane.lease_tx.subscribe();
+        pane.lease = LeaseManager::with_epoch_for_test(host_id, 1, Instant::now() - IDLE_AFTER);
+
+        pane.drain().expect("drain idle controller");
+
+        assert!(lease_rx.has_changed().expect("lease watch"));
+        let lease = lease_rx.borrow_and_update().clone();
+        assert!(lease.controller_peer_id.is_empty());
+        assert_eq!(lease.epoch, 2);
     }
 
     fn split_layout() -> LayoutSnapshot {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -489,6 +489,7 @@ fn pane_border_color(
 ) -> Color {
     match controller_peer_id {
         Some([]) if focused => Color::White,
+        None if focused => Color::Yellow,
         Some([]) | None => Color::DarkGray,
         Some(_) => Color::Rgb(255, 69, 0),
     }
@@ -3019,6 +3020,8 @@ mod tests {
     fn free_panes_use_white_when_focused_and_dark_gray_when_unfocused() {
         assert_eq!(pane_border_color(Some(b""), false, true), Color::White);
         assert_eq!(pane_border_color(Some(b""), false, false), Color::DarkGray);
+        assert_eq!(pane_border_color(None, false, true), Color::Yellow);
+        assert_eq!(pane_border_color(None, false, false), Color::DarkGray);
         assert_eq!(
             pane_border_color(Some(b"guest"), true, true),
             Color::Rgb(255, 69, 0)

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -897,6 +897,7 @@ impl SharedRemotePane {
                 Ok(GuestEvent::Lease(lease)) => {
                     let controls_this_pane =
                         lease.controller_peer_id == self.pane.controls.peer_id();
+                    let pane_is_free = lease.controller_peer_id.is_empty();
                     self.lease = Some(LeaseState {
                         controller_peer_id: lease.controller_peer_id,
                         epoch: lease.lease_epoch,
@@ -905,7 +906,7 @@ impl SharedRemotePane {
                     self.last_lease = Instant::now();
                     if self.pending_control {
                         self.pending_control = false;
-                        if !controls_this_pane {
+                        if !controls_this_pane && !pane_is_free {
                             self.held_input.clear();
                         }
                     }
@@ -921,10 +922,10 @@ impl SharedRemotePane {
         }
         if !self.pending_control
             && !self.held_input.is_empty()
-            && self
-                .lease
-                .as_ref()
-                .is_some_and(|lease| lease.controller_peer_id == self.pane.controls.peer_id())
+            && self.lease.as_ref().is_some_and(|lease| {
+                lease.controller_peer_id == self.pane.controls.peer_id()
+                    || lease.controller_peer_id.is_empty()
+            })
         {
             let bytes = std::mem::take(&mut self.held_input);
             if self
@@ -2262,7 +2263,10 @@ pub fn run_guest(mut pane: GuestPane) -> Result<(), Box<dyn Error>> {
                     last_lease = Instant::now();
                     if pending_control && state.controller_peer_id == pane.controls.peer_id() {
                         pending_control = false;
-                    } else if pending_control && already_received_host_lease {
+                    } else if pending_control
+                        && already_received_host_lease
+                        && !state.controller_peer_id.is_empty()
+                    {
                         pending_control = false;
                         held_input.clear();
                     }
@@ -2284,7 +2288,8 @@ pub fn run_guest(mut pane: GuestPane) -> Result<(), Box<dyn Error>> {
         if !pending_control
             && !held_input.is_empty()
             && let Some(state) = lease.as_ref()
-            && state.controller_peer_id == pane.controls.peer_id()
+            && (state.controller_peer_id == pane.controls.peer_id()
+                || state.controller_peer_id.is_empty())
         {
             let bytes = std::mem::take(&mut held_input);
             if pane
@@ -2799,6 +2804,20 @@ mod tests {
         let lease = lease_rx.borrow_and_update().clone();
         assert!(lease.controller_peer_id.is_empty());
         assert_eq!(lease.epoch, 2);
+    }
+
+    #[test]
+    fn local_input_crossing_the_idle_timeout_reclaims_and_delivers_it() {
+        let host_id = b"host".to_vec();
+        let mut pane = SharedLocalPane::spawn(99, 1, 1, host_id.clone()).expect("local pane");
+        pane.lease =
+            LeaseManager::with_epoch_for_test(b"remote".to_vec(), 1, Instant::now() - IDLE_AFTER);
+
+        pane.input(b"first".to_vec())
+            .expect("first input at idle boundary");
+
+        assert_eq!(pane.lease.state().controller_peer_id, host_id);
+        assert_eq!(pane.lease.state().epoch, 3);
     }
 
     fn split_layout() -> LayoutSnapshot {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -50,7 +50,44 @@ use crate::{
 /// Kept as the module's public marker from the scaffold.
 pub struct Tui;
 
-const CONTROL_HELP: &str = "type to claim idle | active typing is protected | Ctrl+Q quit";
+const FOOTER_BACKGROUND: Color = Color::Rgb(30, 30, 30);
+const FOOTER_MUTED: Color = Color::DarkGray;
+const FOOTER_ACCENT: Color = Color::Red;
+const CONTROL_HELP: &str = "Ctrl+ <p> PANE   <t> TAB   <q> QUIT    type to claim when free";
+
+type FooterSegment = (&'static str, bool);
+
+const NORMAL_FOOTER: &[FooterSegment] = &[
+    ("Ctrl+ <", false),
+    ("p", true),
+    ("> PANE   <", false),
+    ("t", true),
+    ("> TAB   <", false),
+    ("q", true),
+    ("> QUIT    type to claim when free", false),
+];
+const PANE_FOOTER: &[FooterSegment] = &[
+    ("Pane  <", false),
+    ("←↓↑→", true),
+    ("> FOCUS   <", false),
+    ("n", true),
+    ("> NEW   <", false),
+    ("x", true),
+    ("> CLOSE   <", false),
+    ("Esc", true),
+    ("> BACK", false),
+];
+const TAB_FOOTER: &[FooterSegment] = &[
+    ("Tab  <", false),
+    ("←→", true),
+    ("> SWITCH   <", false),
+    ("n", true),
+    ("> NEW   <", false),
+    ("x", true),
+    ("> CLOSE   <", false),
+    ("Esc", true),
+    ("> BACK", false),
+];
 
 /// The in-progress multi-pane command prefix, kept entirely local to one terminal.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -655,21 +692,99 @@ pub fn render_multi_pane(
     render_shared_multi_pane(frame, tui, screens, "", None);
 }
 
-fn shared_footer_text(status: &str, join_code: Option<&str>, chord_mode: ChordMode) -> String {
-    let controls = match chord_mode {
-        ChordMode::None => format!("Ctrl+P panes | Ctrl+T tabs | {CONTROL_HELP}"),
-        ChordMode::Pane => {
-            String::from("arrows move focus | N new pane | X delete pane | Esc cancel")
-        }
-        ChordMode::Tab => String::from("←/→ switch tab | N new tab | X delete tab | Esc cancel"),
-    };
-    match (status.is_empty(), join_code) {
-        (false, Some(join_code)) => {
-            format!("{status} | {controls} | join: p2pmux join {join_code}")
-        }
-        (false, None) => format!("{status} | {controls}"),
-        (true, Some(join_code)) => format!("{controls} | join: p2pmux join {join_code}"),
-        (true, None) => controls,
+fn contextual_footer(chord_mode: ChordMode) -> (&'static str, &'static [FooterSegment]) {
+    match chord_mode {
+        ChordMode::None => (CONTROL_HELP, NORMAL_FOOTER),
+        ChordMode::Pane => (
+            "Pane  <←↓↑→> FOCUS   <n> NEW   <x> CLOSE   <Esc> BACK",
+            PANE_FOOTER,
+        ),
+        ChordMode::Tab => (
+            "Tab  <←→> SWITCH   <n> NEW   <x> CLOSE   <Esc> BACK",
+            TAB_FOOTER,
+        ),
+    }
+}
+
+fn render_footer_segments(
+    buffer: &mut Buffer,
+    mut x: u16,
+    y: u16,
+    end_x: u16,
+    segments: &[FooterSegment],
+) -> u16 {
+    for (text, accent) in segments {
+        let style = Style::default()
+            .fg(if *accent { FOOTER_ACCENT } else { FOOTER_MUTED })
+            .bg(FOOTER_BACKGROUND);
+        x = buffer
+            .set_stringn(x, y, text, usize::from(end_x.saturating_sub(x)), style)
+            .0;
+    }
+    x
+}
+
+fn footer_suffix(text: &str, width: usize) -> &str {
+    if width == 0 {
+        return "";
+    }
+    let start = text
+        .char_indices()
+        .nth(text.chars().count().saturating_sub(width))
+        .map_or(0, |(index, _)| index);
+    &text[start..]
+}
+
+fn render_contextual_footer(
+    buffer: &mut Buffer,
+    area: Rect,
+    status: &str,
+    join_code: Option<&str>,
+    chord_mode: ChordMode,
+) {
+    buffer.set_stringn(
+        area.x,
+        area.y,
+        " ".repeat(usize::from(area.width)),
+        usize::from(area.width),
+        Style::default().bg(FOOTER_BACKGROUND),
+    );
+
+    let end_x = area.right();
+    let mut x = area.x;
+    if !status.is_empty() {
+        x = buffer
+            .set_stringn(
+                x,
+                area.y,
+                format!("{status}  "),
+                usize::from(end_x.saturating_sub(x)),
+                Style::default().fg(FOOTER_MUTED).bg(FOOTER_BACKGROUND),
+            )
+            .0;
+    }
+
+    let join = join_code.map(|code| format!("join: p2pmux join {code}"));
+    let (join_x, join_text) = join
+        .as_deref()
+        .map(|text| {
+            let text = footer_suffix(text, usize::from(end_x.saturating_sub(x)));
+            (
+                end_x.saturating_sub(text.chars().count() as u16),
+                Some(text),
+            )
+        })
+        .unwrap_or((end_x, None));
+    let (_, segments) = contextual_footer(chord_mode);
+    render_footer_segments(buffer, x, area.y, join_x, segments);
+    if let Some(text) = join_text {
+        buffer.set_stringn(
+            join_x,
+            area.y,
+            text,
+            usize::from(end_x.saturating_sub(join_x)),
+            Style::default().fg(FOOTER_MUTED).bg(FOOTER_BACKGROUND),
+        );
     }
 }
 
@@ -714,11 +829,12 @@ fn render_shared_multi_pane(
         }
     }
     if geometry.footer.width > 0 && geometry.footer.height > 0 {
-        frame.buffer_mut().set_string(
-            geometry.footer.x,
-            geometry.footer.y,
-            shared_footer_text(status, join_code, tui.chord_mode),
-            Style::default().fg(Color::DarkGray),
+        render_contextual_footer(
+            frame.buffer_mut(),
+            geometry.footer,
+            status,
+            join_code,
+            tui.chord_mode,
         );
     }
 
@@ -2527,13 +2643,12 @@ mod tests {
     use iroh::{Endpoint, RelayMode, endpoint::presets};
 
     use super::{
-        CONTROL_HELP, ChordMode, HostControlEvent, HostPaneChannels, HostPaneRuntime, KeyHandling,
+        ChordMode, HostControlEvent, HostPaneChannels, HostPaneRuntime, KeyHandling,
         LayoutControlEvent, MultiPaneTui, PaneViewState, RemoteSubscriptionState,
-        SharedLayoutRuntime, SharedLocalPane, UiIntent, VtScreen, encode_key, encode_paste,
-        grid_for_pane, initial_root_pane_grid, lease_allows_held_input, member_label,
+        SharedLayoutRuntime, SharedLocalPane, UiIntent, VtScreen, contextual_footer, encode_key,
+        encode_paste, grid_for_pane, initial_root_pane_grid, lease_allows_held_input, member_label,
         pane_border_color, pane_title, pane_wire_id, reconcile_remote_control_attempt,
-        render_guest_screen, render_multi_pane, render_shared_multi_pane, shared_footer_text,
-        visible_leaf_panes,
+        render_guest_screen, render_multi_pane, render_shared_multi_pane, visible_leaf_panes,
     };
 
     fn layout(tabs: Vec<Tab>, panes: &[(u64, u16, u16)]) -> LayoutSnapshot {
@@ -2783,14 +2898,49 @@ mod tests {
 
     #[test]
     fn shared_footer_keeps_status_visible_when_a_join_code_is_present() {
-        let footer =
-            shared_footer_text("layout request rejected", Some("TESTCODE"), ChordMode::None);
+        let snapshot = layout(
+            vec![Tab {
+                tab_id: 1,
+                root: Node::Leaf { pane_id: 1 },
+            }],
+            &[(1, 1, 1)],
+        );
+        let tui = MultiPaneTui::new(snapshot).expect("layout");
+        let mut terminal = Terminal::new(TestBackend::new(80, 5)).expect("terminal");
+        terminal
+            .draw(|frame| {
+                render_shared_multi_pane(
+                    frame,
+                    &tui,
+                    &BTreeMap::new(),
+                    "layout request rejected",
+                    Some("TESTCODE"),
+                );
+            })
+            .expect("draw");
+        let footer = (0..80)
+            .map(|x| terminal.backend().buffer()[(x, 4)].symbol())
+            .collect::<String>();
         assert!(footer.starts_with("layout request rejected"));
-        assert!(footer.contains("Ctrl+P panes"));
-        assert!(footer.contains(CONTROL_HELP));
-        assert!(!footer.contains("F9"));
-        assert!(!footer.contains("F10"));
-        assert!(footer.contains("join: p2pmux join TESTCODE"));
+        assert!(footer.ends_with("join: p2pmux join TESTCODE"));
+
+        let mut narrow_terminal = Terminal::new(TestBackend::new(20, 5)).expect("terminal");
+        narrow_terminal
+            .draw(|frame| {
+                render_shared_multi_pane(
+                    frame,
+                    &tui,
+                    &BTreeMap::new(),
+                    "layout request rejected",
+                    Some("TESTCODE"),
+                );
+            })
+            .expect("draw");
+        let narrow_footer = (0..20)
+            .map(|x| narrow_terminal.backend().buffer()[(x, 4)].symbol())
+            .collect::<String>();
+        assert!(narrow_footer.starts_with("layout request"));
+        assert!(!narrow_footer.contains("join"));
     }
 
     #[test]
@@ -3451,15 +3601,15 @@ mod tests {
         for (mode, expected) in [
             (
                 ChordMode::None,
-                "Ctrl+P panes | Ctrl+T tabs | type to claim idle | active typing is protected | Ctrl+Q quit",
+                "Ctrl+ <p> PANE   <t> TAB   <q> QUIT    type to claim when free",
             ),
             (
                 ChordMode::Pane,
-                "arrows move focus | N new pane | X delete pane | Esc cancel",
+                "Pane  <←↓↑→> FOCUS   <n> NEW   <x> CLOSE   <Esc> BACK",
             ),
             (
                 ChordMode::Tab,
-                "←/→ switch tab | N new tab | X delete tab | Esc cancel",
+                "Tab  <←→> SWITCH   <n> NEW   <x> CLOSE   <Esc> BACK",
             ),
         ] {
             tui.chord_mode = mode;
@@ -3473,6 +3623,38 @@ mod tests {
                 footer.starts_with(expected),
                 "mode: {mode:?}, footer: {footer}"
             );
+        }
+    }
+
+    #[test]
+    fn shared_footer_accents_key_glyphs_on_a_dark_background() {
+        let mut tui = MultiPaneTui::new(layout(
+            vec![Tab {
+                tab_id: 1,
+                root: Node::Leaf { pane_id: 1 },
+            }],
+            &[(1, 2, 2)],
+        ))
+        .expect("valid layout");
+        let mut terminal = Terminal::new(TestBackend::new(120, 4)).expect("test terminal");
+
+        for mode in [ChordMode::None, ChordMode::Pane, ChordMode::Tab] {
+            tui.chord_mode = mode;
+            terminal
+                .draw(|frame| render_multi_pane(frame, &tui, &BTreeMap::new()))
+                .expect("render");
+            let footer = terminal.backend().buffer();
+            assert_eq!(footer[(0, 3)].bg, Color::Rgb(30, 30, 30));
+            let (_, segments) = contextual_footer(mode);
+            let mut x = 0;
+            for (text, accent) in segments {
+                for key in text.chars() {
+                    if *accent {
+                        assert_eq!(footer[(x, 3)].fg, Color::Red, "mode: {mode:?}, key: {key}");
+                    }
+                    x += 1;
+                }
+            }
         }
     }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -444,6 +444,17 @@ fn first_leaf(node: &Node) -> Option<PaneId> {
     }
 }
 
+fn visible_leaf_panes(node: &Node) -> Vec<PaneId> {
+    match node {
+        Node::Leaf { pane_id } => vec![*pane_id],
+        Node::Split { first, second, .. } => {
+            let mut panes = visible_leaf_panes(first);
+            panes.extend(visible_leaf_panes(second));
+            panes
+        }
+    }
+}
+
 fn pane_at(panes: &BTreeMap<PaneId, Rect>, column: u16, row: u16) -> Option<PaneId> {
     panes.iter().find_map(|(pane_id, rect)| {
         let inside = u32::from(column) >= u32::from(rect.x)
@@ -452,6 +463,35 @@ fn pane_at(panes: &BTreeMap<PaneId, Rect>, column: u16, row: u16) -> Option<Pane
             && u32::from(row) < u32::from(rect.y) + u32::from(rect.height);
         inside.then_some(*pane_id)
     })
+}
+
+fn pane_title(
+    index: usize,
+    host_peer_id: &[u8],
+    controller_peer_id: Option<&[u8]>,
+    members: &[crate::layout::Member],
+) -> String {
+    let control = match controller_peer_id {
+        Some([]) => "free".to_owned(),
+        Some(peer_id) => member_label(peer_id, members),
+        None => "…".to_owned(),
+    };
+    format!(
+        "Pane #{index}  host: {}  control: {control}",
+        member_label(host_peer_id, members)
+    )
+}
+
+fn pane_border_color(
+    controller_peer_id: Option<&[u8]>,
+    _controller_active: bool,
+    focused: bool,
+) -> Color {
+    match controller_peer_id {
+        Some([]) if focused => Color::White,
+        Some([]) | None => Color::DarkGray,
+        Some(_) => Color::Rgb(255, 69, 0),
+    }
 }
 
 fn contains_leaf(node: &Node, pane_id: PaneId) -> bool {
@@ -638,34 +678,28 @@ fn render_shared_multi_pane(
         );
     }
 
-    for (pane_id, rect) in geometry.panes {
+    let pane_ids = tui
+        .current_tab_layout()
+        .map(|tab| visible_leaf_panes(&tab.root))
+        .unwrap_or_default();
+    for (index, pane_id) in pane_ids.into_iter().enumerate() {
+        let Some(rect) = geometry.panes.get(&pane_id).copied() else {
+            continue;
+        };
         let pane = &tui.snapshot.panes[&pane_id];
         let view = tui.pane_views.get(&pane_id).cloned().unwrap_or_default();
         let focused = pane_id == tui.focused_pane;
-        let lease = match view.controller_peer_id.as_deref() {
-            Some(peer) if view.controller_active => {
-                format!(
-                    "ctrl:{} this user is typing",
-                    member_label(peer, &tui.snapshot.members)
-                )
-            }
-            Some(peer) => format!(
-                "ctrl:{} this user has control",
-                member_label(peer, &tui.snapshot.members)
-            ),
-            None => String::from("lease: waiting"),
-        };
-        let title = format!(
-            "{} host:{} {lease}",
-            if focused { "*" } else { " " },
-            member_label(&pane.host_peer_id, &tui.snapshot.members)
+        let title = pane_title(
+            index + 1,
+            &pane.host_peer_id,
+            view.controller_peer_id.as_deref(),
+            &tui.snapshot.members,
         );
-        let border_color = match view.controller_peer_id.as_ref() {
-            Some(_) if view.controller_active => Color::Rgb(255, 69, 0),
-            Some(_) => Color::Rgb(140, 91, 68),
-            None if focused => Color::Yellow,
-            None => Color::DarkGray,
-        };
+        let border_color = pane_border_color(
+            view.controller_peer_id.as_deref(),
+            view.controller_active,
+            focused,
+        );
         let block = Block::bordered()
             .title(title)
             .border_style(Style::default().fg(border_color));
@@ -2450,9 +2484,10 @@ mod tests {
         CONTROL_HELP, ChordMode, HostControlEvent, HostPaneChannels, HostPaneRuntime, KeyHandling,
         LayoutControlEvent, MultiPaneTui, PaneViewState, RemoteSubscriptionState,
         SharedLayoutRuntime, SharedLocalPane, UiIntent, VtScreen, encode_key, encode_paste,
-        grid_for_pane, initial_root_pane_grid, lease_allows_held_input, member_label, pane_wire_id,
-        reconcile_remote_control_attempt, render_guest_screen, render_multi_pane,
-        render_shared_multi_pane, shared_footer_text,
+        grid_for_pane, initial_root_pane_grid, lease_allows_held_input, member_label,
+        pane_border_color, pane_title, pane_wire_id, reconcile_remote_control_attempt,
+        render_guest_screen, render_multi_pane, render_shared_multi_pane, shared_footer_text,
+        visible_leaf_panes,
     };
 
     fn layout(tabs: Vec<Tab>, panes: &[(u64, u16, u16)]) -> LayoutSnapshot {
@@ -2945,6 +2980,56 @@ mod tests {
     }
 
     #[test]
+    fn pane_title_uses_stable_leaf_order_and_control_state() {
+        let snapshot = layout(
+            vec![Tab {
+                tab_id: 1,
+                root: Node::Split {
+                    axis: Axis::LeftRight,
+                    first: Box::new(Node::Leaf { pane_id: 8 }),
+                    second: Box::new(Node::Leaf { pane_id: 3 }),
+                },
+            }],
+            &[(3, 1, 1), (8, 1, 1)],
+        );
+        let mut members = snapshot.members.clone();
+        members[0].display_name = String::from("Host");
+        members.push(crate::layout::Member {
+            peer_id: b"guest".to_vec(),
+            endpoint_addr: b"guest-endpoint".to_vec(),
+            display_name: String::from("Guest"),
+        });
+
+        assert_eq!(visible_leaf_panes(&snapshot.tabs[0].root), vec![8, 3]);
+        assert_eq!(
+            pane_title(1, b"host", Some(b""), &members),
+            "Pane #1  host: Host  control: free"
+        );
+        assert_eq!(
+            pane_title(2, b"host", Some(b"guest"), &members),
+            "Pane #2  host: Host  control: Guest"
+        );
+        assert_eq!(
+            pane_title(2, b"host", None, &members),
+            "Pane #2  host: Host  control: …"
+        );
+    }
+
+    #[test]
+    fn free_panes_use_white_when_focused_and_dark_gray_when_unfocused() {
+        assert_eq!(pane_border_color(Some(b""), false, true), Color::White);
+        assert_eq!(pane_border_color(Some(b""), false, false), Color::DarkGray);
+        assert_eq!(
+            pane_border_color(Some(b"guest"), true, true),
+            Color::Rgb(255, 69, 0)
+        );
+        assert_ne!(
+            pane_border_color(Some(b"guest"), false, false),
+            Color::Rgb(140, 91, 68)
+        );
+    }
+
+    #[test]
     fn multi_pane_geometry_recursively_splits_the_content_area() {
         let tui = MultiPaneTui::new(split_layout()).expect("valid layout");
         let geometry = tui.geometry(Rect::new(0, 0, 80, 24));
@@ -3020,7 +3105,7 @@ mod tests {
     }
 
     #[test]
-    fn chrome_marks_focus_and_reports_host_and_lease() {
+    fn chrome_reports_the_pane_host_and_controller() {
         let mut tui = MultiPaneTui::new(layout(
             vec![Tab {
                 tab_id: 1,
@@ -3045,7 +3130,7 @@ mod tests {
         let buffer = terminal.backend().buffer();
 
         assert_eq!(buffer[(0, 1)].symbol(), "┌");
-        assert_eq!(buffer[(1, 1)].symbol(), "*");
+        assert_eq!(buffer[(1, 1)].symbol(), "P");
         assert!(buffer.content.iter().any(|cell| cell.symbol() == "h"));
         assert!(buffer.content.iter().any(|cell| cell.symbol() == "t"));
     }
@@ -3077,8 +3162,8 @@ mod tests {
             .map(|x| terminal.backend().buffer()[(x, 1)].symbol())
             .collect::<String>();
 
-        assert!(title.contains("host:686f7374"));
-        assert!(!title.contains("host:66616b65"));
+        assert!(title.contains("host: 686f7374"));
+        assert!(!title.contains("host: 66616b65"));
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -721,7 +721,7 @@ impl SharedLocalPane {
         };
         let screen = HostScreen::new(grid_rows, grid_cols)?;
         let (screen_tx, _) = watch::channel(screen.current_frame().clone());
-        let lease = LeaseManager::new(host_peer_id.clone(), Instant::now());
+        let lease = LeaseManager::new(Vec::new(), Instant::now());
         let (lease_tx, _) = watch::channel(lease.state().clone());
         let (control_tx, control_rx) = mpsc::channel(256);
         Ok(Self {
@@ -1755,7 +1755,8 @@ impl HostPaneRuntime {
         join_code: String,
     ) -> Result<Self, Box<dyn Error>> {
         let screen = HostScreen::new(size.rows, size.cols)?;
-        let lease = LeaseManager::new(host_peer_id.clone(), Instant::now());
+        let lease = LeaseManager::new(Vec::new(), Instant::now());
+        lease_tx.send_replace(lease.state().clone());
         Ok(Self {
             host: PtyHost::spawn_default_shell(size)?,
             screen,
@@ -2427,6 +2428,7 @@ mod tests {
     use tokio::sync::{mpsc, watch};
 
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+    use portable_pty::PtySize;
     use ratatui::{
         Terminal,
         backend::TestBackend,
@@ -2445,7 +2447,7 @@ mod tests {
     use iroh::{Endpoint, RelayMode, endpoint::presets};
 
     use super::{
-        CONTROL_HELP, ChordMode, HostControlEvent, HostPaneChannels, KeyHandling,
+        CONTROL_HELP, ChordMode, HostControlEvent, HostPaneChannels, HostPaneRuntime, KeyHandling,
         LayoutControlEvent, MultiPaneTui, PaneViewState, RemoteSubscriptionState,
         SharedLayoutRuntime, SharedLocalPane, UiIntent, VtScreen, encode_key, encode_paste,
         grid_for_pane, initial_root_pane_grid, lease_allows_held_input, member_label, pane_wire_id,
@@ -2775,6 +2777,7 @@ mod tests {
         let requester = b"guest".to_vec();
         let mut pane = SharedLocalPane::spawn(99, 1, 1, owner.clone()).expect("local pane");
         let mut lease_rx = pane.lease_tx.subscribe();
+        pane.lease = LeaseManager::new(owner.clone(), Instant::now());
         pane.control_tx
             .try_send(HostControlEvent::TakeControl {
                 peer_id: requester.clone(),
@@ -2859,6 +2862,50 @@ mod tests {
             "first input was not delivered to the PTY: {:?}",
             String::from_utf8_lossy(&output)
         );
+    }
+
+    #[test]
+    fn new_local_pane_starts_free_while_the_host_retains_pty_ownership() {
+        let host_id = b"host".to_vec();
+        let mut pane = SharedLocalPane::spawn(99, 1, 1, host_id.clone()).expect("local pane");
+
+        assert!(pane.lease.state().controller_peer_id.is_empty());
+        assert_eq!(pane.host_peer_id, host_id);
+
+        pane.shutdown().expect("shutdown local pane");
+    }
+
+    #[test]
+    fn new_host_runtime_starts_free_while_the_host_retains_pty_ownership() {
+        let host_id = b"host".to_vec();
+        let screen = HostScreen::new(1, 1).expect("screen");
+        let (screen_tx, _) = watch::channel(screen.current_frame().clone());
+        let (lease_tx, lease_rx) = watch::channel(LeaseState {
+            controller_peer_id: host_id.clone(),
+            epoch: 1,
+            last_activity: Instant::now(),
+        });
+        let (_control_tx, control_rx) = mpsc::channel(8);
+        let mut runtime = HostPaneRuntime::new(
+            PtySize {
+                rows: 1,
+                cols: 1,
+                pixel_width: 0,
+                pixel_height: 0,
+            },
+            host_id.clone(),
+            screen_tx,
+            lease_tx,
+            control_rx,
+            String::from("TESTCODE"),
+        )
+        .expect("host runtime");
+
+        assert!(runtime.lease.state().controller_peer_id.is_empty());
+        assert_eq!(runtime.host_peer_id, host_id);
+        assert!(lease_rx.borrow().controller_peer_id.is_empty());
+
+        runtime.host.shutdown().expect("shutdown host runtime");
     }
 
     #[test]

--- a/tests/lease.rs
+++ b/tests/lease.rs
@@ -24,6 +24,32 @@ fn controller_input_refreshes_activity_and_stale_input_is_rejected() {
 }
 
 #[test]
+fn free_pane_input_claims_control_and_delivers_the_first_input() {
+    let now = Instant::now();
+    let mut lease = LeaseManager::with_epoch_for_test(Vec::new(), 2, now);
+
+    assert_eq!(
+        lease.input(&[2], 2, b"first".to_vec(), now + Duration::from_secs(1)),
+        LeaseDecision::AcceptInput(b"first".to_vec())
+    );
+    assert_eq!(lease.state().controller_peer_id, vec![2]);
+    assert_eq!(lease.state().epoch, 3);
+}
+
+#[test]
+fn input_from_a_non_controller_is_rejected_while_control_is_active() {
+    let now = Instant::now();
+    let mut lease = LeaseManager::new(vec![1], now);
+
+    assert_eq!(
+        lease.input(&[2], 1, b"no".to_vec(), now + Duration::from_secs(1)),
+        LeaseDecision::RejectStaleInput
+    );
+    assert_eq!(lease.state().controller_peer_id, vec![1]);
+    assert_eq!(lease.state().epoch, 1);
+}
+
+#[test]
 fn take_control_advances_epoch_and_rejects_stale_requests() {
     let now = Instant::now();
     let mut lease = LeaseManager::new(vec![1], now);

--- a/tests/protocol.rs
+++ b/tests/protocol.rs
@@ -1208,6 +1208,19 @@ fn decoder_accepts_maximum_payloads() {
 }
 
 #[test]
+fn control_lease_allows_an_empty_controller_for_a_free_pane() {
+    let free_lease = envelope(envelope::Body::ControlLease(ControlLease {
+        pane_id: b"pane-a".to_vec(),
+        controller_peer_id: Vec::new(),
+        lease_epoch: 2,
+    }));
+    let mut frame = Vec::new();
+    free_lease.encode_length_delimited(&mut frame).unwrap();
+
+    assert_eq!(decode_frame(&frame).unwrap(), free_lease);
+}
+
+#[test]
 fn encode_frame_rejects_invalid_envelopes() {
     let mut wrong_version = sample_envelopes()[0].clone();
     wrong_version.version = PROTOCOL_VERSION + 1;


### PR DESCRIPTION
## Summary
- Clear idle pane leases to a published free state; the first new key claims and delivers input while active typing stays protected.
- Start panes free, add host/control pane titles and free/active chrome, and enable tab-label clicks.
- Restyle contextual footer help and align free-control documentation.

## Test plan
- [x] Lease idle-clear, free-claim/first-input, active-rejection, and timeout-boundary coverage.
- [x] Pane title/border, tab hit-test, and footer-content/accent coverage.
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test`