### PR TITLE
feat: agents overlay roster (Ctrl+A)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,7 +347,7 @@ dependencies = [
  "iana-time-zone",
  "num-traits",
  "serde",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1062,8 +1062,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link",
- "windows-result",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -1387,7 +1387,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -1584,7 +1584,7 @@ dependencies = [
  "socket2",
  "widestring",
  "windows-registry",
- "windows-result",
+ "windows-result 0.4.1",
  "windows-sys 0.61.2",
 ]
 
@@ -1814,7 +1814,7 @@ dependencies = [
  "simd_cesu8",
  "thiserror 2.0.19",
  "walkdir",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2184,8 +2184,8 @@ dependencies = [
  "tokio-util",
  "tracing",
  "web-sys",
- "windows",
- "windows-result",
+ "windows 0.62.2",
+ "windows-result 0.4.1",
  "wmi",
 ]
 
@@ -2261,6 +2261,15 @@ dependencies = [
  "socket2",
  "tracing",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -2374,6 +2383,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "objc2-security"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2450,6 +2469,7 @@ dependencies = [
  "ratatui",
  "serde",
  "serde_json",
+ "sysinfo",
  "tokio",
  "toml",
  "vt100",
@@ -2515,7 +2535,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3494,6 +3514,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.37.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16607d5caffd1c07ce073528f9ed972d88db15dd44023fa57142963be3feb11f"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows 0.61.3",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4203,14 +4237,36 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections 0.2.0",
+ "windows-core 0.61.2",
+ "windows-future 0.2.1",
+ "windows-link 0.1.3",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
- "windows-collections",
- "windows-core",
- "windows-future",
- "windows-numerics",
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -4219,7 +4275,20 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core",
+ "windows-core 0.62.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]
@@ -4230,9 +4299,20 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+ "windows-threading 0.1.0",
 ]
 
 [[package]]
@@ -4241,9 +4321,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core",
- "windows-link",
- "windows-threading",
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -4270,9 +4350,25 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+]
 
 [[package]]
 name = "windows-numerics"
@@ -4280,8 +4376,8 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core",
- "windows-link",
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -4290,9 +4386,18 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
- "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -4301,7 +4406,16 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -4310,7 +4424,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -4337,7 +4451,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -4373,11 +4487,20 @@ dependencies = [
 
 [[package]]
 name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -4514,8 +4637,8 @@ dependencies = [
  "log",
  "serde",
  "thiserror 2.0.19",
- "windows",
- "windows-core",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ ratatui = { version = "0.30", default-features = false, features = ["crossterm"]
 prost = "0.14"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+sysinfo = "0.37"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "time", "sync"] }
 toml = "0.8"
 vt100 = "0.16"

--- a/README.md
+++ b/README.md
@@ -88,6 +88,16 @@ Shared-layout commands are sticky local mux modes and never reach a PTY. `Ctrl+P
 enters its mode; use the listed command repeatedly, press `Esc` to cancel, or type any normal key
 to leave the mode and send that key to the focused PTY.
 
+`Ctrl+A` opens the Agents overlay, which lists only supported coding agents running below hosted
+pane shells: Claude Code (`claude`), Codex (`codex`), Cursor Agent (`cursor-agent`), and Pi
+(`pi`). It shows the agent's best-effort working directory, pane host, control holder, and
+idle/working/done state. Press `Esc` to close, use arrows or `j`/`k` to select, and press Enter
+to jump to that pane (including on another tab). To retain readline's beginning-of-line shortcut,
+press `Ctrl+A` twice within 400ms to forward one Ctrl+A to the focused PTY instead. The overlay is
+keyboard-only in v1. Working directories are shared with every member as part of the existing
+trusted shared-shell model, so do not use a session with people who should not see repository
+paths.
+
 Clicking a pane focuses it locally without taking control or sending input. When p2pmux runs
 inside Zellij, Zellij may swallow mouse events; try Zellij with mouse mode disabled or a locked
 passthrough configuration.

--- a/docs/superpowers/plans/2026-07-26-agents-overlay.md
+++ b/docs/superpowers/plans/2026-07-26-agents-overlay.md
@@ -1,0 +1,187 @@
+# Agents overlay Implementation Plan
+
+> **For agentic workers:** Execute only in `/Users/pelazas/Desktop/p2pmux-agents-overlay` on branch `feat/agents-overlay`. One commit per completed task. Do **not** `git push` or open a PR unless the human/handoff explicitly asks — implementation ends when the suite is green and commits are local.
+
+**Goal:** Ship a `Ctrl+A` agents-only overlay (kind, cwd, host, control, idle/working/done) backed by host-local allowlist detection and coordinator-relayed `AgentRoster` (protocol v4).
+
+**Architecture:** Pure `agent_detect` + `sysinfo` sampler adapter (global interval sample). Hosts send `AgentRoster` to the coordinator; coordinator validates/caches/relays on a **new coalesced roster mailbox** separate from layout `publish_state`. TUI owns modal overlay toggle, double-tap Ctrl+A pass-through, selection-by-pane-id, and jump. Layout/lease semantics unchanged.
+
+**Spec:** `docs/superpowers/specs/2026-07-26-agents-overlay-design.md` (authoritative; follow it when this plan and the code would otherwise drift).
+
+---
+
+## Task 1: Spec + plan docs
+
+**Files:**
+- `docs/superpowers/specs/2026-07-26-agents-overlay-design.md`
+- `docs/superpowers/plans/2026-07-26-agents-overlay.md` (this file)
+
+- [ ] Commit docs only
+
+```bash
+git add docs/superpowers/specs/2026-07-26-agents-overlay-design.md docs/superpowers/plans/2026-07-26-agents-overlay.md
+git commit -m "$(cat <<'EOF'
+docs: specify agents overlay roster and plan
+
+EOF
+)"
+```
+
+---
+
+## Task 2: Agent detection module (pure)
+
+**Files:**
+- Create `src/agent_detect.rs`
+- Update `src/lib.rs`
+- Unit tests in `agent_detect` (fixtures, no live agents)
+
+Implement per spec:
+- Exact basename allowlist table + display labels
+- `classify_pane_tree(...)` with deterministic pick: depth → start_time → pid
+- State helper with `last_output_at`, active agent, done grace (15s), and replacement-before-grace behavior
+- Injected process snapshot type (`pid`, `parent_pid`, `basename`, optional `start_time`, optional `cwd`)
+
+- [ ] `cargo test agent_detect --lib`
+- [ ] Commit
+
+```bash
+git commit -m "$(cat <<'EOF'
+feat: add allowlist agent detection helpers
+
+EOF
+)"
+```
+
+---
+
+## Task 3: PtyHost PID + drain timestamp + sysinfo sampler
+
+**Files:**
+- `src/pty_host.rs` — expose `process_id()`
+- `src/agent_detect.rs` — `SysinfoSampler` adapter + global snapshot helper
+- `src/tui.rs` — `SharedLocalPane::drain` sets `last_output_at`; interval sampling off render path
+- `Cargo.toml` — add `sysinfo` dependency
+
+Rules:
+- Sample once globally per ~1s interval, not per pane on the render loop
+- Soft-fail → no agent
+- Wire local detection into hosted panes only
+
+- [ ] Tests with fake snapshots still primary; sampler adapter testable behind trait
+- [ ] Commit
+
+```bash
+git commit -m "$(cat <<'EOF'
+feat: sample hosted PTY process trees for agents
+
+EOF
+)"
+```
+
+---
+
+## Task 4: Wire `AgentRoster` + PROTOCOL_VERSION 4
+
+**Files:**
+- `src/protocol.rs` — messages, tag 26, validation caps, version bump **3 → 4**
+- `tests/protocol.rs` — update version asserts + new encode/validate cases
+- `tests/module_surface.rs` — `PROTOCOL_VERSION == 4`
+
+Validate: entry cap 32, kind/cwd lengths, known kinds/states, duplicate pane ids, non-zero pane id.
+
+- [ ] `cargo test protocol module_surface`
+- [ ] Commit
+
+```bash
+git commit -m "$(cat <<'EOF'
+feat: add AgentRoster wire message (protocol v4)
+
+EOF
+)"
+```
+
+---
+
+## Task 5: Coordinator relay, cache, bootstrap, mailbox isolation
+
+**Files:**
+- `src/session.rs` — ControlMailbox roster channel; coordinator accept/validate/cache/prune/relay; member apply
+- `tests/session_*.rs` and/or session unit tests
+
+Must implement:
+- Independent coalesced roster watch (must not share `publish_state` with `LayoutCommit`)
+- Per-host generation; full replace including empty clear
+- Reject entries for panes not hosted by sender
+- Prune on pane delete / host change / member leave
+- Bootstrap: after `SessionSnapshot`, deliver cached roster(s)
+- Regression: rapid layout commits + roster publishes never lose layout
+
+- [ ] Coordinator-relay integration tests listed in the spec
+- [ ] Commit
+
+```bash
+git commit -m "$(cat <<'EOF'
+feat: relay agent rosters through the coordinator
+
+EOF
+)"
+```
+
+---
+
+## Task 6: Overlay TUI
+
+**Files:**
+- `src/tui.rs` — modal overlay state, toggle, double-tap pass-through, render, jump, footer
+- TUI unit tests
+
+Must implement:
+- `Ctrl+A` toggle; double-tap ≤400ms → encode/forward Ctrl+A to focused PTY
+- Modal: while open, no arbitrary PTY forwarding; not chord-idle-expiring
+- Selection by `pane_id`; stable sort; empty state `No agents running`
+- Enter jumps (including other tab) and closes; Esc closes
+- Join roster + layout host labels + lease control text; sanitize strings
+- Footer for overlay mode
+- **No mouse** for overlay in v1
+
+- [ ] TUI tests covering toggle, pass-through, jump cross-tab, empty state
+- [ ] Commit
+
+```bash
+git commit -m "$(cat <<'EOF'
+feat: add Ctrl+A agents overlay UI
+
+EOF
+)"
+```
+
+---
+
+## Task 7: README + full suite
+
+**Files:**
+- `README.md` — Ctrl+A toggle, double-tap pass-through, agent-only allowlist, cwd sharing note
+
+- [ ] `cargo test` full suite green
+- [ ] Commit if README/polish needed
+- [ ] Stop. Do not push/PR unless explicitly asked.
+
+```bash
+git commit -m "$(cat <<'EOF'
+docs: document agents overlay chord and detection
+
+EOF
+)"
+```
+
+---
+
+## Out of scope / do not
+
+- Force-detect unknown AI tools / bare `cursor`
+- Sidebar dashboard / mouse overlay
+- Vendor status APIs
+- Changing control lease rules
+- Push or PR from coding tasks
+- Implementing outside this worktree/branch

--- a/docs/superpowers/specs/2026-07-26-agents-overlay-design.md
+++ b/docs/superpowers/specs/2026-07-26-agents-overlay-design.md
@@ -1,0 +1,160 @@
+# Agents overlay: roster of live coding agents
+
+## Goal
+
+Give every member in a shared session a toggleable overlay that lists **coding agents only** (not every shell/process), with enough context to jump into the right pane.
+
+Fields per row:
+
+- agent kind (fixed display label from allowlist)
+- working directory / repo folder (best-effort; may be empty)
+- pane host display name (from layout roster)
+- controller (`free` or display name) — same semantics as pane chrome
+- coarse state: `idle` | `working` | `done`
+
+Interaction:
+
+- `Ctrl+A` **toggles** the Agents overlay open/closed
+- **Pass-through:** if overlay is closed and the user presses `Ctrl+A` twice within 400ms, forward a single Ctrl+A to the focused PTY and do **not** open the overlay (readline beginning-of-line escape hatch). A single `Ctrl+A` after the window elapses opens the overlay.
+- While open: modal and **non-expiring** (not subject to the 2s sticky-chord idle timeout). ↑/↓ or `j`/`k` move selection; Enter focuses that pane’s tab+leaf and closes the overlay; Esc closes without jumping.
+- While open: **no keys are forwarded to any PTY** except that Esc/Enter/arrows/jk are handled by the overlay.
+- Overlay is a floating panel (`Clear` + bordered list over the current layout), not a real mux tab
+- **Mouse: cut from v1** (keyboard only)
+
+## Non-goals
+
+- Agent orchestration, ACLs, or sandboxing
+- Listing arbitrary processes / shells / editors
+- Perfect per-vendor turn state via proprietary APIs
+- Always-on sidebar or dashboard home screen
+- Changing lease / control semantics
+- Windows/Linux (macOS only)
+- Mouse hit-testing for overlay rows (v1)
+- Automatic `git push` / PR creation as part of coding tasks (handoff step only)
+
+## Product framing
+
+Agents remain **processes inside panes**. The overlay is a **lens** over panes whose process tree matches a known agent allowlist. Aligns with “shared session fabric, not a dashboard of agents.”
+
+cwd paths are shared with all session members (same trust model as the shared shell). Mention briefly in README.
+
+## Detection (host-local)
+
+Each pane is a login shell PTY. Agents run as descendants. On the **pane host only**:
+
+1. Resolve the PTY session child PID from `portable_pty::Child::process_id()` via `PtyHost`.
+2. Sample processes on a timer with a **replaceable sampler adapter**.
+3. **v1 sampler choice:** `sysinfo` (safe public API from this crate’s perspective). Collect **once globally per interval** (~1s), then classify each hosted pane’s tree from that snapshot. Never call the sampler on the 16ms TUI render path — run sampling on a dedicated interval tick / blocking task and apply results asynchronously.
+4. Match descendants against the **exact v1 allowlist** below.
+5. If multiple allowlisted agents appear under one pane, pick deterministically:
+   1. greatest descendant depth from the PTY session root
+   2. then newest process start time (if sampler provides it; else skip this key)
+   3. then highest PID
+6. Working directory: cwd of the matched agent process when `sysinfo` provides it; else empty string.
+7. If no allowlisted agent is present → not listed (unless in `done` grace — see state model).
+
+### v1 allowlist (exact)
+
+Matching uses the process **basename** only (last path component of exe/argv0), compared **case-sensitively** as returned by the sampler.
+
+| Basename equals | `agent_kind` wire value | Display label |
+|-----------------|-------------------------|---------------|
+| `claude` | `claude` | Claude Code |
+| `codex` | `codex` | Codex |
+| `cursor-agent` | `cursor` | Cursor Agent |
+| `pi` | `pi` | Pi |
+
+No other names match. Bare `cursor` (the editor) does **not** match. Adding a tool = one table row + tests.
+
+Required snapshot fields per process: `pid`, `parent_pid`, `basename` (from exe or argv0), optional `start_time`, optional `cwd`.
+
+## State model
+
+Host tracks per pane:
+
+- `last_output_at: Option<Instant>` — updated in `SharedLocalPane::drain()` when PTY bytes arrive (this timestamp does not exist today; add it)
+- `active_agent: Option<DetectedAgent>` — current match
+- `done_agent: Option<(kind, cwd, entered_done_at)>` — set when a previously active agent disappears
+
+| State | Meaning |
+|-------|---------|
+| `working` | Active allowlisted agent **and** `last_output_at` within the last 2s |
+| `idle` | Active allowlisted agent **and** quiet |
+| `done` | No active agent, but `done_agent` within 15s grace |
+| (absent) | No active agent and grace expired / never had an agent |
+
+If a **different** agent appears before grace expiry: clear `done_agent`, use the new active agent (`working`/`idle`) immediately — do not keep the old done row.
+
+## Multiplayer / wire topology
+
+Members send control envelopes **to the coordinator**. Members accept layout/roster **state only from the coordinator**. Hosts never peer-publish rosters sideways.
+
+### Messages (PROTOCOL_VERSION = 4)
+
+- `AgentRoster` (new `envelope::Body` tag **26**):
+  - `host_peer_id: bytes` — must equal authenticated sender; coordinator overwrites/ignores mismatches
+  - `generation: u64` — per-host monotonic; coordinator ignores generations ≤ last accepted for that host
+  - `entries: repeated AgentRosterEntry`
+- `AgentRosterEntry`:
+  - `pane_id: u64` — same layout pane id type as `PaneDescriptor.pane_id`
+  - `agent_kind: string` — one of `claude|codex|cursor|pi`
+  - `cwd: string` — may be empty; max length enforced
+  - `state: enum` — `idle|working|done`
+
+Caps (normative): max **32** entries per update; `agent_kind` ≤ 32 bytes; `cwd` ≤ 512 bytes; reject unknown state/kind; reject **duplicate** `pane_id` in one update.
+
+### Coordinator duties
+
+1. Validate sender is an admitted member.
+2. Reject any entry whose `pane_id` is not currently hosted by that sender in the authoritative layout.
+3. Accept only if `generation` > last stored for that host (else ignore).
+4. Store **full replacement** for that host (including empty `entries` to clear).
+5. Prune stored entries when: pane deleted, pane host changes, member departs, or layout reconcile removes the pane.
+6. Relay accepted rosters to all members on an **independent coalesced roster watch channel** — **not** `publish_state` (that slot coalesces layout commits and must not be shared).
+7. Bootstrap: after the existing initial `SessionSnapshot`, deliver a coordinator-built **full roster snapshot** (concatenate cached per-host rosters, or one synthetic `AgentRoster` per host in order). Late joiners must see current agents without waiting for heartbeats. Heartbeat (~5s) remains a liveness/repair aid, not bootstrap.
+
+### Client merge
+
+- Key entries by `pane_id` globally after coordinator validation (one host owns a pane).
+- Replace one host’s contribution as a unit when its `AgentRoster` arrives.
+- Drop host contribution on member leave.
+- Overlay joins entries with layout (host name) + lease (control) + display-name chrome.
+- Sanitize peer strings to single-line for render (strip controls/newlines).
+
+### Regression tests required
+
+- Roster updates must not drop undelivered `LayoutCommit`s (separate mailbox path).
+- Member-hosted agent appears for a second member via coordinator relay.
+- Late joiner receives roster after snapshot.
+- Forged entry for another host’s pane rejected.
+- Empty roster clears that host’s rows.
+
+## UI behavior under live updates
+
+- Deterministic row order: sort by tab order, then pane ordinal within tab, then `pane_id`.
+- Selection keyed by `pane_id` (not list index); if selected pane disappears, clamp to nearest remaining or clear selection.
+- Jump to agent on another tab: switch tab + focus pane (covered by test).
+- Empty state: panel shows `No agents running`.
+- Narrow terminals: truncate cwd with leading ellipsis; keep kind + state visible.
+
+## Keyboard conflicts
+
+`Ctrl+A` is mux-owned with double-tap pass-through as specified. Document in README.
+
+## Testing
+
+- Pure unit tests for allowlist matching (basename fixtures).
+- Pure unit tests for state transitions including done grace and agent replacement.
+- Pure unit tests for deterministic multi-agent pick rule.
+- TUI: toggle open/close; double-tap forwards Ctrl+A; Esc closes; Enter jumps including other tab; overlay modal (no PTY forward); empty state.
+- Protocol encode/decode + caps + version **4** updates to all version/tag tests.
+- Session: coordinator relay, bootstrap, forge reject, layout/roster mailbox isolation.
+
+## Success criteria
+
+1. Only allowlisted agent panes appear (plus short `done` grace rows).
+2. Rows show kind, cwd (when known), host, control, state.
+3. `Ctrl+A` toggle + double-tap pass-through + Esc/Enter behave as specified.
+4. Remote members see agents via coordinator-relayed roster; late joiners bootstrap correctly.
+5. Roster traffic never coalesces away layout commits.
+6. `cargo test` passes; this crate remains `forbid(unsafe_code)`.

--- a/src/agent_detect.rs
+++ b/src/agent_detect.rs
@@ -2,6 +2,8 @@
 
 use std::time::{Duration, Instant};
 
+use sysinfo::{ProcessesToUpdate, System};
+
 const DONE_GRACE: Duration = Duration::from_secs(15);
 const WORKING_WINDOW: Duration = Duration::from_secs(2);
 
@@ -55,6 +57,51 @@ pub struct ProcessSnapshot {
     pub basename: String,
     pub start_time: Option<u64>,
     pub cwd: Option<String>,
+}
+
+/// Replaceable adapter for collecting one global process snapshot.
+pub trait ProcessSampler {
+    fn snapshot(&mut self) -> Vec<ProcessSnapshot>;
+}
+
+/// `sysinfo`-backed process sampler used by the macOS host runtime.
+pub struct SysinfoSampler {
+    system: System,
+}
+
+impl Default for SysinfoSampler {
+    fn default() -> Self {
+        Self {
+            system: System::new(),
+        }
+    }
+}
+
+impl ProcessSampler for SysinfoSampler {
+    fn snapshot(&mut self) -> Vec<ProcessSnapshot> {
+        self.system.refresh_processes(ProcessesToUpdate::All, true);
+        self.system
+            .processes()
+            .values()
+            .map(|process| ProcessSnapshot {
+                pid: process.pid().as_u32(),
+                parent_pid: process.parent().map(|pid| pid.as_u32()),
+                basename: process
+                    .exe()
+                    .and_then(|path| path.file_name())
+                    .unwrap_or(process.name())
+                    .to_string_lossy()
+                    .into_owned(),
+                start_time: Some(process.start_time()),
+                cwd: process.cwd().map(|path| path.to_string_lossy().into_owned()),
+            })
+            .collect()
+    }
+}
+
+/// Collect one global snapshot through an injected sampler.
+pub fn sample_global_snapshot(sampler: &mut dyn ProcessSampler) -> Vec<ProcessSnapshot> {
+    sampler.snapshot()
 }
 
 /// The supported agent selected from a hosted pane's process tree.
@@ -339,5 +386,18 @@ mod tests {
                 AgentState::Idle,
             ))
         );
+    }
+
+    #[test]
+    fn global_snapshot_uses_the_injected_sampler() {
+        struct FakeSampler;
+
+        impl ProcessSampler for FakeSampler {
+            fn snapshot(&mut self) -> Vec<ProcessSnapshot> {
+                vec![process(1, None, "codex", None)]
+            }
+        }
+
+        assert_eq!(sample_global_snapshot(&mut FakeSampler).len(), 1);
     }
 }

--- a/src/agent_detect.rs
+++ b/src/agent_detect.rs
@@ -1,0 +1,343 @@
+//! Pure helpers for detecting supported coding agents in a hosted PTY tree.
+
+use std::time::{Duration, Instant};
+
+const DONE_GRACE: Duration = Duration::from_secs(15);
+const WORKING_WINDOW: Duration = Duration::from_secs(2);
+
+/// A supported coding agent kind.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub enum AgentKind {
+    Claude,
+    Codex,
+    Cursor,
+    Pi,
+}
+
+impl AgentKind {
+    /// Match an exact, case-sensitive executable basename.
+    pub fn from_basename(basename: &str) -> Option<Self> {
+        match basename {
+            "claude" => Some(Self::Claude),
+            "codex" => Some(Self::Codex),
+            "cursor-agent" => Some(Self::Cursor),
+            "pi" => Some(Self::Pi),
+            _ => None,
+        }
+    }
+
+    /// Stable wire value for this agent kind.
+    pub const fn wire_value(self) -> &'static str {
+        match self {
+            Self::Claude => "claude",
+            Self::Codex => "codex",
+            Self::Cursor => "cursor",
+            Self::Pi => "pi",
+        }
+    }
+
+    /// Human-readable label for the overlay.
+    pub const fn display_label(self) -> &'static str {
+        match self {
+            Self::Claude => "Claude Code",
+            Self::Codex => "Codex",
+            Self::Cursor => "Cursor Agent",
+            Self::Pi => "Pi",
+        }
+    }
+}
+
+/// One process from a sampler snapshot.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProcessSnapshot {
+    pub pid: u32,
+    pub parent_pid: Option<u32>,
+    pub basename: String,
+    pub start_time: Option<u64>,
+    pub cwd: Option<String>,
+}
+
+/// The supported agent selected from a hosted pane's process tree.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DetectedAgent {
+    pub kind: AgentKind,
+    pub cwd: String,
+}
+
+#[derive(Clone, Debug)]
+struct Candidate<'a> {
+    process: &'a ProcessSnapshot,
+    depth: usize,
+    kind: AgentKind,
+}
+
+/// Classify a PTY session child process tree from one global process snapshot.
+///
+/// The deepest matching descendant wins, then the newest available start time,
+/// then the highest PID. The PTY session child itself is included in the tree.
+pub fn classify_pane_tree(
+    session_child_pid: u32,
+    processes: &[ProcessSnapshot],
+) -> Option<DetectedAgent> {
+    let mut candidates = Vec::new();
+
+    for process in processes {
+        let Some(kind) = AgentKind::from_basename(&process.basename) else {
+            continue;
+        };
+        let Some(depth) = descendant_depth(session_child_pid, process.pid, processes) else {
+            continue;
+        };
+        candidates.push(Candidate {
+            process,
+            depth,
+            kind,
+        });
+    }
+
+    candidates
+        .into_iter()
+        .max_by(|left, right| {
+            left.depth
+                .cmp(&right.depth)
+                .then_with(|| match (left.process.start_time, right.process.start_time) {
+                    (Some(left), Some(right)) => left.cmp(&right),
+                    _ => std::cmp::Ordering::Equal,
+                })
+                .then_with(|| left.process.pid.cmp(&right.process.pid))
+        })
+        .map(|candidate| DetectedAgent {
+            kind: candidate.kind,
+            cwd: candidate.process.cwd.clone().unwrap_or_default(),
+        })
+}
+
+fn descendant_depth(root_pid: u32, pid: u32, processes: &[ProcessSnapshot]) -> Option<usize> {
+    let mut current_pid = pid;
+    let mut depth = 0;
+
+    while current_pid != root_pid {
+        let process = processes.iter().find(|process| process.pid == current_pid)?;
+        current_pid = process.parent_pid?;
+        depth += 1;
+        if depth > processes.len() {
+            return None;
+        }
+    }
+
+    Some(depth)
+}
+
+/// Coarse activity state shown in the agents overlay.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AgentState {
+    Idle,
+    Working,
+    Done,
+}
+
+/// A just-finished agent retained for the done grace period.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DoneAgent {
+    pub kind: AgentKind,
+    pub cwd: String,
+    pub entered_done_at: Instant,
+}
+
+/// Per-pane agent state maintained between global sampler snapshots.
+#[derive(Clone, Debug, Default)]
+pub struct PaneAgentTracker {
+    pub last_output_at: Option<Instant>,
+    pub active_agent: Option<DetectedAgent>,
+    pub done_agent: Option<DoneAgent>,
+}
+
+impl PaneAgentTracker {
+    /// Record PTY output for the working/idle state calculation.
+    pub fn record_output(&mut self, now: Instant) {
+        self.last_output_at = Some(now);
+    }
+
+    /// Apply this pane's latest process-tree classification.
+    pub fn update(&mut self, detected: Option<DetectedAgent>, now: Instant) {
+        match detected {
+            Some(agent) => {
+                self.active_agent = Some(agent);
+                self.done_agent = None;
+            }
+            None => {
+                if let Some(agent) = self.active_agent.take() {
+                    self.done_agent = Some(DoneAgent {
+                        kind: agent.kind,
+                        cwd: agent.cwd,
+                        entered_done_at: now,
+                    });
+                }
+                if self
+                    .done_agent
+                    .as_ref()
+                    .is_some_and(|done| now.duration_since(done.entered_done_at) > DONE_GRACE)
+                {
+                    self.done_agent = None;
+                }
+            }
+        }
+    }
+
+    /// Return the current agent and coarse state, if the pane should be listed.
+    pub fn listed_agent(&self, now: Instant) -> Option<(DetectedAgent, AgentState)> {
+        if let Some(agent) = &self.active_agent {
+            let state = if self
+                .last_output_at
+                .is_some_and(|last_output| now.duration_since(last_output) <= WORKING_WINDOW)
+            {
+                AgentState::Working
+            } else {
+                AgentState::Idle
+            };
+            return Some((agent.clone(), state));
+        }
+
+        self.done_agent
+            .as_ref()
+            .filter(|done| now.duration_since(done.entered_done_at) <= DONE_GRACE)
+            .map(|done| {
+                (
+                    DetectedAgent {
+                        kind: done.kind,
+                        cwd: done.cwd.clone(),
+                    },
+                    AgentState::Done,
+                )
+            })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn process(
+        pid: u32,
+        parent_pid: Option<u32>,
+        basename: &str,
+        start_time: Option<u64>,
+    ) -> ProcessSnapshot {
+        ProcessSnapshot {
+            pid,
+            parent_pid,
+            basename: basename.into(),
+            start_time,
+            cwd: None,
+        }
+    }
+
+    #[test]
+    fn allowlist_matches_only_exact_basenames() {
+        assert_eq!(AgentKind::from_basename("claude"), Some(AgentKind::Claude));
+        assert_eq!(AgentKind::from_basename("codex"), Some(AgentKind::Codex));
+        assert_eq!(
+            AgentKind::from_basename("cursor-agent"),
+            Some(AgentKind::Cursor)
+        );
+        assert_eq!(AgentKind::from_basename("pi"), Some(AgentKind::Pi));
+        assert_eq!(AgentKind::from_basename("cursor"), None);
+        assert_eq!(AgentKind::from_basename("Codex"), None);
+        assert_eq!(AgentKind::Claude.display_label(), "Claude Code");
+        assert_eq!(AgentKind::Cursor.wire_value(), "cursor");
+    }
+
+    #[test]
+    fn selects_deepest_then_newest_then_highest_pid() {
+        let mut processes = vec![
+            process(10, None, "zsh", None),
+            process(20, Some(10), "claude", Some(1)),
+            process(30, Some(20), "codex", Some(1)),
+            process(40, Some(20), "pi", Some(2)),
+            process(50, Some(20), "cursor-agent", Some(2)),
+        ];
+        processes[4].cwd = Some("/repo".into());
+
+        assert_eq!(
+            classify_pane_tree(10, &processes),
+            Some(DetectedAgent {
+                kind: AgentKind::Cursor,
+                cwd: "/repo".into(),
+            })
+        );
+    }
+
+    #[test]
+    fn ignores_agents_outside_the_pane_tree_and_cycles() {
+        let processes = vec![
+            process(10, None, "zsh", None),
+            process(20, Some(99), "codex", None),
+            process(30, Some(31), "claude", None),
+            process(31, Some(30), "zsh", None),
+        ];
+
+        assert_eq!(classify_pane_tree(10, &processes), None);
+    }
+
+    #[test]
+    fn tracker_marks_working_idle_done_and_expires_done_grace() {
+        let now = Instant::now();
+        let agent = DetectedAgent {
+            kind: AgentKind::Codex,
+            cwd: "/repo".into(),
+        };
+        let mut tracker = PaneAgentTracker::default();
+        tracker.update(Some(agent.clone()), now);
+        assert_eq!(tracker.listed_agent(now), Some((agent.clone(), AgentState::Idle)));
+
+        tracker.record_output(now);
+        assert_eq!(
+            tracker.listed_agent(now + Duration::from_secs(2)),
+            Some((agent.clone(), AgentState::Working))
+        );
+        assert_eq!(
+            tracker.listed_agent(now + Duration::from_secs(3)),
+            Some((agent.clone(), AgentState::Idle))
+        );
+
+        tracker.update(None, now + Duration::from_secs(4));
+        assert_eq!(
+            tracker.listed_agent(now + Duration::from_secs(19)),
+            Some((agent.clone(), AgentState::Done))
+        );
+        tracker.update(None, now + Duration::from_secs(20));
+        assert_eq!(tracker.listed_agent(now + Duration::from_secs(20)), None);
+    }
+
+    #[test]
+    fn replacement_clears_done_agent_immediately() {
+        let now = Instant::now();
+        let mut tracker = PaneAgentTracker::default();
+        tracker.update(
+            Some(DetectedAgent {
+                kind: AgentKind::Claude,
+                cwd: "/old".into(),
+            }),
+            now,
+        );
+        tracker.update(None, now + Duration::from_secs(1));
+        tracker.update(
+            Some(DetectedAgent {
+                kind: AgentKind::Pi,
+                cwd: "/new".into(),
+            }),
+            now + Duration::from_secs(2),
+        );
+
+        assert_eq!(
+            tracker.listed_agent(now + Duration::from_secs(2)),
+            Some((
+                DetectedAgent {
+                    kind: AgentKind::Pi,
+                    cwd: "/new".into(),
+                },
+                AgentState::Idle,
+            ))
+        );
+    }
+}

--- a/src/agent_detect.rs
+++ b/src/agent_detect.rs
@@ -93,7 +93,9 @@ impl ProcessSampler for SysinfoSampler {
                     .to_string_lossy()
                     .into_owned(),
                 start_time: Some(process.start_time()),
-                cwd: process.cwd().map(|path| path.to_string_lossy().into_owned()),
+                cwd: process
+                    .cwd()
+                    .map(|path| path.to_string_lossy().into_owned()),
             })
             .collect()
     }
@@ -147,10 +149,12 @@ pub fn classify_pane_tree(
         .max_by(|left, right| {
             left.depth
                 .cmp(&right.depth)
-                .then_with(|| match (left.process.start_time, right.process.start_time) {
-                    (Some(left), Some(right)) => left.cmp(&right),
-                    _ => std::cmp::Ordering::Equal,
-                })
+                .then_with(
+                    || match (left.process.start_time, right.process.start_time) {
+                        (Some(left), Some(right)) => left.cmp(&right),
+                        _ => std::cmp::Ordering::Equal,
+                    },
+                )
                 .then_with(|| left.process.pid.cmp(&right.process.pid))
         })
         .map(|candidate| DetectedAgent {
@@ -164,7 +168,9 @@ fn descendant_depth(root_pid: u32, pid: u32, processes: &[ProcessSnapshot]) -> O
     let mut depth = 0;
 
     while current_pid != root_pid {
-        let process = processes.iter().find(|process| process.pid == current_pid)?;
+        let process = processes
+            .iter()
+            .find(|process| process.pid == current_pid)?;
         current_pid = process.parent_pid?;
         depth += 1;
         if depth > processes.len() {
@@ -335,7 +341,10 @@ mod tests {
         };
         let mut tracker = PaneAgentTracker::default();
         tracker.update(Some(agent.clone()), now);
-        assert_eq!(tracker.listed_agent(now), Some((agent.clone(), AgentState::Idle)));
+        assert_eq!(
+            tracker.listed_agent(now),
+            Some((agent.clone(), AgentState::Idle))
+        );
 
         tracker.record_output(now);
         assert_eq!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![forbid(unsafe_code)]
 
+pub mod agent_detect;
 pub mod cli;
 pub mod config;
 pub mod layout;

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -3,7 +3,7 @@
 use prost::Message;
 use std::{collections::HashSet, fmt};
 
-pub const PROTOCOL_VERSION: u32 = 3;
+pub const PROTOCOL_VERSION: u32 = 4;
 pub const MAX_FRAME_BYTES: usize = 1_048_576;
 pub const MAX_ENVELOPE_BYTES: usize = 1_048_560;
 pub const MAX_PEER_ID_BYTES: usize = 64;
@@ -13,6 +13,9 @@ pub const MAX_ENDPOINT_ADDR_BYTES: usize = 4096;
 pub const MAX_INPUT_BYTES: usize = 8 * 1024;
 pub const MAX_SNAPSHOT_BYTES: usize = 512 * 1024;
 pub const MAX_DELTA_BYTES: usize = 64 * 1024;
+pub const MAX_AGENT_ROSTER_ENTRIES: usize = 32;
+pub const MAX_AGENT_KIND_BYTES: usize = 32;
+pub const MAX_AGENT_CWD_BYTES: usize = 512;
 
 #[derive(Debug)]
 pub enum ProtocolError {
@@ -108,7 +111,7 @@ pub struct Envelope {
     pub sender_peer_id: Vec<u8>,
     #[prost(
         oneof = "envelope::Body",
-        tags = "10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25"
+        tags = "10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26"
     )]
     pub body: Option<envelope::Body>,
 }
@@ -148,6 +151,8 @@ pub mod envelope {
         PaneFailed(super::PaneFailed),
         #[prost(message, tag = "25")]
         ReleaseControl(super::ReleaseControl),
+        #[prost(message, tag = "26")]
+        AgentRoster(super::AgentRoster),
     }
 }
 
@@ -434,6 +439,37 @@ pub struct PaneSubscribe {
     pub pane_id: u64,
 }
 
+/// Full hosted-agent replacement published by one pane host.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct AgentRoster {
+    #[prost(bytes = "vec", tag = "1")]
+    pub host_peer_id: Vec<u8>,
+    #[prost(uint64, tag = "2")]
+    pub generation: u64,
+    #[prost(message, repeated, tag = "3")]
+    pub entries: Vec<AgentRosterEntry>,
+}
+
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct AgentRosterEntry {
+    #[prost(uint64, tag = "1")]
+    pub pane_id: u64,
+    #[prost(string, tag = "2")]
+    pub agent_kind: String,
+    #[prost(string, tag = "3")]
+    pub cwd: String,
+    #[prost(enumeration = "AgentRosterState", tag = "4")]
+    pub state: i32,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum AgentRosterState {
+    Idle = 0,
+    Working = 1,
+    Done = 2,
+}
+
 pub fn encode_frame(envelope: &Envelope) -> Result<Vec<u8>, ProtocolError> {
     validate_envelope(envelope)?;
 
@@ -707,8 +743,51 @@ fn validate_envelope(envelope: &Envelope) -> Result<(), ProtocolError> {
             )?;
             validate_nonzero("pane_subscribe.pane_id", subscribe.pane_id)?;
         }
+        envelope::Body::AgentRoster(roster) => validate_agent_roster(roster)?,
     }
 
+    Ok(())
+}
+
+fn validate_agent_roster(roster: &AgentRoster) -> Result<(), ProtocolError> {
+    validate_id(
+        "agent_roster.host_peer_id",
+        &roster.host_peer_id,
+        MAX_PEER_ID_BYTES,
+    )?;
+    if roster.entries.len() > MAX_AGENT_ROSTER_ENTRIES {
+        return Err(ProtocolError::FieldTooLarge {
+            field: "agent_roster.entries",
+            limit: MAX_AGENT_ROSTER_ENTRIES,
+            actual: roster.entries.len(),
+        });
+    }
+    let mut pane_ids = HashSet::new();
+    for entry in &roster.entries {
+        validate_nonzero("agent_roster.entry.pane_id", entry.pane_id)?;
+        if !pane_ids.insert(entry.pane_id) {
+            return Err(ProtocolError::InvalidLayout(
+                "agent_roster.entry.pane_id",
+            ));
+        }
+        validate_field_size(
+            "agent_roster.entry.agent_kind",
+            entry.agent_kind.len(),
+            MAX_AGENT_KIND_BYTES,
+        )?;
+        if !matches!(entry.agent_kind.as_str(), "claude" | "codex" | "cursor" | "pi") {
+            return Err(ProtocolError::InvalidLayout(
+                "agent_roster.entry.agent_kind",
+            ));
+        }
+        validate_field_size(
+            "agent_roster.entry.cwd",
+            entry.cwd.len(),
+            MAX_AGENT_CWD_BYTES,
+        )?;
+        AgentRosterState::try_from(entry.state)
+            .map_err(|_| ProtocolError::InvalidLayout("agent_roster.entry.state"))?;
+    }
     Ok(())
 }
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -798,16 +798,17 @@ fn validate_agent_roster(roster: &AgentRoster) -> Result<(), ProtocolError> {
     for entry in &roster.entries {
         validate_nonzero("agent_roster.entry.pane_id", entry.pane_id)?;
         if !pane_ids.insert(entry.pane_id) {
-            return Err(ProtocolError::InvalidLayout(
-                "agent_roster.entry.pane_id",
-            ));
+            return Err(ProtocolError::InvalidLayout("agent_roster.entry.pane_id"));
         }
         validate_field_size(
             "agent_roster.entry.agent_kind",
             entry.agent_kind.len(),
             MAX_AGENT_KIND_BYTES,
         )?;
-        if !matches!(entry.agent_kind.as_str(), "claude" | "codex" | "cursor" | "pi") {
+        if !matches!(
+            entry.agent_kind.as_str(),
+            "claude" | "codex" | "cursor" | "pi"
+        ) {
             return Err(ProtocolError::InvalidLayout(
                 "agent_roster.entry.agent_kind",
             ));

--- a/src/pty_host.rs
+++ b/src/pty_host.rs
@@ -85,6 +85,11 @@ impl PtyHost {
         self.output_closed
     }
 
+    /// Return the PTY session child PID while the child is still owned.
+    pub fn process_id(&self) -> Option<u32> {
+        self.child.as_ref().and_then(|child| child.process_id())
+    }
+
     /// Write terminal input to the child PTY immediately.
     pub fn write_input(&mut self, bytes: &[u8]) -> Result<(), Box<dyn Error>> {
         let writer = self.writer.as_mut().ok_or("PTY writer is shut down")?;

--- a/src/session.rs
+++ b/src/session.rs
@@ -1759,6 +1759,13 @@ struct ControlMailbox {
     next_sequence: Arc<AtomicU64>,
 }
 
+struct ControlMailboxReceivers {
+    initial_rx: mpsc::Receiver<Envelope>,
+    state_rx: watch::Receiver<Option<SequencedEnvelope>>,
+    roster_rx: watch::Receiver<Option<SequencedEnvelope>>,
+    targeted_rx: mpsc::Receiver<SequencedEnvelope>,
+}
+
 #[derive(Clone)]
 struct SequencedEnvelope {
     sequence: u64,
@@ -1766,13 +1773,7 @@ struct SequencedEnvelope {
 }
 
 impl ControlMailbox {
-    fn new() -> (
-        Self,
-        mpsc::Receiver<Envelope>,
-        watch::Receiver<Option<SequencedEnvelope>>,
-        watch::Receiver<Option<SequencedEnvelope>>,
-        mpsc::Receiver<SequencedEnvelope>,
-    ) {
+    fn new() -> (Self, ControlMailboxReceivers) {
         let (initial_tx, initial_rx) = mpsc::channel(33);
         let (state_tx, state_rx) = watch::channel(None);
         let (roster_tx, roster_rx) = watch::channel(None);
@@ -1785,10 +1786,12 @@ impl ControlMailbox {
                 targeted_tx,
                 next_sequence: Arc::new(AtomicU64::new(1)),
             },
-            initial_rx,
-            state_rx,
-            roster_rx,
-            targeted_rx,
+            ControlMailboxReceivers {
+                initial_rx,
+                state_rx,
+                roster_rx,
+                targeted_rx,
+            },
         )
     }
 
@@ -2182,7 +2185,7 @@ impl SharedLayoutHost {
 
             let (writer, reader) = self.transport_open_control(&connection).await?;
             let peer_id = receipt.admitted_peer_id.clone();
-            let (mailbox, initial_rx, state_rx, roster_rx, targeted_rx) = ControlMailbox::new();
+            let (mailbox, receivers) = ControlMailbox::new();
             let peer = ControlPeer::pending_reader(mailbox.clone(), connection.clone());
             let reader_abort = peer.reader_abort.clone();
             self.peers
@@ -2230,10 +2233,7 @@ impl SharedLayoutHost {
             }
             tokio::spawn(layout_peer_writer_task(
                 writer,
-                initial_rx,
-                state_rx,
-                roster_rx,
-                targeted_rx,
+                receivers,
                 receipt.admitted_peer_id.clone(),
                 self.peers.clone(),
                 Some((
@@ -2568,10 +2568,12 @@ pub async fn join_layout_with_display_name(
 
 async fn layout_peer_writer_task<W>(
     mut writer: W,
-    mut initial_rx: mpsc::Receiver<Envelope>,
-    mut state_rx: watch::Receiver<Option<SequencedEnvelope>>,
-    mut roster_rx: watch::Receiver<Option<SequencedEnvelope>>,
-    mut targeted_rx: mpsc::Receiver<SequencedEnvelope>,
+    ControlMailboxReceivers {
+        mut initial_rx,
+        mut state_rx,
+        mut roster_rx,
+        mut targeted_rx,
+    }: ControlMailboxReceivers,
     peer_id: Vec<u8>,
     peers: Arc<Mutex<BTreeMap<Vec<u8>, ControlPeer>>>,
     coordinator: Option<CoordinatorDeparture>,
@@ -3477,7 +3479,7 @@ mod control_queue_tests {
     #[tokio::test]
     async fn failed_writer_removes_the_peer_and_aborts_its_reader() {
         let peers = Arc::new(Mutex::new(BTreeMap::new()));
-        let (mailbox, initial_rx, state_rx, roster_rx, targeted_rx) = ControlMailbox::new();
+        let (mailbox, receivers) = ControlMailbox::new();
         let reader = tokio::spawn(std::future::pending::<()>());
         peers.lock().unwrap().insert(
             b"slow".to_vec(),
@@ -3494,10 +3496,7 @@ mod control_queue_tests {
 
         layout_peer_writer_task(
             FailingWriter,
-            initial_rx,
-            state_rx,
-            roster_rx,
-            targeted_rx,
+            receivers,
             b"slow".to_vec(),
             peers.clone(),
             None,
@@ -3519,21 +3518,14 @@ mod control_queue_tests {
     #[tokio::test]
     async fn stalled_peer_coalesces_commits_while_a_healthy_peer_receives_the_latest() {
         let peers = Arc::new(Mutex::new(BTreeMap::new()));
-        let (slow_mailbox, slow_initial_rx, slow_state_rx, slow_roster_rx, slow_targeted_rx) =
-            ControlMailbox::new();
-        let observed_slow_state = slow_state_rx.clone();
+        let (slow_mailbox, slow_receivers) = ControlMailbox::new();
+        let observed_slow_state = slow_receivers.state_rx.clone();
         let slow_reader = tokio::spawn(std::future::pending::<()>());
         peers.lock().unwrap().insert(
             b"slow".to_vec(),
             ControlPeer::new(slow_mailbox, slow_reader.abort_handle(), None),
         );
-        let (
-            healthy_mailbox,
-            healthy_initial_rx,
-            healthy_state_rx,
-            healthy_roster_rx,
-            healthy_targeted_rx,
-        ) = ControlMailbox::new();
+        let (healthy_mailbox, healthy_receivers) = ControlMailbox::new();
         let healthy_reader = tokio::spawn(std::future::pending::<()>());
         peers.lock().unwrap().insert(
             b"healthy".to_vec(),
@@ -3566,10 +3558,7 @@ mod control_queue_tests {
                 started: Some(started_tx),
                 release: Some(release_rx),
             },
-            slow_initial_rx,
-            slow_state_rx,
-            slow_roster_rx,
-            slow_targeted_rx,
+            slow_receivers,
             b"slow".to_vec(),
             peers.clone(),
             None,
@@ -3577,10 +3566,7 @@ mod control_queue_tests {
         let (healthy_tx, mut healthy_rx) = mpsc::unbounded_channel();
         let healthy_task = tokio::spawn(layout_peer_writer_task(
             RecordingWriter(healthy_tx),
-            healthy_initial_rx,
-            healthy_state_rx,
-            healthy_roster_rx,
-            healthy_targeted_rx,
+            healthy_receivers,
             b"healthy".to_vec(),
             peers.clone(),
             None,
@@ -3628,7 +3614,7 @@ mod control_queue_tests {
     #[tokio::test]
     async fn targeted_queue_overflow_closes_the_peer_before_it_can_keep_reading() {
         let peers = Arc::new(Mutex::new(BTreeMap::new()));
-        let (mailbox, _initial_rx, _state_rx, _roster_rx, targeted_rx) = ControlMailbox::new();
+        let (mailbox, receivers) = ControlMailbox::new();
         let reader = tokio::spawn(std::future::pending::<()>());
         peers.lock().unwrap().insert(
             b"slow".to_vec(),
@@ -3663,7 +3649,7 @@ mod control_queue_tests {
         assert!(!peers.lock().unwrap().contains_key(b"slow".as_slice()));
         tokio::task::yield_now().await;
         assert!(reader.is_finished());
-        drop(targeted_rx);
+        drop(receivers.targeted_rx);
         assert!(!mailbox.enqueue_targeted(coordinator_envelope(
             b"coordinator",
             envelope::Body::LayoutReject(LayoutReject {
@@ -3676,7 +3662,7 @@ mod control_queue_tests {
     #[tokio::test]
     async fn initial_snapshot_is_first_when_a_commit_arrives_before_the_writer_starts() {
         let peers = Arc::new(Mutex::new(BTreeMap::new()));
-        let (mailbox, initial_rx, state_rx, roster_rx, targeted_rx) = ControlMailbox::new();
+        let (mailbox, receivers) = ControlMailbox::new();
         let reader = tokio::spawn(std::future::pending::<()>());
         peers.lock().unwrap().insert(
             b"member".to_vec(),
@@ -3694,10 +3680,7 @@ mod control_queue_tests {
         let (recorded_tx, mut recorded_rx) = mpsc::unbounded_channel();
         let writer_task = tokio::spawn(layout_peer_writer_task(
             RecordingWriter(recorded_tx),
-            initial_rx,
-            state_rx,
-            roster_rx,
-            targeted_rx,
+            receivers,
             b"member".to_vec(),
             peers.clone(),
             None,
@@ -3721,7 +3704,7 @@ mod control_queue_tests {
     #[tokio::test]
     async fn targeted_frame_precedes_later_coalesced_state_updates() {
         let peers = Arc::new(Mutex::new(BTreeMap::new()));
-        let (mailbox, initial_rx, state_rx, roster_rx, targeted_rx) = ControlMailbox::new();
+        let (mailbox, receivers) = ControlMailbox::new();
         let reader = tokio::spawn(std::future::pending::<()>());
         peers.lock().unwrap().insert(
             b"member".to_vec(),
@@ -3745,10 +3728,7 @@ mod control_queue_tests {
         let (recorded_tx, mut recorded_rx) = mpsc::unbounded_channel();
         let writer_task = tokio::spawn(layout_peer_writer_task(
             RecordingWriter(recorded_tx),
-            initial_rx,
-            state_rx,
-            roster_rx,
-            targeted_rx,
+            receivers,
             b"member".to_vec(),
             peers.clone(),
             None,
@@ -3773,7 +3753,7 @@ mod control_queue_tests {
     #[tokio::test]
     async fn roster_watch_does_not_replace_a_pending_layout_commit() {
         let peers = Arc::new(Mutex::new(BTreeMap::new()));
-        let (mailbox, initial_rx, state_rx, roster_rx, targeted_rx) = ControlMailbox::new();
+        let (mailbox, receivers) = ControlMailbox::new();
         let reader = tokio::spawn(std::future::pending::<()>());
         peers.lock().unwrap().insert(
             b"member".to_vec(),
@@ -3787,10 +3767,7 @@ mod control_queue_tests {
         let (recorded_tx, mut recorded_rx) = mpsc::unbounded_channel();
         let writer_task = tokio::spawn(layout_peer_writer_task(
             RecordingWriter(recorded_tx),
-            initial_rx,
-            state_rx,
-            roster_rx,
-            targeted_rx,
+            receivers,
             b"member".to_vec(),
             peers.clone(),
             None,

--- a/src/session.rs
+++ b/src/session.rs
@@ -29,9 +29,10 @@ use crate::{
     },
     lease::LeaseState,
     protocol::{
-        ControlLease, CreatePane, CreateTab, DeletePane, DeleteTab, Delta, Envelope, Input, Join,
-        LayoutCommit, LayoutNode, LayoutReject, LayoutRejectReason, LayoutRequest, LayoutSplit,
-        LayoutState, MemberDescriptor, NewPanePosition as ProtocolNewPanePosition,
+        AgentRoster, ControlLease, CreatePane, CreateTab, DeletePane, DeleteTab, Delta,
+        Envelope, Input, Join, LayoutCommit, LayoutNode,
+        LayoutReject, LayoutRejectReason, LayoutRequest, LayoutSplit, LayoutState,
+        MemberDescriptor, NewPanePosition as ProtocolNewPanePosition,
         PROTOCOL_VERSION, PaneDescriptor, PaneFailed, PaneReady, PaneReservation, PaneSubscribe,
         ReleaseControl, SessionSnapshot, Snapshot, SplitAxis, TabDescriptor, TakeControl, Welcome,
         envelope,
@@ -49,6 +50,7 @@ pub const DEFAULT_RESERVATION_TIMEOUT: Duration = Duration::from_secs(30);
 pub struct LayoutCoordinator {
     state: SessionState,
     reservations: BTreeMap<u64, ReservationContext>,
+    agent_rosters: BTreeMap<Vec<u8>, AgentRoster>,
     reservation_timeout: Duration,
 }
 
@@ -190,6 +192,7 @@ impl LayoutCoordinator {
                 grid_cols,
             )?,
             reservations: BTreeMap::new(),
+            agent_rosters: BTreeMap::new(),
             reservation_timeout,
         })
     }
@@ -198,6 +201,47 @@ impl LayoutCoordinator {
         Ok(SessionSnapshot {
             state: Some(self.protocol_layout_state()?),
         })
+    }
+
+    /// Return the cached full-replacement rosters in deterministic host order.
+    pub fn agent_rosters(&self) -> Vec<AgentRoster> {
+        self.agent_rosters.values().cloned().collect()
+    }
+
+    /// Accept a host's latest full roster after checking the authoritative layout.
+    ///
+    /// The authenticated connection identity always wins over the message's claimed host ID.
+    pub fn accept_agent_roster(
+        &mut self,
+        authenticated_peer_id: &[u8],
+        mut roster: AgentRoster,
+    ) -> Option<AgentRoster> {
+        if !self
+            .state
+            .members()
+            .iter()
+            .any(|member| member.peer_id == authenticated_peer_id)
+        {
+            return None;
+        }
+        if roster.entries.iter().any(|entry| {
+            self.state
+                .pane(entry.pane_id)
+                .is_none_or(|pane| pane.host_peer_id != authenticated_peer_id)
+        }) {
+            return None;
+        }
+        if self
+            .agent_rosters
+            .get(authenticated_peer_id)
+            .is_some_and(|current| roster.generation <= current.generation)
+        {
+            return None;
+        }
+        roster.host_peer_id = authenticated_peer_id.to_vec();
+        self.agent_rosters
+            .insert(authenticated_peer_id.to_vec(), roster.clone());
+        Some(roster)
     }
 
     pub fn admit(
@@ -240,6 +284,7 @@ impl LayoutCoordinator {
 
     pub fn remove_member(&mut self, peer_id: &[u8]) -> Result<MembershipChange, CoordinatorError> {
         let invalidated = self.state.remove_member(peer_id)?;
+        self.prune_agent_rosters();
         self.membership_change(invalidated)
     }
 
@@ -291,7 +336,12 @@ impl LayoutCoordinator {
         };
 
         match result {
-            Ok(response) => response,
+            Ok(response) => {
+                if matches!(response, CoordinatorResponse::Commit(_)) {
+                    self.prune_agent_rosters();
+                }
+                response
+            }
             Err(error) => reject(request_id, reject_reason(&error)),
         }
     }
@@ -551,6 +601,25 @@ impl LayoutCoordinator {
             commit: self.layout_commit()?,
             invalidated_reservation,
         })
+    }
+
+    fn prune_agent_rosters(&mut self) {
+        self.agent_rosters.retain(|host_peer_id, roster| {
+            if !self
+                .state
+                .members()
+                .iter()
+                .any(|member| member.peer_id == *host_peer_id)
+            {
+                return false;
+            }
+            roster.entries.retain(|entry| {
+                self.state
+                    .pane(entry.pane_id)
+                    .is_some_and(|pane| pane.host_peer_id == *host_peer_id)
+            });
+            true
+        });
     }
 }
 
@@ -1573,6 +1642,7 @@ pub struct SharedLayoutHost {
 #[derive(Clone, Debug, PartialEq)]
 pub enum LayoutControlEvent {
     Snapshot(SessionSnapshot),
+    AgentRoster(AgentRoster),
     Reservation(PaneReservation),
     Commit(LayoutCommit),
     Reject(LayoutReject),
@@ -1595,7 +1665,8 @@ impl PaneLayoutReconciler {
         let state = match event {
             LayoutControlEvent::Snapshot(snapshot) => snapshot.state.as_ref(),
             LayoutControlEvent::Commit(commit) => commit.state.as_ref(),
-            LayoutControlEvent::Reservation(_)
+            LayoutControlEvent::AgentRoster(_)
+            | LayoutControlEvent::Reservation(_)
             | LayoutControlEvent::Reject(_)
             | LayoutControlEvent::Disconnected => None,
         };
@@ -1616,6 +1687,7 @@ enum LayoutClientMessage {
     Request(LayoutRequest),
     Ready(PaneReady),
     Failed(PaneFailed),
+    AgentRoster(AgentRoster),
 }
 
 const TARGETED_CONTROL_QUEUE_CAPACITY: usize = 16;
@@ -1624,6 +1696,7 @@ const TARGETED_CONTROL_QUEUE_CAPACITY: usize = 16;
 struct ControlMailbox {
     initial_tx: mpsc::Sender<Envelope>,
     state_tx: watch::Sender<Option<SequencedEnvelope>>,
+    roster_tx: watch::Sender<Option<SequencedEnvelope>>,
     targeted_tx: mpsc::Sender<SequencedEnvelope>,
     next_sequence: Arc<AtomicU64>,
 }
@@ -1639,20 +1712,24 @@ impl ControlMailbox {
         Self,
         mpsc::Receiver<Envelope>,
         watch::Receiver<Option<SequencedEnvelope>>,
+        watch::Receiver<Option<SequencedEnvelope>>,
         mpsc::Receiver<SequencedEnvelope>,
     ) {
-        let (initial_tx, initial_rx) = mpsc::channel(1);
+        let (initial_tx, initial_rx) = mpsc::channel(33);
         let (state_tx, state_rx) = watch::channel(None);
+        let (roster_tx, roster_rx) = watch::channel(None);
         let (targeted_tx, targeted_rx) = mpsc::channel(TARGETED_CONTROL_QUEUE_CAPACITY);
         (
             Self {
                 initial_tx,
                 state_tx,
+                roster_tx,
                 targeted_tx,
                 next_sequence: Arc::new(AtomicU64::new(1)),
             },
             initial_rx,
             state_rx,
+            roster_rx,
             targeted_rx,
         )
     }
@@ -1663,6 +1740,10 @@ impl ControlMailbox {
 
     fn publish_state(&self, envelope: Envelope) {
         self.state_tx.send_replace(Some(self.sequenced(envelope)));
+    }
+
+    fn publish_roster(&self, envelope: Envelope) {
+        self.roster_tx.send_replace(Some(self.sequenced(envelope)));
     }
 
     fn enqueue_targeted(&self, envelope: Envelope) -> bool {
@@ -1771,6 +1852,13 @@ impl SharedLayoutMember {
     pub fn try_failed(&self, failed: PaneFailed) -> Result<(), LayoutControlQueueError> {
         self.outbound
             .try_send(LayoutClientMessage::Failed(failed))
+            .map_err(layout_queue_error)
+    }
+
+    /// Publish this member's full hosted-agent replacement to the coordinator.
+    pub fn try_agent_roster(&self, roster: AgentRoster) -> Result<(), LayoutControlQueueError> {
+        self.outbound
+            .try_send(LayoutClientMessage::AgentRoster(roster))
             .map_err(layout_queue_error)
     }
 
@@ -2019,7 +2107,7 @@ impl SharedLayoutHost {
 
             let (writer, reader) = self.transport_open_control(&connection).await?;
             let peer_id = receipt.admitted_peer_id.clone();
-            let (mailbox, initial_rx, state_rx, targeted_rx) = ControlMailbox::new();
+            let (mailbox, initial_rx, state_rx, roster_rx, targeted_rx) = ControlMailbox::new();
             let peer = ControlPeer::pending_reader(mailbox.clone(), connection.clone());
             let reader_abort = peer.reader_abort.clone();
             self.peers
@@ -2038,6 +2126,20 @@ impl SharedLayoutHost {
                 ))
                 .then_some(())
                 .ok_or(SessionError::PeerTask)?;
+            let rosters = self
+                .coordinator
+                .lock()
+                .map_err(|_| SessionError::PeerTask)?
+                .agent_rosters();
+            for roster in rosters {
+                mailbox
+                    .enqueue_initial(coordinator_envelope(
+                        self.host.ticket().endpoint_addr().id.as_bytes(),
+                        envelope::Body::AgentRoster(roster),
+                    ))
+                    .then_some(())
+                    .ok_or(SessionError::PeerTask)?;
+            }
 
             let reader_task = tokio::spawn(layout_host_reader_task(
                 reader,
@@ -2055,6 +2157,7 @@ impl SharedLayoutHost {
                 writer,
                 initial_rx,
                 state_rx,
+                roster_rx,
                 targeted_rx,
                 receipt.admitted_peer_id.clone(),
                 self.peers.clone(),
@@ -2256,6 +2359,17 @@ fn broadcast_envelope(peers: &Arc<Mutex<BTreeMap<Vec<u8>, ControlPeer>>>, envelo
     }
 }
 
+fn broadcast_roster(peers: &Arc<Mutex<BTreeMap<Vec<u8>, ControlPeer>>>, envelope: Envelope) {
+    let peers = match peers.lock() {
+        Ok(peers) => peers,
+        Err(_) => return,
+    };
+    for peer in peers.values() {
+        // Roster updates supersede only older rosters, never pending layout commits.
+        peer.mailbox.publish_roster(envelope.clone());
+    }
+}
+
 fn send_to_peer(
     peers: &Arc<Mutex<BTreeMap<Vec<u8>, ControlPeer>>>,
     peer_id: &[u8],
@@ -2381,6 +2495,7 @@ async fn layout_peer_writer_task<W>(
     mut writer: W,
     mut initial_rx: mpsc::Receiver<Envelope>,
     mut state_rx: watch::Receiver<Option<SequencedEnvelope>>,
+    mut roster_rx: watch::Receiver<Option<SequencedEnvelope>>,
     mut targeted_rx: mpsc::Receiver<SequencedEnvelope>,
     peer_id: Vec<u8>,
     peers: Arc<Mutex<BTreeMap<Vec<u8>, ControlPeer>>>,
@@ -2396,10 +2511,18 @@ async fn layout_peer_writer_task<W>(
         disconnect_or_remove(&peers, coordinator.as_ref(), &peer_id);
         return;
     }
+    while let Ok(initial) = initial_rx.try_recv() {
+        if !writer.write_control(&initial).await {
+            disconnect_or_remove(&peers, coordinator.as_ref(), &peer_id);
+            return;
+        }
+    }
     let mut targeted_open = true;
     let mut state_open = true;
+    let mut roster_open = true;
     let mut pending_targeted = None;
     let mut pending_state = None;
+    let mut pending_roster = None;
     loop {
         if pending_targeted.is_none() {
             match targeted_rx.try_recv() {
@@ -2411,14 +2534,16 @@ async fn layout_peer_writer_task<W>(
         if pending_state.is_none() && state_open && state_rx.has_changed().unwrap_or(false) {
             pending_state = state_rx.borrow_and_update().clone();
         }
+        if pending_roster.is_none() && roster_open && roster_rx.has_changed().unwrap_or(false) {
+            pending_roster = roster_rx.borrow_and_update().clone();
+        }
 
-        let next = match (&pending_state, &pending_targeted) {
-            (Some(state), Some(targeted)) if state.sequence < targeted.sequence => {
-                pending_state.take()
-            }
-            (Some(_), Some(_)) | (None, Some(_)) => pending_targeted.take(),
-            (Some(_), None) => pending_state.take(),
-            (None, None) => {
+        let next = match (
+            pending_state.as_ref().map(|item| item.sequence),
+            pending_roster.as_ref().map(|item| item.sequence),
+            pending_targeted.as_ref().map(|item| item.sequence),
+        ) {
+            (None, None, None) => {
                 tokio::select! {
                     targeted = targeted_rx.recv(), if targeted_open => match targeted {
                         Some(targeted) => pending_targeted = Some(targeted),
@@ -2428,9 +2553,25 @@ async fn layout_peer_writer_task<W>(
                         Ok(()) => pending_state = state_rx.borrow_and_update().clone(),
                         Err(_) => state_open = false,
                     },
+                    changed = roster_rx.changed(), if roster_open => match changed {
+                        Ok(()) => pending_roster = roster_rx.borrow_and_update().clone(),
+                        Err(_) => roster_open = false,
+                    },
                     else => return,
                 }
                 continue;
+            }
+            (state, roster, targeted) => {
+                let state = state.unwrap_or(u64::MAX);
+                let roster = roster.unwrap_or(u64::MAX);
+                let targeted = targeted.unwrap_or(u64::MAX);
+                if targeted <= state && targeted <= roster {
+                    pending_targeted.take()
+                } else if state <= roster {
+                    pending_state.take()
+                } else {
+                    pending_roster.take()
+                }
             }
         };
         let Some(next) = next else {
@@ -2453,6 +2594,7 @@ async fn layout_member_writer_task(
             LayoutClientMessage::Request(request) => envelope::Body::LayoutRequest(request),
             LayoutClientMessage::Ready(ready) => envelope::Body::PaneReady(ready),
             LayoutClientMessage::Failed(failed) => envelope::Body::PaneFailed(failed),
+            LayoutClientMessage::AgentRoster(roster) => envelope::Body::AgentRoster(roster),
         };
         if writer
             .write_next(&coordinator_envelope(&peer_id, body))
@@ -2477,6 +2619,7 @@ async fn layout_member_reader_task(
             Some(envelope::Body::SessionSnapshot(snapshot)) => {
                 LayoutControlEvent::Snapshot(snapshot)
             }
+            Some(envelope::Body::AgentRoster(roster)) => LayoutControlEvent::AgentRoster(roster),
             Some(envelope::Body::PaneReservation(reservation)) => {
                 LayoutControlEvent::Reservation(reservation)
             }
@@ -2565,6 +2708,21 @@ async fn layout_host_reader_task(
                     ),
                 );
                 drop(coordinator_guard);
+            }
+            Some(envelope::Body::AgentRoster(roster)) => {
+                let accepted = match coordinator.lock() {
+                    Ok(mut coordinator) => coordinator.accept_agent_roster(&peer_id, roster),
+                    Err(_) => break,
+                };
+                if let Some(roster) = accepted {
+                    broadcast_roster(
+                        &peers,
+                        coordinator_envelope(
+                            &coordinator_peer_id,
+                            envelope::Body::AgentRoster(roster),
+                        ),
+                    );
+                }
             }
             _ => break,
         }
@@ -3167,6 +3325,7 @@ mod control_queue_tests {
     use std::{future::Future, pin::Pin};
 
     use super::*;
+    use crate::protocol::{AgentRosterEntry, AgentRosterState};
     use tokio::sync::oneshot;
 
     struct FailingWriter;
@@ -3224,10 +3383,26 @@ mod control_queue_tests {
         )
     }
 
+    fn roster(generation: u64) -> Envelope {
+        coordinator_envelope(
+            b"coordinator",
+            envelope::Body::AgentRoster(AgentRoster {
+                host_peer_id: b"host".to_vec(),
+                generation,
+                entries: vec![AgentRosterEntry {
+                    pane_id: 1,
+                    agent_kind: String::from("codex"),
+                    cwd: String::from("/repo"),
+                    state: AgentRosterState::Working as i32,
+                }],
+            }),
+        )
+    }
+
     #[tokio::test]
     async fn failed_writer_removes_the_peer_and_aborts_its_reader() {
         let peers = Arc::new(Mutex::new(BTreeMap::new()));
-        let (mailbox, initial_rx, state_rx, targeted_rx) = ControlMailbox::new();
+        let (mailbox, initial_rx, state_rx, roster_rx, targeted_rx) = ControlMailbox::new();
         let reader = tokio::spawn(std::future::pending::<()>());
         peers.lock().unwrap().insert(
             b"slow".to_vec(),
@@ -3246,6 +3421,7 @@ mod control_queue_tests {
             FailingWriter,
             initial_rx,
             state_rx,
+            roster_rx,
             targeted_rx,
             b"slow".to_vec(),
             peers.clone(),
@@ -3268,7 +3444,7 @@ mod control_queue_tests {
     #[tokio::test]
     async fn stalled_peer_coalesces_commits_while_a_healthy_peer_receives_the_latest() {
         let peers = Arc::new(Mutex::new(BTreeMap::new()));
-        let (slow_mailbox, slow_initial_rx, slow_state_rx, slow_targeted_rx) =
+        let (slow_mailbox, slow_initial_rx, slow_state_rx, slow_roster_rx, slow_targeted_rx) =
             ControlMailbox::new();
         let observed_slow_state = slow_state_rx.clone();
         let slow_reader = tokio::spawn(std::future::pending::<()>());
@@ -3276,7 +3452,7 @@ mod control_queue_tests {
             b"slow".to_vec(),
             ControlPeer::new(slow_mailbox, slow_reader.abort_handle(), None),
         );
-        let (healthy_mailbox, healthy_initial_rx, healthy_state_rx, healthy_targeted_rx) =
+        let (healthy_mailbox, healthy_initial_rx, healthy_state_rx, healthy_roster_rx, healthy_targeted_rx) =
             ControlMailbox::new();
         let healthy_reader = tokio::spawn(std::future::pending::<()>());
         peers.lock().unwrap().insert(
@@ -3312,6 +3488,7 @@ mod control_queue_tests {
             },
             slow_initial_rx,
             slow_state_rx,
+            slow_roster_rx,
             slow_targeted_rx,
             b"slow".to_vec(),
             peers.clone(),
@@ -3322,6 +3499,7 @@ mod control_queue_tests {
             RecordingWriter(healthy_tx),
             healthy_initial_rx,
             healthy_state_rx,
+            healthy_roster_rx,
             healthy_targeted_rx,
             b"healthy".to_vec(),
             peers.clone(),
@@ -3370,7 +3548,7 @@ mod control_queue_tests {
     #[tokio::test]
     async fn targeted_queue_overflow_closes_the_peer_before_it_can_keep_reading() {
         let peers = Arc::new(Mutex::new(BTreeMap::new()));
-        let (mailbox, _initial_rx, _state_rx, targeted_rx) = ControlMailbox::new();
+        let (mailbox, _initial_rx, _state_rx, _roster_rx, targeted_rx) = ControlMailbox::new();
         let reader = tokio::spawn(std::future::pending::<()>());
         peers.lock().unwrap().insert(
             b"slow".to_vec(),
@@ -3418,7 +3596,7 @@ mod control_queue_tests {
     #[tokio::test]
     async fn initial_snapshot_is_first_when_a_commit_arrives_before_the_writer_starts() {
         let peers = Arc::new(Mutex::new(BTreeMap::new()));
-        let (mailbox, initial_rx, state_rx, targeted_rx) = ControlMailbox::new();
+        let (mailbox, initial_rx, state_rx, roster_rx, targeted_rx) = ControlMailbox::new();
         let reader = tokio::spawn(std::future::pending::<()>());
         peers.lock().unwrap().insert(
             b"member".to_vec(),
@@ -3438,6 +3616,7 @@ mod control_queue_tests {
             RecordingWriter(recorded_tx),
             initial_rx,
             state_rx,
+            roster_rx,
             targeted_rx,
             b"member".to_vec(),
             peers.clone(),
@@ -3462,7 +3641,7 @@ mod control_queue_tests {
     #[tokio::test]
     async fn targeted_frame_precedes_later_coalesced_state_updates() {
         let peers = Arc::new(Mutex::new(BTreeMap::new()));
-        let (mailbox, initial_rx, state_rx, targeted_rx) = ControlMailbox::new();
+        let (mailbox, initial_rx, state_rx, roster_rx, targeted_rx) = ControlMailbox::new();
         let reader = tokio::spawn(std::future::pending::<()>());
         peers.lock().unwrap().insert(
             b"member".to_vec(),
@@ -3488,6 +3667,7 @@ mod control_queue_tests {
             RecordingWriter(recorded_tx),
             initial_rx,
             state_rx,
+            roster_rx,
             targeted_rx,
             b"member".to_vec(),
             peers.clone(),
@@ -3505,6 +3685,55 @@ mod control_queue_tests {
                 })),
                 ..
             })
+        ));
+        remove_control_peer(&peers, b"member");
+        writer_task.abort();
+    }
+
+    #[tokio::test]
+    async fn roster_watch_does_not_replace_a_pending_layout_commit() {
+        let peers = Arc::new(Mutex::new(BTreeMap::new()));
+        let (mailbox, initial_rx, state_rx, roster_rx, targeted_rx) = ControlMailbox::new();
+        let reader = tokio::spawn(std::future::pending::<()>());
+        peers.lock().unwrap().insert(
+            b"member".to_vec(),
+            ControlPeer::new(mailbox.clone(), reader.abort_handle(), None),
+        );
+        assert!(mailbox.enqueue_initial(commit(1)), "initial frame queues");
+        mailbox.publish_state(commit(2));
+        mailbox.publish_roster(roster(1));
+        mailbox.publish_state(commit(3));
+
+        let (recorded_tx, mut recorded_rx) = mpsc::unbounded_channel();
+        let writer_task = tokio::spawn(layout_peer_writer_task(
+            RecordingWriter(recorded_tx),
+            initial_rx,
+            state_rx,
+            roster_rx,
+            targeted_rx,
+            b"member".to_vec(),
+            peers.clone(),
+            None,
+        ));
+
+        assert!(matches!(
+            recorded_rx.recv().await,
+            Some(Envelope {
+                body: Some(envelope::Body::LayoutCommit(LayoutCommit { revision: 1, .. })),
+                ..
+            })
+        ));
+        let first = recorded_rx.recv().await.expect("first coalesced update");
+        let second = recorded_rx.recv().await.expect("second coalesced update");
+        assert!(matches!(
+            (first.body, second.body),
+            (
+                Some(envelope::Body::AgentRoster(_)),
+                Some(envelope::Body::LayoutCommit(LayoutCommit { revision: 3, .. }))
+            ) | (
+                Some(envelope::Body::LayoutCommit(LayoutCommit { revision: 3, .. })),
+                Some(envelope::Body::AgentRoster(_))
+            )
         ));
         remove_control_peer(&peers, b"member");
         writer_task.abort();

--- a/src/session.rs
+++ b/src/session.rs
@@ -1973,6 +1973,23 @@ impl SharedLayoutHost {
             .map_err(|_| SessionError::InvalidPostWelcome)
     }
 
+    /// Publish the coordinator host's own full agent roster through the same relay path.
+    pub fn publish_local_agent_roster(&self, roster: AgentRoster) -> Result<(), SessionError> {
+        let peer_id = self.host.transport.endpoint_id().as_bytes().to_vec();
+        let accepted = self
+            .coordinator
+            .lock()
+            .map_err(|_| SessionError::PeerTask)?
+            .accept_agent_roster(&peer_id, roster);
+        if let Some(roster) = accepted {
+            broadcast_roster(
+                &self.peers,
+                coordinator_envelope(&peer_id, envelope::Body::AgentRoster(roster)),
+            );
+        }
+        Ok(())
+    }
+
     /// Applies a request made by the coordinator process itself. Remote peers receive the same
     /// commit as they would for a member-originated request; the caller applies the returned
     /// response to its own renderer.

--- a/src/session.rs
+++ b/src/session.rs
@@ -29,10 +29,9 @@ use crate::{
     },
     lease::LeaseState,
     protocol::{
-        AgentRoster, ControlLease, CreatePane, CreateTab, DeletePane, DeleteTab, Delta,
-        Envelope, Input, Join, LayoutCommit, LayoutNode,
-        LayoutReject, LayoutRejectReason, LayoutRequest, LayoutSplit, LayoutState,
-        MemberDescriptor, NewPanePosition as ProtocolNewPanePosition,
+        AgentRoster, ControlLease, CreatePane, CreateTab, DeletePane, DeleteTab, Delta, Envelope,
+        Input, Join, LayoutCommit, LayoutNode, LayoutReject, LayoutRejectReason, LayoutRequest,
+        LayoutSplit, LayoutState, MemberDescriptor, NewPanePosition as ProtocolNewPanePosition,
         PROTOCOL_VERSION, PaneDescriptor, PaneFailed, PaneReady, PaneReservation, PaneSubscribe,
         ReleaseControl, SessionSnapshot, SetSplitRatio, Snapshot, SplitAxis, TabDescriptor,
         TakeControl, UpdatePaneGrids, Welcome, envelope,
@@ -3528,8 +3527,13 @@ mod control_queue_tests {
             b"slow".to_vec(),
             ControlPeer::new(slow_mailbox, slow_reader.abort_handle(), None),
         );
-        let (healthy_mailbox, healthy_initial_rx, healthy_state_rx, healthy_roster_rx, healthy_targeted_rx) =
-            ControlMailbox::new();
+        let (
+            healthy_mailbox,
+            healthy_initial_rx,
+            healthy_state_rx,
+            healthy_roster_rx,
+            healthy_targeted_rx,
+        ) = ControlMailbox::new();
         let healthy_reader = tokio::spawn(std::future::pending::<()>());
         peers.lock().unwrap().insert(
             b"healthy".to_vec(),
@@ -3795,7 +3799,10 @@ mod control_queue_tests {
         assert!(matches!(
             recorded_rx.recv().await,
             Some(Envelope {
-                body: Some(envelope::Body::LayoutCommit(LayoutCommit { revision: 1, .. })),
+                body: Some(envelope::Body::LayoutCommit(LayoutCommit {
+                    revision: 1,
+                    ..
+                })),
                 ..
             })
         ));
@@ -3805,9 +3812,15 @@ mod control_queue_tests {
             (first.body, second.body),
             (
                 Some(envelope::Body::AgentRoster(_)),
-                Some(envelope::Body::LayoutCommit(LayoutCommit { revision: 3, .. }))
+                Some(envelope::Body::LayoutCommit(LayoutCommit {
+                    revision: 3,
+                    ..
+                }))
             ) | (
-                Some(envelope::Body::LayoutCommit(LayoutCommit { revision: 3, .. })),
+                Some(envelope::Body::LayoutCommit(LayoutCommit {
+                    revision: 3,
+                    ..
+                })),
                 Some(envelope::Body::AgentRoster(_))
             )
         ));

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -51,9 +51,8 @@ use crate::{
     lease::{IDLE_AFTER, LeaseDecision, LeaseManager, LeaseState},
     protocol::{
         AgentRoster, AgentRosterEntry, AgentRosterState, CreatePane, CreateTab, DeletePane,
-        DeleteTab, LayoutRequest,
-        NewPanePosition as ProtocolNewPanePosition, PaneDescriptor, PaneFailed, PaneReady,
-        SplitAxis,
+        DeleteTab, LayoutRequest, NewPanePosition as ProtocolNewPanePosition, PaneDescriptor,
+        PaneFailed, PaneReady, SplitAxis,
     },
     pty_host::PtyHost,
     screen::{GuestScreen, HostScreen, SCROLLBACK_LINES, ScreenFrame},
@@ -332,26 +331,43 @@ impl MultiPaneTui {
         self.chord_mode
     }
 
-    pub fn overlay_open(&self) -> bool { self.agent_overlay_open }
+    pub fn overlay_open(&self) -> bool {
+        self.agent_overlay_open
+    }
 
     pub fn set_agent_rows(&mut self, mut rows: Vec<AgentOverlayRow>) -> bool {
         rows.retain(|row| self.snapshot.panes.contains_key(&row.pane_id));
         rows.sort_by_key(|row| (self.pane_order(row.pane_id), row.pane_id));
-        if self.agent_rows == rows { return false; }
+        if self.agent_rows == rows {
+            return false;
+        }
         self.agent_rows = rows;
-        if self.agent_selected_pane.is_some_and(|pane_id| !self.agent_rows.iter().any(|row| row.pane_id == pane_id)) {
+        if self
+            .agent_selected_pane
+            .is_some_and(|pane_id| !self.agent_rows.iter().any(|row| row.pane_id == pane_id))
+        {
             self.agent_selected_pane = self.agent_rows.first().map(|row| row.pane_id);
         }
-        if self.agent_selected_pane.is_none() { self.agent_selected_pane = self.agent_rows.first().map(|row| row.pane_id); }
+        if self.agent_selected_pane.is_none() {
+            self.agent_selected_pane = self.agent_rows.first().map(|row| row.pane_id);
+        }
         true
     }
 
     fn pane_order(&self, pane_id: PaneId) -> usize {
-        self.snapshot.tabs.iter().flat_map(|tab| visible_leaf_panes(&tab.root)).position(|id| id == pane_id).unwrap_or(usize::MAX)
+        self.snapshot
+            .tabs
+            .iter()
+            .flat_map(|tab| visible_leaf_panes(&tab.root))
+            .position(|id| id == pane_id)
+            .unwrap_or(usize::MAX)
     }
 
     fn expire_agent_toggle(&mut self, now: Instant) -> bool {
-        if self.pending_agent_toggle.is_some_and(|then| now.duration_since(then) >= AGENT_TOGGLE_WINDOW) {
+        if self
+            .pending_agent_toggle
+            .is_some_and(|then| now.duration_since(then) >= AGENT_TOGGLE_WINDOW)
+        {
             self.pending_agent_toggle = None;
             self.agent_overlay_open = true;
             self.exit_chord_mode();
@@ -726,7 +742,10 @@ impl MultiPaneTui {
             return self.handle_agent_overlay_key(key);
         }
         if key.code == KeyCode::Char('a') && key.modifiers == KeyModifiers::CONTROL {
-            if self.pending_agent_toggle.is_some_and(|then| then.elapsed() <= AGENT_TOGGLE_WINDOW) {
+            if self
+                .pending_agent_toggle
+                .is_some_and(|then| then.elapsed() <= AGENT_TOGGLE_WINDOW)
+            {
                 self.pending_agent_toggle = None;
                 return KeyHandling::Forward;
             }
@@ -785,27 +804,55 @@ impl MultiPaneTui {
 
     fn handle_agent_overlay_key(&mut self, key: KeyEvent) -> KeyHandling {
         match key.code {
-            KeyCode::Esc => { self.agent_overlay_open = false; KeyHandling::Consumed(vec![]) }
-            KeyCode::Up | KeyCode::Char('k') => { self.move_agent_selection(false); KeyHandling::Consumed(vec![]) }
-            KeyCode::Down | KeyCode::Char('j') => { self.move_agent_selection(true); KeyHandling::Consumed(vec![]) }
+            KeyCode::Esc => {
+                self.agent_overlay_open = false;
+                KeyHandling::Consumed(vec![])
+            }
+            KeyCode::Up | KeyCode::Char('k') => {
+                self.move_agent_selection(false);
+                KeyHandling::Consumed(vec![])
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                self.move_agent_selection(true);
+                KeyHandling::Consumed(vec![])
+            }
             KeyCode::Enter => {
-                let Some(pane_id) = self.agent_selected_pane else { return KeyHandling::Consumed(vec![]); };
-                if let Some(tab) = self.snapshot.tabs.iter().find(|tab| contains_leaf(&tab.root, pane_id)) {
+                let Some(pane_id) = self.agent_selected_pane else {
+                    return KeyHandling::Consumed(vec![]);
+                };
+                if let Some(tab) = self
+                    .snapshot
+                    .tabs
+                    .iter()
+                    .find(|tab| contains_leaf(&tab.root, pane_id))
+                {
                     self.current_tab = tab.tab_id;
                     self.focused_pane = pane_id;
                     self.agent_overlay_open = false;
                     KeyHandling::Consumed(vec![UiIntent::FocusPane { pane_id }])
-                } else { KeyHandling::Consumed(vec![]) }
+                } else {
+                    KeyHandling::Consumed(vec![])
+                }
             }
             _ => KeyHandling::Consumed(vec![]),
         }
     }
 
     fn move_agent_selection(&mut self, forward: bool) {
-        if self.agent_rows.is_empty() { self.agent_selected_pane = None; return; }
-        let current = self.agent_selected_pane.and_then(|pane| self.agent_rows.iter().position(|row| row.pane_id == pane)).unwrap_or(0);
+        if self.agent_rows.is_empty() {
+            self.agent_selected_pane = None;
+            return;
+        }
+        let current = self
+            .agent_selected_pane
+            .and_then(|pane| self.agent_rows.iter().position(|row| row.pane_id == pane))
+            .unwrap_or(0);
         let len = self.agent_rows.len();
-        let next = if forward { (current + 1) % len } else { (current + len - 1) % len };
+        let next = if forward {
+            (current + 1) % len
+        } else {
+            (current + len - 1) % len
+        };
         self.agent_selected_pane = Some(self.agent_rows[next].pane_id);
     }
 
@@ -1729,7 +1776,8 @@ fn render_agents_overlay(frame: &mut Frame<'_>, tui: &MultiPaneTui) {
     let height = area.height.saturating_sub(4).min(18).max(5);
     let panel = Rect::new(
         area.x.saturating_add(area.width.saturating_sub(width) / 2),
-        area.y.saturating_add(area.height.saturating_sub(height) / 2),
+        area.y
+            .saturating_add(area.height.saturating_sub(height) / 2),
         width.min(area.width),
         height.min(area.height),
     );
@@ -1741,32 +1789,75 @@ fn render_agents_overlay(frame: &mut Frame<'_>, tui: &MultiPaneTui) {
         frame.render_widget(Paragraph::new("No agents running"), inner);
         return;
     }
-    let lines = tui.agent_rows.iter().map(|row| {
-        let marker = if tui.agent_selected_pane == Some(row.pane_id) { "›" } else { " " };
-        let prefix = format!("{marker} {} {} ", overlay_kind_label(&row.kind), overlay_state_label(row.state));
-        let detail = format!("{} · {} · {}", truncate_leading(&row.cwd, usize::from(inner.width.saturating_sub(text_width(&prefix)))), row.host, row.controller);
-        Line::from(vec![Span::styled(prefix, Style::default().fg(Color::Yellow)), Span::raw(detail)])
-    }).collect::<Vec<_>>();
+    let lines = tui
+        .agent_rows
+        .iter()
+        .map(|row| {
+            let marker = if tui.agent_selected_pane == Some(row.pane_id) {
+                "›"
+            } else {
+                " "
+            };
+            let prefix = format!(
+                "{marker} {} {} ",
+                overlay_kind_label(&row.kind),
+                overlay_state_label(row.state)
+            );
+            let detail = format!(
+                "{} · {} · {}",
+                truncate_leading(
+                    &row.cwd,
+                    usize::from(inner.width.saturating_sub(text_width(&prefix)))
+                ),
+                row.host,
+                row.controller
+            );
+            Line::from(vec![
+                Span::styled(prefix, Style::default().fg(Color::Yellow)),
+                Span::raw(detail),
+            ])
+        })
+        .collect::<Vec<_>>();
     frame.render_widget(Paragraph::new(lines), inner);
 }
 
 fn overlay_kind_label(kind: &str) -> &'static str {
-    match kind { "claude" => "Claude Code", "codex" => "Codex", "cursor" => "Cursor Agent", "pi" => "Pi", _ => "Unknown" }
+    match kind {
+        "claude" => "Claude Code",
+        "codex" => "Codex",
+        "cursor" => "Cursor Agent",
+        "pi" => "Pi",
+        _ => "Unknown",
+    }
 }
 
 fn overlay_state_label(state: AgentRosterState) -> &'static str {
-    match state { AgentRosterState::Idle => "idle", AgentRosterState::Working => "working", AgentRosterState::Done => "done" }
+    match state {
+        AgentRosterState::Idle => "idle",
+        AgentRosterState::Working => "working",
+        AgentRosterState::Done => "done",
+    }
 }
 
 fn truncate_leading(value: &str, width: usize) -> String {
     let count = value.chars().count();
-    if count <= width { return value.into(); }
-    if width <= 1 { return "…".into(); }
-    format!("…{}", value.chars().skip(count - width + 1).collect::<String>())
+    if count <= width {
+        return value.into();
+    }
+    if width <= 1 {
+        return "…".into();
+    }
+    format!(
+        "…{}",
+        value.chars().skip(count - width + 1).collect::<String>()
+    )
 }
 
 fn sanitize_single_line(value: &str) -> String {
-    value.chars().filter(|character| !character.is_control()).collect()
+    value
+        .chars()
+        .filter(|character| !character.is_control())
+        .collect()
 }
 
 /// One fixed-grid PTY owned by this process. Its watch channels are registered with the pane
@@ -1989,7 +2080,10 @@ impl AgentSamplingWorker {
         let join = thread::spawn(move || {
             let mut sampler = SysinfoSampler::default();
             while !worker_stop.load(Ordering::Relaxed) {
-                if snapshot_tx.send(sample_global_snapshot(&mut sampler)).is_err() {
+                if snapshot_tx
+                    .send(sample_global_snapshot(&mut sampler))
+                    .is_err()
+                {
                     break;
                 }
                 thread::sleep(AGENT_SAMPLE_INTERVAL);
@@ -2235,8 +2329,12 @@ impl SharedControl {
 
     fn try_agent_roster(&self, roster: AgentRoster) -> Result<(), String> {
         match self {
-            Self::Host(host) => host.publish_local_agent_roster(roster).map_err(|error| error.to_string()),
-            Self::Member(member) => member.try_agent_roster(roster).map_err(layout_queue_message),
+            Self::Host(host) => host
+                .publish_local_agent_roster(roster)
+                .map_err(|error| error.to_string()),
+            Self::Member(member) => member
+                .try_agent_roster(roster)
+                .map_err(layout_queue_message),
         }
     }
 
@@ -2625,25 +2723,28 @@ impl SharedLayoutRuntime {
                     dirty = true;
                 }
                 Event::Mouse(mouse) if matches!(mouse.kind, MouseEventKind::Moved) => {
-                    if !self.tui.overlay_open() { dirty |= self.tui.hover_pane_at(
-                        mouse.column,
-                        mouse.row,
-                        Rect::new(0, 0, cols, rows),
-                    ); }
+                    if !self.tui.overlay_open() {
+                        dirty |= self.tui.hover_pane_at(
+                            mouse.column,
+                            mouse.row,
+                            Rect::new(0, 0, cols, rows),
+                        );
+                    }
                 }
                 Event::Mouse(mouse)
                     if matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left)) =>
                 {
-                    if self.tui.overlay_open() { dirty = true; continue; }
+                    if self.tui.overlay_open() {
+                        dirty = true;
+                        continue;
+                    }
                     let area = Rect::new(0, 0, cols, rows);
                     let previously_focused = self.tui.focused_pane();
                     dirty |= self.clear_selection();
-                    if self.tui.begin_resize_drag(
-                        mouse.column,
-                        mouse.row,
-                        mouse.modifiers,
-                        area,
-                    ) {
+                    if self
+                        .tui
+                        .begin_resize_drag(mouse.column, mouse.row, mouse.modifiers, area)
+                    {
                         dirty = true;
                     } else if let Some(intent) =
                         self.tui.switch_tab_at(mouse.column, mouse.row, area)
@@ -2828,25 +2929,61 @@ impl SharedLayoutRuntime {
 
     fn publish_local_agent_roster(&mut self) -> bool {
         let now = Instant::now();
-        let entries = self.local.values().filter_map(|pane| pane.agent_roster_entry(now)).collect::<Vec<_>>();
-        if entries == self.last_local_agent_entries && now < self.next_agent_roster_heartbeat { return false; }
+        let entries = self
+            .local
+            .values()
+            .filter_map(|pane| pane.agent_roster_entry(now))
+            .collect::<Vec<_>>();
+        if entries == self.last_local_agent_entries && now < self.next_agent_roster_heartbeat {
+            return false;
+        }
         self.agent_roster_generation = self.agent_roster_generation.saturating_add(1);
-        let roster = AgentRoster { host_peer_id: self.control.peer_id(), generation: self.agent_roster_generation, entries: entries.clone() };
-        if self.control.try_agent_roster(roster.clone()).is_err() { return false; }
+        let roster = AgentRoster {
+            host_peer_id: self.control.peer_id(),
+            generation: self.agent_roster_generation,
+            entries: entries.clone(),
+        };
+        if self.control.try_agent_roster(roster.clone()).is_err() {
+            return false;
+        }
         self.last_local_agent_entries = entries;
         self.next_agent_roster_heartbeat = now + Duration::from_secs(5);
-        self.agent_rosters.insert(roster.host_peer_id.clone(), roster);
+        self.agent_rosters
+            .insert(roster.host_peer_id.clone(), roster);
         true
     }
 
     fn refresh_agent_rows(&mut self) -> bool {
-        let rows = self.agent_rosters.values().flat_map(|roster| roster.entries.iter().filter_map(|entry| {
-            let pane = self.tui.snapshot().panes.get(&entry.pane_id)?;
-            let view = self.tui.pane_view(entry.pane_id)?;
-            let host = sanitize_single_line(&member_label(&pane.host_peer_id, &self.tui.snapshot().members));
-            let controller = view.controller_peer_id.as_deref().filter(|id| !id.is_empty()).map(|id| sanitize_single_line(&member_label(id, &self.tui.snapshot().members))).unwrap_or_else(|| String::from("free"));
-            Some(AgentOverlayRow { pane_id: entry.pane_id, kind: sanitize_single_line(&entry.agent_kind), cwd: sanitize_single_line(&entry.cwd), state: AgentRosterState::try_from(entry.state).ok()?, host, controller })
-        })).collect();
+        let rows = self
+            .agent_rosters
+            .values()
+            .flat_map(|roster| {
+                roster.entries.iter().filter_map(|entry| {
+                    let pane = self.tui.snapshot().panes.get(&entry.pane_id)?;
+                    let view = self.tui.pane_view(entry.pane_id)?;
+                    let host = sanitize_single_line(&member_label(
+                        &pane.host_peer_id,
+                        &self.tui.snapshot().members,
+                    ));
+                    let controller = view
+                        .controller_peer_id
+                        .as_deref()
+                        .filter(|id| !id.is_empty())
+                        .map(|id| {
+                            sanitize_single_line(&member_label(id, &self.tui.snapshot().members))
+                        })
+                        .unwrap_or_else(|| String::from("free"));
+                    Some(AgentOverlayRow {
+                        pane_id: entry.pane_id,
+                        kind: sanitize_single_line(&entry.agent_kind),
+                        cwd: sanitize_single_line(&entry.cwd),
+                        state: AgentRosterState::try_from(entry.state).ok()?,
+                        host,
+                        controller,
+                    })
+                })
+            })
+            .collect();
         self.tui.set_agent_rows(rows)
     }
 
@@ -2857,7 +2994,8 @@ impl SharedLayoutRuntime {
                 self.apply_layout_state(snapshot.state.as_ref().ok_or("missing layout state")?)?;
             }
             LayoutControlEvent::AgentRoster(roster) => {
-                self.agent_rosters.insert(roster.host_peer_id.clone(), roster);
+                self.agent_rosters
+                    .insert(roster.host_peer_id.clone(), roster);
             }
             LayoutControlEvent::Commit(commit) => {
                 self.apply_layout_state(commit.state.as_ref().ok_or("missing layout state")?)?;
@@ -2879,8 +3017,16 @@ impl SharedLayoutRuntime {
             .map_err(|error| io::Error::other(format!("invalid layout state: {error:?}")))?;
         let current_ids = snapshot.panes.keys().copied().collect::<BTreeSet<_>>();
         self.agent_rosters.retain(|host, roster| {
-            roster.entries.retain(|entry| snapshot.panes.get(&entry.pane_id).is_some_and(|pane| pane.host_peer_id == *host));
-            snapshot.members.iter().any(|member| member.peer_id == *host)
+            roster.entries.retain(|entry| {
+                snapshot
+                    .panes
+                    .get(&entry.pane_id)
+                    .is_some_and(|pane| pane.host_peer_id == *host)
+            });
+            snapshot
+                .members
+                .iter()
+                .any(|member| member.peer_id == *host)
         });
         // A successful authoritative commit is the only point at which a provisional local PTY
         // becomes a real pane. Forget the request bookkeeping then; rejection handles the other
@@ -4069,14 +4215,14 @@ mod tests {
     use iroh::{Endpoint, RelayMode, endpoint::presets};
 
     use super::{
-        AGENT_TOGGLE_WINDOW, CHORD_IDLE_TIMEOUT, ChordMode, ESC_PREFIX_WINDOW, FOOTER_ACCENT, FOOTER_BACKGROUND,
-        FOOTER_MUTED, FOOTER_ORANGE, FooterSegment, HostControlEvent, HostPaneChannels,
-        HostPaneRuntime, KeyHandling, LayoutControlEvent, MultiPaneTui, PaneTextSelection,
-        PaneViewState, PendingEscape, RemoteSubscriptionState, ScreenCell, SharedLayoutRuntime,
-        SharedLocalPane, UiIntent, VtScreen, allocate_node, area_from_terminal_size,
-        contextual_footer, copied_line_count, encode_key, encode_paste, grid_for_pane,
-        initial_root_pane_grid, is_chord_command, lease_allows_held_input, member_label,
-        mouse_to_screen_cell, pane_border_color, pane_title, pane_wire_id,
+        AGENT_TOGGLE_WINDOW, CHORD_IDLE_TIMEOUT, ChordMode, ESC_PREFIX_WINDOW, FOOTER_ACCENT,
+        FOOTER_BACKGROUND, FOOTER_MUTED, FOOTER_ORANGE, FooterSegment, HostControlEvent,
+        HostPaneChannels, HostPaneRuntime, KeyHandling, LayoutControlEvent, MultiPaneTui,
+        PaneTextSelection, PaneViewState, PendingEscape, RemoteSubscriptionState, ScreenCell,
+        SharedLayoutRuntime, SharedLocalPane, UiIntent, VtScreen, allocate_node,
+        area_from_terminal_size, contextual_footer, copied_line_count, encode_key, encode_paste,
+        grid_for_pane, initial_root_pane_grid, is_chord_command, lease_allows_held_input,
+        member_label, mouse_to_screen_cell, pane_border_color, pane_title, pane_wire_id,
         reconcile_remote_control_attempt, render_guest_screen, render_multi_pane,
         render_shared_multi_pane, selection_text, text_width, viewed_screen, visible_leaf_panes,
     };
@@ -4128,15 +4274,37 @@ mod tests {
 
     #[test]
     fn agents_overlay_toggles_and_double_tap_forwards_ctrl_a() {
-        let mut tui = MultiPaneTui::new(layout(vec![Tab { tab_id: 1, root: Node::Leaf { pane_id: 1 } }], &[(1, 2, 8)])).unwrap();
+        let mut tui = MultiPaneTui::new(layout(
+            vec![Tab {
+                tab_id: 1,
+                root: Node::Leaf { pane_id: 1 },
+            }],
+            &[(1, 2, 8)],
+        ))
+        .unwrap();
         let ctrl_a = KeyEvent::new(KeyCode::Char('a'), KeyModifiers::CONTROL);
-        assert_eq!(tui.handle_key(ctrl_a, Rect::new(0, 0, 80, 24)), KeyHandling::Consumed(vec![]));
-        assert_eq!(tui.handle_key(ctrl_a, Rect::new(0, 0, 80, 24)), KeyHandling::Forward);
+        assert_eq!(
+            tui.handle_key(ctrl_a, Rect::new(0, 0, 80, 24)),
+            KeyHandling::Consumed(vec![])
+        );
+        assert_eq!(
+            tui.handle_key(ctrl_a, Rect::new(0, 0, 80, 24)),
+            KeyHandling::Forward
+        );
         assert!(!tui.overlay_open());
-        assert_eq!(tui.handle_key(ctrl_a, Rect::new(0, 0, 80, 24)), KeyHandling::Consumed(vec![]));
+        assert_eq!(
+            tui.handle_key(ctrl_a, Rect::new(0, 0, 80, 24)),
+            KeyHandling::Consumed(vec![])
+        );
         assert!(tui.expire_agent_toggle(Instant::now() + AGENT_TOGGLE_WINDOW));
         assert!(tui.overlay_open());
-        assert_eq!(tui.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE), Rect::new(0, 0, 80, 24)), KeyHandling::Consumed(vec![]));
+        assert_eq!(
+            tui.handle_key(
+                KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
+                Rect::new(0, 0, 80, 24)
+            ),
+            KeyHandling::Consumed(vec![])
+        );
         assert!(!tui.overlay_open());
     }
 
@@ -4144,8 +4312,14 @@ mod tests {
     fn agents_overlay_is_modal_and_enter_jumps_to_another_tab() {
         let snapshot = layout(
             vec![
-                Tab { tab_id: 1, root: Node::Leaf { pane_id: 1 } },
-                Tab { tab_id: 2, root: Node::Leaf { pane_id: 2 } },
+                Tab {
+                    tab_id: 1,
+                    root: Node::Leaf { pane_id: 1 },
+                },
+                Tab {
+                    tab_id: 2,
+                    root: Node::Leaf { pane_id: 2 },
+                },
             ],
             &[(1, 2, 8), (2, 2, 8)],
         );
@@ -4153,8 +4327,20 @@ mod tests {
         tui.set_agent_rows(vec![agent_row(2)]);
         tui.pending_agent_toggle = Some(Instant::now() - AGENT_TOGGLE_WINDOW);
         tui.expire_agent_toggle(Instant::now());
-        assert_eq!(tui.handle_key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE), Rect::new(0, 0, 80, 24)), KeyHandling::Consumed(vec![]));
-        assert_eq!(tui.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE), Rect::new(0, 0, 80, 24)), KeyHandling::Consumed(vec![UiIntent::FocusPane { pane_id: 2 }]));
+        assert_eq!(
+            tui.handle_key(
+                KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE),
+                Rect::new(0, 0, 80, 24)
+            ),
+            KeyHandling::Consumed(vec![])
+        );
+        assert_eq!(
+            tui.handle_key(
+                KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+                Rect::new(0, 0, 80, 24)
+            ),
+            KeyHandling::Consumed(vec![UiIntent::FocusPane { pane_id: 2 }])
+        );
         assert_eq!(tui.current_tab(), 2);
         assert_eq!(tui.focused_pane(), 2);
     }
@@ -5609,7 +5795,10 @@ mod tests {
                 "mode: {mode:?}, footer: {footer}"
             );
             if mode == ChordMode::None {
-                assert!(footer.contains("Option+Shift+drag RESIZE"), "footer: {footer}");
+                assert!(
+                    footer.contains("Option+Shift+drag RESIZE"),
+                    "footer: {footer}"
+                );
             }
         }
     }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -48,7 +48,8 @@ use crate::{
     layout::{Axis, LayoutError, LayoutSnapshot, NewPanePosition, Node, PaneId, TabId},
     lease::{IDLE_AFTER, LeaseDecision, LeaseManager, LeaseState},
     protocol::{
-        CreatePane, CreateTab, DeletePane, DeleteTab, LayoutRequest,
+        AgentRoster, AgentRosterEntry, AgentRosterState, CreatePane, CreateTab, DeletePane,
+        DeleteTab, LayoutRequest,
         NewPanePosition as ProtocolNewPanePosition, PaneDescriptor, PaneFailed, PaneReady,
         SplitAxis,
     },
@@ -77,6 +78,7 @@ const CONTROL_HELP: &str = "Ctrl+ <p> PANE   <t> TAB   <q> QUIT   Option+ <shift
 const ESC_PREFIX_WINDOW: Duration = Duration::from_millis(50);
 const CHORD_IDLE_TIMEOUT: Duration = Duration::from_secs(2);
 const AGENT_SAMPLE_INTERVAL: Duration = Duration::from_secs(1);
+const AGENT_TOGGLE_WINDOW: Duration = Duration::from_millis(400);
 
 enum FooterSegment {
     Text(&'static str),
@@ -179,6 +181,16 @@ pub enum KeyHandling {
     Quit,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AgentOverlayRow {
+    pub pane_id: PaneId,
+    pub kind: String,
+    pub cwd: String,
+    pub state: AgentRosterState,
+    pub host: String,
+    pub controller: String,
+}
+
 /// Rectangles for one rendered terminal frame.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PaneGeometry {
@@ -238,6 +250,10 @@ pub struct MultiPaneTui {
     pending_created_pane: Option<PaneId>,
     selection: Option<PaneTextSelection>,
     selection_dragging: bool,
+    agent_rows: Vec<AgentOverlayRow>,
+    agent_overlay_open: bool,
+    agent_selected_pane: Option<PaneId>,
+    pending_agent_toggle: Option<Instant>,
 }
 
 impl MultiPaneTui {
@@ -262,6 +278,10 @@ impl MultiPaneTui {
             pending_created_pane: None,
             selection: None,
             selection_dragging: false,
+            agent_rows: Vec::new(),
+            agent_overlay_open: false,
+            agent_selected_pane: None,
+            pending_agent_toggle: None,
         })
     }
 
@@ -279,6 +299,34 @@ impl MultiPaneTui {
 
     pub fn chord_mode(&self) -> ChordMode {
         self.chord_mode
+    }
+
+    pub fn overlay_open(&self) -> bool { self.agent_overlay_open }
+
+    pub fn set_agent_rows(&mut self, mut rows: Vec<AgentOverlayRow>) -> bool {
+        rows.retain(|row| self.snapshot.panes.contains_key(&row.pane_id));
+        rows.sort_by_key(|row| (self.pane_order(row.pane_id), row.pane_id));
+        if self.agent_rows == rows { return false; }
+        self.agent_rows = rows;
+        if self.agent_selected_pane.is_some_and(|pane_id| !self.agent_rows.iter().any(|row| row.pane_id == pane_id)) {
+            self.agent_selected_pane = self.agent_rows.first().map(|row| row.pane_id);
+        }
+        if self.agent_selected_pane.is_none() { self.agent_selected_pane = self.agent_rows.first().map(|row| row.pane_id); }
+        true
+    }
+
+    fn pane_order(&self, pane_id: PaneId) -> usize {
+        self.snapshot.tabs.iter().flat_map(|tab| visible_leaf_panes(&tab.root)).position(|id| id == pane_id).unwrap_or(usize::MAX)
+    }
+
+    fn expire_agent_toggle(&mut self, now: Instant) -> bool {
+        if self.pending_agent_toggle.is_some_and(|then| now.duration_since(then) >= AGENT_TOGGLE_WINDOW) {
+            self.pending_agent_toggle = None;
+            self.agent_overlay_open = true;
+            self.exit_chord_mode();
+            return true;
+        }
+        false
     }
 
     fn exit_chord_mode(&mut self) {
@@ -545,6 +593,17 @@ impl MultiPaneTui {
     }
 
     pub fn handle_key(&mut self, key: KeyEvent, area: Rect) -> KeyHandling {
+        if self.agent_overlay_open {
+            return self.handle_agent_overlay_key(key);
+        }
+        if key.code == KeyCode::Char('a') && key.modifiers == KeyModifiers::CONTROL {
+            if self.pending_agent_toggle.is_some_and(|then| then.elapsed() <= AGENT_TOGGLE_WINDOW) {
+                self.pending_agent_toggle = None;
+                return KeyHandling::Forward;
+            }
+            self.pending_agent_toggle = Some(Instant::now());
+            return KeyHandling::Consumed(vec![]);
+        }
         if is_quit(key) {
             self.exit_chord_mode();
             return KeyHandling::Quit;
@@ -593,6 +652,32 @@ impl MultiPaneTui {
             self.exit_chord_mode();
             KeyHandling::Forward
         }
+    }
+
+    fn handle_agent_overlay_key(&mut self, key: KeyEvent) -> KeyHandling {
+        match key.code {
+            KeyCode::Esc => { self.agent_overlay_open = false; KeyHandling::Consumed(vec![]) }
+            KeyCode::Up | KeyCode::Char('k') => { self.move_agent_selection(false); KeyHandling::Consumed(vec![]) }
+            KeyCode::Down | KeyCode::Char('j') => { self.move_agent_selection(true); KeyHandling::Consumed(vec![]) }
+            KeyCode::Enter => {
+                let Some(pane_id) = self.agent_selected_pane else { return KeyHandling::Consumed(vec![]); };
+                if let Some(tab) = self.snapshot.tabs.iter().find(|tab| contains_leaf(&tab.root, pane_id)) {
+                    self.current_tab = tab.tab_id;
+                    self.focused_pane = pane_id;
+                    self.agent_overlay_open = false;
+                    KeyHandling::Consumed(vec![UiIntent::FocusPane { pane_id }])
+                } else { KeyHandling::Consumed(vec![]) }
+            }
+            _ => KeyHandling::Consumed(vec![]),
+        }
+    }
+
+    fn move_agent_selection(&mut self, forward: bool) {
+        if self.agent_rows.is_empty() { self.agent_selected_pane = None; return; }
+        let current = self.agent_selected_pane.and_then(|pane| self.agent_rows.iter().position(|row| row.pane_id == pane)).unwrap_or(0);
+        let len = self.agent_rows.len();
+        let next = if forward { (current + 1) % len } else { (current + len - 1) % len };
+        self.agent_selected_pane = Some(self.agent_rows[next].pane_id);
     }
 
     fn handle_pane_chord(&mut self, key: KeyEvent, area: Rect) -> Option<UiIntent> {
@@ -1411,6 +1496,55 @@ fn render_shared_multi_pane(
             frame.render_widget(Paragraph::new("waiting for pane snapshot/lease"), content);
         }
     }
+    if tui.agent_overlay_open {
+        render_agents_overlay(frame, tui);
+    }
+}
+
+fn render_agents_overlay(frame: &mut Frame<'_>, tui: &MultiPaneTui) {
+    let area = frame.area();
+    let width = area.width.saturating_sub(4).min(88).max(24);
+    let height = area.height.saturating_sub(4).min(18).max(5);
+    let panel = Rect::new(
+        area.x.saturating_add(area.width.saturating_sub(width) / 2),
+        area.y.saturating_add(area.height.saturating_sub(height) / 2),
+        width.min(area.width),
+        height.min(area.height),
+    );
+    frame.render_widget(Clear, panel);
+    let block = Block::bordered().title(" Agents ");
+    let inner = block.inner(panel);
+    frame.render_widget(block, panel);
+    if tui.agent_rows.is_empty() {
+        frame.render_widget(Paragraph::new("No agents running"), inner);
+        return;
+    }
+    let lines = tui.agent_rows.iter().map(|row| {
+        let marker = if tui.agent_selected_pane == Some(row.pane_id) { "›" } else { " " };
+        let prefix = format!("{marker} {} {} ", overlay_kind_label(&row.kind), overlay_state_label(row.state));
+        let detail = format!("{} · {} · {}", truncate_leading(&row.cwd, usize::from(inner.width.saturating_sub(text_width(&prefix)))), row.host, row.controller);
+        Line::from(vec![Span::styled(prefix, Style::default().fg(Color::Yellow)), Span::raw(detail)])
+    }).collect::<Vec<_>>();
+    frame.render_widget(Paragraph::new(lines), inner);
+}
+
+fn overlay_kind_label(kind: &str) -> &'static str {
+    match kind { "claude" => "Claude Code", "codex" => "Codex", "cursor" => "Cursor Agent", "pi" => "Pi", _ => "Unknown" }
+}
+
+fn overlay_state_label(state: AgentRosterState) -> &'static str {
+    match state { AgentRosterState::Idle => "idle", AgentRosterState::Working => "working", AgentRosterState::Done => "done" }
+}
+
+fn truncate_leading(value: &str, width: usize) -> String {
+    let count = value.chars().count();
+    if count <= width { return value.into(); }
+    if width <= 1 { return "…".into(); }
+    format!("…{}", value.chars().skip(count - width + 1).collect::<String>())
+}
+
+fn sanitize_single_line(value: &str) -> String {
+    value.chars().filter(|character| !character.is_control()).collect()
 }
 
 /// One fixed-grid PTY owned by this process. Its watch channels are registered with the pane
@@ -1554,6 +1688,20 @@ impl SharedLocalPane {
             .and_then(|pid| classify_pane_tree(pid, processes));
         self.agent_tracker.update(detected, now);
         self.agent_tracker.listed_agent(now) != before
+    }
+
+    fn agent_roster_entry(&self, now: Instant) -> Option<AgentRosterEntry> {
+        let (agent, state) = self.agent_tracker.listed_agent(now)?;
+        Some(AgentRosterEntry {
+            pane_id: self.pane_id,
+            agent_kind: agent.kind.wire_value().into(),
+            cwd: agent.cwd,
+            state: match state {
+                crate::agent_detect::AgentState::Idle => AgentRosterState::Idle as i32,
+                crate::agent_detect::AgentState::Working => AgentRosterState::Working as i32,
+                crate::agent_detect::AgentState::Done => AgentRosterState::Done as i32,
+            },
+        })
     }
 
     fn input(&mut self, bytes: Vec<u8>) -> Result<(), Box<dyn Error>> {
@@ -1848,6 +1996,13 @@ impl SharedControl {
         }
     }
 
+    fn try_agent_roster(&self, roster: AgentRoster) -> Result<(), String> {
+        match self {
+            Self::Host(host) => host.publish_local_agent_roster(roster).map_err(|error| error.to_string()),
+            Self::Member(member) => member.try_agent_roster(roster).map_err(layout_queue_message),
+        }
+    }
+
     fn try_event(&mut self, current_revision: u64) -> Option<LayoutControlEvent> {
         match self {
             // The coordinator is the authority, so it does not receive its own broadcasts. Poll
@@ -1978,6 +2133,10 @@ pub struct SharedLayoutRuntime {
     footer_notice: Option<String>,
     join_code: Option<String>,
     agent_sampler: AgentSamplingWorker,
+    agent_rosters: BTreeMap<Vec<u8>, AgentRoster>,
+    agent_roster_generation: u64,
+    last_local_agent_entries: Vec<AgentRosterEntry>,
+    next_agent_roster_heartbeat: Instant,
 }
 
 impl SharedLayoutRuntime {
@@ -2079,6 +2238,10 @@ impl SharedLayoutRuntime {
             footer_notice: None,
             join_code,
             agent_sampler: AgentSamplingWorker::spawn(),
+            agent_rosters: BTreeMap::new(),
+            agent_roster_generation: 0,
+            last_local_agent_entries: Vec::new(),
+            next_agent_roster_heartbeat: Instant::now(),
         };
         value.refresh_local_views();
         Ok(value)
@@ -2155,6 +2318,9 @@ impl SharedLayoutRuntime {
             if self.tui.expire_chord_mode(Instant::now()) {
                 dirty = true;
             }
+            if self.tui.expire_agent_toggle(Instant::now()) {
+                dirty = true;
+            }
             if pending_escape.take_if_expired(Instant::now()) {
                 if self.handle_key(
                     KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
@@ -2215,20 +2381,23 @@ impl SharedLayoutRuntime {
                     dirty = true;
                 }
                 Event::Paste(text) => {
-                    self.tui.exit_chord_mode();
-                    self.forward_paste(&text)?;
+                    if !self.tui.overlay_open() {
+                        self.tui.exit_chord_mode();
+                        self.forward_paste(&text)?;
+                    }
                     dirty = true;
                 }
                 Event::Mouse(mouse) if matches!(mouse.kind, MouseEventKind::Moved) => {
-                    dirty |= self.tui.hover_pane_at(
+                    if !self.tui.overlay_open() { dirty |= self.tui.hover_pane_at(
                         mouse.column,
                         mouse.row,
                         Rect::new(0, 0, cols, rows),
-                    );
+                    ); }
                 }
                 Event::Mouse(mouse)
                     if matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left)) =>
                 {
+                    if self.tui.overlay_open() { dirty = true; continue; }
                     let area = Rect::new(0, 0, cols, rows);
                     let previously_focused = self.tui.focused_pane();
                     dirty |= self.clear_selection();
@@ -2359,6 +2528,7 @@ impl SharedLayoutRuntime {
                 changed |= pane.apply_agent_snapshot(&snapshot, now);
             }
         }
+        changed |= self.publish_local_agent_roster();
         let disconnected = self
             .remote
             .iter_mut()
@@ -2382,6 +2552,7 @@ impl SharedLayoutRuntime {
             changed = true;
         }
         changed |= self.refresh_local_views();
+        changed |= self.refresh_agent_rows();
         Ok(changed)
     }
 
@@ -2400,13 +2571,39 @@ impl SharedLayoutRuntime {
         changed
     }
 
+    fn publish_local_agent_roster(&mut self) -> bool {
+        let now = Instant::now();
+        let entries = self.local.values().filter_map(|pane| pane.agent_roster_entry(now)).collect::<Vec<_>>();
+        if entries == self.last_local_agent_entries && now < self.next_agent_roster_heartbeat { return false; }
+        self.agent_roster_generation = self.agent_roster_generation.saturating_add(1);
+        let roster = AgentRoster { host_peer_id: self.control.peer_id(), generation: self.agent_roster_generation, entries: entries.clone() };
+        if self.control.try_agent_roster(roster.clone()).is_err() { return false; }
+        self.last_local_agent_entries = entries;
+        self.next_agent_roster_heartbeat = now + Duration::from_secs(5);
+        self.agent_rosters.insert(roster.host_peer_id.clone(), roster);
+        true
+    }
+
+    fn refresh_agent_rows(&mut self) -> bool {
+        let rows = self.agent_rosters.values().flat_map(|roster| roster.entries.iter().filter_map(|entry| {
+            let pane = self.tui.snapshot().panes.get(&entry.pane_id)?;
+            let view = self.tui.pane_view(entry.pane_id)?;
+            let host = sanitize_single_line(&member_label(&pane.host_peer_id, &self.tui.snapshot().members));
+            let controller = view.controller_peer_id.as_deref().filter(|id| !id.is_empty()).map(|id| sanitize_single_line(&member_label(id, &self.tui.snapshot().members))).unwrap_or_else(|| String::from("free"));
+            Some(AgentOverlayRow { pane_id: entry.pane_id, kind: sanitize_single_line(&entry.agent_kind), cwd: sanitize_single_line(&entry.cwd), state: AgentRosterState::try_from(entry.state).ok()?, host, controller })
+        })).collect();
+        self.tui.set_agent_rows(rows)
+    }
+
     fn handle_control_event(&mut self, event: LayoutControlEvent) -> Result<(), Box<dyn Error>> {
         self.reconciler.apply(&event)?;
         match event {
             LayoutControlEvent::Snapshot(snapshot) => {
                 self.apply_layout_state(snapshot.state.as_ref().ok_or("missing layout state")?)?;
             }
-            LayoutControlEvent::AgentRoster(_) => {}
+            LayoutControlEvent::AgentRoster(roster) => {
+                self.agent_rosters.insert(roster.host_peer_id.clone(), roster);
+            }
             LayoutControlEvent::Commit(commit) => {
                 self.apply_layout_state(commit.state.as_ref().ok_or("missing layout state")?)?;
             }
@@ -2426,6 +2623,10 @@ impl SharedLayoutRuntime {
         let snapshot = layout_snapshot_from_state(state)
             .map_err(|error| io::Error::other(format!("invalid layout state: {error:?}")))?;
         let current_ids = snapshot.panes.keys().copied().collect::<BTreeSet<_>>();
+        self.agent_rosters.retain(|host, roster| {
+            roster.entries.retain(|entry| snapshot.panes.get(&entry.pane_id).is_some_and(|pane| pane.host_peer_id == *host));
+            snapshot.members.iter().any(|member| member.peer_id == *host)
+        });
         // A successful authoritative commit is the only point at which a provisional local PTY
         // becomes a real pane. Forget the request bookkeeping then; rejection handles the other
         // path and tears the provisional PTY down.
@@ -3505,7 +3706,7 @@ mod tests {
     use iroh::{Endpoint, RelayMode, endpoint::presets};
 
     use super::{
-        CHORD_IDLE_TIMEOUT, ChordMode, ESC_PREFIX_WINDOW, FOOTER_ACCENT, FOOTER_BACKGROUND,
+        AGENT_TOGGLE_WINDOW, CHORD_IDLE_TIMEOUT, ChordMode, ESC_PREFIX_WINDOW, FOOTER_ACCENT, FOOTER_BACKGROUND,
         FOOTER_MUTED, FOOTER_ORANGE, FooterSegment, HostControlEvent, HostPaneChannels,
         HostPaneRuntime, KeyHandling, LayoutControlEvent, MultiPaneTui, PaneTextSelection,
         PaneViewState, PendingEscape, RemoteSubscriptionState, ScreenCell, SharedLayoutRuntime,
@@ -3540,6 +3741,50 @@ mod tests {
                 })
                 .collect::<BTreeMap<_, _>>(),
         }
+    }
+
+    fn agent_row(pane_id: u64) -> super::AgentOverlayRow {
+        super::AgentOverlayRow {
+            pane_id,
+            kind: String::from("codex"),
+            cwd: String::from("/very/long/repository/path"),
+            state: crate::protocol::AgentRosterState::Working,
+            host: String::from("Host"),
+            controller: String::from("free"),
+        }
+    }
+
+    #[test]
+    fn agents_overlay_toggles_and_double_tap_forwards_ctrl_a() {
+        let mut tui = MultiPaneTui::new(layout(vec![Tab { tab_id: 1, root: Node::Leaf { pane_id: 1 } }], &[(1, 2, 8)])).unwrap();
+        let ctrl_a = KeyEvent::new(KeyCode::Char('a'), KeyModifiers::CONTROL);
+        assert_eq!(tui.handle_key(ctrl_a, Rect::new(0, 0, 80, 24)), KeyHandling::Consumed(vec![]));
+        assert_eq!(tui.handle_key(ctrl_a, Rect::new(0, 0, 80, 24)), KeyHandling::Forward);
+        assert!(!tui.overlay_open());
+        assert_eq!(tui.handle_key(ctrl_a, Rect::new(0, 0, 80, 24)), KeyHandling::Consumed(vec![]));
+        assert!(tui.expire_agent_toggle(Instant::now() + AGENT_TOGGLE_WINDOW));
+        assert!(tui.overlay_open());
+        assert_eq!(tui.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE), Rect::new(0, 0, 80, 24)), KeyHandling::Consumed(vec![]));
+        assert!(!tui.overlay_open());
+    }
+
+    #[test]
+    fn agents_overlay_is_modal_and_enter_jumps_to_another_tab() {
+        let snapshot = layout(
+            vec![
+                Tab { tab_id: 1, root: Node::Leaf { pane_id: 1 } },
+                Tab { tab_id: 2, root: Node::Leaf { pane_id: 2 } },
+            ],
+            &[(1, 2, 8), (2, 2, 8)],
+        );
+        let mut tui = MultiPaneTui::new(snapshot).unwrap();
+        tui.set_agent_rows(vec![agent_row(2)]);
+        tui.pending_agent_toggle = Some(Instant::now() - AGENT_TOGGLE_WINDOW);
+        tui.expire_agent_toggle(Instant::now());
+        assert_eq!(tui.handle_key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE), Rect::new(0, 0, 80, 24)), KeyHandling::Consumed(vec![]));
+        assert_eq!(tui.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE), Rect::new(0, 0, 80, 24)), KeyHandling::Consumed(vec![UiIntent::FocusPane { pane_id: 2 }]));
+        assert_eq!(tui.current_tab(), 2);
+        assert_eq!(tui.focused_pane(), 2);
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1772,8 +1772,8 @@ fn render_shared_multi_pane(
 
 fn render_agents_overlay(frame: &mut Frame<'_>, tui: &MultiPaneTui) {
     let area = frame.area();
-    let width = area.width.saturating_sub(4).min(88).max(24);
-    let height = area.height.saturating_sub(4).min(18).max(5);
+    let width = area.width.saturating_sub(4).clamp(24, 88);
+    let height = area.height.saturating_sub(4).clamp(5, 18);
     let panel = Rect::new(
         area.x.saturating_add(area.width.saturating_sub(width) / 2),
         area.y

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -6,6 +6,12 @@ use std::{
     io,
     io::Write,
     process::{Command, Stdio},
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+        mpsc::{self as sync_mpsc, Receiver},
+    },
+    thread::{self, JoinHandle},
     time::{Duration, Instant},
 };
 use tokio::sync::{mpsc, watch};
@@ -35,6 +41,10 @@ use ratatui::{
 };
 
 use crate::{
+    agent_detect::{
+        PaneAgentTracker, ProcessSnapshot, SysinfoSampler, classify_pane_tree,
+        sample_global_snapshot,
+    },
     layout::{Axis, LayoutError, LayoutSnapshot, NewPanePosition, Node, PaneId, TabId},
     lease::{IDLE_AFTER, LeaseDecision, LeaseManager, LeaseState},
     protocol::{
@@ -66,6 +76,7 @@ const TAB_BAR_SEPARATOR: &str = " · ";
 const CONTROL_HELP: &str = "Ctrl+ <p> PANE   <t> TAB   <q> QUIT   Option+ <shift> + <↑↓←→> FOCUS";
 const ESC_PREFIX_WINDOW: Duration = Duration::from_millis(50);
 const CHORD_IDLE_TIMEOUT: Duration = Duration::from_secs(2);
+const AGENT_SAMPLE_INTERVAL: Duration = Duration::from_secs(1);
 
 enum FooterSegment {
     Text(&'static str),
@@ -1414,6 +1425,7 @@ pub struct SharedLocalPane {
     lease_tx: watch::Sender<LeaseState>,
     control_tx: mpsc::Sender<HostControlEvent>,
     control_rx: mpsc::Receiver<HostControlEvent>,
+    agent_tracker: PaneAgentTracker,
 }
 
 impl SharedLocalPane {
@@ -1444,6 +1456,7 @@ impl SharedLocalPane {
             lease_tx,
             control_tx,
             control_rx,
+            agent_tracker: PaneAgentTracker::default(),
         })
     }
 
@@ -1525,11 +1538,22 @@ impl SharedLocalPane {
             let Some(bytes) = self.host.try_read_output()? else {
                 break;
             };
+            self.agent_tracker.record_output(Instant::now());
             let frame = self.screen.process_pty(&bytes)?;
             self.screen_tx.send_replace(frame);
             changed = true;
         }
         Ok(changed)
+    }
+
+    fn apply_agent_snapshot(&mut self, processes: &[ProcessSnapshot], now: Instant) -> bool {
+        let before = self.agent_tracker.listed_agent(now);
+        let detected = self
+            .host
+            .process_id()
+            .and_then(|pid| classify_pane_tree(pid, processes));
+        self.agent_tracker.update(detected, now);
+        self.agent_tracker.listed_agent(now) != before
     }
 
     fn input(&mut self, bytes: Vec<u8>) -> Result<(), Box<dyn Error>> {
@@ -1563,6 +1587,49 @@ impl SharedLocalPane {
 
     fn shutdown(&mut self) -> Result<(), Box<dyn Error>> {
         self.host.shutdown()
+    }
+}
+
+struct AgentSamplingWorker {
+    snapshots: Receiver<Vec<ProcessSnapshot>>,
+    stop: Arc<AtomicBool>,
+    join: Option<JoinHandle<()>>,
+}
+
+impl AgentSamplingWorker {
+    fn spawn() -> Self {
+        let (snapshot_tx, snapshots) = sync_mpsc::channel();
+        let stop = Arc::new(AtomicBool::new(false));
+        let worker_stop = stop.clone();
+        let join = thread::spawn(move || {
+            let mut sampler = SysinfoSampler::default();
+            while !worker_stop.load(Ordering::Relaxed) {
+                if snapshot_tx.send(sample_global_snapshot(&mut sampler)).is_err() {
+                    break;
+                }
+                thread::sleep(AGENT_SAMPLE_INTERVAL);
+            }
+        });
+        Self {
+            snapshots,
+            stop,
+            join: Some(join),
+        }
+    }
+
+    fn latest_snapshot(&self) -> Option<Vec<ProcessSnapshot>> {
+        let mut latest = None;
+        while let Ok(snapshot) = self.snapshots.try_recv() {
+            latest = Some(snapshot);
+        }
+        latest
+    }
+
+    fn shutdown(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        if let Some(join) = self.join.take() {
+            let _ = join.join();
+        }
     }
 }
 
@@ -1910,6 +1977,7 @@ pub struct SharedLayoutRuntime {
     copied_lines: Option<usize>,
     footer_notice: Option<String>,
     join_code: Option<String>,
+    agent_sampler: AgentSamplingWorker,
 }
 
 impl SharedLayoutRuntime {
@@ -2010,6 +2078,7 @@ impl SharedLayoutRuntime {
             copied_lines: None,
             footer_notice: None,
             join_code,
+            agent_sampler: AgentSamplingWorker::spawn(),
         };
         value.refresh_local_views();
         Ok(value)
@@ -2283,6 +2352,12 @@ impl SharedLayoutRuntime {
         self.start_eligible_subscriptions();
         for pane in self.local.values_mut() {
             changed |= pane.drain()?;
+        }
+        if let Some(snapshot) = self.agent_sampler.latest_snapshot() {
+            let now = Instant::now();
+            for pane in self.local.values_mut() {
+                changed |= pane.apply_agent_snapshot(&snapshot, now);
+            }
         }
         let disconnected = self
             .remote
@@ -2644,6 +2719,7 @@ impl SharedLayoutRuntime {
     }
 
     fn shutdown(mut self) {
+        self.agent_sampler.shutdown();
         for (_, mut pane) in std::mem::take(&mut self.local) {
             let _ = self.panes.remove_local_pane(pane.pane_id);
             let _ = pane.shutdown();

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -2406,6 +2406,7 @@ impl SharedLayoutRuntime {
             LayoutControlEvent::Snapshot(snapshot) => {
                 self.apply_layout_state(snapshot.state.as_ref().ok_or("missing layout state")?)?;
             }
+            LayoutControlEvent::AgentRoster(_) => {}
             LayoutControlEvent::Commit(commit) => {
                 self.apply_layout_state(commit.state.as_ref().ok_or("missing layout state")?)?;
             }

--- a/tests/module_surface.rs
+++ b/tests/module_surface.rs
@@ -17,5 +17,5 @@ fn exposes_the_scaffold_module_boundaries() {
     let _: Option<JoinTicket> = None;
     let _: Option<HostSession> = None;
     let _: Option<Envelope> = None;
-    assert_eq!(PROTOCOL_VERSION, 3);
+    assert_eq!(PROTOCOL_VERSION, 4);
 }

--- a/tests/protocol.rs
+++ b/tests/protocol.rs
@@ -4,9 +4,8 @@ use p2pmux::protocol::{
     LayoutRejectReason, LayoutRequest, LayoutSplit, LayoutState, MAX_AGENT_CWD_BYTES,
     MAX_AGENT_KIND_BYTES, MAX_AGENT_ROSTER_ENTRIES, MAX_DELTA_BYTES, MAX_ENDPOINT_ADDR_BYTES,
     MAX_ENVELOPE_BYTES, MAX_FRAME_BYTES, MAX_INPUT_BYTES, MAX_PANE_ID_BYTES, MAX_PEER_ID_BYTES,
-    MAX_SESSION_ID_BYTES, MAX_SNAPSHOT_BYTES, MemberDescriptor, NewPanePosition, PaneGrid,
-    PROTOCOL_VERSION, PaneDescriptor, PaneFailed, PaneReady, PaneReservation, PaneSubscribe,
-    ProtocolError,
+    MAX_SESSION_ID_BYTES, MAX_SNAPSHOT_BYTES, MemberDescriptor, NewPanePosition, PROTOCOL_VERSION,
+    PaneDescriptor, PaneFailed, PaneGrid, PaneReady, PaneReservation, PaneSubscribe, ProtocolError,
     SessionSnapshot, SetSplitRatio, Snapshot, SplitAxis, TabDescriptor, TakeControl,
     UpdatePaneGrids, Welcome, decode_frame, encode_frame, envelope,
 };
@@ -297,12 +296,20 @@ fn agent_entry(pane_id: u64) -> AgentRosterEntry {
 
 #[test]
 fn agent_roster_uses_tag_26_and_round_trips() {
-    let original = envelope(envelope::Body::AgentRoster(agent_roster(vec![agent_entry(9)])));
+    let original = envelope(envelope::Body::AgentRoster(agent_roster(vec![
+        agent_entry(9),
+    ])));
     let wire = original.encode_to_vec();
-    assert_eq!(field_shape(&parse_fields(&wire)), vec![(1, 0), (2, 2), (26, 2)]);
+    assert_eq!(
+        field_shape(&parse_fields(&wire)),
+        vec![(1, 0), (2, 2), (26, 2)]
+    );
     assert_eq!(Envelope::decode(wire.as_slice()).unwrap(), original);
     let frame = encode_frame(&original).expect("valid roster encodes");
-    assert_eq!(decode_frame(&frame).expect("valid roster decodes"), original);
+    assert_eq!(
+        decode_frame(&frame).expect("valid roster decodes"),
+        original
+    );
 }
 
 #[test]
@@ -326,9 +333,11 @@ fn agent_roster_validation_rejects_bad_entries() {
             cwd: "x".repeat(MAX_AGENT_CWD_BYTES + 1),
             ..agent_entry(1)
         }]),
-        agent_roster((1..=u64::try_from(MAX_AGENT_ROSTER_ENTRIES + 1).unwrap())
-            .map(agent_entry)
-            .collect()),
+        agent_roster(
+            (1..=u64::try_from(MAX_AGENT_ROSTER_ENTRIES + 1).unwrap())
+                .map(agent_entry)
+                .collect(),
+        ),
     ];
 
     for roster in cases {

--- a/tests/protocol.rs
+++ b/tests/protocol.rs
@@ -1,11 +1,13 @@
 use p2pmux::protocol::{
-    ControlLease, CreatePane, CreateTab, DeletePane, DeleteTab, Delta, Envelope, Input, Join,
-    LayoutCommit, LayoutNode, LayoutReject, LayoutRejectReason, LayoutRequest, LayoutSplit,
-    LayoutState, MAX_DELTA_BYTES, MAX_ENDPOINT_ADDR_BYTES, MAX_ENVELOPE_BYTES, MAX_FRAME_BYTES,
-    MAX_INPUT_BYTES, MAX_PANE_ID_BYTES, MAX_PEER_ID_BYTES, MAX_SESSION_ID_BYTES,
-    MAX_SNAPSHOT_BYTES, MemberDescriptor, NewPanePosition, PROTOCOL_VERSION, PaneDescriptor,
-    PaneFailed, PaneReady, PaneReservation, PaneSubscribe, ProtocolError, SessionSnapshot,
-    Snapshot, SplitAxis, TabDescriptor, TakeControl, Welcome, decode_frame, encode_frame, envelope,
+    AgentRoster, AgentRosterEntry, AgentRosterState, ControlLease, CreatePane, CreateTab,
+    DeletePane, DeleteTab, Delta, Envelope, Input, Join, LayoutCommit, LayoutNode, LayoutReject,
+    LayoutRejectReason, LayoutRequest, LayoutSplit, LayoutState, MAX_AGENT_CWD_BYTES,
+    MAX_AGENT_KIND_BYTES, MAX_AGENT_ROSTER_ENTRIES, MAX_DELTA_BYTES, MAX_ENDPOINT_ADDR_BYTES,
+    MAX_ENVELOPE_BYTES, MAX_FRAME_BYTES, MAX_INPUT_BYTES, MAX_PANE_ID_BYTES, MAX_PEER_ID_BYTES,
+    MAX_SESSION_ID_BYTES, MAX_SNAPSHOT_BYTES, MemberDescriptor, NewPanePosition,
+    PROTOCOL_VERSION, PaneDescriptor, PaneFailed, PaneReady, PaneReservation, PaneSubscribe,
+    ProtocolError, SessionSnapshot, Snapshot, SplitAxis, TabDescriptor, TakeControl, Welcome,
+    decode_frame, encode_frame, envelope,
 };
 use prost::Message;
 
@@ -25,8 +27,8 @@ fn envelope(body: envelope::Body) -> Envelope {
 }
 
 #[test]
-fn protocol_version_is_v3() {
-    assert_eq!(PROTOCOL_VERSION, 3);
+fn protocol_version_is_v4() {
+    assert_eq!(PROTOCOL_VERSION, 4);
 }
 
 #[test]
@@ -204,6 +206,67 @@ fn framed_envelopes_round_trip_all_v1_bodies() {
     for original in sample_envelopes() {
         let frame = encode_frame(&original).expect("valid envelope encodes");
         assert_eq!(decode_frame(&frame).expect("valid frame decodes"), original);
+    }
+}
+
+fn agent_roster(entries: Vec<AgentRosterEntry>) -> AgentRoster {
+    AgentRoster {
+        host_peer_id: b"peer-a".to_vec(),
+        generation: 7,
+        entries,
+    }
+}
+
+fn agent_entry(pane_id: u64) -> AgentRosterEntry {
+    AgentRosterEntry {
+        pane_id,
+        agent_kind: String::from("codex"),
+        cwd: String::from("/repo"),
+        state: AgentRosterState::Working as i32,
+    }
+}
+
+#[test]
+fn agent_roster_uses_tag_26_and_round_trips() {
+    let original = envelope(envelope::Body::AgentRoster(agent_roster(vec![agent_entry(9)])));
+    let wire = original.encode_to_vec();
+    assert_eq!(field_shape(&parse_fields(&wire)), vec![(1, 0), (2, 2), (26, 2)]);
+    assert_eq!(Envelope::decode(wire.as_slice()).unwrap(), original);
+    let frame = encode_frame(&original).expect("valid roster encodes");
+    assert_eq!(decode_frame(&frame).expect("valid roster decodes"), original);
+}
+
+#[test]
+fn agent_roster_validation_rejects_bad_entries() {
+    let cases = [
+        agent_roster(vec![agent_entry(0)]),
+        agent_roster(vec![agent_entry(1), agent_entry(1)]),
+        agent_roster(vec![AgentRosterEntry {
+            agent_kind: String::from("unknown"),
+            ..agent_entry(1)
+        }]),
+        agent_roster(vec![AgentRosterEntry {
+            state: 99,
+            ..agent_entry(1)
+        }]),
+        agent_roster(vec![AgentRosterEntry {
+            agent_kind: "x".repeat(MAX_AGENT_KIND_BYTES + 1),
+            ..agent_entry(1)
+        }]),
+        agent_roster(vec![AgentRosterEntry {
+            cwd: "x".repeat(MAX_AGENT_CWD_BYTES + 1),
+            ..agent_entry(1)
+        }]),
+        agent_roster((1..=u64::try_from(MAX_AGENT_ROSTER_ENTRIES + 1).unwrap())
+            .map(agent_entry)
+            .collect()),
+    ];
+
+    for roster in cases {
+        assert!(matches!(
+            encode_frame(&envelope(envelope::Body::AgentRoster(roster))),
+            Err(ProtocolError::FieldTooLarge { .. }) | Err(ProtocolError::InvalidLayout(_))
+        ));
     }
 }
 

--- a/tests/session_layout.rs
+++ b/tests/session_layout.rs
@@ -3,8 +3,7 @@ use p2pmux::{
     protocol::{
         AgentRoster, AgentRosterEntry, AgentRosterState, CreatePane, CreateTab, DeletePane,
         DeleteTab, LayoutCommit, LayoutRejectReason, LayoutRequest, NewPanePosition, PaneFailed,
-        PaneGrid, PaneReady, SetSplitRatio, SplitAxis,
-        UpdatePaneGrids,
+        PaneGrid, PaneReady, SetSplitRatio, SplitAxis, UpdatePaneGrids,
     },
     session::{CoordinatorError, CoordinatorResponse, LayoutCoordinator},
 };
@@ -173,7 +172,9 @@ fn admission_advances_revision_and_publishes_the_member_endpoint() {
 #[test]
 fn agent_rosters_replace_per_host_and_reject_other_hosts_panes() {
     let mut coordinator = coordinator();
-    coordinator.admit(host_b(), addr_b()).expect("guest admitted");
+    coordinator
+        .admit(host_b(), addr_b())
+        .expect("guest admitted");
 
     let forged = AgentRoster {
         host_peer_id: host_a(),

--- a/tests/session_layout.rs
+++ b/tests/session_layout.rs
@@ -1,8 +1,9 @@
 use iroh::{EndpointAddr, SecretKey};
 use p2pmux::{
     protocol::{
-        CreatePane, CreateTab, DeletePane, DeleteTab, LayoutCommit, LayoutRejectReason,
-        LayoutRequest, NewPanePosition, PaneFailed, PaneReady, SplitAxis,
+        AgentRoster, AgentRosterEntry, AgentRosterState, CreatePane, CreateTab, DeletePane,
+        DeleteTab, LayoutCommit, LayoutRejectReason, LayoutRequest, NewPanePosition, PaneFailed,
+        PaneReady, SplitAxis,
     },
     session::{CoordinatorError, CoordinatorResponse, LayoutCoordinator},
 };
@@ -94,6 +95,55 @@ fn admission_advances_revision_and_publishes_the_member_endpoint() {
     let state = commit.commit.state.expect("state present");
     assert!(state.members.iter().any(|member| member.peer_id == host_b()
         && member.endpoint_addr == serde_json::to_vec(&addr_b()).unwrap()));
+}
+
+#[test]
+fn agent_rosters_replace_per_host_and_reject_other_hosts_panes() {
+    let mut coordinator = coordinator();
+    coordinator.admit(host_b(), addr_b()).expect("guest admitted");
+
+    let forged = AgentRoster {
+        host_peer_id: host_a(),
+        generation: 1,
+        entries: vec![AgentRosterEntry {
+            pane_id: 1,
+            agent_kind: String::from("codex"),
+            cwd: String::from("/forged"),
+            state: AgentRosterState::Working as i32,
+        }],
+    };
+    assert_eq!(coordinator.accept_agent_roster(&host_b(), forged), None);
+
+    let accepted = coordinator
+        .accept_agent_roster(
+            &host_a(),
+            AgentRoster {
+                host_peer_id: b"mismatch-is-overwritten".to_vec(),
+                generation: 1,
+                entries: vec![AgentRosterEntry {
+                    pane_id: 1,
+                    agent_kind: String::from("codex"),
+                    cwd: String::from("/repo"),
+                    state: AgentRosterState::Working as i32,
+                }],
+            },
+        )
+        .expect("host roster accepted");
+    assert_eq!(accepted.host_peer_id, host_a());
+    assert_eq!(coordinator.agent_rosters(), vec![accepted]);
+
+    let cleared = coordinator
+        .accept_agent_roster(
+            &host_a(),
+            AgentRoster {
+                host_peer_id: host_a(),
+                generation: 2,
+                entries: Vec::new(),
+            },
+        )
+        .expect("empty replacement clears host rows");
+    assert!(cleared.entries.is_empty());
+    assert_eq!(coordinator.agent_rosters(), vec![cleared]);
 }
 
 #[test]

--- a/tests/session_layout_control.rs
+++ b/tests/session_layout_control.rs
@@ -145,7 +145,10 @@ async fn agent_roster_relays_to_members_and_bootstraps_late_joiners() {
         .await
         .expect("first joins");
     accept_first.await.unwrap().unwrap();
-    assert!(matches!(next_event(&mut first).await, LayoutControlEvent::Snapshot(_)));
+    assert!(matches!(
+        next_event(&mut first).await,
+        LayoutControlEvent::Snapshot(_)
+    ));
 
     first
         .try_request(create_request(1, 2))
@@ -178,7 +181,10 @@ async fn agent_roster_relays_to_members_and_bootstraps_late_joiners() {
         next_event(&mut first).await,
         LayoutControlEvent::Commit(commit) if commit.revision == 4
     ));
-    assert!(matches!(next_event(&mut second).await, LayoutControlEvent::Snapshot(_)));
+    assert!(matches!(
+        next_event(&mut second).await,
+        LayoutControlEvent::Snapshot(_)
+    ));
 
     first
         .try_agent_roster(AgentRoster {

--- a/tests/session_layout_control.rs
+++ b/tests/session_layout_control.rs
@@ -4,8 +4,9 @@ use iroh::{Endpoint, RelayMode, endpoint::presets};
 use p2pmux::{
     lease::LeaseState,
     protocol::{
-        CreatePane, CreateTab, DeletePane, DeleteTab, Envelope, Join, LayoutRejectReason,
-        LayoutRequest, PROTOCOL_VERSION, PaneDescriptor, PaneReady, SplitAxis, envelope,
+        AgentRoster, AgentRosterEntry, AgentRosterState, CreatePane, CreateTab, DeletePane,
+        DeleteTab, Envelope, Join, LayoutRejectReason, LayoutRequest, PROTOCOL_VERSION,
+        PaneDescriptor, PaneReady, SplitAxis, envelope,
     },
     screen::HostScreen,
     session::{
@@ -127,6 +128,97 @@ async fn joining_member_receives_a_snapshot_and_existing_members_receive_admissi
 
     first.shutdown().await;
     second.shutdown().await;
+    coordinator.close().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn agent_roster_relays_to_members_and_bootstraps_late_joiners() {
+    let host = HostSession::from_transport(loopback_transport().await).expect("host");
+    let coordinator = SharedLayoutHost::new(host, 24, 80).expect("shared host");
+    let accept_first = {
+        let coordinator = coordinator.clone();
+        tokio::spawn(async move { coordinator.accept_one_member().await })
+    };
+    let mut first = join_layout(loopback_transport().await, coordinator.ticket().clone())
+        .await
+        .expect("first joins");
+    accept_first.await.unwrap().unwrap();
+    assert!(matches!(next_event(&mut first).await, LayoutControlEvent::Snapshot(_)));
+
+    first
+        .try_request(create_request(1, 2))
+        .expect("first requests a pane");
+    let reservation = match next_event(&mut first).await {
+        LayoutControlEvent::Reservation(reservation) => reservation,
+        event => panic!("expected pane reservation, got {event:?}"),
+    };
+    first
+        .try_ready(PaneReady {
+            reservation_id: reservation.reservation_id,
+            base_revision: 2,
+            request_id: 1,
+        })
+        .expect("first marks pane ready");
+    assert!(matches!(
+        next_event(&mut first).await,
+        LayoutControlEvent::Commit(commit) if commit.revision == 3
+    ));
+
+    let accept_second = {
+        let coordinator = coordinator.clone();
+        tokio::spawn(async move { coordinator.accept_one_member().await })
+    };
+    let mut second = join_layout(loopback_transport().await, coordinator.ticket().clone())
+        .await
+        .expect("second joins");
+    accept_second.await.unwrap().unwrap();
+    assert!(matches!(
+        next_event(&mut first).await,
+        LayoutControlEvent::Commit(commit) if commit.revision == 4
+    ));
+    assert!(matches!(next_event(&mut second).await, LayoutControlEvent::Snapshot(_)));
+
+    first
+        .try_agent_roster(AgentRoster {
+            host_peer_id: first.peer_id.clone(),
+            generation: 1,
+            entries: vec![AgentRosterEntry {
+                pane_id: reservation.pane_id,
+                agent_kind: String::from("codex"),
+                cwd: String::from("/repo"),
+                state: AgentRosterState::Working as i32,
+            }],
+        })
+        .expect("first publishes roster");
+    assert!(matches!(
+        next_event(&mut first).await,
+        LayoutControlEvent::AgentRoster(AgentRoster { entries, .. }) if entries.len() == 1
+    ));
+    assert!(matches!(
+        next_event(&mut second).await,
+        LayoutControlEvent::AgentRoster(AgentRoster { entries, .. }) if entries.len() == 1
+    ));
+
+    let accept_third = {
+        let coordinator = coordinator.clone();
+        tokio::spawn(async move { coordinator.accept_one_member().await })
+    };
+    let mut third = join_layout(loopback_transport().await, coordinator.ticket().clone())
+        .await
+        .expect("third joins");
+    accept_third.await.unwrap().unwrap();
+    assert!(matches!(
+        next_event(&mut third).await,
+        LayoutControlEvent::Snapshot(_)
+    ));
+    assert!(matches!(
+        next_event(&mut third).await,
+        LayoutControlEvent::AgentRoster(AgentRoster { entries, .. }) if entries.len() == 1
+    ));
+
+    first.shutdown().await;
+    second.shutdown().await;
+    third.shutdown().await;
     coordinator.close().await;
 }
 


### PR DESCRIPTION
## Summary
- Adds a `Ctrl+A` modal overlay that lists allowlisted coding agents only (Claude Code, Codex, Cursor Agent, Pi), not every process
- Host-local process-tree detection via `sysinfo`, with coarse `idle` / `working` / `done` state and best-effort cwd
- New protocol v4 `AgentRoster` message, coordinator-validated relay on a mailbox separate from layout commits, plus late-joiner bootstrap
- Enter jumps to the agent pane (including other tabs); Esc closes; double-tap `Ctrl+A` within 400ms forwards beginning-of-line to the PTY

## Test plan
- [x] `cargo test` green in worktree
- [ ] Local: two panes, start `claude`/`codex` in one → `Ctrl+A` lists only the agent pane
- [ ] Esc closes; Enter focuses the agent pane (including cross-tab)
- [ ] Double-tap `Ctrl+A` sends Ctrl+A into the focused PTY without opening the overlay
- [ ] Second member on localhost join sees the first host’s agent row
- [ ] Layout splits/commits still work while roster updates publish


Made with [Cursor](https://cursor.com)