### PR TITLE
fix: bridge Kitty Shift+Enter for agent newlines

### DIFF
--- a/docs/superpowers/plans/2026-07-26-kitty-shift-enter-bridge.md
+++ b/docs/superpowers/plans/2026-07-26-kitty-shift-enter-bridge.md
@@ -1,0 +1,47 @@
+# Kitty Shift+Enter bridge (per-pane)
+
+Keep p2pmux as a PTY host. Add a minimal per-pane Kitty keyboard bridge so agents get Shift+Enter newlines.
+
+## Decisions (locked)
+
+1. Respond to `CSI ? u` with current virtual-pane flags (`CSI ? 0 u` initially; after push of flag 1, `CSI ? 1 u`). Track/support only flag `1` (`DISAMBIGUATE_ESCAPE_CODES`); mask unsupported flags. `active()` means flag 1 is enabled.
+2. Replicate `kitty_keyboard_active` on snapshot/delta as additive protobuf bools without bumping `PROTOCOL_VERSION` (stays 4). Absent fields decode as false → LF fallback.
+3. Query replies are written only by the local PTY owner, never via leases/peer input. Encode: Shift+Enter → `ESC[13;2u` when active, else `LF`. Plain Enter stays `\r`.
+
+## Tasks (one commit each)
+
+### Task 1: Extend tracker into query bridge
+- Files: `src/kitty_keyboard.rs`
+- Add supported-flags bit `1`; parse `CSI ? u`; handle `=` optional `;mode`; mask unsupported flags; `take_query_reply()`; `active()` = flag 1 enabled.
+- Tests: initial query `\x1b[?0u`; after `\x1b[>1u` query `\x1b[?1u`; split query; unsupported flags inactive; push/pop still works.
+- Commit: `Add kitty keyboard query replies`
+
+### Task 2: Reply to queries from local PTYs
+- Files: `src/screen.rs`, `src/tui.rs`, `tests/screen.rs`
+- HostScreen drains pending reply after `process_pty`. `run_local`, `SharedLocalPane::drain`, `run_host` write replies to that PtyHost only. Outer enhancement unchanged.
+- Tests: host observes `CSI ? u`, exposes `\x1b[?0u`, inactive until push.
+- Commit: `Reply to kitty queries from local PTYs`
+
+### Task 3: Propagate mode in screen frames
+- Files: `src/screen.rs`, `src/protocol.rs`, `src/session.rs`, `tests/screen.rs`, `tests/protocol.rs`, `tests/session_stream.rs`
+- Add `kitty_keyboard_active` to `ScreenFrame` and Snapshot/Delta (new tags). Keep PROTOCOL_VERSION 4. GuestScreen stores received flag.
+- Tests: flag survives snapshot/delta and clears on pop; protocol round-trip true; stream carries true after `\x1b[>1u`.
+- Commit: `Propagate kitty mode in screen frames`
+
+### Task 4: Use mode for remote key forwarding
+- Files: `src/tui.rs`
+- Replace remote `encode_key(..., false)` with pane’s `kitty_keyboard_active()`. Apply flag from snapshot/delta in remote drain and `run_guest`.
+- Tests: remote active → CSI-u; inactive → LF; Enter always CR.
+- Commit: `Use kitty mode for remote key forwarding`
+
+### Task 5: End-to-end PTY regression
+- Files: `src/tui.rs` and/or integration test, `tests/fixtures/agent_kitty_keyboard_probe.js`
+- Probe: emit `CSI ? u`, expect `\x1b[?0u`, push `\x1b[>1u`, succeed only on `CSI 13;2u`. Keep existing LF probe.
+- Final gate: `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all-features`
+- Commit: `Cover kitty Shift-Enter bridge end to end`
+
+## Constraints
+- Minimal bridge only; no full emulator rewrite
+- No competing global encodings
+- Extend KittyKeyboardTracker; surgical diffs
+- Commit after each task succeeds (tests for that task green)

