### PR TITLE
feat: Option+Shift+drag pane resize with host PTY reflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ Processes and credential *files* stay on the pane host’s Mac (not uploaded to 
 ## Status
 
 Spike 3 provides a localhost shared layout for up to eight members. The coordinator owns a
-revisioned tab/split tree; every pane is a fixed-grid PTY owned by the member that created it.
+revisioned tab/split tree, including authoritative split ratios. Every pane is a PTY owned by
+the member that created it, and its host publishes the absolute grid for that host's window.
 Each process serves its own locally hosted panes directly to the other admitted members.
 
 This is still a dogfooding spike: relay/internet validation, disconnect grace, coordinator
-failover, presence, and dynamic resize remain later work. The protocol deliberately has no
-resize message: each pane grid is fixed when that pane is created and is letterboxed or clipped
-by smaller local rectangles.
+failover and presence remain later work. Shared ratios are portable while absolute pane grids are
+host-owned: guests consume the host's resized screen stream and never resize a remote PTY.
 
 ## Local Spike 1
 
@@ -93,12 +93,14 @@ inside Zellij, Zellij may swallow mouse events; try Zellij with mouse mode disab
 passthrough configuration.
 
 Drag inside a pane's terminal content to select text; releasing the mouse copies it to the macOS
-clipboard.
+clipboard. `Option+Shift+drag` inside pane content resizes the nearest matching split. It locks to
+one axis after a short motion threshold, previews locally, and commits one shared ratio on release.
+The affected pane hosts then resize their own PTY and VT screen and publish their local grids.
 
 - `Option+` `<shift>` + arrows — move focus to the nearest pane in that direction in the current
   tab. Some terminals need Shift with Option for horizontal arrows.
-- `Ctrl+P`, then `n` — split the focused pane using its current aspect-ratio axis. The new
-  fixed-grid PTY runs on the requester’s Mac.
+- `Ctrl+P`, then `n` — split the focused pane using its current aspect-ratio axis. The new PTY
+  runs on the requester’s Mac.
 - `Ctrl+P`, then `r` / `l` / `d` / `u` — create the new pane right / left / down / up of the
   focused pane.
 - `Ctrl+P`, then `X` — delete the focused pane. Only that pane’s host may delete it.
@@ -108,7 +110,7 @@ clipboard.
 - `Ctrl+T`, then left/right — switch tabs.
 
 The final pane in a tab must be removed by deleting its tab; the final tab cannot be deleted.
-Nested 50/50 splits are part of Spike 3 (depth 4, at most 8 panes per tab, at most 9 tabs). Each
+Nested ratio-controlled splits are part of Spike 3 (depth 4, at most 8 panes per tab, at most 9 tabs). Each
 pane title shows `Pane #N host: <name> control: free|<name>|…`; free focused panes use a white
 border and actively controlled panes use red-orange. Click tab labels to switch tabs without
 claiming control or sending input. Mouse wheel scrolls pane history locally. The dark contextual footer uses red key accents: normal mode is
@@ -117,7 +119,8 @@ claiming control or sending input. Mouse wheel scrolls pane history locally. The
 `Tab  <←→> SWITCH   <n> NEW   <x> CLOSE   <Esc> BACK`.
 
 Slow viewers may receive coalesced screen deltas and then a fresh snapshot to recover. Resizing an
-outer terminal crops or letterboxes the immutable host grid; it never resizes the host PTY.
+outer terminal reflows locally hosted panes: the host resizes its PTY and VT screen and commits any
+changed host-owned grids. Guests only receive the resulting commit and screen snapshot.
 
 Full product/architecture docs live in [`docs/`](./docs/).
 

--- a/docs/superpowers/plans/2026-07-26-option-shift-drag-resize.md
+++ b/docs/superpowers/plans/2026-07-26-option-shift-drag-resize.md
@@ -1,0 +1,316 @@
+# Option+Shift drag pane resize with host PTY reflow Implementation Plan
+
+**Goal:** Add an Option/Alt+Shift drag resize gesture whose ratio is shared and
+revisioned, then reflow real hosted PTYs, VT screens, and published pane grids
+after a ratio or outer-window change.
+
+**Architecture:** Persist `first_share_bps` on each split and make allocation
+ratio-aware with recursive local minima. A drag holds an overlay in
+`MultiPaneTui` and sends one `SetSplitRatio` request on release. The
+coordinator authorizes that ratio mutation for any admitted member. Each pane
+host then derives grids from its own local chrome, resizes only its own
+`PtyHost`/`HostScreen`, and publishes those grids through a host-only,
+revisioned `UpdatePaneGrids` request. A guest only consumes the resulting
+layout and screen stream.
+
+**Tech Stack:** Rust, ratatui, crossterm mouse events, portable-pty, vt100,
+prost, existing revision/reservation coordinator.
+
+**Spec:** `docs/superpowers/specs/2026-07-26-option-shift-drag-resize-design.md`
+
+## File map
+
+| File | Responsibility |
+|---|---|
+| `src/layout.rs` | Split ratio model, validation, nearest-ancestor mutation, hosted grid mutation |
+| `src/protocol.rs` | v4 ratio/grid request fields, `LayoutSplit` ratio wire field, validation |
+| `src/session.rs` | Coordinator dispatch, protocol/model conversions, host-grid authority |
+| `src/tui.rs` | Ratio-aware geometry, drag overlay, event dispatch, runtime PTY reflow and grid requests |
+| `src/pty_host.rs` | Portable-pty master resize wrapper |
+| `src/screen.rs` | vt100 resize and forced full snapshot publication |
+| `tests/layout.rs` | Ratio state, rewrite, revision, and grid ownership tests |
+| `tests/protocol.rs` | v4 wire shape/default/validation tests |
+| `tests/session_layout.rs` | Coordinator ratio/grid request authorization and race tests |
+| `tests/session_layout_control.rs` | v4 layout-control transport coverage |
+| `tests/pty_host.rs` | Real `MasterPty::resize` smoke coverage |
+| `tests/screen.rs` | Resized screen snapshot and guest replacement coverage |
+| `README.md` | Dynamic-grid interaction and behavior documentation |
+
+## Tasks
+
+### Task 1: Commit the design and execution plan
+
+- [ ] Add the normative design and this checkbox plan at the exact paths below.
+- [ ] Confirm no application source, test, or README changes are staged.
+- [ ] Commit:
+
+```bash
+git add docs/superpowers/specs/2026-07-26-option-shift-drag-resize-design.md docs/superpowers/plans/2026-07-26-option-shift-drag-resize.md
+git commit -m "docs: plan Option+Shift+drag pane resize with PTY resize"
+```
+
+### Task 2: Add authoritative split ratios and host grid mutation to the pure layout model
+
+**Files:** `src/layout.rs`, `tests/layout.rs`
+
+- [ ] Write failing `tests/layout.rs` cases for a new split defaulting to
+  `first_share_bps: 5000`; snapshot validation rejecting 0 and 10000; a
+  `SetSplitRatio`-equivalent model method choosing the nearest matching
+  ancestor for `(pane_id, axis)`; and `UnknownPane`/no-matching-axis,
+  stale-revision, non-member, and pending-reservation failures.
+- [ ] Write failing preservation cases: nested split ratios survive a pane
+  delete that retains the split and member-removal rewrites, while a newly
+  created split starts at 5000.
+- [ ] Add failing grid-update cases proving one admitted host may update only
+  its own nonempty, duplicate-free valid pane-grid batch, the revision advances
+  once, and invalid/non-host/stale/frozen batches leave the snapshot unchanged.
+- [ ] Implement `Node::Split { axis, first_share_bps, first, second }`, ratio
+  constants/validation, recursive nearest-ancestor lookup, strict
+  `SessionState::set_split_ratio`, and strict host-only
+  `SessionState::update_pane_grids`. Carry the ratio through every tree rebuild
+  (`replace_leaf`, `remove_leaf`, and member-removal paths) without silently
+  changing it.
+- [ ] Run focused tests:
+
+```bash
+cargo test --test layout
+```
+
+- [ ] Commit:
+
+```bash
+git add src/layout.rs tests/layout.rs
+git commit -m "feat: store revisioned split ratios and hosted pane grids"
+```
+
+### Task 3: Define and validate the v4 wire contract
+
+**Files:** `src/protocol.rs`, `tests/protocol.rs`
+
+- [ ] First add failing protocol tests asserting `PROTOCOL_VERSION == 4`, the
+  exact new `LayoutSplit.first_share_bps` field/tag, absent-ratio decoding to
+  5000 through the session conversion boundary, and rejection of explicit 0,
+  10000, unknown axis, and malformed ratio requests.
+- [ ] Add failing wire/validation tests that `LayoutRequest` still accepts
+  exactly one action and carries `SetSplitRatio { pane_id, axis,
+  first_share_bps }` plus `UpdatePaneGrids { panes }`; require a nonempty,
+  duplicate-free valid grid batch and preserve existing request fields/tags.
+- [ ] Bump the version 3 → 4 and add new, non-conflicting protobuf tags and
+  message types. Validate the optional split field as default-5000 when absent
+  and as `1..=9999` when present. Validate both new request actions before any
+  session code sees them.
+- [ ] Run focused tests:
+
+```bash
+cargo test --test protocol
+```
+
+- [ ] Commit:
+
+```bash
+git add src/protocol.rs tests/protocol.rs
+git commit -m "feat: add v4 split ratio and pane grid protocol"
+```
+
+### Task 4: Route ratio and grid requests through the coordinator and control transport
+
+**Files:** `src/session.rs`, `tests/session_layout.rs`, `tests/session_layout_control.rs`
+
+- [ ] Add failing coordinator tests for an admitted non-host successfully
+  setting a ratio; first-commit-wins stale rejection; no matching ancestor;
+  invalid ratio; and a pending pane reservation freezing ratio mutation.
+- [ ] Add failing grid reconciliation tests for host-only batch admission,
+  strict stale behavior, reservation freeze, atomic rejection when one entry is
+  invalid/not hosted, full `LayoutCommit` pane metadata, and two hosts settling
+  by rebasing the loser on the later revision.
+- [ ] Add an async control-stream test that serializes/deserializes both v4
+  request actions and delivers their commits/rejections to a member.
+- [ ] Extend action counting/dispatch, request conversion, reject mapping, and
+  `protocol_node` / `layout_node_from_protocol` to preserve ratios. Reuse the
+  existing revision and reservation checks; do not create a second authority
+  path or a client-side ratio retry.
+- [ ] Run focused tests:
+
+```bash
+cargo test --test session_layout
+cargo test --test session_layout_control
+```
+
+- [ ] Commit:
+
+```bash
+git add src/session.rs tests/session_layout.rs tests/session_layout_control.rs
+git commit -m "feat: coordinate shared ratios and host grid updates"
+```
+
+### Task 5: Make the real PTY and VT host screen resizable
+
+**Files:** `src/pty_host.rs`, `src/screen.rs`, `tests/pty_host.rs`, `tests/screen.rs`
+
+- [ ] Add failing `tests/pty_host.rs` coverage that spawns the existing shell
+  fixture, calls `PtyHost::resize(PtySize)`, then keeps its reader/writer alive
+  and exits cleanly. Keep the test macOS-compatible and bounded by the current
+  timeout pattern.
+- [ ] Add failing `tests/screen.rs` coverage that `HostScreen::resize(rows,
+  cols)` changes its vt100 dimensions, advances sequence, emits a complete
+  snapshot that replaces a guest's old-size parser, and cannot be sent as a
+  delta based on the old grid.
+- [ ] Implement `PtyHost::resize` by retaining and resizing its
+  `MasterPty`. Implement `HostScreen::resize` with dimension validation,
+  vt100 parser resizing, a refreshed `previous` screen, and a frame whose
+  `base_sequence` forces existing stream selection to choose a snapshot.
+- [ ] Run focused tests:
+
+```bash
+cargo test --test pty_host
+cargo test --test screen
+```
+
+- [ ] Commit:
+
+```bash
+git add src/pty_host.rs src/screen.rs tests/pty_host.rs tests/screen.rs
+git commit -m "feat: resize hosted PTYs and vt100 screens"
+```
+
+### Task 6: Make layout geometry ratio-aware and minimum-safe
+
+**Files:** `src/tui.rs`
+
+- [ ] Add failing `src/tui.rs` unit tests for 5000 compatibility with current
+  equal allocation; non-50/50 left/right and top/bottom allocation; nested
+  recursive 3×3 outer minima; and deterministic safe allocation when the local
+  area cannot meet those minima.
+- [ ] Add tests for a geometry override that changes only rendered rectangles,
+  leaves `MultiPaneTui::snapshot()` byte-for-byte/equality unchanged, and is
+  used consistently by pane-content/grid calculations.
+- [ ] Replace `allocate_node`'s `/ 2` split with the documented integer
+  basis-point allocation and recursive minimum calculation. Add a pure
+  override mechanism keyed to the locally located split for drag rendering;
+  do not mutate `LayoutSnapshot`.
+- [ ] Run focused TUI unit tests while iterating:
+
+```bash
+cargo test tui::tests
+```
+
+- [ ] Commit:
+
+```bash
+git add src/tui.rs
+git commit -m "feat: allocate shared panes by ratio with local minima"
+```
+
+### Task 7: Add captured-modifier drag handling, overlay, and ratio intent
+
+**Files:** `src/tui.rs`
+
+- [ ] Write failing pure-TUI tests for: plain left drag retaining text
+  selection; Alt+Shift down in a content rect starting a pending resize without
+  selection; modifier loss on later drag/up not cancelling it; two-cell axis
+  lock (including horizontal tie); nearest matching ancestor resolution; sign
+  correctness for first versus second child; no-match consume/cancel; and one
+  release intent using the mouse-down revision.
+- [ ] Add tests that a newer authoritative layout application and a stale
+  request rejection clear an active overlay, and that no request is emitted for
+  below-threshold or unchanged drags.
+- [ ] Add `UiIntent::SetSplitRatio`, a private captured resize-drag state, and
+  mouse helpers on `MultiPaneTui`. In `SharedLayoutRuntime::run`, dispatch
+  modifier left down/drag/up to that state before selection handling. Capture
+  modifiers only on down; keep missing-Alt/Shift events on the existing
+  selection path. Render the ratio overlay through Task 6's override.
+- [ ] Add the space-aware normal footer segment
+  `Option+Shift+drag RESIZE` and a renderer test proving it appears when room
+  permits without displacing higher-priority footer content.
+- [ ] Run focused tests:
+
+```bash
+cargo test tui::tests
+```
+
+- [ ] Commit:
+
+```bash
+git add src/tui.rs
+git commit -m "feat: resize panes with Option Shift drag overlays"
+```
+
+### Task 8: Reflow local hosted panes after commits and outer-window resize
+
+**Files:** `src/tui.rs`
+
+- [ ] First add tests around `SharedLocalPane`/runtime helpers using a
+  testable resize abstraction or controlled local pane fixture: only local
+  panes are resized; remote panes are never resized; changed ratios reflow the
+  affected descendant leaves; unchanged grids emit no update; and a resize
+  causes a fresh screen frame for viewers.
+- [ ] Add runtime-helper tests for an outer `Event::Resize` calculating grids
+  from current chrome for every locally hosted pane, including panes in an
+  unselected tab, and for stale grid-update retry recomputing from the current
+  revision without resending a stale ratio.
+- [ ] Extend `SharedLocalPane` with a resize operation that calls Task 5's PTY
+  and screen methods, publishes the fresh frame, and reports the resulting
+  grid. On every authoritative state application, compare old/new ratio-aware
+  geometry before replacing the snapshot, reflow changed local leaves, then
+  send one host-only `UpdatePaneGrids` batch with the current revision. On
+  `Event::Resize`, use the same reflow path. Do this after commit/release, not
+  per mouse movement.
+- [ ] Extend `handle_intent`/`send_request` for `SetSplitRatio` with its
+  captured base revision. Clear overlay on every newer authoritative layout
+  state and on its rejection. Route grid update rejection to recomputation of
+  current local geometry; never blindly retry an absolute ratio.
+- [ ] Run focused tests:
+
+```bash
+cargo test tui::tests
+```
+
+- [ ] Commit:
+
+```bash
+git add src/tui.rs
+git commit -m "feat: reflow hosted pane grids after layout changes"
+```
+
+### Task 9: Align user documentation and perform the full verification pass
+
+**Files:** `README.md`, `docs/superpowers/specs/2026-07-26-option-shift-drag-resize-design.md`, `docs/superpowers/plans/2026-07-26-option-shift-drag-resize.md`
+
+- [ ] Update README status/interaction text to remove the claims that shared
+  panes, split-existing panes, and outer terminal resize have immutable grids.
+  Document `Option+Shift+drag` resize, shared ratios versus host-owned absolute
+  grids, commit-on-release behavior, and that guests never resize remote PTYs.
+- [ ] Re-read the design and plan against the implementation. Check every
+  locked decision: captured modifiers, one-axis lock, nearest ancestor,
+  overlay cancellation, no stale ratio retry, 1..=9999/default 5000, v4,
+  reservation freeze, recursive minima, PTY/HostScreen resize, grid commit,
+  remote-guest rule, outer-window reflow, footer, and non-goals.
+- [ ] Run the required whole-repository verification:
+
+```bash
+cargo fmt --check
+cargo clippy --all-targets -- -D warnings
+cargo test
+```
+
+- [ ] Commit:
+
+```bash
+git add README.md docs/superpowers/specs/2026-07-26-option-shift-drag-resize-design.md docs/superpowers/plans/2026-07-26-option-shift-drag-resize.md
+git commit -m "docs: document dynamic pane resize behavior"
+```
+
+## Success criteria
+
+- A plain drag still selects text, while an Alt+Shift drag is captured at down,
+  locks to one axis, renders only an ephemeral overlay, and sends at most one
+  current-revision ratio request on release.
+- Ratios are validated, shared, revisioned, preserved through valid rewrites,
+  and allocated with recursive local minima without cross-peer ratio churn.
+- Any admitted member can set a ratio; only a pane host can publish that pane's
+  grid; strict revision and reservation freeze apply to both paths.
+- A committed ratio or outer-window resize resizes each affected local PTY and
+  HostScreen, publishes a replacement screen snapshot, and commits host-owned
+  grid metadata. Remote guests only consume those updates.
+- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and
+  `cargo test` pass. Execution produces exactly one commit for each task above.

--- a/docs/superpowers/plans/2026-07-26-option-shift-drag-resize.md
+++ b/docs/superpowers/plans/2026-07-26-option-shift-drag-resize.md
@@ -2,7 +2,8 @@
 
 **Goal:** Add an Option/Alt+Shift drag resize gesture whose ratio is shared and
 revisioned, then reflow real hosted PTYs, VT screens, and published pane grids
-after a ratio or outer-window change.
+after any authoritative layout commit or outer-window change that changes a
+locally hosted pane's allocated chrome rect.
 
 **Architecture:** Persist `first_share_bps` on each split and make allocation
 ratio-aware with recursive local minima. A drag holds an overlay in
@@ -38,16 +39,10 @@ prost, existing revision/reservation coordinator.
 
 ## Tasks
 
-### Task 1: Commit the design and execution plan
+### Task 1: Commit the design and execution plan — DONE (skip)
 
-- [ ] Add the normative design and this checkbox plan at the exact paths below.
-- [ ] Confirm no application source, test, or README changes are staged.
-- [ ] Commit:
-
-```bash
-git add docs/superpowers/specs/2026-07-26-option-shift-drag-resize-design.md docs/superpowers/plans/2026-07-26-option-shift-drag-resize.md
-git commit -m "docs: plan Option+Shift+drag pane resize with PTY resize"
-```
+Completed by docs commit `3f19aba`, already on this branch. Do not recreate or
+amend that commit; execution begins with Task 2.
 
 ### Task 2: Add authoritative split ratios and host grid mutation to the pure layout model
 
@@ -241,20 +236,25 @@ git commit -m "feat: resize panes with Option Shift drag overlays"
 
 - [ ] First add tests around `SharedLocalPane`/runtime helpers using a
   testable resize abstraction or controlled local pane fixture: only local
-  panes are resized; remote panes are never resized; changed ratios reflow the
-  affected descendant leaves; unchanged grids emit no update; and a resize
-  causes a fresh screen frame for viewers.
+  panes are resized; remote panes are never resized; any authoritative
+  `LayoutCommit` that changes a locally hosted pane's allocated chrome rect
+  reflows it; unchanged grids emit no update; and a resize causes a fresh
+  screen frame for viewers. Cover `CreatePane` (including the surviving pane),
+  `DeletePane`, `DeleteTab`, member-removal rewrites, and `SetSplitRatio`.
 - [ ] Add runtime-helper tests for an outer `Event::Resize` calculating grids
   from current chrome for every locally hosted pane, including panes in an
   unselected tab, and for stale grid-update retry recomputing from the current
   revision without resending a stale ratio.
 - [ ] Extend `SharedLocalPane` with a resize operation that calls Task 5's PTY
   and screen methods, publishes the fresh frame, and reports the resulting
-  grid. On every authoritative state application, compare old/new ratio-aware
-  geometry before replacing the snapshot, reflow changed local leaves, then
-  send one host-only `UpdatePaneGrids` batch with the current revision. On
-  `Event::Resize`, use the same reflow path. Do this after commit/release, not
-  per mouse movement.
+  grid. On every authoritative `LayoutCommit`, compare old/new ratio-aware
+  geometry before replacing the snapshot, reflow every locally hosted leaf
+  whose allocated chrome rect changed, then send one host-only
+  `UpdatePaneGrids` batch with the current revision. This applies to
+  `CreatePane`, `DeletePane`, `DeleteTab`, member-removal rewrites,
+  `SetSplitRatio`, and any other allocation-changing commit. On `Event::Resize`,
+  use the same reflow path. Keep the drag gesture overlay-only until its
+  commit-on-release: never resize a PTY per mouse movement.
 - [ ] Extend `handle_intent`/`send_request` for `SetSplitRatio` with its
   captured base revision. Clear overlay on every newer authoritative layout
   state and on its rejection. Route grid update rejection to recomputation of

--- a/docs/superpowers/specs/2026-07-26-option-shift-drag-resize-design.md
+++ b/docs/superpowers/specs/2026-07-26-option-shift-drag-resize-design.md
@@ -1,0 +1,200 @@
+# Option+Shift drag pane resize with host PTY reflow
+
+## Goal
+
+Let any admitted member resize a shared split by dragging inside a pane while
+keeping two facts true at once:
+
+1. the split proportion is one authoritative, revisioned value shared by every
+   member; and
+2. every pane host resizes its own PTY and VT screen to the grid implied by its
+   own local terminal chrome.
+
+This replaces the current fixed-at-birth behavior for shared-layout panes.
+Today a split only gives the newly created pane a birth grid; the existing
+pane's PTY does not resize, and outer terminal resize only crops or letterboxes
+the fixed grids. This feature makes both drag-driven reflow and outer-window
+reflow resize hosted PTYs.
+
+## Non-goals
+
+- Divider-only hit testing or a divider drag alias.
+- Keyboard ratio nudges.
+- Dual-axis / diagonal resize in one gesture.
+- Continuous layout commits while moving the mouse.
+- Resizing a remote PTY from a guest.
+
+## Interaction
+
+### Starting and locking a gesture
+
+The resize gesture is `Option`/`Alt` + `Shift` + left-button drag that starts
+inside a pane's **chrome content rect** (the bordered pane interior, not only
+the currently visible fixed-grid viewport). The down event captures all of:
+
+- the pressed `pane_id`;
+- the snapshot revision (`base_revision`);
+- pointer origin;
+- the modifier decision; and
+- the starting layout ratio.
+
+Both Alt and Shift must be present on mouse-down. Subsequent `Drag` and `Up`
+events use that captured decision; they must not depend on modifiers which the
+terminal may no longer report. A left drag lacking either modifier remains the
+ordinary text-selection path. The implementation must never infer resize from
+an Escape timing sequence.
+
+Before the pointer moves two terminal cells from its origin, the gesture is
+pending and does not alter selection or layout. At that threshold it locks once
+to the axis with the greater displacement; an exact tie locks left/right. It
+does not change axis later in the drag.
+
+For the locked axis, the target is the nearest ancestor `Node::Split` of that
+axis containing the pressed pane. The client may locate that node to draw its
+overlay, but the authoritative target is only `(pane_id, axis)` and is resolved
+again by the coordinator. If there is no such ancestor, the modifier gesture is
+consumed and cancelled: it must neither select text nor send a request.
+
+### Direction and release
+
+The target split's `first_share_bps` denotes its first child's portion. The
+drag maps pointer movement to the share using the target split's original
+allocated span and captured ratio:
+
+- for a pressed pane under the first child, positive movement right/down grows
+  it and negative movement shrinks it;
+- for a pressed pane under the second child, the sign is reversed.
+
+Thus motion toward the pressed pane's outer edge grows it; motion toward the
+shared boundary shrinks it. The value is recomputed from the down-time baseline
+rather than compounded from individual drag events.
+
+After the axis is locked, the TUI draws a local, ephemeral geometry overlay.
+It changes neither `LayoutSnapshot` nor PTYs. On mouse-up it clears the overlay
+and sends one `SetSplitRatio` request with the down-time `base_revision` if a
+target was found and the proposed share differs from the original. A drag that
+never crosses the threshold, has no target, or ends at the original share sends
+no request.
+
+A newer authoritative layout state received while a resize drag is active
+cancels the gesture and drops its overlay before rendering that state. A stale
+ratio rejection also drops the overlay; the client does not retry an old
+absolute ratio. Concurrent changes are therefore first-commit-wins.
+
+Normal footer help includes `Option+Shift+drag RESIZE` when its existing
+space-aware rendering has room; truncation may omit this suffix before it
+displaces status or join-code information.
+
+## Shared ratios and allocation
+
+`Node::Split` gains `first_share_bps: u16`. Valid values are `1..=9999`; every
+new split starts at `5000`. The ratio belongs to the split, so create, delete,
+member-removal, and other tree rewrites preserve it whenever that split
+survives. Collapsing a split removes that split and naturally removes its ratio.
+
+The protobuf `LayoutSplit.first_share_bps` is an optional field. An absent
+field decodes as `5000` for compatibility with stored/in-memory old shapes;
+explicit `0` and `10000` (and every value outside `1..=9999`) are invalid.
+
+The allocator uses the same ratio for rendering and grid calculation. For an
+available split span `S`, its unconstrained first span is
+`floor(S * first_share_bps / 10000)`. It then clamps that split point to the
+recursive minima of its children when the parent can satisfy them. A leaf has a
+minimum **outer** rectangle of 3 columns by 3 rows, including its borders. A
+left/right split has width `first.width + second.width` and height
+`max(first.height, second.height)`; a top/bottom split has width
+`max(first.width, second.width)` and height `first.height + second.height`.
+
+If a local terminal is too small to satisfy those minima, allocation remains
+safe and deterministic using the ratio with saturating rect arithmetic; it may
+render smaller leaves. It never writes a compensating ratio to shared state.
+Different window sizes consequently produce different pixel/cell allocations
+without disagreement about the shared ratio.
+
+## Authority, protocol, and grid ownership
+
+Protocol version moves from 3 to 4. `LayoutRequest` remains exactly one action
+and gains two v4 actions:
+
+- `SetSplitRatio { pane_id, axis, first_share_bps }` (new request field/tag);
+- `UpdatePaneGrids { panes: repeated PaneGrid { pane_id, grid_rows, grid_cols } }`
+  (a separate new request field/tag).
+
+`LayoutSplit.first_share_bps` uses a new tag. Existing `LayoutCommit.state`
+already carries `PaneDescriptor.grid_rows` and `grid_cols`, so no separate
+commit body is needed. All fields fit in v4.
+
+For `SetSplitRatio`, the coordinator requires a nonzero request ID and base
+revision, exactly one action, a valid ratio/axis/pane, and an admitted sender.
+It applies the strict revision check and the existing pending-reservation freeze
+before finding the nearest matching ancestor and changing its ratio. It does
+not require the requester to host the pane: any admitted member may resize.
+The accepted mutation advances the revision and broadcasts the resulting
+`LayoutCommit`.
+
+`UpdatePaneGrids` is the host-only reconciliation path. It has the same strict
+revision and reservation-freeze rules, validates a nonempty, duplicate-free
+batch of nonzero valid grids, and permits a sender to update only panes it
+hosts. It updates `SessionState::Pane` grid metadata, advances the revision,
+and broadcasts the full `LayoutCommit`. A runtime sends only entries that
+actually differ. If a grid-update request is stale, it re-derives grids from
+the newest ratio and local window before trying again; it never retries a stale
+ratio request.
+
+This allows multiple hosts to settle safely: a ratio commit may cause several
+hosts to calculate grids; one grid update wins, later hosts rebase and publish
+only their still-different hosted panes. The process ends once every pane's
+hosted grid matches its host's calculation. Guests never call `MasterPty::resize`
+for a remote pane; they receive the grid metadata through a commit and the
+resized screen through the existing snapshot/delta stream.
+
+## PTY and screen reflow
+
+When a runtime applies an authoritative ratio commit, it compares old and new
+layout, calculates local chrome content rectangles for the changed tab, and
+reflows every locally hosted descendant leaf whose allocated rectangle changed
+(reflowing all locally hosted leaves in that tab is an acceptable equivalent).
+The calculation uses the host's local terminal area, even if that tab is not
+currently selected. It converts each pane content rect with the existing
+`grid_for_pane` rule, so grids remain at least 1 by 1 even under extreme
+terminal sizes.
+
+For each changed hosted grid the runtime, in order:
+
+1. calls `PtyHost::resize` / portable-pty `MasterPty::resize`;
+2. resizes the matching `HostScreen` / vt100 parser;
+3. publishes a fresh screen snapshot to its `watch` subscribers (never a delta
+   based on the pre-resize dimensions); and
+4. batches the changed grids into `UpdatePaneGrids`.
+
+The drag overlay performs none of these operations. v1 commits only on mouse
+release, so PTYs resize after a ratio commit or a received authoritative ratio
+commit, not on every drag event.
+
+Outer `Event::Resize` is intentionally included. The shared-layout runtime
+recomputes all locally hosted panes against its current chrome and follows the
+same PTY/screen/grid-update path. This makes dynamic grids consistent whether
+the allocation changed because of a drag or because the host window changed.
+The single-pane `local` mode remains outside this feature unless its own resize
+loop is deliberately changed in later work.
+
+## Failure behavior
+
+- A PTY or screen resize failure leaves that pane's current published grid
+  unchanged, reports a local status error, and does not send a false grid
+  update. Other panes may continue to reconcile.
+- A rejected or stale `UpdatePaneGrids` is recomputed from the newest state;
+  a rejected `SetSplitRatio` is not retried.
+- A malformed protocol layout, invalid ratio, unknown matching ancestor, a
+  non-host grid update, or a mutation during reservation freeze is rejected by
+  the coordinator and leaves authoritative state untouched.
+
+## Testing and documentation
+
+Tests cover ratio defaults/validation and rewrite preservation, protocol v4
+wire and rejection behavior, coordinator permissions/revisions/freeze,
+ratio-aware recursive allocation, modifier capture and drag cancellation,
+overlay-only rendering, PTY and HostScreen resizing, forced post-resize
+snapshots, host grid reconciliation, and guest non-resize behavior. README
+status and interaction text must be updated to remove the fixed-grid / no
+resize claims and describe host-owned dynamic grids.

