### PR TITLE
Fix agents overlay detection for Cursor and Pi

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,15 +88,15 @@ Shared-layout commands are sticky local mux modes and never reach a PTY. `Ctrl+P
 enters its mode; use the listed command repeatedly, press `Esc` to cancel, or type any normal key
 to leave the mode and send that key to the focused PTY.
 
-`Ctrl+A` opens the Agents overlay, which lists only supported coding agents running below hosted
-pane shells: Claude Code (`claude`), Codex (`codex`), Cursor Agent (`cursor-agent`), and Pi
-(`pi`). It shows the agent's best-effort working directory, pane host, control holder, and
-idle/working/done state. Press `Esc` to close, use arrows or `j`/`k` to select, and press Enter
-to jump to that pane (including on another tab). To retain readline's beginning-of-line shortcut,
-press `Ctrl+A` twice within 400ms to forward one Ctrl+A to the focused PTY instead. The overlay is
-keyboard-only in v1. Working directories are shared with every member as part of the existing
-trusted shared-shell model, so do not use a session with people who should not see repository
-paths.
+`Ctrl+A` opens the Agents overlay, which lists supported coding agents running below hosted pane
+shells: Claude Code (`claude`), Codex (`codex`), Cursor Agent (including its `agent`/Node argv),
+Pi (including Node-based launches), and OpenCode (`opencode`). It shows the agent's best-effort
+working directory, pane number, host, and idle/working/done state. Press `Esc` to close, use
+arrows or `j`/`k` to select, and press Enter or left-click a row to jump to that pane (including
+on another tab). To retain readline's beginning-of-line shortcut, press `Ctrl+A` twice within
+400ms to forward one Ctrl+A to the focused PTY instead. Working directories are shared with every
+member as part of the existing trusted shared-shell model, so do not use a session with people who
+should not see repository paths.
 
 Clicking a pane focuses it locally without taking control or sending input. When p2pmux runs
 inside Zellij, Zellij may swallow mouse events; try Zellij with mouse mode disabled or a locked

--- a/docs/superpowers/plans/2026-07-26-fix-agents-detect.md
+++ b/docs/superpowers/plans/2026-07-26-fix-agents-detect.md
@@ -1,0 +1,58 @@
+# Fix agents overlay detection (Cursor `agent`, Pi node, OpenCode)
+
+## Problem
+
+Overlay shows **No agents running** while panes clearly run Cursor Agent (`agent --yolo`) and Pi. Current matcher only accepts exact exe basenames `claude|codex|cursor-agent|pi`. Live processes often look like:
+
+- Cursor: argv0 `/…/bin/agent` with args containing `…/cursor-agent/…/index.js` (exe may be `node`/`bash`)
+- Pi: `#!/usr/bin/env node` → exe basename `node`, cmdline contains `pi` / `pi-coding-agent` / `cli.js`
+- OpenCode: binary `opencode` (add to allowlist)
+
+## Goal
+
+1. Detect Claude Code, Codex, Cursor Agent, Pi, OpenCode under hosted PTY trees via **cmdline/argv heuristics**, not exe basename alone.
+2. Overlay lists: agent label, coarse activity (`idle`/`working`/`done`), cwd/location, pane #, host.
+3. Enter **or click** a row focuses that pane and switches tab if needed.
+4. Verify with a real terminal session (spawn agents under panes, open Ctrl+A) and iterate until green.
+
+## Non-goals
+
+- Parsing agent chat transcripts for “what it’s coding”
+- Matching bare system `*Agent*` daemons outside the pane tree
+- Matching bare `cursor` editor
+
+## Detection rules (v2)
+
+Sampler must capture for each process: `pid`, `parent_pid`, `exe_basename`, `name`, `cmdline: Vec<String>` (argv), optional `cwd`, optional `start_time`.
+
+Classify using `AgentKind::from_process(exe_basename, name, cmdline)`:
+
+| Kind | Match (any one) |
+|------|-----------------|
+| Claude | basename/name/argv0 == `claude` |
+| Codex | basename/name/argv0 == `codex` (PTY-tree scoped; ignores ChatGPT.app helpers outside tree) |
+| Cursor | basename/name/argv0 == `cursor-agent` **OR** any argv string contains `cursor-agent` (covers live `…/bin/agent --use-system-ca …/cursor-agent/…/index.js`) |
+| Pi | basename/name/argv0 == `pi` **OR** any argv contains `pi-coding-agent` **OR** (exe `node` AND an argv path ends with `/bin/pi` or contains `@earendil-works/pi`) |
+| OpenCode | basename/name/argv0 == `opencode` **OR** any argv contains `/opencode` or ends with `opencode` |
+
+Cursor matching is **argv-based** (not a separate `exe_path` field). Tests must include a fixture mirroring live Cursor argv.
+
+Wire values: keep existing + add `opencode`. Protocol validation allowlist updated; bump protocol only if required by exact-version policy (same v4 additive string allowlist is OK).
+
+Still: only processes under the pane’s PTY session PID; deterministic depth/start/pid pick.
+
+## UI
+
+- Row format roughly: `▸ Cursor Agent  working  ~/proj  Pane #1  host: pelazas`
+- Empty state unchanged when truly none
+- Mouse: left-click on a row → same as Enter (jump + close). Hit-test row rects while overlay open; clicks outside close or ignore (prefer ignore outside / Esc still closes)
+
+## Tasks / commits
+
+1. **docs** — short design note for detection v2 + mouse jump
+2. **detect** — cmdline in snapshot; new matchers + unit fixtures for agent/node/pi/opencode
+3. **protocol** — allow `opencode` kind in validation + tests
+4. **overlay UI** — richer row text; mouse hit-test jump
+5. **manual verify** — build; run `p2pmux create`; in panes start `agent --yolo` / `pi` (or stand-ins); Ctrl+A shows rows; Enter/click jumps incl. cross-tab; commit any fixups; open PR
+
+Worktree: `/Users/pelazas/Desktop/p2pmux-fix-agents-detect` branch `fix/agents-detect-modal`. One commit per task. Push + `gh pr create` at end.