--- a/src/kitty_keyboard.rs
+++ b/src/kitty_keyboard.rs
@@ -1,6 +1,8 @@
 //! Per-PTY kitty keyboard mode tracking.
 
 const MAX_CARRY_BYTES: usize = 64;
+const DISAMBIGUATE_ESCAPE_CODES: u8 = 1;
+const SUPPORTED_FLAGS: u8 = DISAMBIGUATE_ESCAPE_CODES;
 
 /// Observes kitty keyboard mode escape sequences emitted by one child PTY.
 #[derive(Debug, Default)]
@@ -8,6 +10,7 @@ pub struct KittyKeyboardTracker {
     base: u8,
     stack: Vec<u8>,
     carry: Vec<u8>,
+    query_reply: Option<Vec<u8>>,
 }
 
 impl KittyKeyboardTracker {
@@ -34,8 +37,21 @@ impl KittyKeyboardTracker {
             }
 
             let operation = data[index + 2];
-            if !matches!(operation, b'>' | b'<' | b'=') {
+            if !matches!(operation, b'>' | b'<' | b'=' | b'?') {
                 index += 1;
+                continue;
+            }
+
+            if operation == b'?' {
+                if index + 3 >= data.len() {
+                    break;
+                }
+                if data[index + 3] == b'u' {
+                    self.query_reply = Some(format!("\x1b[?{}u", self.flags()).into_bytes());
+                    index += 4;
+                } else {
+                    index += 1;
+                }
                 continue;
             }
 
@@ -46,6 +62,15 @@ impl KittyKeyboardTracker {
             }
             if end == data.len() {
                 break;
+            }
+            if operation == b'=' && data[end] == b';' {
+                end += 1;
+                while end < data.len() && data[end].is_ascii_digit() {
+                    end += 1;
+                }
+                if end == data.len() {
+                    break;
+                }
             }
             if data[end] != b'u' {
                 index += 1;
@@ -66,12 +91,20 @@ impl KittyKeyboardTracker {
     }
 
     pub fn active(&self) -> bool {
-        self.stack.last().copied().unwrap_or(self.base) != 0
+        self.flags() & DISAMBIGUATE_ESCAPE_CODES != 0
+    }
+
+    pub fn take_query_reply(&mut self) -> Option<Vec<u8>> {
+        self.query_reply.take()
+    }
+
+    fn flags(&self) -> u8 {
+        self.stack.last().copied().unwrap_or(self.base)
     }
 
     fn apply(&mut self, operation: u8, value: Option<u8>) {
         match operation {
-            b'>' => self.stack.push(value.unwrap_or(0)),
+            b'>' => self.stack.push(value.unwrap_or(0) & SUPPORTED_FLAGS),
             b'<' => {
                 for _ in 0..usize::from(value.unwrap_or(1)) {
                     if self.stack.pop().is_none() {
@@ -80,7 +113,7 @@ impl KittyKeyboardTracker {
                 }
             }
             b'=' => {
-                let flags = value.unwrap_or(0);
+                let flags = value.unwrap_or(0) & SUPPORTED_FLAGS;
                 if let Some(current) = self.stack.last_mut() {
                     *current = flags;
                 } else {
@@ -142,6 +175,40 @@ mod tests {
         assert!(!tracker.active());
         tracker.observe(b"u");
         assert!(tracker.active());
+    }
+
+    #[test]
+    fn initial_query_replies_with_no_flags() {
+        let mut tracker = KittyKeyboardTracker::default();
+        tracker.observe(b"\x1b[?u");
+        assert_eq!(tracker.take_query_reply(), Some(b"\x1b[?0u".to_vec()));
+    }
+
+    #[test]
+    fn query_replies_with_current_flags() {
+        let mut tracker = KittyKeyboardTracker::default();
+        tracker.observe(b"\x1b[>1u\x1b[?u");
+        assert_eq!(tracker.take_query_reply(), Some(b"\x1b[?1u".to_vec()));
+    }
+
+    #[test]
+    fn split_query_is_observed() {
+        let mut tracker = KittyKeyboardTracker::default();
+        tracker.observe(b"\x1b[?");
+        assert_eq!(tracker.take_query_reply(), None);
+        tracker.observe(b"u");
+        assert_eq!(tracker.take_query_reply(), Some(b"\x1b[?0u".to_vec()));
+    }
+
+    #[test]
+    fn unsupported_flags_are_inactive() {
+        let mut tracker = KittyKeyboardTracker::default();
+        tracker.observe(b"\x1b[>2u");
+        assert!(!tracker.active());
+        tracker.observe(b"\x1b[=3;1u");
+        assert!(tracker.active());
+        tracker.observe(b"\x1b[?u");
+        assert_eq!(tracker.take_query_reply(), Some(b"\x1b[?1u".to_vec()));
     }
 
     #[test]

--- a/src/kitty_keyboard.rs
+++ b/src/kitty_keyboard.rs
@@ -63,6 +63,7 @@ impl KittyKeyboardTracker {
             if end == data.len() {
                 break;
             }
+            let flags_end = end;
             if operation == b'=' && data[end] == b';' {
                 end += 1;
                 while end < data.len() && data[end].is_ascii_digit() {
@@ -77,7 +78,7 @@ impl KittyKeyboardTracker {
                 continue;
             }
 
-            let value = std::str::from_utf8(&data[digits_start..end])
+            let value = std::str::from_utf8(&data[digits_start..flags_end])
                 .ok()
                 .and_then(|digits| (!digits.is_empty()).then_some(digits))
                 .and_then(|digits| digits.parse::<u8>().ok());

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -224,6 +224,8 @@ pub struct Snapshot {
     pub sequence: u64,
     #[prost(bytes = "vec", tag = "4")]
     pub screen: Vec<u8>,
+    #[prost(bool, tag = "5")]
+    pub kitty_keyboard_active: bool,
 }
 
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -238,6 +240,8 @@ pub struct Delta {
     pub sequence: u64,
     #[prost(bytes = "vec", tag = "5")]
     pub changes: Vec<u8>,
+    #[prost(bool, tag = "6")]
+    pub kitty_keyboard_active: bool,
 }
 
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -131,6 +131,10 @@ impl HostScreen {
     pub fn kitty_keyboard_active(&self) -> bool {
         self.kitty_keyboard.active()
     }
+
+    pub fn take_kitty_keyboard_query_reply(&mut self) -> Option<Vec<u8>> {
+        self.kitty_keyboard.take_query_reply()
+    }
 }
 
 #[derive(Debug, Eq, PartialEq)]

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -17,6 +17,7 @@ pub struct ScreenFrame {
     pub base_sequence: u64,
     pub snapshot: Arc<[u8]>,
     pub delta: Arc<[u8]>,
+    pub kitty_keyboard_active: bool,
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -71,6 +72,7 @@ impl HostScreen {
                 base_sequence: 0,
                 snapshot,
                 delta: Arc::from([]),
+                kitty_keyboard_active: false,
             },
             kitty_keyboard: KittyKeyboardTracker::default(),
         })
@@ -94,6 +96,7 @@ impl HostScreen {
             base_sequence: self.current.sequence,
             snapshot,
             delta: Arc::from(delta),
+            kitty_keyboard_active: self.kitty_keyboard.active(),
         };
         self.previous = self.parser.screen().clone();
         self.current = frame.clone();
@@ -115,6 +118,7 @@ impl HostScreen {
             base_sequence: 0,
             snapshot: snapshot_payload(self.parser.screen())?,
             delta: Arc::from([]),
+            kitty_keyboard_active: self.current.kitty_keyboard_active,
         };
         self.current = frame.clone();
         Ok(frame)
@@ -146,6 +150,7 @@ pub enum ApplyDelta {
 pub struct GuestScreen {
     parser: Option<vt100::Parser>,
     sequence: Option<u64>,
+    kitty_keyboard_active: bool,
 }
 
 impl Default for GuestScreen {
@@ -159,6 +164,7 @@ impl GuestScreen {
         Self {
             parser: None,
             sequence: None,
+            kitty_keyboard_active: false,
         }
     }
 
@@ -204,6 +210,14 @@ impl GuestScreen {
 
     pub fn sequence(&self) -> Option<u64> {
         self.sequence
+    }
+
+    pub fn set_kitty_keyboard_active(&mut self, active: bool) {
+        self.kitty_keyboard_active = active;
+    }
+
+    pub fn kitty_keyboard_active(&self) -> bool {
+        self.kitty_keyboard_active
     }
 }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -2959,6 +2959,7 @@ async fn screen_writer_task(
                             base_sequence: frame.base_sequence,
                             sequence: frame.sequence,
                             changes: frame.delta.to_vec(),
+                            kitty_keyboard_active: frame.kitty_keyboard_active,
                         })),
                     }).await?;
                 }
@@ -2990,6 +2991,7 @@ async fn write_snapshot(
                 host_peer_id: host_peer_id.to_vec(),
                 sequence: frame.sequence,
                 screen: frame.snapshot.to_vec(),
+                kitty_keyboard_active: frame.kitty_keyboard_active,
             })),
         })
         .await

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -2111,6 +2111,9 @@ impl SharedLocalPane {
             };
             self.agent_tracker.record_output(Instant::now());
             let frame = self.screen.process_pty(&bytes)?;
+            if let Some(reply) = self.screen.take_kitty_keyboard_query_reply() {
+                self.host.write_input(&reply)?;
+            }
             self.screen_tx.send_replace(frame);
             changed = true;
         }
@@ -3917,6 +3920,9 @@ pub fn run_local() -> Result<(), Box<dyn Error>> {
             };
             kitty_keyboard.observe(&bytes);
             parser.process(&bytes);
+            if let Some(reply) = kitty_keyboard.take_query_reply() {
+                host.write_input(&reply)?;
+            }
             dirty = true;
         }
         if host.output_closed() {
@@ -4037,6 +4043,9 @@ pub fn run_host(mut runtime: HostPaneRuntime) -> Result<(), Box<dyn Error>> {
                 break;
             };
             if let Ok(frame) = runtime.screen.process_pty(&bytes) {
+                if let Some(reply) = runtime.screen.take_kitty_keyboard_query_reply() {
+                    runtime.host.write_input(&reply)?;
+                }
                 runtime.screen_tx.send_replace(frame);
             }
             dirty = true;

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -2304,16 +2304,26 @@ impl SharedRemotePane {
         loop {
             match self.pane.events.try_recv() {
                 Ok(GuestEvent::ScreenSnapshot(snapshot)) => {
-                    changed |= self
+                    if self
                         .screen
                         .apply_snapshot(snapshot.sequence, &snapshot.screen)
-                        .is_ok();
+                        .is_ok()
+                    {
+                        self.screen
+                            .set_kitty_keyboard_active(snapshot.kitty_keyboard_active);
+                        changed = true;
+                    }
                 }
                 Ok(GuestEvent::ScreenDelta(delta)) => {
-                    changed |= self
+                    if self
                         .screen
                         .apply_delta(delta.base_sequence, delta.sequence, &delta.changes)
-                        .is_ok();
+                        .is_ok()
+                    {
+                        self.screen
+                            .set_kitty_keyboard_active(delta.kitty_keyboard_active);
+                        changed = true;
+                    }
                 }
                 Ok(GuestEvent::Lease(lease)) => {
                     received_lease = true;
@@ -3504,7 +3514,7 @@ impl SharedLayoutRuntime {
         }
         if let Some(pane) = self.remote.get_mut(&pane_id)
             && let Some(screen) = pane.screen.screen()
-            && let Some(bytes) = encode_key(key, screen, false)
+            && let Some(bytes) = encode_key(key, screen, pane.screen.kitty_keyboard_active())
         {
             pane.input(bytes);
             sent = true;
@@ -4156,6 +4166,7 @@ pub fn run_guest(mut pane: GuestPane) -> Result<(), Box<dyn Error>> {
                         .apply_snapshot(snapshot.sequence, &snapshot.screen)
                         .is_ok()
                     {
+                        remote.set_kitty_keyboard_active(snapshot.kitty_keyboard_active);
                         dirty = true;
                     }
                 }
@@ -4164,6 +4175,7 @@ pub fn run_guest(mut pane: GuestPane) -> Result<(), Box<dyn Error>> {
                         .apply_delta(delta.base_sequence, delta.sequence, &delta.changes)
                         .is_ok()
                     {
+                        remote.set_kitty_keyboard_active(delta.kitty_keyboard_active);
                         dirty = true;
                     }
                 }
@@ -4236,7 +4248,7 @@ pub fn run_guest(mut pane: GuestPane) -> Result<(), Box<dyn Error>> {
             }
             Event::Key(key) if matches!(key.kind, KeyEventKind::Press | KeyEventKind::Repeat) => {
                 if let (Some(state), Some(screen)) = (lease.as_ref(), remote.screen())
-                    && let Some(bytes) = encode_key(key, screen, false)
+                    && let Some(bytes) = encode_key(key, screen, remote.kitty_keyboard_active())
                 {
                     if state.controller_peer_id == pane.controls.peer_id() {
                         if held_input.is_empty() {

--- a/tests/fixtures/agent_kitty_keyboard_probe.js
+++ b/tests/fixtures/agent_kitty_keyboard_probe.js
@@ -1,0 +1,30 @@
+if (process.stdin.setRawMode) process.stdin.setRawMode(true);
+
+const query = '\x1b[?u';
+const reply = '\x1b[?0u';
+const push = '\x1b[>1u';
+const shiftedEnter = '\x1b[13;2u';
+let input = '';
+let phase = 'query';
+
+process.stdout.write(query);
+process.stdin.on('data', (chunk) => {
+  input += chunk.toString('utf8');
+  if (phase === 'query') {
+    if (!input.includes(reply)) return;
+    phase = 'shift-enter';
+    input = '';
+    process.stdout.write(push);
+    process.stdout.write('KITTY_READY\n');
+    return;
+  }
+
+  if (input.includes(shiftedEnter)) {
+    process.stdout.write('KITTY_SHIFT_ENTER\n');
+    process.exit(0);
+  }
+  if (input.length >= shiftedEnter.length) {
+    process.stdout.write('KITTY_UNEXPECTED_INPUT\n');
+    process.exit(1);
+  }
+});

--- a/tests/protocol.rs
+++ b/tests/protocol.rs
@@ -133,6 +133,7 @@ fn envelope_exposes_each_v1_body() {
             host_peer_id: b"peer-host".to_vec(),
             sequence: u32::MAX as u64 + 4,
             screen: b"full screen".to_vec(),
+            kitty_keyboard_active: false,
         })),
         envelope(envelope::Body::Delta(Delta {
             pane_id: b"pane-a".to_vec(),
@@ -140,6 +141,7 @@ fn envelope_exposes_each_v1_body() {
             base_sequence: u32::MAX as u64 + 4,
             sequence: u32::MAX as u64 + 5,
             changes: b"patch".to_vec(),
+            kitty_keyboard_active: false,
         })),
     ];
 
@@ -258,6 +260,7 @@ fn sample_envelopes() -> Vec<Envelope> {
             host_peer_id: b"peer-host".to_vec(),
             sequence: 1,
             screen: b"full screen".to_vec(),
+            kitty_keyboard_active: false,
         })),
         envelope(envelope::Body::Delta(Delta {
             pane_id: b"pane-a".to_vec(),
@@ -265,6 +268,7 @@ fn sample_envelopes() -> Vec<Envelope> {
             base_sequence: 1,
             sequence: 2,
             changes: b"patch".to_vec(),
+            kitty_keyboard_active: false,
         })),
     ]
 }
@@ -274,6 +278,32 @@ fn framed_envelopes_round_trip_all_v1_bodies() {
     for original in sample_envelopes() {
         let frame = encode_frame(&original).expect("valid envelope encodes");
         assert_eq!(decode_frame(&frame).expect("valid frame decodes"), original);
+    }
+}
+
+#[test]
+fn kitty_keyboard_flag_round_trips() {
+    let messages = [
+        envelope(envelope::Body::Snapshot(Snapshot {
+            pane_id: b"pane-a".to_vec(),
+            host_peer_id: b"peer-host".to_vec(),
+            sequence: 1,
+            screen: b"full screen".to_vec(),
+            kitty_keyboard_active: true,
+        })),
+        envelope(envelope::Body::Delta(Delta {
+            pane_id: b"pane-a".to_vec(),
+            host_peer_id: b"peer-host".to_vec(),
+            base_sequence: 1,
+            sequence: 2,
+            changes: b"patch".to_vec(),
+            kitty_keyboard_active: true,
+        })),
+    ];
+
+    for message in messages {
+        let frame = encode_frame(&message).expect("valid envelope encodes");
+        assert_eq!(decode_frame(&frame).expect("valid frame decodes"), message);
     }
 }
 
@@ -1233,6 +1263,7 @@ fn decoder_rejects_oversize_declared_and_decoded_payloads() {
         host_peer_id: b"peer-host".to_vec(),
         sequence: 1,
         screen: vec![0; MAX_SNAPSHOT_BYTES + 1],
+        kitty_keyboard_active: false,
     }));
     let mut snapshot_frame = Vec::new();
     oversized_snapshot
@@ -1252,6 +1283,7 @@ fn decoder_rejects_oversize_declared_and_decoded_payloads() {
         base_sequence: 1,
         sequence: 2,
         changes: vec![0; MAX_DELTA_BYTES + 1],
+        kitty_keyboard_active: false,
     }));
     let mut delta_frame = Vec::new();
     oversized_delta
@@ -1357,6 +1389,7 @@ fn decoder_rejects_missing_fields_and_invalid_sequences() {
         base_sequence: 1,
         sequence: 1,
         changes: Vec::new(),
+        kitty_keyboard_active: false,
     }));
     let mut invalid_delta_frame = Vec::new();
     invalid_delta
@@ -1380,6 +1413,7 @@ fn decoder_accepts_maximum_payloads() {
         host_peer_id: b"peer-host".to_vec(),
         sequence: 1,
         screen: vec![0; MAX_SNAPSHOT_BYTES],
+        kitty_keyboard_active: false,
     }));
     let maximum_delta = envelope(envelope::Body::Delta(Delta {
         pane_id: b"pane-a".to_vec(),
@@ -1387,6 +1421,7 @@ fn decoder_accepts_maximum_payloads() {
         base_sequence: 1,
         sequence: 2,
         changes: vec![0; MAX_DELTA_BYTES],
+        kitty_keyboard_active: false,
     }));
 
     for envelope in [maximum_input, maximum_snapshot, maximum_delta] {
@@ -1433,6 +1468,7 @@ fn encode_frame_rejects_invalid_envelopes() {
         host_peer_id: b"peer-host".to_vec(),
         sequence: 0,
         screen: Vec::new(),
+        kitty_keyboard_active: false,
     }));
 
     let cases = vec![
@@ -1490,6 +1526,7 @@ fn encode_frame_rejects_invalid_envelopes() {
                 host_peer_id: b"peer-host".to_vec(),
                 sequence: 1,
                 screen: vec![0; MAX_SNAPSHOT_BYTES + 1],
+                kitty_keyboard_active: false,
             })),
         ),
         (
@@ -1500,6 +1537,7 @@ fn encode_frame_rejects_invalid_envelopes() {
                 base_sequence: 1,
                 sequence: 2,
                 changes: vec![0; MAX_DELTA_BYTES + 1],
+                kitty_keyboard_active: false,
             })),
         ),
     ];