--- a/docs/superpowers/specs/2026-07-26-option-shift-drag-resize-design.md
+++ b/docs/superpowers/specs/2026-07-26-option-shift-drag-resize-design.md
@@ -13,8 +13,9 @@ keeping two facts true at once:
 This replaces the current fixed-at-birth behavior for shared-layout panes.
 Today a split only gives the newly created pane a birth grid; the existing
 pane's PTY does not resize, and outer terminal resize only crops or letterboxes
-the fixed grids. This feature makes both drag-driven reflow and outer-window
-reflow resize hosted PTYs.
+the fixed grids. This feature makes reflow resize hosted PTYs whenever an
+authoritative layout change or outer-window resize changes their allocated
+chrome.
 
 ## Non-goals
 
@@ -150,10 +151,18 @@ resized screen through the existing snapshot/delta stream.
 
 ## PTY and screen reflow
 
-When a runtime applies an authoritative ratio commit, it compares old and new
-layout, calculates local chrome content rectangles for the changed tab, and
-reflows every locally hosted descendant leaf whose allocated rectangle changed
-(reflowing all locally hosted leaves in that tab is an acceptable equivalent).
+When a runtime applies any authoritative `LayoutCommit`, it compares old and
+new layout, calculates local chrome content rectangles for affected tabs, and
+reflows every locally hosted leaf whose allocated chrome rect changed
+(reflowing all locally hosted leaves in each affected tab is an acceptable
+equivalent). This is not limited to `SetSplitRatio`: it includes `CreatePane`
+(split), `DeletePane`, `DeleteTab`, member-removal rewrites, and every other
+authoritative layout mutation that changes a local pane's allocation. A new
+split must therefore reflow its surviving locally hosted pane as well as giving
+the new pane its grid.
+For every such locally hosted pane, the runtime must reflow its PTY and
+`HostScreen`; it may publish an `UpdatePaneGrids` batch for grids that actually
+changed.
 The calculation uses the host's local terminal area, even if that tab is not
 currently selected. It converts each pane content rect with the existing
 `grid_for_pane` rule, so grids remain at least 1 by 1 even under extreme