--- a/src/agent_detect.rs
+++ b/src/agent_detect.rs
@@ -14,17 +14,40 @@ pub enum AgentKind {
     Codex,
     Cursor,
     Pi,
+    OpenCode,
 }
 
 impl AgentKind {
-    /// Match an exact, case-sensitive executable basename.
-    pub fn from_basename(basename: &str) -> Option<Self> {
-        match basename {
-            "claude" => Some(Self::Claude),
-            "codex" => Some(Self::Codex),
-            "cursor-agent" => Some(Self::Cursor),
-            "pi" => Some(Self::Pi),
-            _ => None,
+    /// Match supported agent launchers from process metadata.
+    pub fn from_process(exe_basename: &str, name: &str, cmdline: &[String]) -> Option<Self> {
+        if matches_launcher(exe_basename, name, cmdline, "claude") {
+            Some(Self::Claude)
+        } else if matches_launcher(exe_basename, name, cmdline, "codex") {
+            Some(Self::Codex)
+        } else if matches_launcher(exe_basename, name, cmdline, "cursor-agent")
+            || cmdline
+                .iter()
+                .any(|argument| argument.contains("cursor-agent"))
+        {
+            Some(Self::Cursor)
+        } else if matches_launcher(exe_basename, name, cmdline, "pi")
+            || cmdline
+                .iter()
+                .any(|argument| argument.contains("pi-coding-agent"))
+            || (exe_basename == "node"
+                && cmdline.iter().any(|argument| {
+                    argument.ends_with("/bin/pi") || argument.contains("@earendil-works/pi")
+                }))
+        {
+            Some(Self::Pi)
+        } else if matches_launcher(exe_basename, name, cmdline, "opencode")
+            || cmdline
+                .iter()
+                .any(|argument| argument.contains("/opencode") || argument.ends_with("opencode"))
+        {
+            Some(Self::OpenCode)
+        } else {
+            None
         }
     }
 
@@ -35,6 +58,7 @@ impl AgentKind {
             Self::Codex => "codex",
             Self::Cursor => "cursor",
             Self::Pi => "pi",
+            Self::OpenCode => "opencode",
         }
     }
 
@@ -45,8 +69,15 @@ impl AgentKind {
             Self::Codex => "Codex",
             Self::Cursor => "Cursor Agent",
             Self::Pi => "Pi",
+            Self::OpenCode => "OpenCode",
         }
     }
+}
+
+fn matches_launcher(exe_basename: &str, name: &str, cmdline: &[String], launcher: &str) -> bool {
+    exe_basename == launcher
+        || name == launcher
+        || cmdline.first().is_some_and(|argv0| argv0 == launcher)
 }
 
 /// One process from a sampler snapshot.