--- a/tests/screen.rs
+++ b/tests/screen.rs
@@ -35,6 +35,20 @@ fn host_screen_tracks_child_kitty_keyboard_mode() {
 }
 
 #[test]
+fn host_screen_replies_to_kitty_keyboard_queries() {
+    let mut host = HostScreen::new(1, 1).expect("valid fixed grid");
+    host.process_pty(b"\x1b[?u").expect("kitty query");
+    assert_eq!(
+        host.take_kitty_keyboard_query_reply(),
+        Some(b"\x1b[?0u".to_vec())
+    );
+    assert!(!host.kitty_keyboard_active());
+
+    host.process_pty(b"\x1b[>1u").expect("kitty push");
+    assert!(host.kitty_keyboard_active());
+}
+
+#[test]
 fn host_snapshots_the_live_edge_after_scrollback_accumulates() {
     let mut host = HostScreen::new(1, 3).expect("valid fixed grid");
     let frame = host.process_pty(b"a\r\nb\r\nc").expect("scrollback update");

--- a/tests/screen.rs
+++ b/tests/screen.rs
@@ -28,10 +28,25 @@ fn initial_snapshot_describes_the_empty_fixed_grid() {
 #[test]
 fn host_screen_tracks_child_kitty_keyboard_mode() {
     let mut host = HostScreen::new(1, 1).expect("valid fixed grid");
-    host.process_pty(b"\x1b[>1u").expect("kitty push");
+    let pushed = host.process_pty(b"\x1b[>1u").expect("kitty push");
     assert!(host.kitty_keyboard_active());
-    host.process_pty(b"\x1b[<1u").expect("kitty pop");
+    assert!(pushed.kitty_keyboard_active);
+    let popped = host.process_pty(b"\x1b[<1u").expect("kitty pop");
     assert!(!host.kitty_keyboard_active());
+    assert!(!popped.kitty_keyboard_active);
+
+    let mut guest = GuestScreen::new();
+    guest
+        .apply_snapshot(pushed.sequence, &pushed.snapshot)
+        .expect("pushed snapshot applies");
+    guest.set_kitty_keyboard_active(pushed.kitty_keyboard_active);
+    assert!(guest.kitty_keyboard_active());
+    assert_eq!(
+        guest.apply_delta(popped.base_sequence, popped.sequence, &popped.delta),
+        Ok(ApplyDelta::Applied)
+    );
+    guest.set_kitty_keyboard_active(popped.kitty_keyboard_active);
+    assert!(!guest.kitty_keyboard_active());
 }
 
 #[test]

--- a/tests/session_stream.rs
+++ b/tests/session_stream.rs
@@ -85,9 +85,9 @@ async fn join_pane_delivers_snapshot_then_delta_in_order() {
         saw_snapshot && saw_lease,
         "host must publish the initial lease"
     );
-    screen_tx.send_replace(screen.process_pty(b"abc").expect("screen update"));
+    screen_tx.send_replace(screen.process_pty(b"\x1b[>1u").expect("screen update"));
     assert!(
-        matches!(timeout(TEST_TIMEOUT, pane.events.recv()).await.expect("event timeout"), Some(GuestEvent::ScreenDelta(delta)) if delta.base_sequence == 1 && delta.sequence == 2)
+        matches!(timeout(TEST_TIMEOUT, pane.events.recv()).await.expect("event timeout"), Some(GuestEvent::ScreenDelta(delta)) if delta.base_sequence == 1 && delta.sequence == 2 && delta.kitty_keyboard_active)
     );
     pane.shutdown().await;
     let _ = timeout(TEST_TIMEOUT, host_task).await;

--- a/tests/shift_enter_forward.rs
+++ b/tests/shift_enter_forward.rs
@@ -3,7 +3,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use p2pmux::pty_host::PtyHost;
+use p2pmux::{pty_host::PtyHost, screen::HostScreen};
 use portable_pty::{CommandBuilder, PtySize};
 
 fn read_until(host: &mut PtyHost, expected: &str) -> String {
@@ -15,6 +15,29 @@ fn read_until(host: &mut PtyHost, expected: &str) -> String {
             .expect("PTY reader should stay healthy")
         {
             output.push_str(&String::from_utf8_lossy(&bytes));
+        }
+        if output.contains(expected) {
+            return output;
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+    panic!("did not receive {expected:?}; received {output:?}");
+}
+
+fn bridge_until(host: &mut PtyHost, screen: &mut HostScreen, expected: &str) -> String {
+    let deadline = Instant::now() + Duration::from_secs(2);
+    let mut output = String::new();
+    while Instant::now() < deadline {
+        while let Some(bytes) = host
+            .try_read_output()
+            .expect("PTY reader should stay healthy")
+        {
+            output.push_str(&String::from_utf8_lossy(&bytes));
+            screen.process_pty(&bytes).expect("PTY output processes");
+            if let Some(reply) = screen.take_kitty_keyboard_query_reply() {
+                host.write_input(&reply)
+                    .expect("PTY should accept query reply");
+            }
         }
         if output.contains(expected) {
             return output;
@@ -51,6 +74,39 @@ fn shift_enter_forwards_as_newline() {
 
     host.write_input(b"\r").expect("PTY should accept CR");
     assert!(read_until(&mut host, "SUBMIT").contains("SUBMIT"));
+
+    host.shutdown().expect("PTY should shut down cleanly");
+}
+
+#[test]
+fn shift_enter_uses_kitty_csi_u_after_pty_opt_in() {
+    let probe = format!(
+        "{}/tests/fixtures/agent_kitty_keyboard_probe.js",
+        env!("CARGO_MANIFEST_DIR")
+    );
+    let mut command = CommandBuilder::new("node");
+    command.arg(probe);
+    let mut host = PtyHost::spawn(
+        command,
+        PtySize {
+            rows: 24,
+            cols: 80,
+            pixel_width: 0,
+            pixel_height: 0,
+        },
+    )
+    .expect("Node probe PTY should spawn");
+    let mut screen = HostScreen::new(24, 80).expect("screen");
+
+    assert!(bridge_until(&mut host, &mut screen, "KITTY_READY").contains("KITTY_READY"));
+    assert!(screen.kitty_keyboard_active());
+
+    // `encode_key(Enter + SHIFT)` emits this CSI-u sequence after the PTY opts in.
+    host.write_input(b"\x1b[13;2u")
+        .expect("PTY should accept kitty Shift+Enter");
+    assert!(
+        bridge_until(&mut host, &mut screen, "KITTY_SHIFT_ENTER").contains("KITTY_SHIFT_ENTER")
+    );
 
     host.shutdown().expect("PTY should shut down cleanly");
 }


### PR DESCRIPTION
## Summary
- Add a per-pane Kitty keyboard bridge (query reply + mode tracking) so agents can negotiate extended keys without turning p2pmux into a full terminal emulator.
- When a pane has Kitty flag 1 active, Shift+Enter is encoded as `ESC[13;2u`; otherwise keep the LF fallback. Plain Enter stays CR.
- Propagate `kitty_keyboard_active` on snapshot/delta (additive, protocol v4 unchanged) so remote key forwarding matches the host pane.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features` (Codex full gate)
- [x] `cargo test --all-features --test shift_enter_forward`
- [ ] Manual: in a Kitty-capable outer terminal, run an agent in a local pane and confirm Shift+Enter inserts a newline
- [ ] Manual: confirm plain Enter still submits
- [ ] Manual (optional): remote viewer controlling a host pane with an agent also gets Shift+Enter newlines


Made with [Cursor](https://cursor.com)