@@ -167,14 +176,16 @@ For each changed hosted grid the runtime, in order:
    based on the pre-resize dimensions); and
 4. batches the changed grids into `UpdatePaneGrids`.
 
-The drag overlay performs none of these operations. v1 commits only on mouse
-release, so PTYs resize after a ratio commit or a received authoritative ratio
-commit, not on every drag event.
+The drag overlay performs none of these operations. v1 commits the drag
+gesture only on mouse release, so it never resizes PTYs on mouse movement; its
+resulting `SetSplitRatio` commit (like any other qualifying authoritative
+commit) triggers reflow after release.
 
 Outer `Event::Resize` is intentionally included. The shared-layout runtime
 recomputes all locally hosted panes against its current chrome and follows the
-same PTY/screen/grid-update path. This makes dynamic grids consistent whether
-the allocation changed because of a drag or because the host window changed.
+same PTY/HostScreen/`UpdatePaneGrids` path whenever their allocated chrome
+rects change. This makes dynamic grids consistent whether the allocation
+changed because of a layout commit or because the host window changed.
 The single-pane `local` mode remains outside this feature unless its own resize
 loop is deliberately changed in later work.
 

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -4,6 +4,9 @@ pub const MAX_MEMBERS: usize = 8;
 pub const MAX_TABS: usize = 9;
 pub const MAX_PANES_PER_TAB: usize = 8;
 pub const MAX_SPLIT_DEPTH: usize = 4;
+pub const DEFAULT_FIRST_SHARE_BPS: u16 = 5_000;
+pub const MIN_FIRST_SHARE_BPS: u16 = 1;
+pub const MAX_FIRST_SHARE_BPS: u16 = 9_999;
 /// Maximum peer-identifier size, aligned with the protocol boundary.
 pub const MAX_PEER_ID_BYTES: usize = 64;
 /// Maximum serialized endpoint-address size accepted by this pure model.
@@ -33,6 +36,7 @@ pub enum Node {
     },
     Split {
         axis: Axis,
+        first_share_bps: u16,
         first: Box<Node>,
         second: Box<Node>,
     },
