### PR TITLE
feat: Option-arrow focus and directional Ctrl+P splits

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,13 @@ passthrough configuration.
 Drag inside a pane's terminal content to select text; releasing the mouse copies it to the macOS
 clipboard.
 
-- `Ctrl+P`, then `N` — split the focused pane. The new fixed-grid PTY runs on the requester’s Mac.
+- `Option` (Alt) + arrows — move focus to the nearest pane in that direction in the current tab.
+  Some terminals and outer multiplexers do not send Option+arrow as an Alt-modified key, so this
+  binding may require terminal or mux configuration.
+- `Ctrl+P`, then `n` — split the focused pane using its current aspect-ratio axis. The new
+  fixed-grid PTY runs on the requester’s Mac.
+- `Ctrl+P`, then `r` / `l` / `d` / `u` — create the new pane right / left / down / up of the
+  focused pane.
 - `Ctrl+P`, then `X` — delete the focused pane. Only that pane’s host may delete it.
 - `Ctrl+P`, then arrows — move focus.
 - `Ctrl+T`, then `N` — create a tab with a local PTY on the requester’s Mac.
@@ -107,8 +113,8 @@ Nested 50/50 splits are part of Spike 3 (depth 4, at most 8 panes per tab, at mo
 pane title shows `Pane #N host: <name> control: free|<name>|…`; free focused panes use a white
 border and actively controlled panes use red-orange. Click tab labels to switch tabs without
 claiming control or sending input. Mouse wheel scrolls pane history locally. The dark contextual footer uses red key accents: normal mode is
-`Ctrl+ <p> PANE   <t> TAB   <q> QUIT    type to claim when free`; pane mode is
-`Pane  <←↓↑→> FOCUS   <n> NEW   <x> CLOSE   <Esc> BACK`; tab mode is
+`Ctrl+ <p> PANE   <t> TAB   <Alt+←↓↑→> FOCUS   <q> QUIT    type to claim when free`; pane mode is
+`Pane  <←↓↑→> FOCUS   <n> NEW   <r/l/d/u> SPLIT   <x> CLOSE   <Esc> BACK`; tab mode is
 `Tab  <←→> SWITCH   <n> NEW   <x> CLOSE   <Esc> BACK`.
 
 Slow viewers may receive coalesced screen deltas and then a fresh snapshot to recover. Resizing an

--- a/docs/superpowers/plans/2026-07-25-option-focus-directional-splits.md
+++ b/docs/superpowers/plans/2026-07-25-option-focus-directional-splits.md
@@ -1,0 +1,40 @@
+# Option Focus and Directional Pane Splits Implementation Plan
+
+**Goal:** Add Option/Alt-arrow pane focus and directional `Ctrl+P` splits while
+making split placement authoritative through the layout protocol.
+
+**Architecture:** Store a first/second placement enum in the layout reservation
+and apply it when `pane_ready` builds the split. Carry that value through the
+protocol and runtime; TUI key handling only chooses it. Preserve all current
+grid sizing, focus, and split-depth rules.
+
+**Spec:** `docs/superpowers/specs/2026-07-25-option-focus-directional-splits-design.md`
+
+## File map
+
+| File | Responsibility |
+|---|---|
+| `src/layout.rs` | Placement enum, reservation state, child order |
+| `src/protocol.rs` | CreatePane field, validation, protocol v3 |
+| `src/session.rs` | Map protocol placement into layout reservation |
+| `src/tui.rs` | Alt focus, directional intents, footer help |
+| `tests/*` | Layout, protocol, session, and wire compatibility coverage |
+| `README.md` | User-facing keybinding and terminal caveat |
+
+## Tasks
+
+1. Add this design and plan documentation.
+2. Add `NewPanePosition` to the layout model; default missing placement to
+   `Second`; test both child orders and depth rejection.
+3. Add a `CreatePane` protobuf placement field, reject unknown values, bump the
+   protocol to v3, and map it through session coordination.
+4. Add exact Alt-arrow focus in normal and pane modes and `r/l/d/u` pane-chord
+   intents, retaining sticky mode and existing `n` behaviour.
+5. Update normal and pane footer segments and their rendering tests.
+6. Document the bindings and Option-arrow terminal/mux caveat in the README.
+
+## Verification
+
+Run `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, and `cargo test`.
+Confirm six focused commits on `ux/option-focus-directional-splits` and no
+remote push or PR.

--- a/docs/superpowers/specs/2026-07-25-option-focus-directional-splits-design.md
+++ b/docs/superpowers/specs/2026-07-25-option-focus-directional-splits-design.md
@@ -1,0 +1,67 @@
+# Option Focus and Directional Pane Splits
+
+## Goal
+
+Make pane navigation available without entering pane mode, and let pane creation
+choose which side of the focused pane receives the new PTY.
+
+## Interaction model
+
+### Option (Alt) focus
+
+- Exact `Option` / `Alt` plus an arrow key moves focus to the nearest pane in
+  that direction within the current tab.
+- The existing nearest-neighbour geometry selection remains authoritative.
+- The shortcut works in normal mode and pane mode. It is consumed in both
+  modes, including when no neighbour exists, so it never reaches a PTY.
+- Tab mode is unchanged.
+- Some terminals and outer multiplexers do not encode Option+arrow as an Alt
+  modified key; that is a terminal/mux configuration caveat, not a fallback
+  binding.
+
+### Directional pane creation
+
+`Ctrl+P` remains a sticky pane chord. Existing lowercase `n` keeps its current
+aspect-ratio axis choice and inserts the new pane as the second child. New
+lowercase commands explicitly select an axis and placement:
+
+| Key | Axis | New pane position |
+|---|---|---|
+| `r` | left/right | second (right) |
+| `l` | left/right | first (left) |
+| `d` | top/bottom | second (down) |
+| `u` | top/bottom | first (up) |
+
+The existing split depth limit of four remains unchanged. Creating a pane keeps
+focus on the original pane and retains the current pre-split grid sizing.
+Directional command keys count as chord commands even when no creation intent
+can be issued, preserving sticky pane mode on a depth-limit rejection.
+
+## Authority and wire compatibility
+
+Placement is layout authority, not a TUI rendering preference. A
+`NewPanePosition { First, Second }` value flows from `UiIntent::CreatePane`
+through the runtime request, protocol, coordinator reservation, and pending
+reservation into the `pane_ready` split child order. Missing placement defaults
+to `Second` to retain `n` semantics.
+
+`CreatePane` gets a new protobuf field using a new tag. Protocol version moves
+from 2 to 3 so an older coordinator cannot silently ignore a left/up placement
+and create it on the wrong side. Protocol validation rejects unknown enum
+values.
+
+## Footer text
+
+Normal mode includes `Alt+←↓↑→ FOCUS`. Pane mode includes
+`r/l/d/u SPLIT`. Tab mode is unchanged. The renderer continues to style the
+key portions with its existing accent treatment.
+
+## Testing
+
+- Layout tests cover first and second child order, default-second compatibility,
+  and depth rejection for both placements.
+- Protocol tests cover the new field's stable wire shape, default, validation,
+  and version 3 behaviour.
+- TUI tests cover Option-arrow consumption/focus in normal and pane modes,
+  directional chord intents, sticky handling, and unchanged `n` semantics.
+- Footer tests assert the new normal and pane help strings.

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -400,6 +400,7 @@ impl SessionState {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn reserve_pane_at(
         &mut self,
         creator: &[u8],
@@ -629,6 +630,7 @@ impl SessionState {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn create_pane_at(
         &mut self,
         requester: &[u8],

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -19,6 +19,13 @@ pub enum Axis {
     TopBottom,
 }
 
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum NewPanePosition {
+    First,
+    #[default]
+    Second,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Node {
     Leaf {
@@ -85,6 +92,7 @@ enum PendingReservationKind {
         pane_id: PaneId,
         target_pane_id: PaneId,
         axis: Axis,
+        position: NewPanePosition,
         grid_rows: u16,
         grid_cols: u16,
     },
@@ -381,6 +389,27 @@ impl SessionState {
         grid_rows: u16,
         grid_cols: u16,
     ) -> Result<PaneReservation, LayoutError> {
+        self.reserve_pane_at(
+            creator,
+            base_revision,
+            target_pane_id,
+            axis,
+            NewPanePosition::Second,
+            grid_rows,
+            grid_cols,
+        )
+    }
+
+    pub fn reserve_pane_at(
+        &mut self,
+        creator: &[u8],
+        base_revision: u64,
+        target_pane_id: PaneId,
+        axis: Axis,
+        position: NewPanePosition,
+        grid_rows: u16,
+        grid_cols: u16,
+    ) -> Result<PaneReservation, LayoutError> {
         self.check_reservation(base_revision)?;
         self.require_member(creator)?;
         validate_grid(grid_rows, grid_cols)?;
@@ -400,6 +429,7 @@ impl SessionState {
                 pane_id,
                 target_pane_id,
                 axis,
+                position,
                 grid_rows,
                 grid_cols,
             },
@@ -471,6 +501,7 @@ impl SessionState {
                 pane_id,
                 target_pane_id,
                 axis,
+                position,
                 grid_rows,
                 grid_cols,
             } => {
@@ -478,12 +509,18 @@ impl SessionState {
                 let tab_index = self
                     .tab_index_for_pane(target_pane_id)
                     .ok_or(LayoutError::ReservationInvalid)?;
+                let target = Box::new(Node::Leaf {
+                    pane_id: target_pane_id,
+                });
+                let new_pane = Box::new(Node::Leaf { pane_id });
+                let (first, second) = match position {
+                    NewPanePosition::First => (new_pane, target),
+                    NewPanePosition::Second => (target, new_pane),
+                };
                 let split = Node::Split {
                     axis,
-                    first: Box::new(Node::Leaf {
-                        pane_id: target_pane_id,
-                    }),
-                    second: Box::new(Node::Leaf { pane_id }),
+                    first,
+                    second,
                 };
                 if !self.tabs[tab_index]
                     .root
@@ -581,11 +618,33 @@ impl SessionState {
         grid_rows: u16,
         grid_cols: u16,
     ) -> Result<PaneId, LayoutError> {
-        let reservation = self.reserve_pane(
+        self.create_pane_at(
             requester,
             base_revision,
             target_pane_id,
             axis,
+            NewPanePosition::Second,
+            grid_rows,
+            grid_cols,
+        )
+    }
+
+    pub fn create_pane_at(
+        &mut self,
+        requester: &[u8],
+        base_revision: u64,
+        target_pane_id: PaneId,
+        axis: Axis,
+        position: NewPanePosition,
+        grid_rows: u16,
+        grid_cols: u16,
+    ) -> Result<PaneId, LayoutError> {
+        let reservation = self.reserve_pane_at(
+            requester,
+            base_revision,
+            target_pane_id,
+            axis,
+            position,
             grid_rows,
             grid_cols,
         )?;

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -3,7 +3,7 @@
 use prost::Message;
 use std::{collections::HashSet, fmt};
 
-pub const PROTOCOL_VERSION: u32 = 2;
+pub const PROTOCOL_VERSION: u32 = 3;
 pub const MAX_FRAME_BYTES: usize = 1_048_576;
 pub const MAX_ENVELOPE_BYTES: usize = 1_048_560;
 pub const MAX_PEER_ID_BYTES: usize = 64;
@@ -300,6 +300,13 @@ pub enum SplitAxis {
     TopBottom = 1,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum NewPanePosition {
+    First = 0,
+    Second = 1,
+}
+
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LayoutRequest {
     #[prost(uint64, tag = "1")]
@@ -326,6 +333,8 @@ pub struct CreatePane {
     pub grid_rows: u32,
     #[prost(uint32, tag = "4")]
     pub grid_cols: u32,
+    #[prost(enumeration = "NewPanePosition", optional, tag = "5")]
+    pub position: Option<i32>,
 }
 
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -715,6 +724,13 @@ fn validate_axis(field: &'static str, axis: Option<i32>) -> Result<(), ProtocolE
     Ok(())
 }
 
+fn validate_pane_position(field: &'static str, position: Option<i32>) -> Result<(), ProtocolError> {
+    if let Some(position) = position {
+        NewPanePosition::try_from(position).map_err(|_| ProtocolError::InvalidLayout(field))?;
+    }
+    Ok(())
+}
+
 fn validate_layout_request(request: &LayoutRequest) -> Result<(), ProtocolError> {
     validate_nonzero("layout_request.request_id", request.request_id)?;
     validate_nonzero("layout_request.base_revision", request.base_revision)?;
@@ -733,6 +749,7 @@ fn validate_layout_request(request: &LayoutRequest) -> Result<(), ProtocolError>
             create_pane.target_pane_id,
         )?;
         validate_axis("layout_request.create_pane.axis", create_pane.axis)?;
+        validate_pane_position("layout_request.create_pane.position", create_pane.position)?;
         validate_grid(
             "layout_request.create_pane.grid",
             create_pane.grid_rows,

--- a/src/session.rs
+++ b/src/session.rs
@@ -23,14 +23,17 @@ use tokio::{
 };
 
 use crate::{
-    layout::{Axis, LayoutError, LayoutSnapshot, Member, Node, Pane, SessionState, Tab},
+    layout::{
+        Axis, LayoutError, LayoutSnapshot, Member, NewPanePosition as LayoutNewPanePosition, Node,
+        Pane, SessionState, Tab,
+    },
     lease::LeaseState,
     protocol::{
         ControlLease, CreatePane, CreateTab, DeletePane, DeleteTab, Delta, Envelope, Input, Join,
         LayoutCommit, LayoutNode, LayoutReject, LayoutRejectReason, LayoutRequest, LayoutSplit,
-        LayoutState, MemberDescriptor, PROTOCOL_VERSION, PaneDescriptor, PaneFailed, PaneReady,
-        PaneReservation, PaneSubscribe, SessionSnapshot, Snapshot, SplitAxis, TabDescriptor,
-        TakeControl, Welcome, envelope,
+        LayoutState, MemberDescriptor, NewPanePosition as ProtocolNewPanePosition,
+        PROTOCOL_VERSION, PaneDescriptor, PaneFailed, PaneReady, PaneReservation, PaneSubscribe,
+        SessionSnapshot, Snapshot, SplitAxis, TabDescriptor, TakeControl, Welcome, envelope,
     },
     screen::ScreenFrame,
     ticket::{JoinTicket, TicketError},
@@ -430,15 +433,17 @@ impl LayoutCoordinator {
         now: Instant,
     ) -> Result<CoordinatorResponse, LayoutError> {
         let axis = protocol_axis(create.axis)?;
+        let position = protocol_pane_position(create.position)?;
         let (grid_rows, grid_cols) = protocol_grid(create.grid_rows, create.grid_cols)?;
         if create.target_pane_id == 0 {
             return Err(LayoutError::InvalidSnapshot);
         }
-        let reservation = self.state.reserve_pane(
+        let reservation = self.state.reserve_pane_at(
             authenticated_peer_id,
             base_revision,
             create.target_pane_id,
             axis,
+            position,
             grid_rows,
             grid_cols,
         )?;
@@ -598,6 +603,19 @@ fn protocol_axis(axis: Option<i32>) -> Result<Axis, LayoutError> {
         Some(SplitAxis::LeftRight) => Ok(Axis::LeftRight),
         Some(SplitAxis::TopBottom) => Ok(Axis::TopBottom),
         None => Err(LayoutError::InvalidSnapshot),
+    }
+}
+
+fn protocol_pane_position(position: Option<i32>) -> Result<LayoutNewPanePosition, LayoutError> {
+    match position {
+        None => Ok(LayoutNewPanePosition::Second),
+        Some(value) if value == ProtocolNewPanePosition::Second as i32 => {
+            Ok(LayoutNewPanePosition::Second)
+        }
+        Some(value) if value == ProtocolNewPanePosition::First as i32 => {
+            Ok(LayoutNewPanePosition::First)
+        }
+        Some(_) => Err(LayoutError::InvalidSnapshot),
     }
 }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -61,7 +61,7 @@ const FOOTER_ACCENT: Color = Color::Rgb(220, 50, 47);
 const TOP_BAR_BRAND: &str = "p2pmux";
 const TOP_BAR_BRAND_SEPARATOR: &str = " │ ";
 const TAB_BAR_SEPARATOR: &str = " · ";
-const CONTROL_HELP: &str = "Ctrl+ <p> PANE   <t> TAB   <q> QUIT";
+const CONTROL_HELP: &str = "Ctrl+ <p> PANE   <t> TAB   <Alt+←↓↑→> FOCUS   <q> QUIT";
 
 type FooterSegment = (&'static str, bool);
 
@@ -71,6 +71,8 @@ const NORMAL_FOOTER: &[FooterSegment] = &[
     ("> PANE   <", false),
     ("t", true),
     ("> TAB   <", false),
+    ("Alt+←↓↑→", true),
+    ("> FOCUS   <", false),
     ("q", true),
     ("> QUIT", false),
 ];
@@ -80,6 +82,8 @@ const PANE_FOOTER: &[FooterSegment] = &[
     ("> FOCUS   <", false),
     ("n", true),
     ("> NEW   <", false),
+    ("r/l/d/u", true),
+    ("> SPLIT   <", false),
     ("x", true),
     ("> CLOSE   <", false),
     ("Esc", true),
@@ -976,7 +980,7 @@ fn contextual_footer(chord_mode: ChordMode) -> (&'static str, &'static [FooterSe
     match chord_mode {
         ChordMode::None => (CONTROL_HELP, NORMAL_FOOTER),
         ChordMode::Pane => (
-            "Pane  <←↓↑→> FOCUS   <n> NEW   <x> CLOSE   <Esc> BACK",
+            "Pane  <←↓↑→> FOCUS   <n> NEW   <r/l/d/u> SPLIT   <x> CLOSE   <Esc> BACK",
             PANE_FOOTER,
         ),
         ChordMode::Tab => (
@@ -3140,7 +3144,7 @@ mod tests {
         initial_root_pane_grid, is_chord_command, lease_allows_held_input, member_label,
         mouse_to_screen_cell, pane_border_color, pane_title, pane_wire_id,
         reconcile_remote_control_attempt, render_guest_screen, render_multi_pane,
-        render_shared_multi_pane, selection_text, viewed_screen, visible_leaf_panes,
+        render_shared_multi_pane, selection_text, text_width, viewed_screen, visible_leaf_panes,
     };
 
     fn layout(tabs: Vec<Tab>, panes: &[(u64, u16, u16)]) -> LayoutSnapshot {
@@ -3529,11 +3533,11 @@ mod tests {
 
         assert!(copied > quit + "> QUIT".len());
         assert_eq!(
-            terminal.backend().buffer()[(copied as u16, 4)].fg,
+            terminal.backend().buffer()[(text_width(&footer[..copied]), 4)].fg,
             Color::White
         );
         assert_eq!(
-            terminal.backend().buffer()[(count as u16, 4)].fg,
+            terminal.backend().buffer()[(text_width(&footer[..count]), 4)].fg,
             Color::Rgb(255, 69, 0)
         );
     }
@@ -4345,10 +4349,13 @@ mod tests {
         let mut terminal = Terminal::new(TestBackend::new(120, 4)).expect("test terminal");
 
         for (mode, expected) in [
-            (ChordMode::None, "Ctrl+ <p> PANE   <t> TAB   <q> QUIT"),
+            (
+                ChordMode::None,
+                "Ctrl+ <p> PANE   <t> TAB   <Alt+←↓↑→> FOCUS   <q> QUIT",
+            ),
             (
                 ChordMode::Pane,
-                "Pane  <←↓↑→> FOCUS   <n> NEW   <x> CLOSE   <Esc> BACK",
+                "Pane  <←↓↑→> FOCUS   <n> NEW   <r/l/d/u> SPLIT   <x> CLOSE   <Esc> BACK",
             ),
             (
                 ChordMode::Tab,

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -34,11 +34,12 @@ use ratatui::{
 };
 
 use crate::{
-    layout::{Axis, LayoutError, LayoutSnapshot, Node, PaneId, TabId},
+    layout::{Axis, LayoutError, LayoutSnapshot, NewPanePosition, Node, PaneId, TabId},
     lease::{IDLE_AFTER, LeaseDecision, LeaseManager, LeaseState},
     protocol::{
-        CreatePane, CreateTab, DeletePane, DeleteTab, LayoutRequest, PaneDescriptor, PaneFailed,
-        PaneReady, SplitAxis,
+        CreatePane, CreateTab, DeletePane, DeleteTab, LayoutRequest,
+        NewPanePosition as ProtocolNewPanePosition, PaneDescriptor, PaneFailed, PaneReady,
+        SplitAxis,
     },
     pty_host::PtyHost,
     screen::{GuestScreen, HostScreen, SCROLLBACK_LINES, ScreenFrame},
@@ -120,6 +121,7 @@ pub enum UiIntent {
     CreatePane {
         target_pane_id: PaneId,
         axis: Axis,
+        position: NewPanePosition,
         grid_rows: u16,
         grid_cols: u16,
     },
@@ -493,6 +495,15 @@ impl MultiPaneTui {
             self.chord_mode = ChordMode::None;
             return KeyHandling::Consumed(vec![]);
         }
+        if matches!(self.chord_mode, ChordMode::None | ChordMode::Pane)
+            && key.modifiers == KeyModifiers::ALT
+            && matches!(
+                key.code,
+                KeyCode::Left | KeyCode::Right | KeyCode::Up | KeyCode::Down
+            )
+        {
+            return KeyHandling::Consumed(self.move_focus(key.code, area).into_iter().collect());
+        }
         if self.chord_mode == ChordMode::None {
             if key.code == KeyCode::Char('p') && key.modifiers == KeyModifiers::CONTROL {
                 self.chord_mode = ChordMode::Pane;
@@ -531,17 +542,27 @@ impl MultiPaneTui {
         match key.code {
             KeyCode::Char('n') if key.modifiers.is_empty() => {
                 let rect = self.geometry(area).panes.get(&self.focused_pane).copied()?;
-                let (grid_rows, grid_cols) = grid_for_pane(rect);
-                Some(UiIntent::CreatePane {
-                    target_pane_id: self.focused_pane,
-                    axis: if rect.width > rect.height {
+                self.create_pane(
+                    if rect.width > rect.height {
                         Axis::LeftRight
                     } else {
                         Axis::TopBottom
                     },
-                    grid_rows,
-                    grid_cols,
-                })
+                    NewPanePosition::Second,
+                    area,
+                )
+            }
+            KeyCode::Char('r') if key.modifiers.is_empty() => {
+                self.create_pane(Axis::LeftRight, NewPanePosition::Second, area)
+            }
+            KeyCode::Char('l') if key.modifiers.is_empty() => {
+                self.create_pane(Axis::LeftRight, NewPanePosition::First, area)
+            }
+            KeyCode::Char('d') if key.modifiers.is_empty() => {
+                self.create_pane(Axis::TopBottom, NewPanePosition::Second, area)
+            }
+            KeyCode::Char('u') if key.modifiers.is_empty() => {
+                self.create_pane(Axis::TopBottom, NewPanePosition::First, area)
             }
             KeyCode::Char('x') if key.modifiers.is_empty() => Some(UiIntent::DeletePane {
                 pane_id: self.focused_pane,
@@ -553,6 +574,18 @@ impl MultiPaneTui {
             }
             _ => None,
         }
+    }
+
+    fn create_pane(&self, axis: Axis, position: NewPanePosition, area: Rect) -> Option<UiIntent> {
+        let rect = self.geometry(area).panes.get(&self.focused_pane).copied()?;
+        let (grid_rows, grid_cols) = grid_for_pane(rect);
+        Some(UiIntent::CreatePane {
+            target_pane_id: self.focused_pane,
+            axis,
+            position,
+            grid_rows,
+            grid_cols,
+        })
     }
 
     fn handle_tab_chord(&mut self, key: KeyEvent, area: Rect) -> Option<UiIntent> {
@@ -653,6 +686,10 @@ fn is_chord_command(mode: ChordMode, key: KeyEvent) -> bool {
         ChordMode::Pane => matches!(
             key.code,
             KeyCode::Char('n')
+                | KeyCode::Char('r')
+                | KeyCode::Char('l')
+                | KeyCode::Char('d')
+                | KeyCode::Char('u')
                 | KeyCode::Char('x')
                 | KeyCode::Left
                 | KeyCode::Right
@@ -2124,10 +2161,11 @@ impl SharedLayoutRuntime {
             UiIntent::CreatePane {
                 target_pane_id,
                 axis,
+                position,
                 grid_rows,
                 grid_cols,
             } => {
-                self.begin_create(Some((target_pane_id, axis)), grid_rows, grid_cols)?;
+                self.begin_create(Some((target_pane_id, axis, position)), grid_rows, grid_cols)?;
             }
             UiIntent::CreateTab {
                 grid_rows,
@@ -2164,7 +2202,7 @@ impl SharedLayoutRuntime {
 
     fn begin_create(
         &mut self,
-        pane: Option<(PaneId, Axis)>,
+        pane: Option<(PaneId, Axis, NewPanePosition)>,
         grid_rows: u16,
         grid_cols: u16,
     ) -> Result<(), Box<dyn Error>> {
@@ -2183,7 +2221,7 @@ impl SharedLayoutRuntime {
         self.send_request(LayoutRequest {
             request_id,
             base_revision,
-            create_pane: pane.map(|(target_pane_id, axis)| CreatePane {
+            create_pane: pane.map(|(target_pane_id, axis, position)| CreatePane {
                 target_pane_id,
                 axis: Some(match axis {
                     Axis::LeftRight => SplitAxis::LeftRight as i32,
@@ -2191,7 +2229,10 @@ impl SharedLayoutRuntime {
                 }),
                 grid_rows: u32::from(grid_rows),
                 grid_cols: u32::from(grid_cols),
-                position: None,
+                position: Some(match position {
+                    NewPanePosition::First => ProtocolNewPanePosition::First as i32,
+                    NewPanePosition::Second => ProtocolNewPanePosition::Second as i32,
+                }),
             }),
             delete_pane: None,
             create_tab: pane.is_none().then_some(CreateTab {
@@ -3081,7 +3122,7 @@ mod tests {
         style::{Color, Modifier},
     };
 
-    use crate::layout::{Axis, LayoutSnapshot, Node, Pane, Tab};
+    use crate::layout::{Axis, LayoutSnapshot, NewPanePosition, Node, Pane, Tab};
     use crate::lease::{IDLE_AFTER, LeaseManager, LeaseState};
     use crate::screen::{GuestScreen, HostScreen};
     use crate::{
@@ -3096,10 +3137,10 @@ mod tests {
         LayoutControlEvent, MultiPaneTui, PaneTextSelection, PaneViewState,
         RemoteSubscriptionState, ScreenCell, SharedLayoutRuntime, SharedLocalPane, UiIntent,
         VtScreen, contextual_footer, copied_line_count, encode_key, encode_paste, grid_for_pane,
-        initial_root_pane_grid, lease_allows_held_input, member_label, mouse_to_screen_cell,
-        pane_border_color, pane_title, pane_wire_id, reconcile_remote_control_attempt,
-        render_guest_screen, render_multi_pane, render_shared_multi_pane, selection_text,
-        viewed_screen, visible_leaf_panes,
+        initial_root_pane_grid, is_chord_command, lease_allows_held_input, member_label,
+        mouse_to_screen_cell, pane_border_color, pane_title, pane_wire_id,
+        reconcile_remote_control_attempt, render_guest_screen, render_multi_pane,
+        render_shared_multi_pane, selection_text, viewed_screen, visible_leaf_panes,
     };
 
     fn layout(tabs: Vec<Tab>, panes: &[(u64, u16, u16)]) -> LayoutSnapshot {
@@ -3207,6 +3248,7 @@ mod tests {
             .handle_intent(UiIntent::CreatePane {
                 target_pane_id: 1,
                 axis: Axis::LeftRight,
+                position: NewPanePosition::Second,
                 grid_rows: 2,
                 grid_cols: 8,
             })
@@ -4138,6 +4180,7 @@ mod tests {
             KeyHandling::Consumed(vec![UiIntent::CreatePane {
                 target_pane_id: 1,
                 axis: Axis::LeftRight,
+                position: NewPanePosition::Second,
                 grid_rows: 20,
                 grid_cols: 38,
             }])
@@ -4153,6 +4196,73 @@ mod tests {
             KeyHandling::Consumed(vec![UiIntent::FocusPane { pane_id: 2 }])
         );
         assert_eq!(tui.focused_pane(), 2);
+    }
+
+    #[test]
+    fn option_arrows_focus_in_normal_and_pane_modes_without_forwarding_at_edges() {
+        let mut tui = MultiPaneTui::new(split_layout()).expect("valid layout");
+        let area = Rect::new(0, 0, 80, 24);
+
+        assert_eq!(
+            tui.handle_key(KeyEvent::new(KeyCode::Right, KeyModifiers::ALT), area),
+            KeyHandling::Consumed(vec![UiIntent::FocusPane { pane_id: 2 }])
+        );
+        assert_eq!(tui.chord_mode(), ChordMode::None);
+        assert_eq!(
+            tui.handle_key(KeyEvent::new(KeyCode::Right, KeyModifiers::ALT), area),
+            KeyHandling::Consumed(vec![]),
+            "an edge Option-arrow is still consumed"
+        );
+
+        let _ = tui.handle_key(
+            KeyEvent::new(KeyCode::Char('p'), KeyModifiers::CONTROL),
+            area,
+        );
+        assert_eq!(
+            tui.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::ALT), area),
+            KeyHandling::Consumed(vec![UiIntent::FocusPane { pane_id: 3 }])
+        );
+        assert_eq!(tui.chord_mode(), ChordMode::Pane);
+    }
+
+    #[test]
+    fn pane_chord_directional_splits_select_axis_and_child_position() {
+        let area = Rect::new(0, 0, 80, 24);
+        for (key, axis, position) in [
+            ('r', Axis::LeftRight, NewPanePosition::Second),
+            ('l', Axis::LeftRight, NewPanePosition::First),
+            ('d', Axis::TopBottom, NewPanePosition::Second),
+            ('u', Axis::TopBottom, NewPanePosition::First),
+        ] {
+            let mut tui = MultiPaneTui::new(split_layout()).expect("valid layout");
+            let _ = tui.handle_key(
+                KeyEvent::new(KeyCode::Char('p'), KeyModifiers::CONTROL),
+                area,
+            );
+            assert_eq!(
+                tui.handle_key(KeyEvent::new(KeyCode::Char(key), KeyModifiers::NONE), area),
+                KeyHandling::Consumed(vec![UiIntent::CreatePane {
+                    target_pane_id: 1,
+                    axis,
+                    position,
+                    grid_rows: 20,
+                    grid_cols: 38,
+                }]),
+                "key: {key}"
+            );
+            assert_eq!(tui.focused_pane(), 1, "key: {key}");
+            assert_eq!(tui.chord_mode(), ChordMode::Pane, "key: {key}");
+        }
+    }
+
+    #[test]
+    fn directional_split_keys_are_sticky_pane_commands_even_without_an_intent() {
+        for key in ['r', 'l', 'd', 'u'] {
+            assert!(is_chord_command(
+                ChordMode::Pane,
+                KeyEvent::new(KeyCode::Char(key), KeyModifiers::NONE)
+            ));
+        }
     }
 
     #[test]
@@ -4401,6 +4511,7 @@ mod tests {
             KeyHandling::Consumed(vec![UiIntent::CreatePane {
                 target_pane_id: 1,
                 axis: Axis::TopBottom,
+                position: NewPanePosition::Second,
                 grid_rows: 10,
                 grid_cols: 10,
             }])
@@ -4449,6 +4560,7 @@ mod tests {
             KeyHandling::Consumed(vec![UiIntent::CreatePane {
                 target_pane_id: 1,
                 axis: Axis::TopBottom,
+                position: NewPanePosition::Second,
                 grid_rows: 36,
                 grid_cols: 18,
             }])

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -2191,6 +2191,7 @@ impl SharedLayoutRuntime {
                 }),
                 grid_rows: u32::from(grid_rows),
                 grid_cols: u32::from(grid_cols),
+                position: None,
             }),
             delete_pane: None,
             create_tab: pane.is_none().then_some(CreateTab {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -440,10 +440,7 @@ impl MultiPaneTui {
             area.width,
             footer_height,
         );
-        let tab_bar_gap = area
-            .height
-            .saturating_sub(tab_bar.height + footer_height)
-            .min(0);
+        let tab_bar_gap = 0;
         let content = Rect::new(
             area.x,
             area.y.saturating_add(tab_bar.height + tab_bar_gap),

--- a/tests/layout.rs
+++ b/tests/layout.rs
@@ -1,6 +1,6 @@
 use p2pmux::layout::{
     Axis, LayoutError, LayoutSnapshot, MAX_ENDPOINT_ADDR_BYTES, MAX_MEMBERS, MAX_PANES_PER_TAB,
-    MAX_PEER_ID_BYTES, MAX_TABS, Node, ReservationCommit, SessionState,
+    MAX_PEER_ID_BYTES, MAX_TABS, NewPanePosition, Node, ReservationCommit, SessionState,
 };
 
 const HOST_A: &[u8] = b"host-a";
@@ -144,6 +144,42 @@ fn creating_panes_uses_the_requested_split_axis() {
 }
 
 #[test]
+fn creating_panes_honors_first_or_second_placement_and_defaults_to_second() {
+    let mut state = state();
+    let second_pane = state
+        .create_pane(HOST_A, state.revision(), 1, Axis::LeftRight, 24, 80)
+        .expect("default second split");
+    assert!(matches!(
+        snapshot(&state).tabs[0].root,
+        Node::Split { ref first, ref second, .. }
+            if matches!(first.as_ref(), Node::Leaf { pane_id: 1 })
+                && matches!(second.as_ref(), Node::Leaf { pane_id } if *pane_id == second_pane)
+    ));
+
+    let first = state
+        .create_pane_at(
+            HOST_A,
+            state.revision(),
+            second_pane,
+            Axis::TopBottom,
+            NewPanePosition::First,
+            24,
+            80,
+        )
+        .expect("first split");
+    assert!(matches!(
+        snapshot(&state).tabs[0].root,
+        Node::Split { second: ref right_split, .. }
+            if matches!(
+                right_split.as_ref(),
+                Node::Split { first: child_first, second: child_second, .. }
+                    if matches!(child_first.as_ref(), Node::Leaf { pane_id } if *pane_id == first)
+                        && matches!(child_second.as_ref(), Node::Leaf { pane_id } if *pane_id == second_pane)
+            )
+    ));
+}
+
+#[test]
 fn deleting_a_pane_expands_its_sibling() {
     let mut state = state();
     let sibling = state
@@ -211,22 +247,36 @@ fn membership_tab_pane_and_depth_limits_are_enforced() {
     let mut leaf = 1;
     for _ in 0..4 {
         leaf = depth_state
-            .create_pane(
+            .create_pane_at(
                 HOST_A,
                 depth_state.revision(),
                 leaf,
                 Axis::TopBottom,
+                NewPanePosition::Second,
                 24,
                 80,
             )
             .expect("within depth limit");
     }
     assert_eq!(
-        depth_state.create_pane(
+        depth_state.create_pane_at(
             HOST_A,
             depth_state.revision(),
             leaf,
             Axis::TopBottom,
+            NewPanePosition::First,
+            24,
+            80
+        ),
+        Err(LayoutError::SplitDepthLimit)
+    );
+    assert_eq!(
+        depth_state.create_pane_at(
+            HOST_A,
+            depth_state.revision(),
+            leaf,
+            Axis::TopBottom,
+            NewPanePosition::Second,
             24,
             80
         ),

--- a/tests/module_surface.rs
+++ b/tests/module_surface.rs
@@ -17,5 +17,5 @@ fn exposes_the_scaffold_module_boundaries() {
     let _: Option<JoinTicket> = None;
     let _: Option<HostSession> = None;
     let _: Option<Envelope> = None;
-    assert_eq!(PROTOCOL_VERSION, 2);
+    assert_eq!(PROTOCOL_VERSION, 3);
 }

--- a/tests/protocol.rs
+++ b/tests/protocol.rs
@@ -3,9 +3,9 @@ use p2pmux::protocol::{
     LayoutCommit, LayoutNode, LayoutReject, LayoutRejectReason, LayoutRequest, LayoutSplit,
     LayoutState, MAX_DELTA_BYTES, MAX_ENDPOINT_ADDR_BYTES, MAX_ENVELOPE_BYTES, MAX_FRAME_BYTES,
     MAX_INPUT_BYTES, MAX_PANE_ID_BYTES, MAX_PEER_ID_BYTES, MAX_SESSION_ID_BYTES,
-    MAX_SNAPSHOT_BYTES, MemberDescriptor, PROTOCOL_VERSION, PaneDescriptor, PaneFailed, PaneReady,
-    PaneReservation, PaneSubscribe, ProtocolError, SessionSnapshot, Snapshot, SplitAxis,
-    TabDescriptor, TakeControl, Welcome, decode_frame, encode_frame, envelope,
+    MAX_SNAPSHOT_BYTES, MemberDescriptor, NewPanePosition, PROTOCOL_VERSION, PaneDescriptor,
+    PaneFailed, PaneReady, PaneReservation, PaneSubscribe, ProtocolError, SessionSnapshot,
+    Snapshot, SplitAxis, TabDescriptor, TakeControl, Welcome, decode_frame, encode_frame, envelope,
 };
 use prost::Message;
 
@@ -25,8 +25,8 @@ fn envelope(body: envelope::Body) -> Envelope {
 }
 
 #[test]
-fn protocol_version_is_v2() {
-    assert_eq!(PROTOCOL_VERSION, 2);
+fn protocol_version_is_v3() {
+    assert_eq!(PROTOCOL_VERSION, 3);
 }
 
 #[test]
@@ -249,6 +249,7 @@ fn v2_envelopes() -> Vec<Envelope> {
                 axis: Some(SplitAxis::LeftRight as i32),
                 grid_rows: 24,
                 grid_cols: 80,
+                position: None,
             }),
             delete_pane: None,
             create_tab: None,
@@ -342,6 +343,7 @@ fn layout_messages_reject_invalid_shapes_and_bounds() {
             axis: Some(SplitAxis::LeftRight as i32),
             grid_rows: 24,
             grid_cols: 80,
+            position: None,
         }),
         delete_pane: Some(DeletePane { pane_id: 1 }),
         ..empty_action.clone()
@@ -526,8 +528,8 @@ fn join_endpoint_and_reservation_lifecycle_identifiers_are_required() {
 }
 
 #[test]
-fn create_and_split_axes_must_be_explicitly_present_and_valid() {
-    fn create_request(axis: Option<i32>) -> Envelope {
+fn create_pane_axis_and_position_are_validated() {
+    fn create_request(axis: Option<i32>, position: Option<i32>) -> Envelope {
         envelope(envelope::Body::LayoutRequest(LayoutRequest {
             request_id: 1,
             base_revision: 1,
@@ -536,6 +538,7 @@ fn create_and_split_axes_must_be_explicitly_present_and_valid() {
                 axis,
                 grid_rows: 24,
                 grid_cols: 80,
+                position,
             }),
             delete_pane: None,
             create_tab: None,
@@ -578,14 +581,15 @@ fn create_and_split_axes_must_be_explicitly_present_and_valid() {
     }
 
     for invalid in [
-        create_request(None),
-        create_request(Some(99)),
+        create_request(None, None),
+        create_request(Some(99), None),
+        create_request(Some(SplitAxis::LeftRight as i32), Some(99)),
         split_snapshot(None),
         split_snapshot(Some(99)),
     ] {
         assert!(
             encode_frame(&invalid).is_err(),
-            "layout axes must not silently default to LeftRight"
+            "layout axes and placement must be valid"
         );
         let mut raw = Vec::new();
         invalid
@@ -593,6 +597,34 @@ fn create_and_split_axes_must_be_explicitly_present_and_valid() {
             .expect("raw invalid frame should encode");
         assert!(decode_frame(&raw).is_err());
     }
+}
+
+#[test]
+fn create_pane_position_has_a_stable_new_wire_tag_and_defaults_to_second() {
+    let default = CreatePane {
+        target_pane_id: 1,
+        axis: Some(SplitAxis::LeftRight as i32),
+        grid_rows: 24,
+        grid_cols: 80,
+        position: None,
+    };
+    assert_eq!(
+        field_shape(&parse_fields(&default.encode_to_vec())),
+        vec![(1, 0), (2, 0), (3, 0), (4, 0)]
+    );
+
+    let first = CreatePane {
+        position: Some(NewPanePosition::First as i32),
+        ..default.clone()
+    };
+    assert_eq!(
+        field_shape(&parse_fields(&first.encode_to_vec())),
+        vec![(1, 0), (2, 0), (3, 0), (4, 0), (5, 0)]
+    );
+    assert_eq!(
+        CreatePane::decode(first.encode_to_vec().as_slice()).unwrap(),
+        first
+    );
 }
 
 #[test]
@@ -616,6 +648,7 @@ fn layout_grids_must_fit_the_reducer_u16_grid() {
                 axis: Some(SplitAxis::LeftRight as i32),
                 grid_rows: maximum,
                 grid_cols: maximum,
+                position: None,
             }),
             ..empty_action.clone()
         })),
@@ -650,6 +683,7 @@ fn layout_grids_must_fit_the_reducer_u16_grid() {
                 axis: Some(SplitAxis::LeftRight as i32),
                 grid_rows: oversized,
                 grid_cols: 80,
+                position: None,
             }),
             ..empty_action.clone()
         })),
@@ -659,6 +693,7 @@ fn layout_grids_must_fit_the_reducer_u16_grid() {
                 axis: Some(SplitAxis::LeftRight as i32),
                 grid_rows: 24,
                 grid_cols: oversized,
+                position: None,
             }),
             ..empty_action.clone()
         })),

--- a/tests/session_layout.rs
+++ b/tests/session_layout.rs
@@ -2,7 +2,7 @@ use iroh::{EndpointAddr, SecretKey};
 use p2pmux::{
     protocol::{
         CreatePane, CreateTab, DeletePane, DeleteTab, LayoutCommit, LayoutRejectReason,
-        LayoutRequest, PaneFailed, PaneReady, SplitAxis,
+        LayoutRequest, NewPanePosition, PaneFailed, PaneReady, SplitAxis,
     },
     session::{CoordinatorError, CoordinatorResponse, LayoutCoordinator},
 };
@@ -105,6 +105,7 @@ fn pane_creation_is_hidden_until_its_creator_marks_the_reservation_ready() {
         axis: Some(SplitAxis::LeftRight as i32),
         grid_rows: 30,
         grid_cols: 100,
+        position: None,
     });
 
     let reservation = match coordinator.handle_request(&host_a(), create) {
@@ -141,6 +142,46 @@ fn pane_creation_is_hidden_until_its_creator_marks_the_reservation_ready() {
 }
 
 #[test]
+fn pane_creation_maps_protocol_placement_to_authoritative_child_order() {
+    let mut coordinator = coordinator();
+    let mut create = request(15, 1);
+    create.create_pane = Some(CreatePane {
+        target_pane_id: 1,
+        axis: Some(SplitAxis::LeftRight as i32),
+        grid_rows: 24,
+        grid_cols: 80,
+        position: Some(NewPanePosition::First as i32),
+    });
+    let reservation = match coordinator.handle_request(&host_a(), create) {
+        CoordinatorResponse::Reservation(reservation) => reservation,
+        other => panic!("expected reservation, got {other:?}"),
+    };
+
+    let state = commit(coordinator.handle_pane_ready(
+        &host_a(),
+        PaneReady {
+            reservation_id: reservation.reservation_id,
+            base_revision: 1,
+            request_id: 15,
+        },
+    ))
+    .state
+    .expect("state present");
+    let split = state.tabs[0]
+        .root
+        .as_ref()
+        .expect("root present")
+        .split
+        .as_ref();
+    let split = split.expect("split present");
+    assert_eq!(
+        split.first.as_ref().unwrap().leaf_pane_id,
+        Some(reservation.pane_id)
+    );
+    assert_eq!(split.second.as_ref().unwrap().leaf_pane_id, Some(1));
+}
+
+#[test]
 fn ready_cannot_commit_a_reservation_after_membership_advances_its_revision() {
     let mut coordinator = coordinator();
     let mut create = request(101, 1);
@@ -149,6 +190,7 @@ fn ready_cannot_commit_a_reservation_after_membership_advances_its_revision() {
         axis: Some(SplitAxis::LeftRight as i32),
         grid_rows: 30,
         grid_cols: 100,
+        position: None,
     });
     let reservation = match coordinator.handle_request(&host_a(), create) {
         CoordinatorResponse::Reservation(reservation) => reservation,
@@ -200,6 +242,7 @@ fn admitted_guest_hosts_its_own_pane_after_ready() {
         axis: Some(SplitAxis::TopBottom as i32),
         grid_rows: 31,
         grid_cols: 101,
+        position: None,
     });
     let reservation = match coordinator.handle_request(&host_b(), create) {
         CoordinatorResponse::Reservation(reservation) => reservation,
@@ -270,6 +313,7 @@ fn mixed_host_tab_deletion_is_rejected() {
         axis: Some(SplitAxis::LeftRight as i32),
         grid_rows: 24,
         grid_cols: 80,
+        position: None,
     });
     let reservation = match coordinator.handle_request(&host_b(), create) {
         CoordinatorResponse::Reservation(reservation) => reservation,

--- a/tests/session_layout_control.rs
+++ b/tests/session_layout_control.rs
@@ -79,6 +79,7 @@ fn create_request(request_id: u64, base_revision: u64) -> LayoutRequest {
             axis: Some(SplitAxis::LeftRight as i32),
             grid_rows: 24,
             grid_cols: 80,
+            position: None,
         }),
         delete_pane: None,
         create_tab: None,


### PR DESCRIPTION
## Summary
- Add Option/Alt+arrow focus between panes in the current tab (normal and pane modes); keys are always consumed and never forwarded to the PTY
- Extend sticky Ctrl+P with `r`/`l`/`d`/`u` directional splits (keep `n`); plumb authoritative `NewPanePosition` through layout/session/protocol and bump `PROTOCOL_VERSION` to 3
- Update normal/pane footers and README; max split depth remains 4

## Test plan
- [ ] `cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test`
- [ ] Option+←/→/↑/↓ moves focus across panes without Ctrl+P; edge presses do not type into the PTY
- [ ] Ctrl+P then `n` still creates with aspect-ratio axis; `r`/`l`/`d`/`u` create on the correct side of the focused pane
- [ ] Nested splits reject past depth 4
- [ ] Footers show Alt+arrows (normal) and `r/l/d/u` (pane mode)
- [ ] Mixed old/new peers fail on protocol version mismatch (v3)


Made with [Cursor](https://cursor.com)