@@ -54,7 +85,9 @@ impl AgentKind {
 pub struct ProcessSnapshot {
     pub pid: u32,
     pub parent_pid: Option<u32>,
-    pub basename: String,
+    pub exe_basename: String,
+    pub name: String,
+    pub cmdline: Vec<String>,
     pub start_time: Option<u64>,
     pub cwd: Option<String>,
 }
@@ -86,12 +119,18 @@ impl ProcessSampler for SysinfoSampler {
             .map(|process| ProcessSnapshot {
                 pid: process.pid().as_u32(),
                 parent_pid: process.parent().map(|pid| pid.as_u32()),
-                basename: process
+                exe_basename: process
                     .exe()
                     .and_then(|path| path.file_name())
                     .unwrap_or(process.name())
                     .to_string_lossy()
                     .into_owned(),
+                name: process.name().to_string_lossy().into_owned(),
+                cmdline: process
+                    .cmd()
+                    .iter()
+                    .map(|argument| argument.to_string_lossy().into_owned())
+                    .collect(),
                 start_time: Some(process.start_time()),
                 cwd: process
                     .cwd()
@@ -131,7 +170,9 @@ pub fn classify_pane_tree(
     let mut candidates = Vec::new();
 
     for process in processes {
-        let Some(kind) = AgentKind::from_basename(&process.basename) else {
+        let Some(kind) =
+            AgentKind::from_process(&process.exe_basename, &process.name, &process.cmdline)
+        else {
             continue;
         };
         let Some(depth) = descendant_depth(session_child_pid, process.pid, processes) else {
@@ -273,31 +314,86 @@ mod tests {
     fn process(
         pid: u32,
         parent_pid: Option<u32>,
-        basename: &str,
+        exe_basename: &str,
         start_time: Option<u64>,
     ) -> ProcessSnapshot {
         ProcessSnapshot {
             pid,
             parent_pid,
-            basename: basename.into(),
+            exe_basename: exe_basename.into(),
+            name: exe_basename.into(),
+            cmdline: Vec::new(),
             start_time,
             cwd: None,
         }
     }
 
     #[test]
-    fn allowlist_matches_only_exact_basenames() {
-        assert_eq!(AgentKind::from_basename("claude"), Some(AgentKind::Claude));
-        assert_eq!(AgentKind::from_basename("codex"), Some(AgentKind::Codex));
+    fn process_matchers_cover_direct_and_wrapped_agent_launches() {
         assert_eq!(
-            AgentKind::from_basename("cursor-agent"),
+            AgentKind::from_process("claude", "claude", &[]),
+            Some(AgentKind::Claude)
+        );
+        assert_eq!(
+            AgentKind::from_process("sh", "codex", &[]),
+            Some(AgentKind::Codex)
+        );
+        assert_eq!(
+            AgentKind::from_process("cursor-agent", "node", &[]),
             Some(AgentKind::Cursor)
         );
-        assert_eq!(AgentKind::from_basename("pi"), Some(AgentKind::Pi));
-        assert_eq!(AgentKind::from_basename("cursor"), None);
-        assert_eq!(AgentKind::from_basename("Codex"), None);
+        assert_eq!(
+            AgentKind::from_process("pi", "pi", &[]),
+            Some(AgentKind::Pi)
+        );
+        assert_eq!(
+            AgentKind::from_process("opencode", "opencode", &[]),
+            Some(AgentKind::OpenCode)
+        );
+
+        let cursor_argv = vec![
+            String::from("/Applications/Cursor.app/Contents/Resources/app/bin/agent"),
+            String::from("--use-system-ca"),
+            String::from(
+                "/Applications/Cursor.app/Contents/Resources/app/extensions/cursor-agent/dist/index.js",
+            ),
+        ];
+        assert_eq!(
+            AgentKind::from_process("node", "node", &cursor_argv),
+            Some(AgentKind::Cursor)
+        );
+
+        let pi_argv = vec![
+            String::from("node"),
+            String::from("/tmp/pi-coding-agent/dist/cli.js"),
+        ];
+        assert_eq!(
+            AgentKind::from_process("node", "node", &pi_argv),
+            Some(AgentKind::Pi)
+        );
+        let pi_bin_argv = vec![
+            String::from("node"),
+            String::from("/Users/me/.local/bin/pi"),
+        ];
+        assert_eq!(
+            AgentKind::from_process("node", "node", &pi_bin_argv),
+            Some(AgentKind::Pi)
+        );
+        let opencode_argv = vec![
+            String::from("node"),
+            String::from("/usr/local/lib/node_modules/opencode/bin/opencode"),
+        ];
+        assert_eq!(
+            AgentKind::from_process("node", "node", &opencode_argv),
+            Some(AgentKind::OpenCode)
+        );
+
+        assert_eq!(AgentKind::from_process("cursor", "cursor", &[]), None);
+        assert_eq!(AgentKind::from_process("node", "node", &[]), None);
+        assert_eq!(AgentKind::from_process("Codex", "Codex", &[]), None);
         assert_eq!(AgentKind::Claude.display_label(), "Claude Code");
         assert_eq!(AgentKind::Cursor.wire_value(), "cursor");
+        assert_eq!(AgentKind::OpenCode.wire_value(), "opencode");
     }
 
     #[test]

--- a/src/agent_detect.rs
+++ b/src/agent_detect.rs
@@ -2,7 +2,7 @@
 
 use std::time::{Duration, Instant};
 
-use sysinfo::{ProcessesToUpdate, System};
+use sysinfo::{ProcessRefreshKind, ProcessesToUpdate, System, UpdateKind};
 
 const DONE_GRACE: Duration = Duration::from_secs(15);
 const WORKING_WINDOW: Duration = Duration::from_secs(2);
@@ -22,14 +22,14 @@ impl AgentKind {
     pub fn from_process(exe_basename: &str, name: &str, cmdline: &[String]) -> Option<Self> {
         if matches_launcher(exe_basename, name, cmdline, "claude") {
             Some(Self::Claude)
-        } else if matches_launcher(exe_basename, name, cmdline, "codex") {
-            Some(Self::Codex)
         } else if matches_launcher(exe_basename, name, cmdline, "cursor-agent")
             || cmdline
                 .iter()
                 .any(|argument| argument.contains("cursor-agent"))
         {
             Some(Self::Cursor)
+        } else if matches_launcher(exe_basename, name, cmdline, "codex") {
+            Some(Self::Codex)
         } else if matches_launcher(exe_basename, name, cmdline, "pi")
             || cmdline
                 .iter()
@@ -112,7 +112,14 @@ impl Default for SysinfoSampler {
 
 impl ProcessSampler for SysinfoSampler {
     fn snapshot(&mut self) -> Vec<ProcessSnapshot> {
-        self.system.refresh_processes(ProcessesToUpdate::All, true);
+        self.system.refresh_processes_specifics(
+            ProcessesToUpdate::All,
+            true,
+            ProcessRefreshKind::nothing()
+                .with_exe(UpdateKind::Always)
+                .with_cmd(UpdateKind::Always)
+                .with_cwd(UpdateKind::Always),
+        );
         self.system
             .processes()
             .values()
@@ -360,6 +367,10 @@ mod tests {
         ];
         assert_eq!(
             AgentKind::from_process("node", "node", &cursor_argv),
+            Some(AgentKind::Cursor)
+        );
+        assert_eq!(
+            AgentKind::from_process("codex", "agent", &cursor_argv),
             Some(AgentKind::Cursor)
         );
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -807,7 +807,7 @@ fn validate_agent_roster(roster: &AgentRoster) -> Result<(), ProtocolError> {
         )?;
         if !matches!(
             entry.agent_kind.as_str(),
-            "claude" | "codex" | "cursor" | "pi"
+            "claude" | "codex" | "cursor" | "pi" | "opencode"
         ) {
             return Err(ProtocolError::InvalidLayout(
                 "agent_roster.entry.agent_kind",

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -840,22 +840,43 @@ impl MultiPaneTui {
                 let Some(pane_id) = self.agent_selected_pane else {
                     return KeyHandling::Consumed(vec![]);
                 };
-                if let Some(tab) = self
-                    .snapshot
-                    .tabs
-                    .iter()
-                    .find(|tab| contains_leaf(&tab.root, pane_id))
-                {
-                    self.current_tab = tab.tab_id;
-                    self.focused_pane = pane_id;
-                    self.agent_overlay_open = false;
-                    KeyHandling::Consumed(vec![UiIntent::FocusPane { pane_id }])
-                } else {
-                    KeyHandling::Consumed(vec![])
-                }
+                KeyHandling::Consumed(self.jump_to_agent_pane(pane_id))
             }
             _ => KeyHandling::Consumed(vec![]),
         }
+    }
+
+    fn handle_agent_overlay_click(&mut self, column: u16, row: u16, area: Rect) -> Vec<UiIntent> {
+        let Some(pane_id) = self.agent_overlay_row_at(column, row, area) else {
+            return Vec::new();
+        };
+        self.agent_selected_pane = Some(pane_id);
+        self.jump_to_agent_pane(pane_id)
+    }
+
+    fn agent_overlay_row_at(&self, column: u16, row: u16, area: Rect) -> Option<PaneId> {
+        let inner = agents_overlay_inner(area);
+        if !rect_contains(inner, column, row) {
+            return None;
+        }
+        self.agent_rows
+            .get(usize::from(row.saturating_sub(inner.y)))
+            .map(|agent| agent.pane_id)
+    }
+
+    fn jump_to_agent_pane(&mut self, pane_id: PaneId) -> Vec<UiIntent> {
+        let Some(tab) = self
+            .snapshot
+            .tabs
+            .iter()
+            .find(|tab| contains_leaf(&tab.root, pane_id))
+        else {
+            return Vec::new();
+        };
+        self.current_tab = tab.tab_id;
+        self.focused_pane = pane_id;
+        self.agent_overlay_open = false;
+        vec![UiIntent::FocusPane { pane_id }]
     }
 
     fn move_agent_selection(&mut self, forward: bool) {
@@ -1896,18 +1917,10 @@ fn render_shared_multi_pane(
 
 fn render_agents_overlay(frame: &mut Frame<'_>, tui: &MultiPaneTui) {
     let area = frame.area();
-    let width = area.width.saturating_sub(4).clamp(24, 88);
-    let height = area.height.saturating_sub(4).clamp(5, 18);
-    let panel = Rect::new(
-        area.x.saturating_add(area.width.saturating_sub(width) / 2),
-        area.y
-            .saturating_add(area.height.saturating_sub(height) / 2),
-        width.min(area.width),
-        height.min(area.height),
-    );
+    let panel = agents_overlay_panel(area);
     frame.render_widget(Clear, panel);
     let block = Block::bordered().title(" Agents ");
-    let inner = block.inner(panel);
+    let inner = agents_overlay_inner(area);
     frame.render_widget(block, panel);
     if tui.agent_rows.is_empty() {
         frame.render_widget(Paragraph::new("No agents running"), inner);
@@ -1917,32 +1930,48 @@ fn render_agents_overlay(frame: &mut Frame<'_>, tui: &MultiPaneTui) {
         .agent_rows
         .iter()
         .map(|row| {
-            let marker = if tui.agent_selected_pane == Some(row.pane_id) {
-                "›"
-            } else {
-                " "
-            };
-            let prefix = format!(
-                "{marker} {} {} ",
-                overlay_kind_label(&row.kind),
-                overlay_state_label(row.state)
-            );
-            let detail = format!(
-                "{} · {} · {}",
-                truncate_leading(
-                    &row.cwd,
-                    usize::from(inner.width.saturating_sub(text_width(&prefix)))
+            Line::styled(
+                format_agent_overlay_row(
+                    row,
+                    tui.agent_selected_pane == Some(row.pane_id),
+                    inner.width,
                 ),
-                row.host,
-                row.controller
-            );
-            Line::from(vec![
-                Span::styled(prefix, Style::default().fg(Color::Yellow)),
-                Span::raw(detail),
-            ])
+                Style::default().fg(Color::Yellow),
+            )
         })
         .collect::<Vec<_>>();
     frame.render_widget(Paragraph::new(lines), inner);
+}
+
+fn agents_overlay_panel(area: Rect) -> Rect {
+    let width = area.width.saturating_sub(4).clamp(24, 88);
+    let height = area.height.saturating_sub(4).clamp(5, 18);
+    Rect::new(
+        area.x.saturating_add(area.width.saturating_sub(width) / 2),
+        area.y
+            .saturating_add(area.height.saturating_sub(height) / 2),
+        width.min(area.width),
+        height.min(area.height),
+    )
+}
+
+fn agents_overlay_inner(area: Rect) -> Rect {
+    Block::bordered().inner(agents_overlay_panel(area))
+}
+
+fn format_agent_overlay_row(row: &AgentOverlayRow, selected: bool, width: u16) -> String {
+    let marker = if selected { "›" } else { " " };
+    let prefix = format!(
+        "{marker} {}  {}  ",
+        overlay_kind_label(&row.kind),
+        overlay_state_label(row.state)
+    );
+    let suffix = format!("  Pane #{}  host: {}", row.pane_id, row.host);
+    let cwd_width = width.saturating_sub(text_width(&prefix).saturating_add(text_width(&suffix)));
+    format!(
+        "{prefix}{}{suffix}",
+        truncate_leading(&row.cwd, usize::from(cwd_width))
+    )
 }
 
 fn overlay_kind_label(kind: &str) -> &'static str {
@@ -1951,6 +1980,7 @@ fn overlay_kind_label(kind: &str) -> &'static str {
         "codex" => "Codex",
         "cursor" => "Cursor Agent",
         "pi" => "Pi",
+        "opencode" => "OpenCode",
         _ => "Unknown",
     }
 }
@@ -2859,6 +2889,15 @@ impl SharedLayoutRuntime {
                     if matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left)) =>
                 {
                     if self.tui.overlay_open() {
+                        let previously_focused = self.tui.focused_pane();
+                        for intent in self.tui.handle_agent_overlay_click(
+                            mouse.column,
+                            mouse.row,
+                            Rect::new(0, 0, cols, rows),
+                        ) {
+                            self.handle_intent(intent)?;
+                        }
+                        self.release_blurred_pane(previously_focused)?;
                         dirty = true;
                         continue;
                     }
@@ -4462,6 +4501,50 @@ mod tests {
             ),
             KeyHandling::Consumed(vec![UiIntent::FocusPane { pane_id: 2 }])
         );
+        assert_eq!(tui.current_tab(), 2);
+        assert_eq!(tui.focused_pane(), 2);
+    }
+
+    #[test]
+    fn agents_overlay_rows_include_location_pane_and_host() {
+        let row = agent_row(2);
+
+        let rendered = super::format_agent_overlay_row(&row, true, 120);
+
+        assert!(rendered.starts_with("› Codex  working  "));
+        assert!(rendered.contains("/very/long/repository/path"));
+        assert!(rendered.contains("Pane #2"));
+        assert!(rendered.ends_with("host: Host"));
+    }
+
+    #[test]
+    fn agents_overlay_click_jumps_to_the_clicked_row_and_ignores_outside_clicks() {
+        let snapshot = layout(
+            vec![
+                Tab {
+                    tab_id: 1,
+                    root: Node::Leaf { pane_id: 1 },
+                },
+                Tab {
+                    tab_id: 2,
+                    root: Node::Leaf { pane_id: 2 },
+                },
+            ],
+            &[(1, 2, 8), (2, 2, 8)],
+        );
+        let mut tui = MultiPaneTui::new(snapshot).unwrap();
+        tui.set_agent_rows(vec![agent_row(2)]);
+        tui.pending_agent_toggle = Some(Instant::now() - AGENT_TOGGLE_WINDOW);
+        tui.expire_agent_toggle(Instant::now());
+        let area = Rect::new(0, 0, 80, 24);
+
+        assert_eq!(tui.handle_agent_overlay_click(0, 0, area), Vec::new());
+        assert!(tui.overlay_open());
+        assert_eq!(
+            tui.handle_agent_overlay_click(4, 4, area),
+            vec![UiIntent::FocusPane { pane_id: 2 }]
+        );
+        assert!(!tui.overlay_open());
         assert_eq!(tui.current_tab(), 2);
         assert_eq!(tui.focused_pane(), 2);
     }

--- a/tests/agent_detect_live.rs
+++ b/tests/agent_detect_live.rs
@@ -1,0 +1,83 @@
+use std::{
+    fs,
+    process::{Command, Stdio},
+    thread,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use p2pmux::agent_detect::{AgentKind, SysinfoSampler, classify_pane_tree, sample_global_snapshot};
+
+#[test]
+fn sysinfo_sampler_classifies_a_live_node_pi_child() {
+    if !Command::new("node")
+        .arg("--version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .is_ok_and(|status| status.success())
+    {
+        return;
+    }
+
+    let temporary_root = std::env::temp_dir().join(format!(
+        "p2pmux-agent-detect-{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock is after epoch")
+            .as_nanos()
+    ));
+    let script = temporary_root.join("pi-coding-agent/dist/cli.js");
+    fs::create_dir_all(script.parent().expect("script has a parent")).expect("create script tree");
+    fs::write(&script, "setInterval(() => {}, 1_000);\n").expect("write script");
+    let mut child = Command::new("node")
+        .arg(&script)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn live Node child");
+    let child_pid = child.id();
+    let mut sampler = SysinfoSampler::default();
+    let mut last_child = None;
+
+    let detected = (0..20).find_map(|_| {
+        let snapshot = sample_global_snapshot(&mut sampler);
+        let child_seen = snapshot.iter().find(|process| process.pid == child_pid);
+        last_child = child_seen.cloned();
+        let result = classify_pane_tree(std::process::id(), &snapshot);
+        if child_seen.is_some() && result.is_some() {
+            result
+        } else {
+            thread::sleep(Duration::from_millis(25));
+            None
+        }
+    });
+
+    let _ = child.kill();
+    let _ = child.wait();
+    fs::remove_dir_all(temporary_root).expect("remove script tree");
+    assert_eq!(
+        detected.map(|agent| agent.kind),
+        Some(AgentKind::Pi),
+        "live child snapshot: {last_child:?}"
+    );
+}
+
+#[test]
+fn sysinfo_sampler_captures_a_running_cursor_agent_argv_when_present() {
+    let mut sampler = SysinfoSampler::default();
+    let snapshot = sample_global_snapshot(&mut sampler);
+    let Some(cursor) = snapshot.iter().find(|process| {
+        process
+            .cmdline
+            .iter()
+            .any(|argument| argument.contains("cursor-agent"))
+    }) else {
+        return;
+    };
+    let cursor_only = vec![cursor.clone()];
+    assert_eq!(
+        classify_pane_tree(cursor.pid, &cursor_only).map(|agent| agent.kind),
+        Some(AgentKind::Cursor)
+    );
+}

--- a/tests/protocol.rs
+++ b/tests/protocol.rs
@@ -313,6 +313,16 @@ fn agent_roster_uses_tag_26_and_round_trips() {
 }
 
 #[test]
+fn agent_roster_accepts_opencode_kind() {
+    let roster = agent_roster(vec![AgentRosterEntry {
+        agent_kind: String::from("opencode"),
+        ..agent_entry(9)
+    }]);
+
+    assert!(encode_frame(&envelope(envelope::Body::AgentRoster(roster))).is_ok());
+}
+
+#[test]
 fn agent_roster_validation_rejects_bad_entries() {
     let cases = [
         agent_roster(vec![agent_entry(0)]),


### PR DESCRIPTION
## Summary
- capture argv, cwd, and executable metadata when sampling processes
- detect wrapped Cursor Agent, Pi, and OpenCode processes
- add richer, clickable agent overlay rows

## Verification
- cargo fmt --check
- cargo test
- cargo clippy --all-targets -- -D warnings
- cargo build --release
- live SysinfoSampler integration for Node/Pi and running Cursor Agent argv