@@ -138,7 +142,9 @@ pub enum LayoutError {
     PaneLimit,
     SplitDepthLimit,
     InvalidGrid,
+    InvalidSplitRatio,
     UnknownPane { pane_id: PaneId },
+    NoMatchingSplit { pane_id: PaneId, axis: Axis },
     UnknownTab { tab_id: TabId },
     NotPaneHost { pane_id: PaneId },
     NotTabHost { tab_id: TabId },
@@ -264,6 +270,9 @@ impl SessionState {
             if !tab.root.collect_pane_ids(0, &mut pane_ids)
                 || pane_ids.len() - before > MAX_PANES_PER_TAB
             {
+                return Err(LayoutError::InvalidSnapshot);
+            }
+            if !tab.root.has_valid_ratios() {
                 return Err(LayoutError::InvalidSnapshot);
             }
         }
@@ -520,6 +529,7 @@ impl SessionState {
                 };
                 let split = Node::Split {
                     axis,
+                    first_share_bps: DEFAULT_FIRST_SHARE_BPS,
                     first,
                     second,
                 };
@@ -736,6 +746,66 @@ impl SessionState {
         Ok(())
     }
 
+    pub fn set_split_ratio(
+        &mut self,
+        requester: &[u8],
+        base_revision: u64,
+        pane_id: PaneId,
+        axis: Axis,
+        first_share_bps: u16,
+    ) -> Result<(), LayoutError> {
+        self.check_mutation(base_revision)?;
+        self.require_member(requester)?;
+        self.ensure_no_reservation()?;
+        validate_first_share_bps(first_share_bps)?;
+        let tab_index = self
+            .tab_index_for_pane(pane_id)
+            .ok_or(LayoutError::UnknownPane { pane_id })?;
+        if !self.tabs[tab_index]
+            .root
+            .set_nearest_split_ratio(pane_id, axis, first_share_bps)
+        {
+            return Err(LayoutError::NoMatchingSplit { pane_id, axis });
+        }
+        self.advance_revision();
+        Ok(())
+    }
+
+    pub fn update_pane_grids(
+        &mut self,
+        requester: &[u8],
+        base_revision: u64,
+        grids: &[(PaneId, u16, u16)],
+    ) -> Result<(), LayoutError> {
+        self.check_mutation(base_revision)?;
+        self.require_member(requester)?;
+        self.ensure_no_reservation()?;
+        if grids.is_empty() {
+            return Err(LayoutError::InvalidGrid);
+        }
+        let mut pane_ids = BTreeSet::new();
+        for &(pane_id, rows, cols) in grids {
+            validate_grid(rows, cols)?;
+            if !pane_ids.insert(pane_id) {
+                return Err(LayoutError::InvalidGrid);
+            }
+            let pane = self
+                .panes
+                .get(&pane_id)
+                .ok_or(LayoutError::UnknownPane { pane_id })?;
+            if pane.host_peer_id != requester {
+                return Err(LayoutError::NotPaneHost { pane_id });
+            }
+        }
+        for &(pane_id, rows, cols) in grids {
+            let pane = self.panes.get_mut(&pane_id).expect("validated pane exists");
+            pane.grid_rows = rows;
+            pane.grid_cols = cols;
+        }
+        self.advance_revision();
+        Ok(())
+    }
+
     pub fn pane_ids_in_tab(&self, tab_id: TabId) -> Vec<PaneId> {
         self.tabs
             .iter()
@@ -887,6 +957,22 @@ impl Node {
         }
     }
 
+    fn has_valid_ratios(&self) -> bool {
+        match self {
+            Self::Leaf { .. } => true,
+            Self::Split {
+                first_share_bps,
+                first,
+                second,
+                ..
+            } => {
+                validate_first_share_bps(*first_share_bps).is_ok()
+                    && first.has_valid_ratios()
+                    && second.has_valid_ratios()
+            }
+        }
+    }
+
     fn replace_leaf(&mut self, wanted: PaneId, replacement: Node) -> bool {
         match self {
             Self::Leaf { pane_id } if *pane_id == wanted => {
@@ -901,11 +987,47 @@ impl Node {
         }
     }
 
+    fn set_nearest_split_ratio(
+        &mut self,
+        wanted: PaneId,
+        axis: Axis,
+        first_share_bps: u16,
+    ) -> bool {
+        match self {
+            Self::Leaf { .. } => false,
+            Self::Split {
+                axis: split_axis,
+                first,
+                second,
+                ..
+            } => {
+                if first.contains_leaf(wanted)
+                    && first.set_nearest_split_ratio(wanted, axis, first_share_bps)
+                {
+                    return true;
+                }
+                if second.contains_leaf(wanted)
+                    && second.set_nearest_split_ratio(wanted, axis, first_share_bps)
+                {
+                    return true;
+                }
+                if *split_axis == axis && (first.contains_leaf(wanted) || second.contains_leaf(wanted)) {
+                    if let Self::Split { first_share_bps: share, .. } = self {
+                        *share = first_share_bps;
+                    }
+                    return true;
+                }
+                false
+            }
+        }
+    }
+
     fn remove_leaf(self, wanted: PaneId) -> Option<Node> {
         match self {
             Self::Leaf { pane_id } => (pane_id != wanted).then_some(Self::Leaf { pane_id }),
             Self::Split {
                 axis,
+                first_share_bps,
                 first,
                 second,
             } => {
@@ -913,6 +1035,7 @@ impl Node {
                     match first.remove_leaf(wanted) {
                         Some(first) => Some(Self::Split {
                             axis,
+                            first_share_bps,
                             first: Box::new(first),
                             second,
                         }),
@@ -922,6 +1045,7 @@ impl Node {
                     match second.remove_leaf(wanted) {
                         Some(second) => Some(Self::Split {
                             axis,
+                            first_share_bps,
                             first,
                             second: Box::new(second),
                         }),
@@ -930,6 +1054,7 @@ impl Node {
                 } else {
                     Some(Self::Split {
                         axis,
+                        first_share_bps,
                         first,
                         second,
                     })
@@ -937,6 +1062,13 @@ impl Node {
             }
         }
     }
+}
+
+pub fn validate_first_share_bps(first_share_bps: u16) -> Result<(), LayoutError> {
+    if !(MIN_FIRST_SHARE_BPS..=MAX_FIRST_SHARE_BPS).contains(&first_share_bps) {
+        return Err(LayoutError::InvalidSplitRatio);
+    }
+    Ok(())
 }
 
 fn validate_grid(grid_rows: u16, grid_cols: u16) -> Result<(), LayoutError> {

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -1011,8 +1011,14 @@ impl Node {
                 {
                     return true;
                 }
-                if *split_axis == axis && (first.contains_leaf(wanted) || second.contains_leaf(wanted)) {
-                    if let Self::Split { first_share_bps: share, .. } = self {
+                if *split_axis == axis
+                    && (first.contains_leaf(wanted) || second.contains_leaf(wanted))
+                {
+                    if let Self::Split {
+                        first_share_bps: share,
+                        ..
+                    } = self
+                    {
                         *share = first_share_bps;
                     }
                     return true;

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -829,7 +829,9 @@ fn validate_layout_request(request: &LayoutRequest) -> Result<(), ProtocolError>
     }
     if let Some(update) = &request.update_pane_grids {
         if update.panes.is_empty() {
-            return Err(ProtocolError::InvalidLayout("layout_request.update_pane_grids.panes"));
+            return Err(ProtocolError::InvalidLayout(
+                "layout_request.update_pane_grids.panes",
+            ));
         }
         let mut pane_ids = HashSet::with_capacity(update.panes.len());
         for pane in &update.panes {
@@ -840,7 +842,9 @@ fn validate_layout_request(request: &LayoutRequest) -> Result<(), ProtocolError>
                 pane.grid_cols,
             )?;
             if !pane_ids.insert(pane.pane_id) {
-                return Err(ProtocolError::InvalidLayout("layout_request.update_pane_grids.pane_id"));
+                return Err(ProtocolError::InvalidLayout(
+                    "layout_request.update_pane_grids.pane_id",
+                ));
             }
         }
     }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -3,7 +3,7 @@
 use prost::Message;
 use std::{collections::HashSet, fmt};
 
-pub const PROTOCOL_VERSION: u32 = 3;
+pub const PROTOCOL_VERSION: u32 = 4;
 pub const MAX_FRAME_BYTES: usize = 1_048_576;
 pub const MAX_ENVELOPE_BYTES: usize = 1_048_560;
 pub const MAX_PEER_ID_BYTES: usize = 64;
@@ -299,6 +299,8 @@ pub struct LayoutSplit {
     pub first: Option<LayoutNode>,
     #[prost(message, optional, tag = "3")]
     pub second: Option<LayoutNode>,
+    #[prost(uint32, optional, tag = "4")]
+    pub first_share_bps: Option<u32>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, ::prost::Enumeration)]
@@ -329,6 +331,10 @@ pub struct LayoutRequest {
     pub create_tab: Option<CreateTab>,
     #[prost(message, optional, tag = "6")]
     pub delete_tab: Option<DeleteTab>,
+    #[prost(message, optional, tag = "7")]
+    pub set_split_ratio: Option<SetSplitRatio>,
+    #[prost(message, optional, tag = "8")]
+    pub update_pane_grids: Option<UpdatePaneGrids>,
 }
 
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -363,6 +369,32 @@ pub struct CreateTab {
 pub struct DeleteTab {
     #[prost(uint64, tag = "1")]
     pub tab_id: u64,
+}
+
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SetSplitRatio {
+    #[prost(uint64, tag = "1")]
+    pub pane_id: u64,
+    #[prost(enumeration = "SplitAxis", optional, tag = "2")]
+    pub axis: Option<i32>,
+    #[prost(uint32, tag = "3")]
+    pub first_share_bps: u32,
+}
+
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PaneGrid {
+    #[prost(uint64, tag = "1")]
+    pub pane_id: u64,
+    #[prost(uint32, tag = "2")]
+    pub grid_rows: u32,
+    #[prost(uint32, tag = "3")]
+    pub grid_cols: u32,
+}
+
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UpdatePaneGrids {
+    #[prost(message, repeated, tag = "1")]
+    pub panes: Vec<PaneGrid>,
 }
 
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -753,7 +785,9 @@ fn validate_layout_request(request: &LayoutRequest) -> Result<(), ProtocolError>
     let actions = usize::from(request.create_pane.is_some())
         + usize::from(request.delete_pane.is_some())
         + usize::from(request.create_tab.is_some())
-        + usize::from(request.delete_tab.is_some());
+        + usize::from(request.delete_tab.is_some())
+        + usize::from(request.set_split_ratio.is_some())
+        + usize::from(request.update_pane_grids.is_some());
     if actions != 1 {
         return Err(ProtocolError::InvalidLayout("layout_request.action"));
     }
@@ -783,6 +817,32 @@ fn validate_layout_request(request: &LayoutRequest) -> Result<(), ProtocolError>
     }
     if let Some(delete_tab) = &request.delete_tab {
         validate_nonzero("layout_request.delete_tab.tab_id", delete_tab.tab_id)?;
+    }
+    if let Some(ratio) = &request.set_split_ratio {
+        validate_nonzero("layout_request.set_split_ratio.pane_id", ratio.pane_id)?;
+        validate_axis("layout_request.set_split_ratio.axis", ratio.axis)?;
+        if !(1..=9_999).contains(&ratio.first_share_bps) {
+            return Err(ProtocolError::InvalidLayout(
+                "layout_request.set_split_ratio.first_share_bps",
+            ));
+        }
+    }
+    if let Some(update) = &request.update_pane_grids {
+        if update.panes.is_empty() {
+            return Err(ProtocolError::InvalidLayout("layout_request.update_pane_grids.panes"));
+        }
+        let mut pane_ids = HashSet::with_capacity(update.panes.len());
+        for pane in &update.panes {
+            validate_nonzero("layout_request.update_pane_grids.pane_id", pane.pane_id)?;
+            validate_grid(
+                "layout_request.update_pane_grids.grid",
+                pane.grid_rows,
+                pane.grid_cols,
+            )?;
+            if !pane_ids.insert(pane.pane_id) {
+                return Err(ProtocolError::InvalidLayout("layout_request.update_pane_grids.pane_id"));
+            }
+        }
     }
     Ok(())
 }
@@ -879,6 +939,13 @@ fn validate_layout_node(
         }
         (None, Some(split)) => {
             validate_axis("layout_state.node.split.axis", split.axis)?;
+            if let Some(first_share_bps) = split.first_share_bps
+                && !(1..=9_999).contains(&first_share_bps)
+            {
+                return Err(ProtocolError::InvalidLayout(
+                    "layout_state.node.split.first_share_bps",
+                ));
+            }
             let first = split.first.as_ref().ok_or(ProtocolError::InvalidLayout(
                 "layout_state.node.split.first",
             ))?;

--- a/src/pty_host.rs
+++ b/src/pty_host.rs
@@ -93,6 +93,15 @@ impl PtyHost {
         Ok(())
     }
 
+    /// Resize the local PTY while retaining its existing reader and writer handles.
+    pub fn resize(&mut self, size: PtySize) -> Result<(), Box<dyn Error>> {
+        self.master
+            .as_mut()
+            .ok_or("PTY master is shut down")?
+            .resize(size)?;
+        Ok(())
+    }
+
     /// Stop the child, release its PTY handles, and join the reader once.
     pub fn shutdown(&mut self) -> Result<(), Box<dyn Error>> {
         if let Some(mut child) = self.child.take()

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -94,6 +94,26 @@ impl HostScreen {
         Ok(frame)
     }
 
+    /// Resize the parser and force consumers to replace rather than delta-apply their screen.
+    pub fn resize(&mut self, rows: u16, cols: u16) -> Result<ScreenFrame, ScreenError> {
+        validate_dimensions(rows, cols)?;
+        let sequence = self
+            .current
+            .sequence
+            .checked_add(1)
+            .ok_or(ScreenError::SequenceExhausted)?;
+        self.parser.screen_mut().set_size(rows, cols);
+        self.previous = self.parser.screen().clone();
+        let frame = ScreenFrame {
+            sequence,
+            base_sequence: 0,
+            snapshot: snapshot_payload(self.parser.screen())?,
+            delta: Arc::from([]),
+        };
+        self.current = frame.clone();
+        Ok(frame)
+    }
+
     pub fn current_frame(&self) -> &ScreenFrame {
         &self.current
     }

--- a/src/session.rs
+++ b/src/session.rs
@@ -33,9 +33,8 @@ use crate::{
         LayoutCommit, LayoutNode, LayoutReject, LayoutRejectReason, LayoutRequest, LayoutSplit,
         LayoutState, MemberDescriptor, NewPanePosition as ProtocolNewPanePosition,
         PROTOCOL_VERSION, PaneDescriptor, PaneFailed, PaneReady, PaneReservation, PaneSubscribe,
-        ReleaseControl, SessionSnapshot, Snapshot, SplitAxis, TabDescriptor, TakeControl, Welcome,
-        SetSplitRatio, UpdatePaneGrids,
-        envelope,
+        ReleaseControl, SessionSnapshot, SetSplitRatio, Snapshot, SplitAxis, TabDescriptor,
+        TakeControl, UpdatePaneGrids, Welcome, envelope,
     },
     screen::ScreenFrame,
     ticket::{JoinTicket, TicketError},
@@ -532,8 +531,8 @@ impl LayoutCoordinator {
         ratio: SetSplitRatio,
     ) -> Result<CoordinatorResponse, LayoutError> {
         let axis = protocol_axis(ratio.axis)?;
-        let first_share_bps = u16::try_from(ratio.first_share_bps)
-            .map_err(|_| LayoutError::InvalidSplitRatio)?;
+        let first_share_bps =
+            u16::try_from(ratio.first_share_bps).map_err(|_| LayoutError::InvalidSplitRatio)?;
         self.state.set_split_ratio(
             authenticated_peer_id,
             base_revision,
@@ -831,9 +830,9 @@ fn reject_reason(error: &LayoutError) -> LayoutRejectReason {
         | LayoutError::PaneLimit
         | LayoutError::SplitDepthLimit
         | LayoutError::IdExhausted => LayoutRejectReason::Limit,
-        LayoutError::UnknownPane { .. } | LayoutError::NoMatchingSplit { .. } | LayoutError::UnknownTab { .. } => {
-            LayoutRejectReason::UnknownId
-        }
+        LayoutError::UnknownPane { .. }
+        | LayoutError::NoMatchingSplit { .. }
+        | LayoutError::UnknownTab { .. } => LayoutRejectReason::UnknownId,
         LayoutError::LastPaneInTab { .. } | LayoutError::LastTab => {
             LayoutRejectReason::LastPaneOrTab
         }

--- a/src/session.rs
+++ b/src/session.rs
@@ -34,6 +34,7 @@ use crate::{
         LayoutState, MemberDescriptor, NewPanePosition as ProtocolNewPanePosition,
         PROTOCOL_VERSION, PaneDescriptor, PaneFailed, PaneReady, PaneReservation, PaneSubscribe,
         ReleaseControl, SessionSnapshot, Snapshot, SplitAxis, TabDescriptor, TakeControl, Welcome,
+        SetSplitRatio, UpdatePaneGrids,
         envelope,
     },
     screen::ScreenFrame,
@@ -261,7 +262,9 @@ impl LayoutCoordinator {
         let action_count = usize::from(request.create_pane.is_some())
             + usize::from(request.delete_pane.is_some())
             + usize::from(request.create_tab.is_some())
-            + usize::from(request.delete_tab.is_some());
+            + usize::from(request.delete_tab.is_some())
+            + usize::from(request.set_split_ratio.is_some())
+            + usize::from(request.update_pane_grids.is_some());
         if request_id == 0 || request.base_revision == 0 || action_count != 1 {
             return reject(request_id, LayoutRejectReason::Malformed);
         }
@@ -286,6 +289,10 @@ impl LayoutCoordinator {
             )
         } else if let Some(delete) = request.delete_tab {
             self.delete_tab(authenticated_peer_id, request.base_revision, delete)
+        } else if let Some(ratio) = request.set_split_ratio {
+            self.set_split_ratio(authenticated_peer_id, request.base_revision, ratio)
+        } else if let Some(grids) = request.update_pane_grids {
+            self.update_pane_grids(authenticated_peer_id, request.base_revision, grids)
         } else {
             Err(LayoutError::InvalidSnapshot)
         };
@@ -518,6 +525,51 @@ impl LayoutCoordinator {
         ))
     }
 
+    fn set_split_ratio(
+        &mut self,
+        authenticated_peer_id: &[u8],
+        base_revision: u64,
+        ratio: SetSplitRatio,
+    ) -> Result<CoordinatorResponse, LayoutError> {
+        let axis = protocol_axis(ratio.axis)?;
+        let first_share_bps = u16::try_from(ratio.first_share_bps)
+            .map_err(|_| LayoutError::InvalidSplitRatio)?;
+        self.state.set_split_ratio(
+            authenticated_peer_id,
+            base_revision,
+            ratio.pane_id,
+            axis,
+            first_share_bps,
+        )?;
+        Ok(CoordinatorResponse::Commit(
+            self.layout_commit().map_err(layout_error)?,
+        ))
+    }
+
+    fn update_pane_grids(
+        &mut self,
+        authenticated_peer_id: &[u8],
+        base_revision: u64,
+        update: UpdatePaneGrids,
+    ) -> Result<CoordinatorResponse, LayoutError> {
+        let grids = update
+            .panes
+            .into_iter()
+            .map(|pane| {
+                Ok((
+                    pane.pane_id,
+                    u16::try_from(pane.grid_rows).map_err(|_| LayoutError::InvalidGrid)?,
+                    u16::try_from(pane.grid_cols).map_err(|_| LayoutError::InvalidGrid)?,
+                ))
+            })
+            .collect::<Result<Vec<_>, LayoutError>>()?;
+        self.state
+            .update_pane_grids(authenticated_peer_id, base_revision, &grids)?;
+        Ok(CoordinatorResponse::Commit(
+            self.layout_commit().map_err(layout_error)?,
+        ))
+    }
+
     fn layout_commit(&self) -> Result<LayoutCommit, CoordinatorError> {
         let state = self.protocol_layout_state()?;
         Ok(LayoutCommit {
@@ -718,6 +770,11 @@ fn layout_node_from_protocol(node: &LayoutNode) -> Result<Node, LayoutError> {
         (Some(pane_id), None) if *pane_id != 0 => Ok(Node::Leaf { pane_id: *pane_id }),
         (None, Some(split)) => Ok(Node::Split {
             axis: protocol_axis(split.axis)?,
+            first_share_bps: split
+                .first_share_bps
+                .map(|share| u16::try_from(share).map_err(|_| LayoutError::InvalidSnapshot))
+                .transpose()?
+                .unwrap_or(crate::layout::DEFAULT_FIRST_SHARE_BPS),
             first: Box::new(layout_node_from_protocol(
                 split.first.as_ref().ok_or(LayoutError::InvalidSnapshot)?,
             )?),
@@ -737,6 +794,7 @@ fn protocol_node(node: Node) -> LayoutNode {
         },
         Node::Split {
             axis,
+            first_share_bps,
             first,
             second,
         } => LayoutNode {
@@ -748,6 +806,7 @@ fn protocol_node(node: Node) -> LayoutNode {
                 }),
                 first: Some(protocol_node(*first)),
                 second: Some(protocol_node(*second)),
+                first_share_bps: Some(u32::from(first_share_bps)),
             })),
         },
     }
@@ -772,7 +831,7 @@ fn reject_reason(error: &LayoutError) -> LayoutRejectReason {
         | LayoutError::PaneLimit
         | LayoutError::SplitDepthLimit
         | LayoutError::IdExhausted => LayoutRejectReason::Limit,
-        LayoutError::UnknownPane { .. } | LayoutError::UnknownTab { .. } => {
+        LayoutError::UnknownPane { .. } | LayoutError::NoMatchingSplit { .. } | LayoutError::UnknownTab { .. } => {
             LayoutRejectReason::UnknownId
         }
         LayoutError::LastPaneInTab { .. } | LayoutError::LastTab => {
@@ -786,6 +845,7 @@ fn reject_reason(error: &LayoutError) -> LayoutRejectReason {
         | LayoutError::InvalidEndpointAddress
         | LayoutError::InvalidDisplayName
         | LayoutError::InvalidGrid
+        | LayoutError::InvalidSplitRatio
         | LayoutError::AlreadyMember
         | LayoutError::InvalidSnapshot => LayoutRejectReason::Malformed,
     }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -899,6 +899,29 @@ fn contains_leaf(node: &Node, pane_id: PaneId) -> bool {
     }
 }
 
+fn node_minimum(node: &Node) -> (u16, u16) {
+    match node {
+        Node::Leaf { .. } => (3, 3),
+        Node::Split { axis, first, second, .. } => {
+            let (first_width, first_height) = node_minimum(first);
+            let (second_width, second_height) = node_minimum(second);
+            match axis {
+                Axis::LeftRight => (first_width.saturating_add(second_width), first_height.max(second_height)),
+                Axis::TopBottom => (first_width.max(second_width), first_height.saturating_add(second_height)),
+            }
+        }
+    }
+}
+
+fn allocated_first_span(span: u16, share_bps: u16, first_min: u16, second_min: u16) -> u16 {
+    let unconstrained = ((u32::from(span) * u32::from(share_bps)) / 10_000) as u16;
+    if span >= first_min.saturating_add(second_min) {
+        unconstrained.clamp(first_min, span.saturating_sub(second_min))
+    } else {
+        unconstrained.min(span)
+    }
+}
+
 fn allocate_node(node: &Node, area: Rect, panes: &mut BTreeMap<PaneId, Rect>) {
     match node {
         Node::Leaf { pane_id } => {
@@ -906,12 +929,20 @@ fn allocate_node(node: &Node, area: Rect, panes: &mut BTreeMap<PaneId, Rect>) {
         }
         Node::Split {
             axis,
+            first_share_bps,
             first,
             second,
         } => {
             let (first_area, second_area) = match axis {
                 Axis::LeftRight => {
-                    let first_width = area.width / 2;
+                    let (first_min, _) = node_minimum(first);
+                    let (second_min, _) = node_minimum(second);
+                    let first_width = allocated_first_span(
+                        area.width,
+                        *first_share_bps,
+                        first_min,
+                        second_min,
+                    );
                     (
                         Rect::new(area.x, area.y, first_width, area.height),
                         Rect::new(
@@ -923,7 +954,14 @@ fn allocate_node(node: &Node, area: Rect, panes: &mut BTreeMap<PaneId, Rect>) {
                     )
                 }
                 Axis::TopBottom => {
-                    let first_height = area.height / 2;
+                    let (_, first_min) = node_minimum(first);
+                    let (_, second_min) = node_minimum(second);
+                    let first_height = allocated_first_span(
+                        area.height,
+                        *first_share_bps,
+                        first_min,
+                        second_min,
+                    );
                     (
                         Rect::new(area.x, area.y, area.width, first_height),
                         Rect::new(
@@ -2447,6 +2485,8 @@ impl SharedLayoutRuntime {
                     delete_pane: Some(DeletePane { pane_id }),
                     create_tab: None,
                     delete_tab: None,
+                    set_split_ratio: None,
+                    update_pane_grids: None,
                 })?
             }
             UiIntent::DeleteTab { tab_id } => {
@@ -2458,6 +2498,8 @@ impl SharedLayoutRuntime {
                     delete_pane: None,
                     create_tab: None,
                     delete_tab: Some(DeleteTab { tab_id }),
+                    set_split_ratio: None,
+                    update_pane_grids: None,
                 })?
             }
             UiIntent::FocusPane { .. } | UiIntent::SwitchTab { .. } => {}
@@ -2505,6 +2547,8 @@ impl SharedLayoutRuntime {
                 grid_cols: u32::from(grid_cols),
             }),
             delete_tab: None,
+            set_split_ratio: None,
+            update_pane_grids: None,
         })
     }
 
@@ -3411,7 +3455,7 @@ mod tests {
         FOOTER_MUTED, FOOTER_ORANGE, FooterSegment, HostControlEvent, HostPaneChannels,
         HostPaneRuntime, KeyHandling, LayoutControlEvent, MultiPaneTui, PaneTextSelection,
         PaneViewState, PendingEscape, RemoteSubscriptionState, ScreenCell, SharedLayoutRuntime,
-        SharedLocalPane, UiIntent, VtScreen, contextual_footer, copied_line_count, encode_key,
+        SharedLocalPane, UiIntent, VtScreen, allocate_node, contextual_footer, copied_line_count, encode_key,
         encode_paste, grid_for_pane, initial_root_pane_grid, is_chord_command,
         lease_allows_held_input, member_label, mouse_to_screen_cell, pane_border_color, pane_title,
         pane_wire_id, reconcile_remote_control_attempt, render_guest_screen, render_multi_pane,
@@ -4016,9 +4060,11 @@ mod tests {
                 tab_id: 1,
                 root: Node::Split {
                     axis: Axis::LeftRight,
+                    first_share_bps: crate::layout::DEFAULT_FIRST_SHARE_BPS,
                     first: Box::new(Node::Leaf { pane_id: 1 }),
                     second: Box::new(Node::Split {
                         axis: Axis::TopBottom,
+                        first_share_bps: crate::layout::DEFAULT_FIRST_SHARE_BPS,
                         first: Box::new(Node::Leaf { pane_id: 2 }),
                         second: Box::new(Node::Leaf { pane_id: 3 }),
                     }),
@@ -4029,12 +4075,37 @@ mod tests {
     }
 
     #[test]
+    fn ratio_allocation_respects_recursive_minima_and_small_areas() {
+        let node = Node::Split {
+            axis: Axis::LeftRight,
+            first_share_bps: 7_500,
+            first: Box::new(Node::Leaf { pane_id: 1 }),
+            second: Box::new(Node::Split {
+                axis: Axis::LeftRight,
+                first_share_bps: 5_000,
+                first: Box::new(Node::Leaf { pane_id: 2 }),
+                second: Box::new(Node::Leaf { pane_id: 3 }),
+            }),
+        };
+        let mut panes = BTreeMap::new();
+        allocate_node(&node, Rect::new(0, 0, 12, 9), &mut panes);
+        assert_eq!(panes[&1].width, 6, "nested sibling needs six columns");
+        assert_eq!(panes[&2].width, 3);
+        assert_eq!(panes[&3].width, 3);
+
+        panes.clear();
+        allocate_node(&node, Rect::new(0, 0, 2, 2), &mut panes);
+        assert_eq!(panes[&1].width + panes[&2].width + panes[&3].width, 2);
+    }
+
+    #[test]
     fn pane_title_uses_stable_leaf_order_and_control_state() {
         let snapshot = layout(
             vec![Tab {
                 tab_id: 1,
                 root: Node::Split {
                     axis: Axis::LeftRight,
+                    first_share_bps: crate::layout::DEFAULT_FIRST_SHARE_BPS,
                     first: Box::new(Node::Leaf { pane_id: 8 }),
                     second: Box::new(Node::Leaf { pane_id: 3 }),
                 },

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -87,6 +87,7 @@ const NORMAL_FOOTER: &[FooterSegment] = &[
     FooterSegment::Text("> + <"),
     FooterSegment::Key("↑↓←→"),
     FooterSegment::Text("> FOCUS"),
+    FooterSegment::Text("   Option+Shift+drag RESIZE"),
 ];
 const PANE_FOOTER: &[FooterSegment] = &[
     FooterSegment::Text("Pane  <"),
@@ -157,6 +158,12 @@ pub enum UiIntent {
     SwitchTab {
         tab_id: TabId,
     },
+    SetSplitRatio {
+        pane_id: PaneId,
+        axis: Axis,
+        first_share_bps: u16,
+        base_revision: u64,
+    },
 }
 
 /// Whether a terminal key belongs to the mux or should later be offered to the focused pane.
@@ -190,6 +197,17 @@ struct PaneTextSelection {
     pane_id: PaneId,
     anchor: ScreenCell,
     cursor: ScreenCell,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct ResizeDrag {
+    pane_id: PaneId,
+    base_revision: u64,
+    origin_column: u16,
+    origin_row: u16,
+    axis: Option<Axis>,
+    original_share_bps: u16,
+    first_child: bool,
 }
 
 impl PaneTextSelection {
@@ -226,6 +244,7 @@ pub struct MultiPaneTui {
     pending_created_pane: Option<PaneId>,
     selection: Option<PaneTextSelection>,
     selection_dragging: bool,
+    resize_drag: Option<ResizeDrag>,
 }
 
 impl MultiPaneTui {
@@ -250,6 +269,7 @@ impl MultiPaneTui {
             pending_created_pane: None,
             selection: None,
             selection_dragging: false,
+            resize_drag: None,
         })
     }
 
@@ -337,6 +357,68 @@ impl MultiPaneTui {
 
     fn end_selection_drag(&mut self) -> bool {
         std::mem::replace(&mut self.selection_dragging, false)
+    }
+
+    fn begin_resize_drag(&mut self, column: u16, row: u16, area: Rect, modifiers: KeyModifiers) -> bool {
+        if !modifiers.contains(KeyModifiers::ALT) || !modifiers.contains(KeyModifiers::SHIFT) {
+            return false;
+        }
+        let Some((pane_id, rect)) = self.geometry(area).panes.iter().find_map(|(pane_id, rect)| {
+            rect_contains(pane_content_rect(*rect), column, row).then_some((*pane_id, *rect))
+        }) else { return false; };
+        let _ = rect;
+        self.resize_drag = Some(ResizeDrag {
+            pane_id,
+            base_revision: self.snapshot.revision,
+            origin_column: column,
+            origin_row: row,
+            axis: None,
+            original_share_bps: 0,
+            first_child: false,
+        });
+        true
+    }
+
+    fn extend_resize_drag(&mut self, column: u16, row: u16) -> bool {
+        let Some(drag) = self.resize_drag else { return false; };
+        if drag.axis.is_some() { return true; }
+        let horizontal = i32::from(column) - i32::from(drag.origin_column);
+        let vertical = i32::from(row) - i32::from(drag.origin_row);
+        if horizontal.unsigned_abs().max(vertical.unsigned_abs()) < 2 { return true; }
+        let axis = if horizontal.unsigned_abs() >= vertical.unsigned_abs() { Axis::LeftRight } else { Axis::TopBottom };
+        let Some(tab) = self.current_tab_layout() else { self.resize_drag = None; return true; };
+        let Some((share, first_child)) = nearest_split_for_pane(&tab.root, drag.pane_id, axis) else {
+            self.resize_drag = None;
+            return true;
+        };
+        let drag = self.resize_drag.as_mut().expect("drag remains active");
+        drag.axis = Some(axis);
+        drag.original_share_bps = share;
+        drag.first_child = first_child;
+        true
+    }
+
+    fn end_resize_drag(&mut self, column: u16, row: u16, area: Rect) -> Option<UiIntent> {
+        let drag = self.resize_drag.take()?;
+        let axis = drag.axis?;
+        let delta = match axis {
+            Axis::LeftRight => i32::from(column) - i32::from(drag.origin_column),
+            Axis::TopBottom => i32::from(row) - i32::from(drag.origin_row),
+        };
+        let span = match axis { Axis::LeftRight => area.width, Axis::TopBottom => area.height }.max(1);
+        let signed = if drag.first_child { delta } else { -delta };
+        let proposed = (i32::from(drag.original_share_bps) + signed * 10_000 / i32::from(span))
+            .clamp(1, 9_999) as u16;
+        (proposed != drag.original_share_bps).then_some(UiIntent::SetSplitRatio {
+            pane_id: drag.pane_id,
+            axis,
+            first_share_bps: proposed,
+            base_revision: drag.base_revision,
+        })
+    }
+
+    fn cancel_resize_drag(&mut self) -> bool {
+        self.resize_drag.take().is_some()
     }
 
     fn selection(&self) -> Option<PaneTextSelection> {
@@ -897,6 +979,17 @@ fn contains_leaf(node: &Node, pane_id: PaneId) -> bool {
             contains_leaf(first, pane_id) || contains_leaf(second, pane_id)
         }
     }
+}
+
+fn nearest_split_for_pane(node: &Node, pane_id: PaneId, axis: Axis) -> Option<(u16, bool)> {
+    let Node::Split { axis: split_axis, first_share_bps, first, second } = node else { return None; };
+    if contains_leaf(first, pane_id) {
+        nearest_split_for_pane(first, pane_id, axis)
+            .or_else(|| (*split_axis == axis).then_some((*first_share_bps, true)))
+    } else if contains_leaf(second, pane_id) {
+        nearest_split_for_pane(second, pane_id, axis)
+            .or_else(|| (*split_axis == axis).then_some((*first_share_bps, false)))
+    } else { None }
 }
 
 fn node_minimum(node: &Node) -> (u16, u16) {
@@ -2199,7 +2292,9 @@ impl SharedLayoutRuntime {
                     let area = Rect::new(0, 0, cols, rows);
                     let previously_focused = self.tui.focused_pane();
                     dirty |= self.clear_selection();
-                    if let Some(intent) = self.tui.switch_tab_at(mouse.column, mouse.row, area) {
+                    if self.tui.begin_resize_drag(mouse.column, mouse.row, area, mouse.modifiers) {
+                        dirty = true;
+                    } else if let Some(intent) = self.tui.switch_tab_at(mouse.column, mouse.row, area) {
                         self.handle_intent(intent)?;
                         dirty = true;
                     } else {
@@ -2211,16 +2306,23 @@ impl SharedLayoutRuntime {
                 Event::Mouse(mouse)
                     if matches!(mouse.kind, MouseEventKind::Drag(MouseButton::Left)) =>
                 {
-                    dirty |= self.tui.extend_selection_at(
-                        mouse.column,
-                        mouse.row,
-                        Rect::new(0, 0, cols, rows),
-                    );
+                    if self.tui.extend_resize_drag(mouse.column, mouse.row) {
+                        dirty = true;
+                    } else {
+                        dirty |= self.tui.extend_selection_at(
+                            mouse.column,
+                            mouse.row,
+                            Rect::new(0, 0, cols, rows),
+                        );
+                    }
                 }
                 Event::Mouse(mouse)
                     if matches!(mouse.kind, MouseEventKind::Up(MouseButton::Left)) =>
                 {
-                    if self.tui.end_selection_drag() {
+                    let area = Rect::new(0, 0, cols, rows);
+                    if let Some(intent) = self.tui.end_resize_drag(mouse.column, mouse.row, area) {
+                        self.handle_intent(intent)?;
+                    } else if self.tui.end_selection_drag() {
                         self.copy_selection_to_clipboard();
                     }
                     dirty = true;
@@ -2412,6 +2514,7 @@ impl SharedLayoutRuntime {
         self.tui
             .apply_snapshot(snapshot.clone())
             .map_err(|error| io::Error::other(format!("invalid layout state: {error:?}")))?;
+        self.tui.cancel_resize_drag();
         self.release_blurred_pane(previously_focused)?;
         let me = self.control.peer_id();
         self.remote_descriptors.clear();
@@ -2501,6 +2604,23 @@ impl SharedLayoutRuntime {
                     set_split_ratio: None,
                     update_pane_grids: None,
                 })?
+            }
+            UiIntent::SetSplitRatio { pane_id, axis, first_share_bps, base_revision } => {
+                let request_id = self.next_id();
+                self.send_request(LayoutRequest {
+                    request_id,
+                    base_revision,
+                    create_pane: None,
+                    delete_pane: None,
+                    create_tab: None,
+                    delete_tab: None,
+                    set_split_ratio: Some(crate::protocol::SetSplitRatio {
+                        pane_id,
+                        axis: Some(match axis { Axis::LeftRight => SplitAxis::LeftRight as i32, Axis::TopBottom => SplitAxis::TopBottom as i32 }),
+                        first_share_bps: u32::from(first_share_bps),
+                    }),
+                    update_pane_grids: None,
+                })?;
             }
             UiIntent::FocusPane { .. } | UiIntent::SwitchTab { .. } => {}
         }
@@ -4096,6 +4216,20 @@ mod tests {
         panes.clear();
         allocate_node(&node, Rect::new(0, 0, 2, 2), &mut panes);
         assert_eq!(panes[&1].width + panes[&2].width + panes[&3].width, 2);
+    }
+
+    #[test]
+    fn option_shift_drag_locks_once_and_emits_one_ratio_intent() {
+        let mut tui = MultiPaneTui::new(split_layout()).expect("layout");
+        let area = Rect::new(0, 0, 80, 24);
+        assert!(tui.begin_resize_drag(10, 5, area, KeyModifiers::ALT | KeyModifiers::SHIFT));
+        assert!(tui.extend_resize_drag(11, 5), "under threshold remains pending");
+        assert!(tui.extend_resize_drag(20, 6), "horizontal lock");
+        assert!(matches!(
+            tui.end_resize_drag(20, 6, area),
+            Some(UiIntent::SetSplitRatio { pane_id: 1, axis: Axis::LeftRight, base_revision: 1, .. })
+        ));
+        assert!(tui.end_resize_drag(20, 6, area).is_none());
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -359,13 +359,26 @@ impl MultiPaneTui {
         std::mem::replace(&mut self.selection_dragging, false)
     }
 
-    fn begin_resize_drag(&mut self, column: u16, row: u16, area: Rect, modifiers: KeyModifiers) -> bool {
+    fn begin_resize_drag(
+        &mut self,
+        column: u16,
+        row: u16,
+        area: Rect,
+        modifiers: KeyModifiers,
+    ) -> bool {
         if !modifiers.contains(KeyModifiers::ALT) || !modifiers.contains(KeyModifiers::SHIFT) {
             return false;
         }
-        let Some((pane_id, rect)) = self.geometry(area).panes.iter().find_map(|(pane_id, rect)| {
-            rect_contains(pane_content_rect(*rect), column, row).then_some((*pane_id, *rect))
-        }) else { return false; };
+        let Some((pane_id, rect)) = self
+            .geometry(area)
+            .panes
+            .iter()
+            .find_map(|(pane_id, rect)| {
+                rect_contains(pane_content_rect(*rect), column, row).then_some((*pane_id, *rect))
+            })
+        else {
+            return false;
+        };
         let _ = rect;
         self.resize_drag = Some(ResizeDrag {
             pane_id,
@@ -380,14 +393,28 @@ impl MultiPaneTui {
     }
 
     fn extend_resize_drag(&mut self, column: u16, row: u16) -> bool {
-        let Some(drag) = self.resize_drag else { return false; };
-        if drag.axis.is_some() { return true; }
+        let Some(drag) = self.resize_drag else {
+            return false;
+        };
+        if drag.axis.is_some() {
+            return true;
+        }
         let horizontal = i32::from(column) - i32::from(drag.origin_column);
         let vertical = i32::from(row) - i32::from(drag.origin_row);
-        if horizontal.unsigned_abs().max(vertical.unsigned_abs()) < 2 { return true; }
-        let axis = if horizontal.unsigned_abs() >= vertical.unsigned_abs() { Axis::LeftRight } else { Axis::TopBottom };
-        let Some(tab) = self.current_tab_layout() else { self.resize_drag = None; return true; };
-        let Some((share, first_child)) = nearest_split_for_pane(&tab.root, drag.pane_id, axis) else {
+        if horizontal.unsigned_abs().max(vertical.unsigned_abs()) < 2 {
+            return true;
+        }
+        let axis = if horizontal.unsigned_abs() >= vertical.unsigned_abs() {
+            Axis::LeftRight
+        } else {
+            Axis::TopBottom
+        };
+        let Some(tab) = self.current_tab_layout() else {
+            self.resize_drag = None;
+            return true;
+        };
+        let Some((share, first_child)) = nearest_split_for_pane(&tab.root, drag.pane_id, axis)
+        else {
             self.resize_drag = None;
             return true;
         };
@@ -405,7 +432,11 @@ impl MultiPaneTui {
             Axis::LeftRight => i32::from(column) - i32::from(drag.origin_column),
             Axis::TopBottom => i32::from(row) - i32::from(drag.origin_row),
         };
-        let span = match axis { Axis::LeftRight => area.width, Axis::TopBottom => area.height }.max(1);
+        let span = match axis {
+            Axis::LeftRight => area.width,
+            Axis::TopBottom => area.height,
+        }
+        .max(1);
         let signed = if drag.first_child { delta } else { -delta };
         let proposed = (i32::from(drag.original_share_bps) + signed * 10_000 / i32::from(span))
             .clamp(1, 9_999) as u16;
@@ -982,25 +1013,46 @@ fn contains_leaf(node: &Node, pane_id: PaneId) -> bool {
 }
 
 fn nearest_split_for_pane(node: &Node, pane_id: PaneId, axis: Axis) -> Option<(u16, bool)> {
-    let Node::Split { axis: split_axis, first_share_bps, first, second } = node else { return None; };
+    let Node::Split {
+        axis: split_axis,
+        first_share_bps,
+        first,
+        second,
+    } = node
+    else {
+        return None;
+    };
     if contains_leaf(first, pane_id) {
         nearest_split_for_pane(first, pane_id, axis)
             .or_else(|| (*split_axis == axis).then_some((*first_share_bps, true)))
     } else if contains_leaf(second, pane_id) {
         nearest_split_for_pane(second, pane_id, axis)
             .or_else(|| (*split_axis == axis).then_some((*first_share_bps, false)))
-    } else { None }
+    } else {
+        None
+    }
 }
 
 fn node_minimum(node: &Node) -> (u16, u16) {
     match node {
         Node::Leaf { .. } => (3, 3),
-        Node::Split { axis, first, second, .. } => {
+        Node::Split {
+            axis,
+            first,
+            second,
+            ..
+        } => {
             let (first_width, first_height) = node_minimum(first);
             let (second_width, second_height) = node_minimum(second);
             match axis {
-                Axis::LeftRight => (first_width.saturating_add(second_width), first_height.max(second_height)),
-                Axis::TopBottom => (first_width.max(second_width), first_height.saturating_add(second_height)),
+                Axis::LeftRight => (
+                    first_width.saturating_add(second_width),
+                    first_height.max(second_height),
+                ),
+                Axis::TopBottom => (
+                    first_width.max(second_width),
+                    first_height.saturating_add(second_height),
+                ),
             }
         }
     }
@@ -1030,12 +1082,8 @@ fn allocate_node(node: &Node, area: Rect, panes: &mut BTreeMap<PaneId, Rect>) {
                 Axis::LeftRight => {
                     let (first_min, _) = node_minimum(first);
                     let (second_min, _) = node_minimum(second);
-                    let first_width = allocated_first_span(
-                        area.width,
-                        *first_share_bps,
-                        first_min,
-                        second_min,
-                    );
+                    let first_width =
+                        allocated_first_span(area.width, *first_share_bps, first_min, second_min);
                     (
                         Rect::new(area.x, area.y, first_width, area.height),
                         Rect::new(
@@ -1049,12 +1097,8 @@ fn allocate_node(node: &Node, area: Rect, panes: &mut BTreeMap<PaneId, Rect>) {
                 Axis::TopBottom => {
                     let (_, first_min) = node_minimum(first);
                     let (_, second_min) = node_minimum(second);
-                    let first_height = allocated_first_span(
-                        area.height,
-                        *first_share_bps,
-                        first_min,
-                        second_min,
-                    );
+                    let first_height =
+                        allocated_first_span(area.height, *first_share_bps, first_min, second_min);
                     (
                         Rect::new(area.x, area.y, area.width, first_height),
                         Rect::new(
@@ -2307,9 +2351,14 @@ impl SharedLayoutRuntime {
                     let area = Rect::new(0, 0, cols, rows);
                     let previously_focused = self.tui.focused_pane();
                     dirty |= self.clear_selection();
-                    if self.tui.begin_resize_drag(mouse.column, mouse.row, area, mouse.modifiers) {
+                    if self
+                        .tui
+                        .begin_resize_drag(mouse.column, mouse.row, area, mouse.modifiers)
+                    {
                         dirty = true;
-                    } else if let Some(intent) = self.tui.switch_tab_at(mouse.column, mouse.row, area) {
+                    } else if let Some(intent) =
+                        self.tui.switch_tab_at(mouse.column, mouse.row, area)
+                    {
                         self.handle_intent(intent)?;
                         dirty = true;
                     } else {
@@ -2567,14 +2616,28 @@ impl SharedLayoutRuntime {
         let geometry = self.tui.geometry(area);
         let mut updates = Vec::new();
         for (pane_id, rect) in geometry.panes {
-            let Some(pane) = self.local.get_mut(&pane_id) else { continue; };
+            let Some(pane) = self.local.get_mut(&pane_id) else {
+                continue;
+            };
             let (rows, cols) = grid_for_pane(rect);
             if pane.screen.screen().size() == (rows, cols) {
                 continue;
             }
             pane.resize(rows, cols)?;
-            if self.tui.snapshot().panes.get(&pane_id).is_some_and(|descriptor| (descriptor.grid_rows, descriptor.grid_cols) != (rows, cols)) {
-                updates.push(crate::protocol::PaneGrid { pane_id, grid_rows: u32::from(rows), grid_cols: u32::from(cols) });
+            if self
+                .tui
+                .snapshot()
+                .panes
+                .get(&pane_id)
+                .is_some_and(|descriptor| {
+                    (descriptor.grid_rows, descriptor.grid_cols) != (rows, cols)
+                })
+            {
+                updates.push(crate::protocol::PaneGrid {
+                    pane_id,
+                    grid_rows: u32::from(rows),
+                    grid_cols: u32::from(cols),
+                });
             }
         }
         if !updates.is_empty() {
@@ -2655,7 +2718,12 @@ impl SharedLayoutRuntime {
                     update_pane_grids: None,
                 })?
             }
-            UiIntent::SetSplitRatio { pane_id, axis, first_share_bps, base_revision } => {
+            UiIntent::SetSplitRatio {
+                pane_id,
+                axis,
+                first_share_bps,
+                base_revision,
+            } => {
                 let request_id = self.next_id();
                 self.send_request(LayoutRequest {
                     request_id,
@@ -2666,7 +2734,10 @@ impl SharedLayoutRuntime {
                     delete_tab: None,
                     set_split_ratio: Some(crate::protocol::SetSplitRatio {
                         pane_id,
-                        axis: Some(match axis { Axis::LeftRight => SplitAxis::LeftRight as i32, Axis::TopBottom => SplitAxis::TopBottom as i32 }),
+                        axis: Some(match axis {
+                            Axis::LeftRight => SplitAxis::LeftRight as i32,
+                            Axis::TopBottom => SplitAxis::TopBottom as i32,
+                        }),
                         first_share_bps: u32::from(first_share_bps),
                     }),
                     update_pane_grids: None,
@@ -3626,8 +3697,8 @@ mod tests {
         FOOTER_MUTED, FOOTER_ORANGE, FooterSegment, HostControlEvent, HostPaneChannels,
         HostPaneRuntime, KeyHandling, LayoutControlEvent, MultiPaneTui, PaneTextSelection,
         PaneViewState, PendingEscape, RemoteSubscriptionState, ScreenCell, SharedLayoutRuntime,
-        SharedLocalPane, UiIntent, VtScreen, allocate_node, contextual_footer, copied_line_count, encode_key,
-        encode_paste, grid_for_pane, initial_root_pane_grid, is_chord_command,
+        SharedLocalPane, UiIntent, VtScreen, allocate_node, contextual_footer, copied_line_count,
+        encode_key, encode_paste, grid_for_pane, initial_root_pane_grid, is_chord_command,
         lease_allows_held_input, member_label, mouse_to_screen_cell, pane_border_color, pane_title,
         pane_wire_id, reconcile_remote_control_attempt, render_guest_screen, render_multi_pane,
         render_shared_multi_pane, selection_text, text_width, viewed_screen, visible_leaf_panes,
@@ -4285,11 +4356,19 @@ mod tests {
         let mut tui = MultiPaneTui::new(split_layout()).expect("layout");
         let area = Rect::new(0, 0, 80, 24);
         assert!(tui.begin_resize_drag(10, 5, area, KeyModifiers::ALT | KeyModifiers::SHIFT));
-        assert!(tui.extend_resize_drag(11, 5), "under threshold remains pending");
+        assert!(
+            tui.extend_resize_drag(11, 5),
+            "under threshold remains pending"
+        );
         assert!(tui.extend_resize_drag(20, 6), "horizontal lock");
         assert!(matches!(
             tui.end_resize_drag(20, 6, area),
-            Some(UiIntent::SetSplitRatio { pane_id: 1, axis: Axis::LeftRight, base_revision: 1, .. })
+            Some(UiIntent::SetSplitRatio {
+                pane_id: 1,
+                axis: Axis::LeftRight,
+                base_revision: 1,
+                ..
+            })
         ));
         assert!(tui.end_resize_drag(20, 6, area).is_none());
     }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -2607,8 +2607,9 @@ impl SharedLayoutRuntime {
         self.subscriptions.nudge();
         self.start_eligible_subscriptions();
         self.refresh_local_views();
-        let (width, height) = terminal::size()?;
-        self.reflow_local_panes(Rect::new(0, 0, width, height))?;
+        if let Some(area) = area_from_terminal_size(terminal::size()) {
+            self.reflow_local_panes(area)?;
+        }
         Ok(())
     }
 
@@ -2937,6 +2938,11 @@ impl SharedLayoutRuntime {
         }
         self.runtime.block_on(self.control.shutdown());
     }
+}
+
+fn area_from_terminal_size(size: io::Result<(u16, u16)>) -> Option<Rect> {
+    size.ok()
+        .map(|(width, height)| Rect::new(0, 0, width, height))
 }
 
 pub struct HostPaneRuntime {
@@ -3667,6 +3673,7 @@ fn member_label(peer_id: &[u8], members: &[crate::layout::Member]) -> String {
 mod tests {
     use std::{
         collections::BTreeMap,
+        io,
         net::Ipv4Addr,
         thread,
         time::{Duration, Instant},
@@ -3697,10 +3704,11 @@ mod tests {
         FOOTER_MUTED, FOOTER_ORANGE, FooterSegment, HostControlEvent, HostPaneChannels,
         HostPaneRuntime, KeyHandling, LayoutControlEvent, MultiPaneTui, PaneTextSelection,
         PaneViewState, PendingEscape, RemoteSubscriptionState, ScreenCell, SharedLayoutRuntime,
-        SharedLocalPane, UiIntent, VtScreen, allocate_node, contextual_footer, copied_line_count,
-        encode_key, encode_paste, grid_for_pane, initial_root_pane_grid, is_chord_command,
-        lease_allows_held_input, member_label, mouse_to_screen_cell, pane_border_color, pane_title,
-        pane_wire_id, reconcile_remote_control_attempt, render_guest_screen, render_multi_pane,
+        SharedLocalPane, UiIntent, VtScreen, allocate_node, area_from_terminal_size,
+        contextual_footer, copied_line_count, encode_key, encode_paste, grid_for_pane,
+        initial_root_pane_grid, is_chord_command, lease_allows_held_input, member_label,
+        mouse_to_screen_cell, pane_border_color, pane_title, pane_wire_id,
+        reconcile_remote_control_attempt, render_guest_screen, render_multi_pane,
         render_shared_multi_pane, selection_text, text_width, viewed_screen, visible_leaf_panes,
     };
 
@@ -3728,6 +3736,14 @@ mod tests {
                 })
                 .collect::<BTreeMap<_, _>>(),
         }
+    }
+
+    #[test]
+    fn terminal_area_is_absent_when_terminal_size_is_unavailable() {
+        assert_eq!(
+            area_from_terminal_size(Err(io::Error::from(io::ErrorKind::WouldBlock))),
+            None
+        );
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1691,6 +1691,21 @@ impl SharedLocalPane {
         Ok(true)
     }
 
+    fn resize(&mut self, rows: u16, cols: u16) -> Result<(), Box<dyn Error>> {
+        if self.screen.screen().size() == (rows, cols) {
+            return Ok(());
+        }
+        self.host.resize(PtySize {
+            rows,
+            cols,
+            pixel_width: 0,
+            pixel_height: 0,
+        })?;
+        let frame = self.screen.resize(rows, cols)?;
+        self.screen_tx.send_replace(frame);
+        Ok(())
+    }
+
     fn shutdown(&mut self) -> Result<(), Box<dyn Error>> {
         self.host.shutdown()
     }
@@ -2352,7 +2367,10 @@ impl SharedLayoutRuntime {
                         matches!(mouse.kind, MouseEventKind::ScrollUp),
                     );
                 }
-                Event::Resize(_, _) => dirty = true,
+                Event::Resize(width, height) => {
+                    self.reflow_local_panes(Rect::new(0, 0, width, height))?;
+                    dirty = true;
+                }
                 _ => {}
             }
         }
@@ -2540,6 +2558,38 @@ impl SharedLayoutRuntime {
         self.subscriptions.nudge();
         self.start_eligible_subscriptions();
         self.refresh_local_views();
+        let (width, height) = terminal::size()?;
+        self.reflow_local_panes(Rect::new(0, 0, width, height))?;
+        Ok(())
+    }
+
+    fn reflow_local_panes(&mut self, area: Rect) -> Result<(), Box<dyn Error>> {
+        let geometry = self.tui.geometry(area);
+        let mut updates = Vec::new();
+        for (pane_id, rect) in geometry.panes {
+            let Some(pane) = self.local.get_mut(&pane_id) else { continue; };
+            let (rows, cols) = grid_for_pane(rect);
+            if pane.screen.screen().size() == (rows, cols) {
+                continue;
+            }
+            pane.resize(rows, cols)?;
+            if self.tui.snapshot().panes.get(&pane_id).is_some_and(|descriptor| (descriptor.grid_rows, descriptor.grid_cols) != (rows, cols)) {
+                updates.push(crate::protocol::PaneGrid { pane_id, grid_rows: u32::from(rows), grid_cols: u32::from(cols) });
+            }
+        }
+        if !updates.is_empty() {
+            let request_id = self.next_id();
+            self.send_request(LayoutRequest {
+                request_id,
+                base_revision: self.tui.snapshot().revision,
+                create_pane: None,
+                delete_pane: None,
+                create_tab: None,
+                delete_tab: None,
+                set_split_ratio: None,
+                update_pane_grids: Some(crate::protocol::UpdatePaneGrids { panes: updates }),
+            })?;
+        }
         Ok(())
     }
 
@@ -2751,6 +2801,7 @@ impl SharedLayoutRuntime {
     }
 
     fn reject_request(&mut self, request_id: u64) {
+        self.tui.cancel_resize_drag();
         self.pending_create = self
             .pending_create
             .filter(|pending| pending.request_id != request_id);
@@ -4121,6 +4172,17 @@ mod tests {
         assert_eq!(pane.host_peer_id, host_id);
 
         pane.shutdown().expect("shutdown local pane");
+    }
+
+    #[test]
+    fn local_pane_resize_publishes_a_replacement_screen_frame() {
+        let mut pane = SharedLocalPane::spawn(99, 1, 1, b"host".to_vec()).expect("pane");
+        let before = pane.screen.current_frame().sequence;
+        pane.resize(3, 4).expect("resize");
+        assert_eq!(pane.screen.screen().size(), (3, 4));
+        assert!(pane.screen.current_frame().sequence > before);
+        assert_eq!(pane.screen.current_frame().base_sequence, 0);
+        pane.shutdown().expect("shutdown");
     }
 
     #[test]

--- a/tests/layout.rs
+++ b/tests/layout.rs
@@ -1,6 +1,7 @@
 use p2pmux::layout::{
     Axis, LayoutError, LayoutSnapshot, MAX_ENDPOINT_ADDR_BYTES, MAX_MEMBERS, MAX_PANES_PER_TAB,
     MAX_PEER_ID_BYTES, MAX_TABS, NewPanePosition, Node, ReservationCommit, SessionState,
+    DEFAULT_FIRST_SHARE_BPS,
 };
 
 const HOST_A: &[u8] = b"host-a";
@@ -57,6 +58,62 @@ fn initial_state_has_one_tab_and_one_hosted_pane() {
     assert_eq!(snapshot.tabs[0].root, Node::Leaf { pane_id: 1 });
     assert_eq!(snapshot.panes[&1].host_peer_id, HOST_A);
     assert_eq!(snapshot.members[0].endpoint_addr, ADDR_A);
+}
+
+#[test]
+fn splits_default_to_a_valid_shared_ratio_and_ratio_updates_are_revisioned() {
+    let mut state = state();
+    let second = state
+        .create_pane(HOST_A, state.revision(), 1, Axis::LeftRight, 24, 80)
+        .expect("split");
+    assert!(matches!(
+        snapshot(&state).tabs[0].root,
+        Node::Split { first_share_bps: DEFAULT_FIRST_SHARE_BPS, .. }
+    ));
+
+    state
+        .set_split_ratio(HOST_A, state.revision(), second, Axis::LeftRight, 7_500)
+        .expect("ratio update");
+    assert!(matches!(
+        snapshot(&state).tabs[0].root,
+        Node::Split { first_share_bps: 7_500, .. }
+    ));
+}
+
+#[test]
+fn ratios_and_host_grid_batches_are_strict_and_atomic() {
+    let mut state = state();
+    state
+        .add_member(state.revision(), HOST_B.to_vec(), ADDR_B.to_vec())
+        .expect("member");
+    let second = state
+        .create_pane(HOST_B, state.revision(), 1, Axis::LeftRight, 24, 80)
+        .expect("pane");
+    let before = snapshot(&state);
+    assert_eq!(
+        state.set_split_ratio(HOST_B, state.revision(), second, Axis::TopBottom, 5_000),
+        Err(LayoutError::NoMatchingSplit { pane_id: second, axis: Axis::TopBottom })
+    );
+    assert_eq!(
+        state.set_split_ratio(HOST_B, state.revision(), 99, Axis::LeftRight, 5_000),
+        Err(LayoutError::UnknownPane { pane_id: 99 })
+    );
+    assert_eq!(snapshot(&state), before);
+
+    state
+        .update_pane_grids(HOST_B, state.revision(), &[(second, 30, 100)])
+        .expect("host grid update");
+    assert_eq!(state.pane(second).expect("pane").grid_rows, 30);
+    let after = snapshot(&state);
+    assert_eq!(
+        state.update_pane_grids(HOST_A, state.revision(), &[(second, 31, 100)]),
+        Err(LayoutError::NotPaneHost { pane_id: second })
+    );
+    assert_eq!(
+        state.update_pane_grids(HOST_B, state.revision(), &[(second, 0, 100)]),
+        Err(LayoutError::InvalidGrid)
+    );
+    assert_eq!(snapshot(&state), after);
 }
 
 #[test]
@@ -137,6 +194,7 @@ fn creating_panes_uses_the_requested_split_axis() {
                 axis: Axis::TopBottom,
                 first,
                 second,
+                ..
             } if matches!(first.as_ref(), Node::Leaf { pane_id } if *pane_id == right)
                 && matches!(second.as_ref(), Node::Leaf { pane_id } if *pane_id == down)
         )

--- a/tests/layout.rs
+++ b/tests/layout.rs
@@ -1,7 +1,7 @@
 use p2pmux::layout::{
-    Axis, LayoutError, LayoutSnapshot, MAX_ENDPOINT_ADDR_BYTES, MAX_MEMBERS, MAX_PANES_PER_TAB,
-    MAX_PEER_ID_BYTES, MAX_TABS, NewPanePosition, Node, ReservationCommit, SessionState,
-    DEFAULT_FIRST_SHARE_BPS,
+    Axis, DEFAULT_FIRST_SHARE_BPS, LayoutError, LayoutSnapshot, MAX_ENDPOINT_ADDR_BYTES,
+    MAX_MEMBERS, MAX_PANES_PER_TAB, MAX_PEER_ID_BYTES, MAX_TABS, NewPanePosition, Node,
+    ReservationCommit, SessionState,
 };
 
 const HOST_A: &[u8] = b"host-a";
@@ -68,7 +68,10 @@ fn splits_default_to_a_valid_shared_ratio_and_ratio_updates_are_revisioned() {
         .expect("split");
     assert!(matches!(
         snapshot(&state).tabs[0].root,
-        Node::Split { first_share_bps: DEFAULT_FIRST_SHARE_BPS, .. }
+        Node::Split {
+            first_share_bps: DEFAULT_FIRST_SHARE_BPS,
+            ..
+        }
     ));
 
     state
@@ -76,7 +79,10 @@ fn splits_default_to_a_valid_shared_ratio_and_ratio_updates_are_revisioned() {
         .expect("ratio update");
     assert!(matches!(
         snapshot(&state).tabs[0].root,
-        Node::Split { first_share_bps: 7_500, .. }
+        Node::Split {
+            first_share_bps: 7_500,
+            ..
+        }
     ));
 }
 
@@ -92,7 +98,10 @@ fn ratios_and_host_grid_batches_are_strict_and_atomic() {
     let before = snapshot(&state);
     assert_eq!(
         state.set_split_ratio(HOST_B, state.revision(), second, Axis::TopBottom, 5_000),
-        Err(LayoutError::NoMatchingSplit { pane_id: second, axis: Axis::TopBottom })
+        Err(LayoutError::NoMatchingSplit {
+            pane_id: second,
+            axis: Axis::TopBottom
+        })
     );
     assert_eq!(
         state.set_split_ratio(HOST_B, state.revision(), 99, Axis::LeftRight, 5_000),

--- a/tests/module_surface.rs
+++ b/tests/module_surface.rs
@@ -17,5 +17,5 @@ fn exposes_the_scaffold_module_boundaries() {
     let _: Option<JoinTicket> = None;
     let _: Option<HostSession> = None;
     let _: Option<Envelope> = None;
-    assert_eq!(PROTOCOL_VERSION, 3);
+    assert_eq!(PROTOCOL_VERSION, 4);
 }

--- a/tests/protocol.rs
+++ b/tests/protocol.rs
@@ -6,6 +6,7 @@ use p2pmux::protocol::{
     MAX_SNAPSHOT_BYTES, MemberDescriptor, NewPanePosition, PROTOCOL_VERSION, PaneDescriptor,
     PaneFailed, PaneReady, PaneReservation, PaneSubscribe, ProtocolError, SessionSnapshot,
     Snapshot, SplitAxis, TabDescriptor, TakeControl, Welcome, decode_frame, encode_frame, envelope,
+    PaneGrid, SetSplitRatio, UpdatePaneGrids,
 };
 use prost::Message;
 
@@ -25,8 +26,62 @@ fn envelope(body: envelope::Body) -> Envelope {
 }
 
 #[test]
-fn protocol_version_is_v3() {
-    assert_eq!(PROTOCOL_VERSION, 3);
+fn protocol_version_is_v4() {
+    assert_eq!(PROTOCOL_VERSION, 4);
+}
+
+#[test]
+fn ratio_and_grid_actions_validate_strictly() {
+    let request = LayoutRequest {
+        request_id: 1,
+        base_revision: 1,
+        create_pane: None,
+        delete_pane: None,
+        create_tab: None,
+        delete_tab: None,
+        set_split_ratio: Some(SetSplitRatio {
+            pane_id: 1,
+            axis: Some(SplitAxis::LeftRight as i32),
+            first_share_bps: 7_500,
+        }),
+        update_pane_grids: None,
+    };
+    let encoded = encode_frame(&envelope(envelope::Body::LayoutRequest(request.clone())))
+        .expect("valid request");
+    assert_eq!(decode_frame(&encoded).expect("round trip"), envelope(envelope::Body::LayoutRequest(request)));
+
+    for first_share_bps in [0, 10_000] {
+        let invalid = LayoutRequest {
+            set_split_ratio: Some(SetSplitRatio {
+                pane_id: 1,
+                axis: Some(SplitAxis::LeftRight as i32),
+                first_share_bps,
+            }),
+            ..LayoutRequest {
+                request_id: 1,
+                base_revision: 1,
+                create_pane: None,
+                delete_pane: None,
+                create_tab: None,
+                delete_tab: None,
+                set_split_ratio: None,
+                update_pane_grids: None,
+            }
+        };
+        assert!(encode_frame(&envelope(envelope::Body::LayoutRequest(invalid))).is_err());
+    }
+
+    let grids = LayoutRequest {
+        request_id: 2,
+        base_revision: 1,
+        create_pane: None,
+        delete_pane: None,
+        create_tab: None,
+        delete_tab: None,
+        set_split_ratio: None,
+        update_pane_grids: Some(UpdatePaneGrids { panes: vec![PaneGrid { pane_id: 1, grid_rows: 24, grid_cols: 80 }] }),
+    };
+    assert!(decode_frame(&encode_frame(&envelope(envelope::Body::LayoutRequest(grids))).expect("encode")).is_ok());
 }
 
 #[test]
@@ -254,6 +309,8 @@ fn v2_envelopes() -> Vec<Envelope> {
             delete_pane: None,
             create_tab: None,
             delete_tab: None,
+            set_split_ratio: None,
+            update_pane_grids: None,
         })),
         envelope(envelope::Body::PaneReservation(PaneReservation {
             reservation_id: 1,
@@ -336,6 +393,8 @@ fn layout_messages_reject_invalid_shapes_and_bounds() {
         delete_pane: None,
         create_tab: None,
         delete_tab: None,
+        set_split_ratio: None,
+        update_pane_grids: None,
     };
     let multiple_actions = LayoutRequest {
         create_pane: Some(CreatePane {
@@ -367,6 +426,7 @@ fn layout_messages_reject_invalid_shapes_and_bounds() {
                     axis: Some(SplitAxis::LeftRight as i32),
                     first: Some(leaf(1)),
                     second: Some(leaf(1)),
+                    first_share_bps: None,
                 })),
             }),
         }],
@@ -543,6 +603,8 @@ fn create_pane_axis_and_position_are_validated() {
             delete_pane: None,
             create_tab: None,
             delete_tab: None,
+            set_split_ratio: None,
+            update_pane_grids: None,
         }))
     }
 
@@ -570,6 +632,7 @@ fn create_pane_axis_and_position_are_validated() {
                         axis,
                         first: Some(leaf(1)),
                         second: Some(leaf(2)),
+                        first_share_bps: None,
                     })),
                 }),
             }],
@@ -639,6 +702,8 @@ fn layout_grids_must_fit_the_reducer_u16_grid() {
         delete_pane: None,
         create_tab: None,
         delete_tab: None,
+        set_split_ratio: None,
+        update_pane_grids: None,
     };
 
     for valid in [
@@ -842,6 +907,7 @@ fn layout_state_rejects_empty_duplicate_and_dangling_references() {
                     axis: Some(SplitAxis::LeftRight as i32),
                     first: Some(leaf(1)),
                     second: Some(leaf(1)),
+                    first_share_bps: None,
                 })),
             }),
         }],
@@ -927,6 +993,7 @@ fn layout_state_wire_shape_includes_all_nested_fields() {
                     axis: Some(SplitAxis::TopBottom as i32),
                     first: Some(leaf(11)),
                     second: Some(leaf(11)),
+                    first_share_bps: None,
                 })),
             }),
         }],
@@ -989,6 +1056,7 @@ fn layout_messages_reject_deep_or_wide_trees_and_oversize_join_endpoint() {
                 axis: Some(SplitAxis::TopBottom as i32),
                 first: Some(full_tree(depth - 1, next_pane_id)),
                 second: Some(full_tree(depth - 1, next_pane_id)),
+                first_share_bps: None,
             })),
         }
     }

--- a/tests/protocol.rs
+++ b/tests/protocol.rs
@@ -4,9 +4,9 @@ use p2pmux::protocol::{
     LayoutState, MAX_DELTA_BYTES, MAX_ENDPOINT_ADDR_BYTES, MAX_ENVELOPE_BYTES, MAX_FRAME_BYTES,
     MAX_INPUT_BYTES, MAX_PANE_ID_BYTES, MAX_PEER_ID_BYTES, MAX_SESSION_ID_BYTES,
     MAX_SNAPSHOT_BYTES, MemberDescriptor, NewPanePosition, PROTOCOL_VERSION, PaneDescriptor,
-    PaneFailed, PaneReady, PaneReservation, PaneSubscribe, ProtocolError, SessionSnapshot,
-    Snapshot, SplitAxis, TabDescriptor, TakeControl, Welcome, decode_frame, encode_frame, envelope,
-    PaneGrid, SetSplitRatio, UpdatePaneGrids,
+    PaneFailed, PaneGrid, PaneReady, PaneReservation, PaneSubscribe, ProtocolError,
+    SessionSnapshot, SetSplitRatio, Snapshot, SplitAxis, TabDescriptor, TakeControl,
+    UpdatePaneGrids, Welcome, decode_frame, encode_frame, envelope,
 };
 use prost::Message;
 
@@ -48,7 +48,10 @@ fn ratio_and_grid_actions_validate_strictly() {
     };
     let encoded = encode_frame(&envelope(envelope::Body::LayoutRequest(request.clone())))
         .expect("valid request");
-    assert_eq!(decode_frame(&encoded).expect("round trip"), envelope(envelope::Body::LayoutRequest(request)));
+    assert_eq!(
+        decode_frame(&encoded).expect("round trip"),
+        envelope(envelope::Body::LayoutRequest(request))
+    );
 
     for first_share_bps in [0, 10_000] {
         let invalid = LayoutRequest {
@@ -79,9 +82,20 @@ fn ratio_and_grid_actions_validate_strictly() {
         create_tab: None,
         delete_tab: None,
         set_split_ratio: None,
-        update_pane_grids: Some(UpdatePaneGrids { panes: vec![PaneGrid { pane_id: 1, grid_rows: 24, grid_cols: 80 }] }),
+        update_pane_grids: Some(UpdatePaneGrids {
+            panes: vec![PaneGrid {
+                pane_id: 1,
+                grid_rows: 24,
+                grid_cols: 80,
+            }],
+        }),
     };
-    assert!(decode_frame(&encode_frame(&envelope(envelope::Body::LayoutRequest(grids))).expect("encode")).is_ok());
+    assert!(
+        decode_frame(
+            &encode_frame(&envelope(envelope::Body::LayoutRequest(grids))).expect("encode")
+        )
+        .is_ok()
+    );
 }
 
 #[test]

--- a/tests/pty_host.rs
+++ b/tests/pty_host.rs
@@ -53,16 +53,30 @@ fn pty_host_reads_output_and_writes_input() {
 #[test]
 fn pty_host_resizes_without_disrupting_io() {
     let mut command = CommandBuilder::new("/bin/sh");
-    command.args(["-c", "printf ready; IFS= read -r line; printf ':reply:%s' \"$line\""]);
+    command.args([
+        "-c",
+        "printf ready; IFS= read -r line; printf ':reply:%s' \"$line\"",
+    ]);
     let mut host = PtyHost::spawn(
         command,
-        PtySize { rows: 24, cols: 80, pixel_width: 0, pixel_height: 0 },
+        PtySize {
+            rows: 24,
+            cols: 80,
+            pixel_width: 0,
+            pixel_height: 0,
+        },
     )
     .expect("PTY should spawn");
-    host.resize(PtySize { rows: 30, cols: 100, pixel_width: 0, pixel_height: 0 })
-        .expect("resize succeeds");
+    host.resize(PtySize {
+        rows: 30,
+        cols: 100,
+        pixel_width: 0,
+        pixel_height: 0,
+    })
+    .expect("resize succeeds");
     assert!(read_until(&mut host, "ready").contains("ready"));
-    host.write_input(b"still alive\n").expect("writer stays alive");
+    host.write_input(b"still alive\n")
+        .expect("writer stays alive");
     assert!(read_until(&mut host, ":reply:still alive").contains("still alive"));
     host.shutdown().expect("clean shutdown");
 }

--- a/tests/pty_host.rs
+++ b/tests/pty_host.rs
@@ -49,3 +49,20 @@ fn pty_host_reads_output_and_writes_input() {
     host.shutdown().expect("PTY should shut down cleanly");
     assert!(host.output_closed());
 }
+
+#[test]
+fn pty_host_resizes_without_disrupting_io() {
+    let mut command = CommandBuilder::new("/bin/sh");
+    command.args(["-c", "printf ready; IFS= read -r line; printf ':reply:%s' \"$line\""]);
+    let mut host = PtyHost::spawn(
+        command,
+        PtySize { rows: 24, cols: 80, pixel_width: 0, pixel_height: 0 },
+    )
+    .expect("PTY should spawn");
+    host.resize(PtySize { rows: 30, cols: 100, pixel_width: 0, pixel_height: 0 })
+        .expect("resize succeeds");
+    assert!(read_until(&mut host, "ready").contains("ready"));
+    host.write_input(b"still alive\n").expect("writer stays alive");
+    assert!(read_until(&mut host, ":reply:still alive").contains("still alive"));
+    host.shutdown().expect("clean shutdown");
+}

--- a/tests/screen.rs
+++ b/tests/screen.rs
@@ -140,8 +140,15 @@ fn resize_forces_a_replacement_snapshot_for_guests() {
     assert!(resized.delta.is_empty());
 
     let mut guest = GuestScreen::new();
-    guest.apply_snapshot(before.sequence, &before.snapshot).expect("old snapshot");
-    assert_eq!(guest.apply_delta(resized.base_sequence, resized.sequence, &resized.delta), Err(p2pmux::screen::ScreenError::InvalidSequence));
-    guest.apply_snapshot(resized.sequence, &resized.snapshot).expect("replacement snapshot");
+    guest
+        .apply_snapshot(before.sequence, &before.snapshot)
+        .expect("old snapshot");
+    assert_eq!(
+        guest.apply_delta(resized.base_sequence, resized.sequence, &resized.delta),
+        Err(p2pmux::screen::ScreenError::InvalidSequence)
+    );
+    guest
+        .apply_snapshot(resized.sequence, &resized.snapshot)
+        .expect("replacement snapshot");
     assert_eq!(guest.screen().expect("screen").size(), (4, 5));
 }

--- a/tests/screen.rs
+++ b/tests/screen.rs
@@ -128,3 +128,20 @@ fn malformed_and_oversize_payloads_are_rejected() {
             .is_err()
     );
 }
+
+#[test]
+fn resize_forces_a_replacement_snapshot_for_guests() {
+    let mut host = HostScreen::new(2, 3).expect("grid");
+    let before = host.process_pty(b"abc").expect("frame");
+    let resized = host.resize(4, 5).expect("resize");
+    assert_eq!(host.screen().size(), (4, 5));
+    assert!(resized.sequence > before.sequence);
+    assert_eq!(resized.base_sequence, 0);
+    assert!(resized.delta.is_empty());
+
+    let mut guest = GuestScreen::new();
+    guest.apply_snapshot(before.sequence, &before.snapshot).expect("old snapshot");
+    assert_eq!(guest.apply_delta(resized.base_sequence, resized.sequence, &resized.delta), Err(p2pmux::screen::ScreenError::InvalidSequence));
+    guest.apply_snapshot(resized.sequence, &resized.snapshot).expect("replacement snapshot");
+    assert_eq!(guest.screen().expect("screen").size(), (4, 5));
+}

--- a/tests/session_layout.rs
+++ b/tests/session_layout.rs
@@ -2,7 +2,8 @@ use iroh::{EndpointAddr, SecretKey};
 use p2pmux::{
     protocol::{
         CreatePane, CreateTab, DeletePane, DeleteTab, LayoutCommit, LayoutRejectReason,
-        LayoutRequest, NewPanePosition, PaneFailed, PaneReady, SplitAxis,
+        LayoutRequest, NewPanePosition, PaneFailed, PaneReady, SplitAxis, SetSplitRatio,
+        PaneGrid, UpdatePaneGrids,
     },
     session::{CoordinatorError, CoordinatorResponse, LayoutCoordinator},
 };
@@ -41,7 +42,49 @@ fn request(request_id: u64, base_revision: u64) -> LayoutRequest {
         delete_pane: None,
         create_tab: None,
         delete_tab: None,
+        set_split_ratio: None,
+        update_pane_grids: None,
     }
+}
+
+#[test]
+fn admitted_members_set_ratios_and_hosts_reconcile_their_grids() {
+    let mut coordinator = coordinator();
+    coordinator
+        .admit(host_b(), addr_b())
+        .expect("member admitted");
+    // Create through the established reservation flow so pane 2 is hosted by B.
+    let reservation = coordinator.handle_request(
+        &host_b(),
+        LayoutRequest {
+            create_pane: Some(p2pmux::protocol::CreatePane {
+                target_pane_id: 1,
+                axis: Some(SplitAxis::LeftRight as i32),
+                grid_rows: 24,
+                grid_cols: 80,
+                position: None,
+            }),
+            ..request(1, 2)
+        },
+    );
+    let reservation = match reservation { CoordinatorResponse::Reservation(value) => value, other => panic!("reservation: {other:?}") };
+    let _ = commit(coordinator.handle_pane_ready(&host_b(), PaneReady { reservation_id: reservation.reservation_id, base_revision: 2, request_id: 1 }));
+    let ratio = commit(coordinator.handle_request(
+        &host_a(),
+        LayoutRequest {
+            set_split_ratio: Some(SetSplitRatio { pane_id: 2, axis: Some(SplitAxis::LeftRight as i32), first_share_bps: 7_500 }),
+            ..request(2, 3)
+        },
+    ));
+    assert_eq!(ratio.revision, 4);
+    let grids = commit(coordinator.handle_request(
+        &host_b(),
+        LayoutRequest {
+            update_pane_grids: Some(UpdatePaneGrids { panes: vec![PaneGrid { pane_id: 2, grid_rows: 30, grid_cols: 100 }] }),
+            ..request(3, 4)
+        },
+    ));
+    assert_eq!(grids.state.expect("state").panes.iter().find(|pane| pane.pane_id == 2).expect("pane").grid_rows, 30);
 }
 
 fn commit(response: CoordinatorResponse) -> LayoutCommit {

--- a/tests/session_layout.rs
+++ b/tests/session_layout.rs
@@ -2,8 +2,8 @@ use iroh::{EndpointAddr, SecretKey};
 use p2pmux::{
     protocol::{
         CreatePane, CreateTab, DeletePane, DeleteTab, LayoutCommit, LayoutRejectReason,
-        LayoutRequest, NewPanePosition, PaneFailed, PaneReady, SplitAxis, SetSplitRatio,
-        PaneGrid, UpdatePaneGrids,
+        LayoutRequest, NewPanePosition, PaneFailed, PaneGrid, PaneReady, SetSplitRatio, SplitAxis,
+        UpdatePaneGrids,
     },
     session::{CoordinatorError, CoordinatorResponse, LayoutCoordinator},
 };
@@ -67,12 +67,26 @@ fn admitted_members_set_ratios_and_hosts_reconcile_their_grids() {
             ..request(1, 2)
         },
     );
-    let reservation = match reservation { CoordinatorResponse::Reservation(value) => value, other => panic!("reservation: {other:?}") };
-    let _ = commit(coordinator.handle_pane_ready(&host_b(), PaneReady { reservation_id: reservation.reservation_id, base_revision: 2, request_id: 1 }));
+    let reservation = match reservation {
+        CoordinatorResponse::Reservation(value) => value,
+        other => panic!("reservation: {other:?}"),
+    };
+    let _ = commit(coordinator.handle_pane_ready(
+        &host_b(),
+        PaneReady {
+            reservation_id: reservation.reservation_id,
+            base_revision: 2,
+            request_id: 1,
+        },
+    ));
     let ratio = commit(coordinator.handle_request(
         &host_a(),
         LayoutRequest {
-            set_split_ratio: Some(SetSplitRatio { pane_id: 2, axis: Some(SplitAxis::LeftRight as i32), first_share_bps: 7_500 }),
+            set_split_ratio: Some(SetSplitRatio {
+                pane_id: 2,
+                axis: Some(SplitAxis::LeftRight as i32),
+                first_share_bps: 7_500,
+            }),
             ..request(2, 3)
         },
     ));
@@ -80,11 +94,27 @@ fn admitted_members_set_ratios_and_hosts_reconcile_their_grids() {
     let grids = commit(coordinator.handle_request(
         &host_b(),
         LayoutRequest {
-            update_pane_grids: Some(UpdatePaneGrids { panes: vec![PaneGrid { pane_id: 2, grid_rows: 30, grid_cols: 100 }] }),
+            update_pane_grids: Some(UpdatePaneGrids {
+                panes: vec![PaneGrid {
+                    pane_id: 2,
+                    grid_rows: 30,
+                    grid_cols: 100,
+                }],
+            }),
             ..request(3, 4)
         },
     ));
-    assert_eq!(grids.state.expect("state").panes.iter().find(|pane| pane.pane_id == 2).expect("pane").grid_rows, 30);
+    assert_eq!(
+        grids
+            .state
+            .expect("state")
+            .panes
+            .iter()
+            .find(|pane| pane.pane_id == 2)
+            .expect("pane")
+            .grid_rows,
+        30
+    );
 }
 
 fn commit(response: CoordinatorResponse) -> LayoutCommit {

--- a/tests/session_layout_control.rs
+++ b/tests/session_layout_control.rs
@@ -84,6 +84,8 @@ fn create_request(request_id: u64, base_revision: u64) -> LayoutRequest {
         delete_pane: None,
         create_tab: None,
         delete_tab: None,
+        set_split_ratio: None,
+        update_pane_grids: None,
     }
 }
 
@@ -373,6 +375,8 @@ async fn forged_post_welcome_sender_is_rejected_without_a_layout_mutation() {
                     grid_cols: 80,
                 }),
                 delete_tab: None,
+                set_split_ratio: None,
+                update_pane_grids: None,
             })),
         })
         .await
@@ -438,6 +442,8 @@ async fn deleting_a_member_owned_tab_broadcasts_the_full_commit() {
                 grid_cols: 80,
             }),
             delete_tab: None,
+            set_split_ratio: None,
+            update_pane_grids: None,
         })
         .expect("queue tab request");
     let reservation = match next_event(&mut second).await {
@@ -469,6 +475,8 @@ async fn deleting_a_member_owned_tab_broadcasts_the_full_commit() {
             delete_tab: Some(DeleteTab {
                 tab_id: reservation.tab_id.expect("tab reservation"),
             }),
+            set_split_ratio: None,
+            update_pane_grids: None,
         })
         .expect("queue tab delete");
     for member in [&mut first, &mut second] {
@@ -546,6 +554,8 @@ async fn reservation_is_targeted_and_ready_broadcasts_the_commit() {
             }),
             create_tab: None,
             delete_tab: None,
+            set_split_ratio: None,
+            update_pane_grids: None,
         })
         .expect("queue deletion");
     assert!(
@@ -563,6 +573,8 @@ async fn reservation_is_targeted_and_ready_broadcasts_the_commit() {
             delete_pane: Some(DeletePane { pane_id: 1 }),
             create_tab: None,
             delete_tab: None,
+            set_split_ratio: None,
+            update_pane_grids: None,
         })
         .expect("queue foreign deletion");
     assert!(matches!(


### PR DESCRIPTION
## Summary
- Adds shared, revisioned split ratios (`first_share_bps`) and protocol v4 `SetSplitRatio` / `UpdatePaneGrids` actions so any member can drag-resize layout chrome.
- Option+Shift+left-drag locks to one axis, previews an ephemeral overlay, and commits on release; hosts then resize their own PTYs/vt100 screens and publish updated grids.
- Reflows hosted panes whenever allocated chrome changes (ratio drag, create/delete/split, outer window resize), while guests only consume layout + screen updates.

## Test plan
- [ ] `cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test`
- [ ] Split a pane, then Option+Shift+drag to grow/shrink; confirm both shells reflow (e.g. `stty size` / vim)
- [ ] Confirm plain left-drag still selects/copies text
- [ ] Two-member session: one peer drags; the other sees shared ratio; each host owns its absolute grid
- [ ] Resize the outer terminal window and confirm hosted panes reflow
- [ ] Verify footer shows `Option+Shift+drag RESIZE` when space permits


Made with [Cursor](https://cursor.com)