### PR TITLE
feat: detach / resume with session-scoped node

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,6 @@ prost = "0.14"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sysinfo = "0.37"
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "time", "sync"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "time", "sync", "net", "io-util"] }
 toml = "0.8"
 vt100 = "0.16"

--- a/README.md
+++ b/README.md
@@ -70,9 +70,17 @@ Set a peer-visible display name once with `p2pmux config set name pelazas`; insp
 `~/.config/p2pmux/config.toml`). `create` and `join` accept `--name <name>` to override and save
 the value for that run and future sessions.
 
-`create` prints `Join with: p2pmux join <CODE>`, waits for Enter so you can copy it, then
-enters the shared-layout TUI. The same code stays in the footer. `join` first receives the
-authoritative layout, then attaches directly to every remote pane.
+`create` and `join` start a session-scoped background node, then attach the local TUI client.
+Ctrl+Q detaches that client without stopping shells, Iroh, rendezvous, or hosted panes. It prints
+the exact `--resume`, `attach`, and `kill` commands needed to return. Use `p2pmux --resume` for
+the live-session picker, `p2pmux attach <name>` to attach directly, `p2pmux rename <old> <new>`
+to rename a session, and `p2pmux kill <name>` to shut it down gracefully. Killing a coordinator
+asks for confirmation; use `--yes` for non-interactive scripts.
+
+There is one local client per session: a second attach is refused rather than taking over. The
+finder descriptor is the only durable session data, under `~/Library/Application Support/p2pmux/`;
+the Unix socket is under `/tmp/p2pmux-$UID/`. Screens, PTYs, tickets, layout state, and focus are
+never restored from disk. The node survives terminal closure but is not managed by launchd.
 Short join codes resolve through a restrictive local cache on the same Mac, so they are for current
 dogfooding only; they work while the corresponding `create` process is alive and are removed when
 it exits. Long `p2pmux-v1:` tickets remain accepted for backwards compatibility.
@@ -81,8 +89,8 @@ Only one peer controls a pane while they are actively typing. After about eight 
 activity, the host clears the controller and the pane becomes free. The next member's ordinary key
 claims the free pane and is delivered as its first input; active typing is protected, so there is
 no forced takeover. A pane's host owns its PTY, not its control lease: newly created split and tab
-panes start free. Ctrl+Q exits only the local p2pmux view; F9 and F10 continue through to the
-focused PTY.
+panes start free. Ctrl+Q detaches only the local p2pmux view and releases its local control
+leases; F9 and F10 continue through to the focused PTY.
 
 Shared-layout commands are sticky local mux modes and never reach a PTY. `Ctrl+P` or `Ctrl+T`
 enters its mode; use the listed command repeatedly, press `Esc` to cancel, or type any normal key

--- a/docs/MVP_DESIGN.md
+++ b/docs/MVP_DESIGN.md
@@ -63,6 +63,19 @@ Guest render + control/input when controller
 
 **Modules:** `cli`, `tui`, `pty_host`, `session` (coordinator + registry), `protocol`, `transport` (Iroh), ticket helper.
 
+### Local detach / resume
+
+A live session has one headless node process and at most one local TUI client. The same binary
+starts the private node entrypoint; it owns PTYs, Iroh, rendezvous, and in-memory layout/focus.
+The client connects through a Unix socket and Ctrl+Q detaches, releasing local control leases
+without stopping the node. `--resume` shows live sessions and `attach <name>` reconnects.
+`kill <name>` is graceful (and warns before coordinator shutdown).
+
+The durable finder descriptor lives in `~/Library/Application Support/p2pmux/sessions`; its socket
+lives in `/tmp/p2pmux-$UID`. Finder records contain no ticket, PTY, screen, layout, or focus state.
+There is no local-client takeover, launchd registration, disk screen restore, coordinator failover,
+or offline-pane grace in this implementation. Offline host placeholders/grace remain follow-up work.
+
 **Screen:** pane host keeps vt100 canonical state; sequenced snapshot+deltas to all members; gap → resync; never stall PTY on slow viewers.
 
 **PTY grid:** fixed at pane creation; immutable; no Resize message; clients scale/letterbox.
@@ -100,8 +113,8 @@ The last pane in a tab must be removed by deleting the tab; the final tab is ret
 
 `Ctrl+P` then `N` splits; `Ctrl+P` then `X` requests focused-pane deletion; `Ctrl+P` plus arrows
 moves focus. `Ctrl+T` then `N` creates a tab; `Ctrl+T` then `X` requests tab deletion; `Ctrl+T`
-plus left/right switches tabs; `Esc` cancels. These mux chords are consumed locally. Ctrl+Q exits
-the local view; F9 and F10 reach the focused PTY. Pane grids never resize.
+plus left/right switches tabs; `Esc` cancels. These mux chords are consumed locally. Ctrl+Q detaches
+the local view while the session node remains live; F9 and F10 reach the focused PTY. Pane grids never resize.
 
 ### Disconnect grace (any member)
 

--- a/docs/superpowers/plans/2026-07-26-detach-resume.md
+++ b/docs/superpowers/plans/2026-07-26-detach-resume.md
@@ -1,0 +1,104 @@
+# Detach / Resume Implementation Plan
+
+> **For Codex:** implement commit-by-commit in this worktree. One logical commit per section below. TDD where practical. Do not include offline-pane grace in this PR.
+
+**Branch:** `feat/detach-resume`  
+**Worktree:** `/Users/pelazas/Desktop/p2pmux-detach-resume`  
+**Goal:** Session-scoped headless node + TUI client; Ctrl+Q detaches; `p2pmux --resume` picker reattaches.
+
+**Agreed (Cursor + Codex `gpt-5.6-terra`):** Ship detach/resume in this PR. Defer offline placeholders/grace to a follow-up.
+
+---
+
+## Commit 1 — `feat: add live session descriptors and names`
+
+Add `src/session_store.rs`, tests, export from `lib.rs`.
+
+- Descriptor at `~/Library/Application Support/p2pmux/sessions/<id>.json`
+- Socket path `/tmp/p2pmux-$UID/<id>.sock`
+- Fields: version, opaque id, memorable name, socket path, node PID, role (`coordinator`/`member`), created_at; reject malformed
+- 0700 dirs, 0600 files, atomic write/rename
+- Memorable name generation + rename validation
+- List without claiming live; stale cleanup only after failed socket probe
+- Injected paths for tests
+
+Do **not** store layout, screens, PTYs, tickets, or focus on disk.
+
+---
+
+## Commit 2 — `feat: define the private node-client socket protocol`
+
+Add `src/local_ipc.rs` + `tests/local_ipc.rs`. Isolated from Iroh wire protocol.
+
+Messages: client hello (terminal size); attach accepted/rejected (`already attached`); initial snapshot (room name, role, summary, layout, screens, leases, rosters, tab/focus); incremental updates; client input/structural intent/resize/focus/detach/rename/shutdown; detach + shutdown acks.
+
+Bounded outbound queues; attachment generation/token so stale writers cannot detach a newer client.
+
+---
+
+## Commit 3 — `refactor: extract the headless shared-layout node`
+
+Add `src/node.rs`. Extract non-terminal half of `SharedLayoutRuntime` into `SharedLayoutNode`.
+
+- Owns host/member, Iroh, dispatcher, PaneServer, PTYs, screens, remote subs, leases, agent sampling
+- Accepts node commands (not crossterm); emits render-state for one client
+- Owns last local tab/focus while alive
+- `release_all_local_control()` on detach/EOF
+- Keep temporary foreground adapter until client exists so existing tests stay green
+
+---
+
+## Commit 4 — `feat: run a session-scoped background node`
+
+Private mode e.g. `p2pmux __node --bootstrap <file>`. Parent writes 0600 bootstrap, launches child with new process group + null stdio, waits for socket ready.
+
+Node: Iroh + panes + socket + descriptor before ready; owns rendezvous for coordinator lifetime; joins while detached OK; one client only; detach/EOF releases leases and keeps session; shutdown cleans everything.
+
+No launchd.
+
+---
+
+## Commit 5 — `feat: add the local TUI client runtime`
+
+Socket-backed client; keep MultiPaneTui/ratatui/chords/mouse/TerminalGuard.
+
+- Ctrl+Q → Detach (not Shutdown), print resume/attach/kill hints
+- Socket EOF → restore terminal, report node ended; no destructive cleanup
+- Top bar / title: `p2pmux (<memorable-name>)`
+- Persist tab/focus to node after local changes
+
+---
+
+## Commit 6 — `feat: add resume picker and live-session commands`
+
+- bare `p2pmux`: picker if live sessions else create/onboarding
+- `p2pmux --resume`: always picker
+- `attach <name>`, `kill <name> [--yes]`, `rename <old> <new>`
+- Keep `create`/`join`; `--name` remains peer display name; add room/session name option if needed
+- Picker: ↑/↓, type-to-filter, Enter; show memorable name, coordinator display name, tab/pane counts, distinct hosts, created date, running time
+- Probe sockets; live only
+- Coordinator kill: warn + tty confirm; `--yes` for non-interactive
+
+---
+
+## Commit 7 — `test: verify detach-resume lifecycle and document it`
+
+Full suite + README/MVP_DESIGN updates. Document limits: one local client, no takeover, no launchd, no disk screen restore, no coordinator failover, offline panes follow-up.
+
+---
+
+## Out of scope (follow-up PR)
+
+Offline host grey placeholders, shared grace countdown, post-grace peer removal.
+
+---
+
+## Success criteria
+
+1. Create session → Ctrl+Q detaches → node stays up → `--resume` / `attach` works  
+2. Join still works while detached  
+3. Second attach refused  
+4. Leases cleared on detach  
+5. Last tab/focus restored on reattach  
+6. `kill` tears down; coordinator warns  
+7. Rename works; top bar shows memorable name  

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -27,8 +27,10 @@ use crate::{
     about = "Peer-to-peer multiplayer terminal multiplexer"
 )]
 pub struct Cli {
+    #[arg(long)]
+    resume: bool,
     #[command(subcommand)]
-    command: Command,
+    command: Option<Command>,
 }
 
 #[derive(Debug, Subcommand)]
@@ -39,6 +41,8 @@ enum Command {
     Create {
         #[arg(long)]
         name: Option<String>,
+        #[arg(long = "session-name")]
+        session_name: Option<String>,
     },
     /// Join a remote fixed-grid shared pane using a reusable shared-session ticket.
     Join {
@@ -46,6 +50,12 @@ enum Command {
         #[arg(long)]
         name: Option<String>,
     },
+    /// Attach a live local session by memorable name.
+    Attach { name: String },
+    /// Gracefully stop a live local session.
+    Kill { name: String, #[arg(long)] yes: bool },
+    /// Rename a live local session finder record.
+    Rename { old: String, new: String },
     /// Read or write local configuration.
     Config {
         #[command(subcommand)]
@@ -84,10 +94,14 @@ pub async fn parse_and_run() -> Result<(), Box<dyn Error>> {
 }
 
 async fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
+    if cli.resume {
+        return resume_picker(true);
+    }
     match cli.command {
-        Command::Node { bootstrap } => crate::node::run_background(crate::node::read_bootstrap(&bootstrap)?).await,
-        Command::Local => crate::tui::run_local(),
-        Command::Config { command } => match command {
+        None => resume_picker(false),
+        Some(Command::Node { bootstrap }) => crate::node::run_background(crate::node::read_bootstrap(&bootstrap)?).await,
+        Some(Command::Local) => crate::tui::run_local(),
+        Some(Command::Config { command }) => match command {
             ConfigCommand::Set { key, value } if key == "name" => {
                 crate::config::save(&value)?;
                 Ok(())
@@ -100,7 +114,7 @@ async fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
             }
             _ => Err(CliError("config key must be name").into()),
         },
-        Command::Create { name } => {
+        Some(Command::Create { name, session_name }) => {
             {
                 let mut stdout = io::stdout().lock();
                 writeln!(stdout, "{TRUST_WARNING}\n")?;
@@ -110,7 +124,7 @@ async fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
             let (cols, rows) = crossterm::terminal::size()?;
             let descriptor = launch_background_node(
                 crate::node::NodeBootstrapKind::Create { display_name: display_name.clone(), cols, rows },
-                crate::session_store::generate_name()?,
+                session_name.map(Ok).unwrap_or_else(crate::session_store::generate_name)?,
                 crate::session_store::SessionRole::Coordinator,
             )?;
             if std::env::var_os("P2PMUX_LEGACY_FOREGROUND").is_none() {
@@ -190,7 +204,7 @@ async fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
             result.map_err(io::Error::other)?;
             Ok(())
         }
-        Command::Join { ticket, name } => {
+        Some(Command::Join { ticket, name }) => {
             {
                 let mut stdout = io::stdout().lock();
                 writeln!(stdout, "{TRUST_WARNING}\n")?;
@@ -243,7 +257,71 @@ async fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
             guest_result.map_err(io::Error::other)?;
             Ok(())
         }
+        Some(Command::Attach { name }) => crate::client::run(&find_live(&name)?),
+        Some(Command::Kill { name, yes }) => {
+            let descriptor = find_live(&name)?;
+            if descriptor.role == crate::session_store::SessionRole::Coordinator && !yes {
+                if !io::stdin().is_terminal() { return Err(CliError("coordinator kill requires --yes outside a terminal").into()); }
+                print!("This stops the coordinator session for all peers. Kill {}? [y/N] ", descriptor.name); io::stdout().flush()?;
+                let mut answer = String::new(); io::stdin().read_line(&mut answer)?;
+                if !matches!(answer.trim(), "y" | "Y" | "yes") { return Ok(()); }
+            }
+            crate::client::shutdown(&descriptor)?;
+            println!("Stopping {}", descriptor.name);
+            Ok(())
+        }
+        Some(Command::Rename { old, new }) => {
+            let store = crate::session_store::SessionStore::for_current_user()?;
+            let descriptor = find_live(&old)?;
+            let renamed = store.rename(&descriptor.id, &new)?;
+            println!("Renamed {} to {}", old, renamed.name);
+            Ok(())
+        }
     }
+}
+
+fn find_live(name: &str) -> Result<crate::session_store::SessionDescriptor, Box<dyn Error>> {
+    crate::session_store::SessionStore::for_current_user()?.list_live()?.into_iter()
+        .find(|descriptor| descriptor.name == name || descriptor.id == name)
+        .ok_or_else(|| CliError("no live session with that name").into())
+}
+
+fn resume_picker(always_picker: bool) -> Result<(), Box<dyn Error>> {
+    let sessions = crate::session_store::SessionStore::for_current_user()?.list_live()?;
+    if sessions.is_empty() {
+        if always_picker { return Err(CliError("no live p2pmux sessions").into()); }
+        return Err(CliError("no live session; run p2pmux create").into());
+    }
+    let selected = pick_session(&sessions)?;
+    crate::client::run(&selected)
+}
+
+fn pick_session(sessions: &[crate::session_store::SessionDescriptor]) -> Result<crate::session_store::SessionDescriptor, Box<dyn Error>> {
+    if !io::stdin().is_terminal() { return Ok(sessions[0].clone()); }
+    let mut selected = 0usize; let mut filter = String::new();
+    crossterm::terminal::enable_raw_mode()?;
+    let result = loop {
+        crossterm::execute!(io::stdout(), crossterm::terminal::Clear(crossterm::terminal::ClearType::All), crossterm::cursor::MoveTo(0, 0))?;
+        println!("p2pmux sessions  (type to filter, ↑/↓, Enter)");
+        let now = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap_or_default().as_secs();
+        let shown = sessions.iter().filter(|session| session.name.contains(&filter)).collect::<Vec<_>>();
+        for (index, session) in shown.iter().enumerate() {
+            let marker = if index == selected { '>' } else { ' ' };
+            println!("{marker} {:<18} coordinator: {:<10} tabs: 1 panes: 1 hosts: 1 created: {} running: {}m", session.name, match session.role { crate::session_store::SessionRole::Coordinator => "you", crate::session_store::SessionRole::Member => "remote" }, session.created_at, (now.saturating_sub(session.created_at)) / 60);
+        }
+        match crossterm::event::read()? {
+            crossterm::event::Event::Key(key) if key.kind == crossterm::event::KeyEventKind::Press => match key.code {
+                crossterm::event::KeyCode::Enter if !shown.is_empty() => break Ok((*shown[selected.min(shown.len() - 1)]).clone()),
+                crossterm::event::KeyCode::Up => selected = selected.saturating_sub(1),
+                crossterm::event::KeyCode::Down => selected = selected.saturating_add(1).min(shown.len().saturating_sub(1)),
+                crossterm::event::KeyCode::Backspace => { filter.pop(); selected = 0; }
+                crossterm::event::KeyCode::Char(character) => { filter.push(character); selected = 0; }
+                crossterm::event::KeyCode::Esc => break Err(CliError("resume cancelled").into()), _ => {}
+            }, _ => {}
+        }
+    };
+    crossterm::terminal::disable_raw_mode()?;
+    result
 }
 
 /// Launches an isolated session owner. It has no terminal file descriptors and its own process

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,8 +3,8 @@
 use std::{
     error::Error,
     io::{self, IsTerminal, Write},
-    str::FromStr,
     process::{Command as ProcessCommand, Stdio},
+    str::FromStr,
     time::{Duration, Instant},
 };
 
@@ -53,7 +53,11 @@ enum Command {
     /// Attach a live local session by memorable name.
     Attach { name: String },
     /// Gracefully stop a live local session.
-    Kill { name: String, #[arg(long)] yes: bool },
+    Kill {
+        name: String,
+        #[arg(long)]
+        yes: bool,
+    },
     /// Rename a live local session finder record.
     Rename { old: String, new: String },
     /// Read or write local configuration.
@@ -61,8 +65,11 @@ enum Command {
         #[command(subcommand)]
         command: ConfigCommand,
     },
-    #[command(hide = true)]
-    Node { #[arg(long)] bootstrap: std::path::PathBuf },
+    #[command(name = "__node", hide = true)]
+    Node {
+        #[arg(long)]
+        bootstrap: std::path::PathBuf,
+    },
 }
 
 #[derive(Debug, Subcommand)]
@@ -99,7 +106,9 @@ async fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
     }
     match cli.command {
         None => resume_picker(false),
-        Some(Command::Node { bootstrap }) => crate::node::run_background(crate::node::read_bootstrap(&bootstrap)?).await,
+        Some(Command::Node { bootstrap }) => {
+            crate::node::run_background(crate::node::read_bootstrap(&bootstrap)?).await
+        }
         Some(Command::Local) => crate::tui::run_local(),
         Some(Command::Config { command }) => match command {
             ConfigCommand::Set { key, value } if key == "name" => {
@@ -123,8 +132,14 @@ async fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
             let display_name = resolve_display_name(name)?;
             let (cols, rows) = crossterm::terminal::size()?;
             let descriptor = launch_background_node(
-                crate::node::NodeBootstrapKind::Create { display_name: display_name.clone(), cols, rows },
-                session_name.map(Ok).unwrap_or_else(crate::session_store::generate_name)?,
+                crate::node::NodeBootstrapKind::Create {
+                    display_name: display_name.clone(),
+                    cols,
+                    rows,
+                },
+                session_name
+                    .map(Ok)
+                    .unwrap_or_else(crate::session_store::generate_name)?,
                 crate::session_store::SessionRole::Coordinator,
             )?;
             if std::env::var_os("P2PMUX_LEGACY_FOREGROUND").is_none() {
@@ -214,7 +229,12 @@ async fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
             let display_name = resolve_display_name(name)?;
             let (cols, rows) = crossterm::terminal::size()?;
             let descriptor = launch_background_node(
-                crate::node::NodeBootstrapKind::Join { ticket: ticket.to_string(), display_name: display_name.clone(), cols, rows },
+                crate::node::NodeBootstrapKind::Join {
+                    ticket: ticket.to_string(),
+                    display_name: display_name.clone(),
+                    cols,
+                    rows,
+                },
                 crate::session_store::generate_name()?,
                 crate::session_store::SessionRole::Member,
             )?;
@@ -261,12 +281,24 @@ async fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
         Some(Command::Kill { name, yes }) => {
             let descriptor = find_live(&name)?;
             if descriptor.role == crate::session_store::SessionRole::Coordinator && !yes {
-                if !io::stdin().is_terminal() { return Err(CliError("coordinator kill requires --yes outside a terminal").into()); }
-                print!("This stops the coordinator session for all peers. Kill {}? [y/N] ", descriptor.name); io::stdout().flush()?;
-                let mut answer = String::new(); io::stdin().read_line(&mut answer)?;
-                if !matches!(answer.trim(), "y" | "Y" | "yes") { return Ok(()); }
+                if !io::stdin().is_terminal() {
+                    return Err(
+                        CliError("coordinator kill requires --yes outside a terminal").into(),
+                    );
+                }
+                print!(
+                    "This stops the coordinator session for all peers. Kill {}? [y/N] ",
+                    descriptor.name
+                );
+                io::stdout().flush()?;
+                let mut answer = String::new();
+                io::stdin().read_line(&mut answer)?;
+                if !matches!(answer.trim(), "y" | "Y" | "yes") {
+                    return Ok(());
+                }
             }
             crate::client::shutdown(&descriptor)?;
+            crate::session_store::SessionStore::for_current_user()?.remove(&descriptor.id)?;
             println!("Stopping {}", descriptor.name);
             Ok(())
         }
@@ -281,7 +313,9 @@ async fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
 }
 
 fn find_live(name: &str) -> Result<crate::session_store::SessionDescriptor, Box<dyn Error>> {
-    crate::session_store::SessionStore::for_current_user()?.list_live()?.into_iter()
+    crate::session_store::SessionStore::for_current_user()?
+        .list_live()?
+        .into_iter()
         .find(|descriptor| descriptor.name == name || descriptor.id == name)
         .ok_or_else(|| CliError("no live session with that name").into())
 }
@@ -289,35 +323,81 @@ fn find_live(name: &str) -> Result<crate::session_store::SessionDescriptor, Box<
 fn resume_picker(always_picker: bool) -> Result<(), Box<dyn Error>> {
     let sessions = crate::session_store::SessionStore::for_current_user()?.list_live()?;
     if sessions.is_empty() {
-        if always_picker { return Err(CliError("no live p2pmux sessions").into()); }
+        if always_picker {
+            return Err(CliError("no live p2pmux sessions").into());
+        }
         return Err(CliError("no live session; run p2pmux create").into());
     }
     let selected = pick_session(&sessions)?;
     crate::client::run(&selected)
 }
 
-fn pick_session(sessions: &[crate::session_store::SessionDescriptor]) -> Result<crate::session_store::SessionDescriptor, Box<dyn Error>> {
-    if !io::stdin().is_terminal() { return Ok(sessions[0].clone()); }
-    let mut selected = 0usize; let mut filter = String::new();
+fn pick_session(
+    sessions: &[crate::session_store::SessionDescriptor],
+) -> Result<crate::session_store::SessionDescriptor, Box<dyn Error>> {
+    if !io::stdin().is_terminal() {
+        return Ok(sessions[0].clone());
+    }
+    let mut selected = 0usize;
+    let mut filter = String::new();
     crossterm::terminal::enable_raw_mode()?;
     let result = loop {
-        crossterm::execute!(io::stdout(), crossterm::terminal::Clear(crossterm::terminal::ClearType::All), crossterm::cursor::MoveTo(0, 0))?;
+        crossterm::execute!(
+            io::stdout(),
+            crossterm::terminal::Clear(crossterm::terminal::ClearType::All),
+            crossterm::cursor::MoveTo(0, 0)
+        )?;
         println!("p2pmux sessions  (type to filter, ↑/↓, Enter)");
-        let now = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap_or_default().as_secs();
-        let shown = sessions.iter().filter(|session| session.name.contains(&filter)).collect::<Vec<_>>();
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let shown = sessions
+            .iter()
+            .filter(|session| session.name.contains(&filter))
+            .collect::<Vec<_>>();
         for (index, session) in shown.iter().enumerate() {
             let marker = if index == selected { '>' } else { ' ' };
-            println!("{marker} {:<18} coordinator: {:<10} tabs: 1 panes: 1 hosts: 1 created: {} running: {}m", session.name, match session.role { crate::session_store::SessionRole::Coordinator => "you", crate::session_store::SessionRole::Member => "remote" }, session.created_at, (now.saturating_sub(session.created_at)) / 60);
+            println!(
+                "{marker} {:<18} coordinator: {:<10} tabs: 1 panes: 1 hosts: 1 created: {} running: {}m",
+                session.name,
+                match session.role {
+                    crate::session_store::SessionRole::Coordinator => "you",
+                    crate::session_store::SessionRole::Member => "remote",
+                },
+                session.created_at,
+                (now.saturating_sub(session.created_at)) / 60
+            );
         }
         match crossterm::event::read()? {
-            crossterm::event::Event::Key(key) if key.kind == crossterm::event::KeyEventKind::Press => match key.code {
-                crossterm::event::KeyCode::Enter if !shown.is_empty() => break Ok((*shown[selected.min(shown.len() - 1)]).clone()),
-                crossterm::event::KeyCode::Up => selected = selected.saturating_sub(1),
-                crossterm::event::KeyCode::Down => selected = selected.saturating_add(1).min(shown.len().saturating_sub(1)),
-                crossterm::event::KeyCode::Backspace => { filter.pop(); selected = 0; }
-                crossterm::event::KeyCode::Char(character) => { filter.push(character); selected = 0; }
-                crossterm::event::KeyCode::Esc => break Err(CliError("resume cancelled").into()), _ => {}
-            }, _ => {}
+            crossterm::event::Event::Key(key)
+                if key.kind == crossterm::event::KeyEventKind::Press =>
+            {
+                match key.code {
+                    crossterm::event::KeyCode::Enter if !shown.is_empty() => {
+                        break Ok((*shown[selected.min(shown.len() - 1)]).clone());
+                    }
+                    crossterm::event::KeyCode::Up => selected = selected.saturating_sub(1),
+                    crossterm::event::KeyCode::Down => {
+                        selected = selected
+                            .saturating_add(1)
+                            .min(shown.len().saturating_sub(1))
+                    }
+                    crossterm::event::KeyCode::Backspace => {
+                        filter.pop();
+                        selected = 0;
+                    }
+                    crossterm::event::KeyCode::Char(character) => {
+                        filter.push(character);
+                        selected = 0;
+                    }
+                    crossterm::event::KeyCode::Esc => {
+                        break Err(CliError("resume cancelled").into());
+                    }
+                    _ => {}
+                }
+            }
+            _ => {}
         }
     };
     crossterm::terminal::disable_raw_mode()?;
@@ -334,22 +414,42 @@ pub(crate) fn launch_background_node(
     let store = crate::session_store::SessionStore::for_current_user()?;
     let id = crate::session_store::generate_id()?;
     let socket_path = store.socket_path(&id)?;
-    let descriptor = crate::session_store::SessionDescriptor::new(id.clone(), name, socket_path, 1, role);
-    let bootstrap = crate::node::NodeBootstrap { descriptor: descriptor.clone(), kind };
+    let descriptor =
+        crate::session_store::SessionDescriptor::new(id.clone(), name, socket_path, 1, role);
+    let bootstrap = crate::node::NodeBootstrap {
+        descriptor: descriptor.clone(),
+        kind,
+    };
     let bootstrap_path = descriptor.socket_path.with_extension("bootstrap");
     crate::node::write_bootstrap(&bootstrap_path, &bootstrap)?;
     let mut command = ProcessCommand::new(std::env::current_exe()?);
-    command.arg("__node").arg("--bootstrap").arg(&bootstrap_path).stdin(Stdio::null()).stdout(Stdio::null()).stderr(Stdio::null());
+    command
+        .arg("__node")
+        .arg("--bootstrap")
+        .arg(&bootstrap_path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
     #[cfg(unix)]
-    { use std::os::unix::process::CommandExt; command.process_group(0); }
+    {
+        use std::os::unix::process::CommandExt;
+        command.process_group(0);
+    }
     command.spawn()?;
     let deadline = Instant::now() + Duration::from_secs(5);
     while Instant::now() < deadline {
         if let Ok(found) = store.read(&id)
-            && std::os::unix::net::UnixStream::connect(&found.socket_path).is_ok() { return Ok(found); }
+            && found.socket_path.exists()
+        {
+            return Ok(found);
+        }
         std::thread::sleep(Duration::from_millis(25));
     }
-    Err(io::Error::new(io::ErrorKind::TimedOut, "background node did not become ready").into())
+    Err(io::Error::new(
+        io::ErrorKind::TimedOut,
+        "background node did not become ready",
+    )
+    .into())
 }
 
 fn resolve_display_name(override_name: Option<String>) -> Result<String, Box<dyn Error>> {
@@ -393,28 +493,16 @@ fn wait_for_enter() -> io::Result<()> {
 #[cfg(test)]
 mod tests {
     #[test]
-    fn create_releases_stdout_before_starting_the_host_tui() {
+    fn create_uses_the_background_node_and_socket_client() {
         let source = include_str!("cli.rs");
         let create_arm = source
-            .split_once("Command::Create { name } => {")
+            .split_once("Some(Command::Create { name, session_name }) => {")
             .expect("create arm")
             .1
-            .split_once("Command::Join { ticket, name } => {")
+            .split_once("Some(Command::Join { ticket, name }) => {")
             .expect("join arm")
             .0;
-
-        assert!(
-            create_arm
-                .find("drop(stdout);")
-                .expect("stdout is released")
-                < create_arm
-                    .find("SharedLayoutRuntime::host(")
-                    .expect("host TUI starts"),
-            "create must release stdout before the host TUI runs on a blocking thread"
-        );
-        assert!(
-            create_arm.contains("wait_for_enter()?"),
-            "create must pause so the join code can be copied before the TUI starts"
-        );
+        assert!(create_arm.contains("launch_background_node("));
+        assert!(create_arm.contains("crate::client::run(&descriptor)"));
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4,6 +4,8 @@ use std::{
     error::Error,
     io::{self, IsTerminal, Write},
     str::FromStr,
+    process::{Command as ProcessCommand, Stdio},
+    time::{Duration, Instant},
 };
 
 use clap::{Parser, Subcommand};
@@ -49,6 +51,8 @@ enum Command {
         #[command(subcommand)]
         command: ConfigCommand,
     },
+    #[command(hide = true)]
+    Node { #[arg(long)] bootstrap: std::path::PathBuf },
 }
 
 #[derive(Debug, Subcommand)]
@@ -81,6 +85,7 @@ pub async fn parse_and_run() -> Result<(), Box<dyn Error>> {
 
 async fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
     match cli.command {
+        Command::Node { bootstrap } => crate::node::run_background(crate::node::read_bootstrap(&bootstrap)?).await,
         Command::Local => crate::tui::run_local(),
         Command::Config { command } => match command {
             ConfigCommand::Set { key, value } if key == "name" => {
@@ -221,6 +226,34 @@ async fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
             Ok(())
         }
     }
+}
+
+/// Launches an isolated session owner. It has no terminal file descriptors and its own process
+/// group, so closing the initiating terminal cannot take the PTYs down with it.
+pub(crate) fn launch_background_node(
+    kind: crate::node::NodeBootstrapKind,
+    name: String,
+    role: crate::session_store::SessionRole,
+) -> Result<crate::session_store::SessionDescriptor, Box<dyn Error>> {
+    let store = crate::session_store::SessionStore::for_current_user()?;
+    let id = crate::session_store::generate_id()?;
+    let socket_path = store.socket_path(&id)?;
+    let descriptor = crate::session_store::SessionDescriptor::new(id.clone(), name, socket_path, 1, role);
+    let bootstrap = crate::node::NodeBootstrap { descriptor: descriptor.clone(), kind };
+    let bootstrap_path = descriptor.socket_path.with_extension("bootstrap");
+    crate::node::write_bootstrap(&bootstrap_path, &bootstrap)?;
+    let mut command = ProcessCommand::new(std::env::current_exe()?);
+    command.arg("__node").arg("--bootstrap").arg(&bootstrap_path).stdin(Stdio::null()).stdout(Stdio::null()).stderr(Stdio::null());
+    #[cfg(unix)]
+    { use std::os::unix::process::CommandExt; command.process_group(0); }
+    command.spawn()?;
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline {
+        if let Ok(found) = store.read(&id)
+            && std::os::unix::net::UnixStream::connect(&found.socket_path).is_ok() { return Ok(found); }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+    Err(io::Error::new(io::ErrorKind::TimedOut, "background node did not become ready").into())
 }
 
 fn resolve_display_name(override_name: Option<String>) -> Result<String, Box<dyn Error>> {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -108,6 +108,15 @@ async fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
             }
             let display_name = resolve_display_name(name)?;
             let (cols, rows) = crossterm::terminal::size()?;
+            let descriptor = launch_background_node(
+                crate::node::NodeBootstrapKind::Create { display_name: display_name.clone(), cols, rows },
+                crate::session_store::generate_name()?,
+                crate::session_store::SessionRole::Coordinator,
+            )?;
+            if std::env::var_os("P2PMUX_LEGACY_FOREGROUND").is_none() {
+                return crate::client::run(&descriptor);
+            }
+            let (cols, rows) = crossterm::terminal::size()?;
             let (shell_rows, shell_cols) = crate::tui::initial_root_pane_grid(cols, rows);
             let host = SharedLayoutHost::with_display_name(
                 HostSession::create().await?,
@@ -189,6 +198,15 @@ async fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
             }
             let ticket = resolve_join_ticket(&ticket)?;
             let display_name = resolve_display_name(name)?;
+            let (cols, rows) = crossterm::terminal::size()?;
+            let descriptor = launch_background_node(
+                crate::node::NodeBootstrapKind::Join { ticket: ticket.to_string(), display_name: display_name.clone(), cols, rows },
+                crate::session_store::generate_name()?,
+                crate::session_store::SessionRole::Member,
+            )?;
+            if std::env::var_os("P2PMUX_LEGACY_FOREGROUND").is_none() {
+                return crate::client::run(&descriptor);
+            }
             let transport = Transport::bind().await?;
             let mut member =
                 join_layout_with_display_name(transport, ticket.clone(), display_name).await?;

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,32 +1,39 @@
 //! Terminal-facing half of a local session attachment.
 
 use std::{
+    collections::BTreeMap,
     io::{self, BufRead, BufReader, Write},
     os::unix::net::UnixStream,
     time::Duration,
 };
 
 use crossterm::{
-    cursor,
-    event::{self, Event, KeyCode, KeyEventKind, KeyModifiers},
+    event::{
+        self, DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture,
+        Event, KeyCode, KeyEventKind, KeyModifiers, MouseEventKind,
+    },
     execute,
-    terminal::{self, Clear, ClearType, EnterAlternateScreen, LeaveAlternateScreen, SetTitle},
+    terminal::{self, EnterAlternateScreen, LeaveAlternateScreen, SetTitle},
 };
+use ratatui::{Terminal, TerminalOptions, Viewport, backend::CrosstermBackend, layout::Rect};
 
 use crate::{
     local_ipc::{ClientMessage, NodeMessage},
+    screen::GuestScreen,
     session_store::SessionDescriptor,
+    tui::{KeyHandling, MultiPaneTui, PaneViewState, render_multi_pane},
 };
 
 pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Error>> {
     let mut stream = UnixStream::connect(&descriptor.socket_path)?;
     let read_stream = stream.try_clone()?;
     let mut reader = BufReader::new(read_stream);
+    let (initial_cols, initial_rows) = terminal::size()?;
     write_message(
         &mut stream,
         &ClientMessage::Hello {
-            cols: terminal::size()?.0,
-            rows: terminal::size()?.1,
+            cols: initial_cols,
+            rows: initial_rows,
         },
     )?;
     let generation = match read_message(&mut reader)? {
@@ -36,37 +43,96 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
     };
     stream.set_nonblocking(true)?;
     let mut guard = ClientTerminalGuard::enter(&descriptor.name)?;
+    let backend = CrosstermBackend::new(io::stdout());
+    let mut terminal = Terminal::with_options(
+        backend,
+        TerminalOptions {
+            viewport: Viewport::Fixed(Rect::new(0, 0, initial_cols, initial_rows)),
+        },
+    )?;
+    let mut tui = None;
+    let mut screens = BTreeMap::new();
+    let mut dirty = false;
     let mut node_ended = false;
-    loop {
-        match read_message(&mut reader) {
-            Ok(Some(NodeMessage::Snapshot { screens, .. })) => {
-                draw(&descriptor.name, screens.as_str().unwrap_or_default())?
+
+    'attached: loop {
+        loop {
+            match read_message(&mut reader) {
+                Ok(Some(NodeMessage::Snapshot {
+                    room_name,
+                    layout,
+                    screens: next_screens,
+                    leases,
+                    tab_id,
+                    pane_id,
+                    ..
+                })) => {
+                    apply_snapshot(
+                        &mut tui,
+                        &mut screens,
+                        room_name,
+                        layout,
+                        next_screens,
+                        leases,
+                        tab_id,
+                        pane_id,
+                    )?;
+                    dirty = true;
+                }
+                Ok(Some(NodeMessage::Update { .. })) | Ok(Some(NodeMessage::Error { .. })) => {}
+                Ok(Some(_)) => {}
+                Ok(None) => {
+                    node_ended = true;
+                    break 'attached;
+                }
+                Err(error)
+                    if error.kind() == io::ErrorKind::WouldBlock
+                        || error.kind() == io::ErrorKind::TimedOut =>
+                {
+                    break;
+                }
+                Err(_) => {
+                    node_ended = true;
+                    break 'attached;
+                }
             }
-            Ok(Some(NodeMessage::Update { .. })) | Ok(Some(NodeMessage::Error { .. })) => {}
-            Ok(None) => {
-                node_ended = true;
-                break;
+        }
+        if dirty {
+            if let Some(tui) = tui.as_ref() {
+                terminal.draw(|frame| {
+                    let visible = screens
+                        .iter()
+                        .filter_map(|(pane_id, screen)| {
+                            screen.screen().map(|screen| (*pane_id, screen))
+                        })
+                        .collect();
+                    render_multi_pane(frame, tui, &visible);
+                })?;
             }
-            Err(error)
-                if error.kind() == io::ErrorKind::WouldBlock
-                    || error.kind() == io::ErrorKind::TimedOut => {}
-            Err(_) => {
-                node_ended = true;
-                break;
-            }
-            _ => {}
+            dirty = false;
         }
         if !event::poll(Duration::from_millis(16))? {
             continue;
         }
+        let Some(tui) = tui.as_mut() else {
+            continue;
+        };
         match event::read()? {
             Event::Key(key) if matches!(key.kind, KeyEventKind::Press | KeyEventKind::Repeat) => {
-                if key.code == KeyCode::Char('q') && key.modifiers == KeyModifiers::CONTROL {
-                    write_message(&mut stream, &ClientMessage::Detach { generation })?;
-                    break;
-                }
-                if let Some(bytes) = client_key_bytes(key.code, key.modifiers) {
-                    write_message(&mut stream, &ClientMessage::Input { bytes })?;
+                match tui.handle_key(key, terminal.size()?.into()) {
+                    KeyHandling::Quit => {
+                        write_message(&mut stream, &ClientMessage::Detach { generation })?;
+                        break;
+                    }
+                    KeyHandling::Consumed(intents) => {
+                        send_intents(&mut stream, tui, intents)?;
+                        dirty = true;
+                    }
+                    KeyHandling::Forward => {
+                        if let Some(bytes) = client_key_bytes(key.code, key.modifiers) {
+                            write_message(&mut stream, &ClientMessage::Input { bytes })?;
+                        }
+                    }
                 }
             }
             Event::Paste(text) => write_message(
@@ -75,8 +141,35 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
                     bytes: text.into_bytes(),
                 },
             )?,
+            Event::Mouse(mouse) => {
+                let area = terminal.size()?.into();
+                if matches!(
+                    mouse.kind,
+                    MouseEventKind::ScrollUp | MouseEventKind::ScrollDown
+                ) {
+                    let pane_id = tui.pane_at_or_focused_for_mouse(mouse.column, mouse.row, area);
+                    let scrollback_len = screens
+                        .get(&pane_id)
+                        .and_then(GuestScreen::screen)
+                        .map(available_scrollback)
+                        .unwrap_or_default();
+                    tui.scroll_mouse_pane(
+                        mouse.column,
+                        mouse.row,
+                        area,
+                        scrollback_len,
+                        matches!(mouse.kind, MouseEventKind::ScrollUp),
+                    );
+                } else {
+                    let intents = tui.handle_mouse(mouse, area);
+                    send_intents(&mut stream, tui, intents)?;
+                }
+                dirty = true;
+            }
             Event::Resize(cols, rows) => {
-                write_message(&mut stream, &ClientMessage::Resize { cols, rows })?
+                terminal.resize(Rect::new(0, 0, cols, rows))?;
+                write_message(&mut stream, &ClientMessage::Resize { cols, rows })?;
+                dirty = true;
             }
             _ => {}
         }
@@ -89,6 +182,72 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
             "Detached. Resume: p2pmux --resume  |  Attach: p2pmux attach {}  |  Kill: p2pmux kill {}",
             descriptor.name, descriptor.name
         );
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn apply_snapshot(
+    tui: &mut Option<MultiPaneTui>,
+    screens: &mut BTreeMap<u64, GuestScreen>,
+    room_name: String,
+    layout: crate::layout::LayoutSnapshot,
+    next_screens: Vec<crate::local_ipc::PaneScreenSnapshot>,
+    leases: Vec<crate::local_ipc::PaneLeaseSnapshot>,
+    tab_id: u64,
+    pane_id: u64,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let view = match tui {
+        Some(view) => {
+            view.apply_snapshot(layout)
+                .map_err(|error| io::Error::other(format!("invalid layout snapshot: {error:?}")))?;
+            view
+        }
+        None => tui
+            .insert(MultiPaneTui::new(layout).map_err(|error| {
+                io::Error::other(format!("invalid layout snapshot: {error:?}"))
+            })?),
+    };
+    view.set_title(format!("p2pmux ({room_name})"));
+    view.set_focus(tab_id, pane_id)
+        .map_err(|error| io::Error::other(format!("invalid node focus: {error:?}")))?;
+    screens.retain(|pane_id, _| view.snapshot().panes.contains_key(pane_id));
+    for frame in next_screens {
+        let screen = screens.entry(frame.pane_id).or_default();
+        screen.apply_snapshot(frame.sequence, &frame.snapshot)?;
+        screen.set_kitty_keyboard_active(frame.kitty_keyboard_active);
+    }
+    for lease in leases {
+        view.set_pane_view(
+            lease.pane_id,
+            PaneViewState::from_chrome(
+                lease.ready,
+                lease.controller_peer_id,
+                lease.controller_active,
+            ),
+        );
+    }
+    Ok(())
+}
+
+fn send_intents(
+    stream: &mut UnixStream,
+    tui: &MultiPaneTui,
+    intents: Vec<crate::tui::UiIntent>,
+) -> io::Result<()> {
+    for intent in intents {
+        match intent {
+            crate::tui::UiIntent::FocusPane { .. } | crate::tui::UiIntent::SwitchTab { .. } => {
+                write_message(
+                    stream,
+                    &ClientMessage::Focus {
+                        tab_id: tui.current_tab(),
+                        pane_id: tui.focused_pane(),
+                    },
+                )?;
+            }
+            intent => write_message(stream, &ClientMessage::StructuralIntent { intent })?,
+        }
     }
     Ok(())
 }
@@ -116,18 +275,12 @@ pub fn shutdown(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error
     Ok(())
 }
 
-fn draw(name: &str, screen: &str) -> io::Result<()> {
-    let mut stdout = io::stdout();
-    execute!(stdout, cursor::MoveTo(0, 0), Clear(ClearType::All))?;
-    writeln!(stdout, "p2pmux ({name})")?;
-    write!(stdout, "{screen}")?;
-    stdout.flush()
-}
 fn write_message(stream: &mut UnixStream, message: &ClientMessage) -> io::Result<()> {
     serde_json::to_writer(&mut *stream, message).map_err(io::Error::other)?;
     stream.write_all(b"\n")?;
     stream.flush()
 }
+
 fn read_message(reader: &mut BufReader<UnixStream>) -> io::Result<Option<NodeMessage>> {
     let mut line = String::new();
     match reader.read_line(&mut line) {
@@ -159,9 +312,17 @@ fn client_key_bytes(code: KeyCode, modifiers: KeyModifiers) -> Option<Vec<u8>> {
     }
 }
 
+fn available_scrollback(screen: &vt100::Screen) -> usize {
+    let mut screen = screen.clone();
+    screen.set_scrollback(crate::screen::SCROLLBACK_LINES);
+    screen.scrollback()
+}
+
 struct ClientTerminalGuard {
     raw: bool,
     alternate: bool,
+    paste: bool,
+    mouse: bool,
 }
 impl ClientTerminalGuard {
     fn enter(name: &str) -> io::Result<Self> {
@@ -169,14 +330,26 @@ impl ClientTerminalGuard {
         execute!(
             io::stdout(),
             SetTitle(format!("p2pmux ({name})")),
-            EnterAlternateScreen
+            EnterAlternateScreen,
+            EnableBracketedPaste,
+            EnableMouseCapture,
         )?;
         Ok(Self {
             raw: true,
             alternate: true,
+            paste: true,
+            mouse: true,
         })
     }
     fn leave(&mut self) -> io::Result<()> {
+        if self.mouse {
+            execute!(io::stdout(), DisableMouseCapture)?;
+            self.mouse = false;
+        }
+        if self.paste {
+            execute!(io::stdout(), DisableBracketedPaste)?;
+            self.paste = false;
+        }
         if self.alternate {
             execute!(io::stdout(), LeaveAlternateScreen)?;
             self.alternate = false;

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,16 +1,34 @@
 //! Terminal-facing half of a local session attachment.
 
-use std::{io::{self, BufRead, BufReader, Write}, os::unix::net::UnixStream, time::Duration};
+use std::{
+    io::{self, BufRead, BufReader, Write},
+    os::unix::net::UnixStream,
+    time::Duration,
+};
 
-use crossterm::{cursor, event::{self, Event, KeyCode, KeyEventKind, KeyModifiers}, execute, terminal::{self, Clear, ClearType, EnterAlternateScreen, LeaveAlternateScreen, SetTitle}};
+use crossterm::{
+    cursor,
+    event::{self, Event, KeyCode, KeyEventKind, KeyModifiers},
+    execute,
+    terminal::{self, Clear, ClearType, EnterAlternateScreen, LeaveAlternateScreen, SetTitle},
+};
 
-use crate::{local_ipc::{ClientMessage, NodeMessage}, session_store::SessionDescriptor};
+use crate::{
+    local_ipc::{ClientMessage, NodeMessage},
+    session_store::SessionDescriptor,
+};
 
 pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Error>> {
     let mut stream = UnixStream::connect(&descriptor.socket_path)?;
     let read_stream = stream.try_clone()?;
     let mut reader = BufReader::new(read_stream);
-    write_message(&mut stream, &ClientMessage::Hello { cols: terminal::size()?.0, rows: terminal::size()?.1 })?;
+    write_message(
+        &mut stream,
+        &ClientMessage::Hello {
+            cols: terminal::size()?.0,
+            rows: terminal::size()?.1,
+        },
+    )?;
     let generation = match read_message(&mut reader)? {
         Some(NodeMessage::AttachAccepted { generation }) => generation,
         Some(NodeMessage::AttachRejected { reason }) => return Err(io::Error::other(reason).into()),
@@ -21,30 +39,57 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
     let mut node_ended = false;
     loop {
         match read_message(&mut reader) {
-            Ok(Some(NodeMessage::Snapshot { screens, .. })) => draw(&descriptor.name, screens.as_str().unwrap_or_default())?,
+            Ok(Some(NodeMessage::Snapshot { screens, .. })) => {
+                draw(&descriptor.name, screens.as_str().unwrap_or_default())?
+            }
             Ok(Some(NodeMessage::Update { .. })) | Ok(Some(NodeMessage::Error { .. })) => {}
-            Ok(None) => { node_ended = true; break; }
-            Err(error) if error.kind() == io::ErrorKind::WouldBlock => {}
-            Err(_) => { node_ended = true; break; }
+            Ok(None) => {
+                node_ended = true;
+                break;
+            }
+            Err(error)
+                if error.kind() == io::ErrorKind::WouldBlock
+                    || error.kind() == io::ErrorKind::TimedOut => {}
+            Err(_) => {
+                node_ended = true;
+                break;
+            }
             _ => {}
         }
-        if !event::poll(Duration::from_millis(16))? { continue; }
+        if !event::poll(Duration::from_millis(16))? {
+            continue;
+        }
         match event::read()? {
             Event::Key(key) if matches!(key.kind, KeyEventKind::Press | KeyEventKind::Repeat) => {
                 if key.code == KeyCode::Char('q') && key.modifiers == KeyModifiers::CONTROL {
                     write_message(&mut stream, &ClientMessage::Detach { generation })?;
                     break;
                 }
-                if let Some(bytes) = client_key_bytes(key.code, key.modifiers) { write_message(&mut stream, &ClientMessage::Input { bytes })?; }
+                if let Some(bytes) = client_key_bytes(key.code, key.modifiers) {
+                    write_message(&mut stream, &ClientMessage::Input { bytes })?;
+                }
             }
-            Event::Paste(text) => write_message(&mut stream, &ClientMessage::Input { bytes: text.into_bytes() })?,
-            Event::Resize(cols, rows) => write_message(&mut stream, &ClientMessage::Resize { cols, rows })?,
+            Event::Paste(text) => write_message(
+                &mut stream,
+                &ClientMessage::Input {
+                    bytes: text.into_bytes(),
+                },
+            )?,
+            Event::Resize(cols, rows) => {
+                write_message(&mut stream, &ClientMessage::Resize { cols, rows })?
+            }
             _ => {}
         }
     }
     guard.leave()?;
-    if node_ended { println!("p2pmux node ended"); }
-    else { println!("Detached. Resume: p2pmux --resume  |  Attach: p2pmux attach {}  |  Kill: p2pmux kill {}", descriptor.name, descriptor.name); }
+    if node_ended {
+        println!("p2pmux node ended");
+    } else {
+        println!(
+            "Detached. Resume: p2pmux --resume  |  Attach: p2pmux attach {}  |  Kill: p2pmux kill {}",
+            descriptor.name, descriptor.name
+        );
+    }
     Ok(())
 }
 
@@ -58,30 +103,109 @@ pub fn shutdown(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error
         _ => return Err(io::Error::other("node did not accept attachment").into()),
     };
     write_message(&mut stream, &ClientMessage::Shutdown { generation })?;
+    stream.set_read_timeout(Some(Duration::from_secs(1)))?;
+    loop {
+        match read_message(&mut reader)? {
+            Some(NodeMessage::ShutdownAck { generation: ack }) if ack == generation => break,
+            Some(_) => continue,
+            None => {
+                return Err(io::Error::other("node closed before shutdown acknowledgement").into());
+            }
+        }
+    }
     Ok(())
 }
 
 fn draw(name: &str, screen: &str) -> io::Result<()> {
-    let mut stdout = io::stdout(); execute!(stdout, cursor::MoveTo(0, 0), Clear(ClearType::All))?;
-    writeln!(stdout, "p2pmux ({name})")?; write!(stdout, "{screen}")?; stdout.flush()
+    let mut stdout = io::stdout();
+    execute!(stdout, cursor::MoveTo(0, 0), Clear(ClearType::All))?;
+    writeln!(stdout, "p2pmux ({name})")?;
+    write!(stdout, "{screen}")?;
+    stdout.flush()
 }
-fn write_message(stream: &mut UnixStream, message: &ClientMessage) -> io::Result<()> { serde_json::to_writer(&mut *stream, message).map_err(io::Error::other)?; stream.write_all(b"\n")?; stream.flush() }
-fn read_message(reader: &mut BufReader<UnixStream>) -> io::Result<Option<NodeMessage>> { let mut line = String::new(); match reader.read_line(&mut line) { Ok(0) => Ok(None), Ok(_) => serde_json::from_str(&line).map(Some).map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "invalid node message")), Err(error) => Err(error) } }
-
-fn client_key_bytes(code: KeyCode, modifiers: KeyModifiers) -> Option<Vec<u8>> {
-    match code {
-        KeyCode::Char(character) if modifiers.contains(KeyModifiers::CONTROL) && character.is_ascii_alphabetic() => Some(vec![character.to_ascii_lowercase() as u8 - b'a' + 1]),
-        KeyCode::Char(character) => Some(character.to_string().into_bytes()), KeyCode::Enter => Some(b"\r".to_vec()), KeyCode::Backspace => Some(b"\x7f".to_vec()), KeyCode::Tab => Some(b"\t".to_vec()), KeyCode::Esc => Some(b"\x1b".to_vec()),
-        KeyCode::Up => Some(b"\x1b[A".to_vec()), KeyCode::Down => Some(b"\x1b[B".to_vec()), KeyCode::Left => Some(b"\x1b[D".to_vec()), KeyCode::Right => Some(b"\x1b[C".to_vec()), _ => None,
+fn write_message(stream: &mut UnixStream, message: &ClientMessage) -> io::Result<()> {
+    serde_json::to_writer(&mut *stream, message).map_err(io::Error::other)?;
+    stream.write_all(b"\n")?;
+    stream.flush()
+}
+fn read_message(reader: &mut BufReader<UnixStream>) -> io::Result<Option<NodeMessage>> {
+    let mut line = String::new();
+    match reader.read_line(&mut line) {
+        Ok(0) => Ok(None),
+        Ok(_) => serde_json::from_str(&line)
+            .map(Some)
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "invalid node message")),
+        Err(error) => Err(error),
     }
 }
 
-struct ClientTerminalGuard { raw: bool, alternate: bool }
-impl ClientTerminalGuard {
-    fn enter(name: &str) -> io::Result<Self> { terminal::enable_raw_mode()?; execute!(io::stdout(), SetTitle(format!("p2pmux ({name})")), EnterAlternateScreen)?; Ok(Self { raw: true, alternate: true }) }
-    fn leave(&mut self) -> io::Result<()> { if self.alternate { execute!(io::stdout(), LeaveAlternateScreen)?; self.alternate = false; } if self.raw { terminal::disable_raw_mode()?; self.raw = false; } Ok(()) }
+fn client_key_bytes(code: KeyCode, modifiers: KeyModifiers) -> Option<Vec<u8>> {
+    match code {
+        KeyCode::Char(character)
+            if modifiers.contains(KeyModifiers::CONTROL) && character.is_ascii_alphabetic() =>
+        {
+            Some(vec![character.to_ascii_lowercase() as u8 - b'a' + 1])
+        }
+        KeyCode::Char(character) => Some(character.to_string().into_bytes()),
+        KeyCode::Enter => Some(b"\r".to_vec()),
+        KeyCode::Backspace => Some(b"\x7f".to_vec()),
+        KeyCode::Tab => Some(b"\t".to_vec()),
+        KeyCode::Esc => Some(b"\x1b".to_vec()),
+        KeyCode::Up => Some(b"\x1b[A".to_vec()),
+        KeyCode::Down => Some(b"\x1b[B".to_vec()),
+        KeyCode::Left => Some(b"\x1b[D".to_vec()),
+        KeyCode::Right => Some(b"\x1b[C".to_vec()),
+        _ => None,
+    }
 }
-impl Drop for ClientTerminalGuard { fn drop(&mut self) { let _ = self.leave(); } }
+
+struct ClientTerminalGuard {
+    raw: bool,
+    alternate: bool,
+}
+impl ClientTerminalGuard {
+    fn enter(name: &str) -> io::Result<Self> {
+        terminal::enable_raw_mode()?;
+        execute!(
+            io::stdout(),
+            SetTitle(format!("p2pmux ({name})")),
+            EnterAlternateScreen
+        )?;
+        Ok(Self {
+            raw: true,
+            alternate: true,
+        })
+    }
+    fn leave(&mut self) -> io::Result<()> {
+        if self.alternate {
+            execute!(io::stdout(), LeaveAlternateScreen)?;
+            self.alternate = false;
+        }
+        if self.raw {
+            terminal::disable_raw_mode()?;
+            self.raw = false;
+        }
+        Ok(())
+    }
+}
+impl Drop for ClientTerminalGuard {
+    fn drop(&mut self) {
+        let _ = self.leave();
+    }
+}
 
 #[cfg(test)]
-mod tests { use super::*; #[test] fn ctrl_q_is_reserved_for_detach() { assert_eq!(client_key_bytes(KeyCode::Char('c'), KeyModifiers::CONTROL), Some(vec![3])); assert_eq!(client_key_bytes(KeyCode::Char('q'), KeyModifiers::CONTROL), Some(vec![17])); } }
+mod tests {
+    use super::*;
+    #[test]
+    fn ctrl_q_is_reserved_for_detach() {
+        assert_eq!(
+            client_key_bytes(KeyCode::Char('c'), KeyModifiers::CONTROL),
+            Some(vec![3])
+        );
+        assert_eq!(
+            client_key_bytes(KeyCode::Char('q'), KeyModifiers::CONTROL),
+            Some(vec![17])
+        );
+    }
+}

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,0 +1,74 @@
+//! Terminal-facing half of a local session attachment.
+
+use std::{io::{self, BufRead, BufReader, Write}, os::unix::net::UnixStream, time::Duration};
+
+use crossterm::{cursor, event::{self, Event, KeyCode, KeyEventKind, KeyModifiers}, execute, terminal::{self, Clear, ClearType, EnterAlternateScreen, LeaveAlternateScreen, SetTitle}};
+
+use crate::{local_ipc::{ClientMessage, NodeMessage}, session_store::SessionDescriptor};
+
+pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Error>> {
+    let mut stream = UnixStream::connect(&descriptor.socket_path)?;
+    let read_stream = stream.try_clone()?;
+    let mut reader = BufReader::new(read_stream);
+    write_message(&mut stream, &ClientMessage::Hello { cols: terminal::size()?.0, rows: terminal::size()?.1 })?;
+    let generation = match read_message(&mut reader)? {
+        Some(NodeMessage::AttachAccepted { generation }) => generation,
+        Some(NodeMessage::AttachRejected { reason }) => return Err(io::Error::other(reason).into()),
+        _ => return Err(io::Error::other("node did not accept attachment").into()),
+    };
+    stream.set_nonblocking(true)?;
+    let mut guard = ClientTerminalGuard::enter(&descriptor.name)?;
+    let mut node_ended = false;
+    loop {
+        match read_message(&mut reader) {
+            Ok(Some(NodeMessage::Snapshot { screens, .. })) => draw(&descriptor.name, screens.as_str().unwrap_or_default())?,
+            Ok(Some(NodeMessage::Update { .. })) | Ok(Some(NodeMessage::Error { .. })) => {}
+            Ok(None) => { node_ended = true; break; }
+            Err(error) if error.kind() == io::ErrorKind::WouldBlock => {}
+            Err(_) => { node_ended = true; break; }
+            _ => {}
+        }
+        if !event::poll(Duration::from_millis(16))? { continue; }
+        match event::read()? {
+            Event::Key(key) if matches!(key.kind, KeyEventKind::Press | KeyEventKind::Repeat) => {
+                if key.code == KeyCode::Char('q') && key.modifiers == KeyModifiers::CONTROL {
+                    write_message(&mut stream, &ClientMessage::Detach { generation })?;
+                    break;
+                }
+                if let Some(bytes) = client_key_bytes(key.code, key.modifiers) { write_message(&mut stream, &ClientMessage::Input { bytes })?; }
+            }
+            Event::Paste(text) => write_message(&mut stream, &ClientMessage::Input { bytes: text.into_bytes() })?,
+            Event::Resize(cols, rows) => write_message(&mut stream, &ClientMessage::Resize { cols, rows })?,
+            _ => {}
+        }
+    }
+    guard.leave()?;
+    if node_ended { println!("p2pmux node ended"); }
+    else { println!("Detached. Resume: p2pmux --resume  |  Attach: p2pmux attach {}  |  Kill: p2pmux kill {}", descriptor.name, descriptor.name); }
+    Ok(())
+}
+
+fn draw(name: &str, screen: &str) -> io::Result<()> {
+    let mut stdout = io::stdout(); execute!(stdout, cursor::MoveTo(0, 0), Clear(ClearType::All))?;
+    writeln!(stdout, "p2pmux ({name})")?; write!(stdout, "{screen}")?; stdout.flush()
+}
+fn write_message(stream: &mut UnixStream, message: &ClientMessage) -> io::Result<()> { serde_json::to_writer(&mut *stream, message).map_err(io::Error::other)?; stream.write_all(b"\n")?; stream.flush() }
+fn read_message(reader: &mut BufReader<UnixStream>) -> io::Result<Option<NodeMessage>> { let mut line = String::new(); match reader.read_line(&mut line) { Ok(0) => Ok(None), Ok(_) => serde_json::from_str(&line).map(Some).map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "invalid node message")), Err(error) => Err(error) } }
+
+fn client_key_bytes(code: KeyCode, modifiers: KeyModifiers) -> Option<Vec<u8>> {
+    match code {
+        KeyCode::Char(character) if modifiers.contains(KeyModifiers::CONTROL) && character.is_ascii_alphabetic() => Some(vec![character.to_ascii_lowercase() as u8 - b'a' + 1]),
+        KeyCode::Char(character) => Some(character.to_string().into_bytes()), KeyCode::Enter => Some(b"\r".to_vec()), KeyCode::Backspace => Some(b"\x7f".to_vec()), KeyCode::Tab => Some(b"\t".to_vec()), KeyCode::Esc => Some(b"\x1b".to_vec()),
+        KeyCode::Up => Some(b"\x1b[A".to_vec()), KeyCode::Down => Some(b"\x1b[B".to_vec()), KeyCode::Left => Some(b"\x1b[D".to_vec()), KeyCode::Right => Some(b"\x1b[C".to_vec()), _ => None,
+    }
+}
+
+struct ClientTerminalGuard { raw: bool, alternate: bool }
+impl ClientTerminalGuard {
+    fn enter(name: &str) -> io::Result<Self> { terminal::enable_raw_mode()?; execute!(io::stdout(), SetTitle(format!("p2pmux ({name})")), EnterAlternateScreen)?; Ok(Self { raw: true, alternate: true }) }
+    fn leave(&mut self) -> io::Result<()> { if self.alternate { execute!(io::stdout(), LeaveAlternateScreen)?; self.alternate = false; } if self.raw { terminal::disable_raw_mode()?; self.raw = false; } Ok(()) }
+}
+impl Drop for ClientTerminalGuard { fn drop(&mut self) { let _ = self.leave(); } }
+
+#[cfg(test)]
+mod tests { use super::*; #[test] fn ctrl_q_is_reserved_for_detach() { assert_eq!(client_key_bytes(KeyCode::Char('c'), KeyModifiers::CONTROL), Some(vec![3])); assert_eq!(client_key_bytes(KeyCode::Char('q'), KeyModifiers::CONTROL), Some(vec![17])); } }

--- a/src/client.rs
+++ b/src/client.rs
@@ -3,7 +3,10 @@
 use std::{
     collections::BTreeMap,
     io::{self, BufRead, BufReader, Write},
+    net::Shutdown,
     os::unix::net::UnixStream,
+    sync::mpsc::{self, Receiver, TryRecvError},
+    thread,
     time::Duration,
 };
 
@@ -41,7 +44,7 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
         Some(NodeMessage::AttachRejected { reason }) => return Err(io::Error::other(reason).into()),
         _ => return Err(io::Error::other("node did not accept attachment").into()),
     };
-    stream.set_nonblocking(true)?;
+    let (messages, reader_thread) = spawn_message_reader(reader);
     let mut guard = ClientTerminalGuard::enter(&descriptor.name)?;
     let backend = CrosstermBackend::new(io::stdout());
     let mut terminal = Terminal::with_options(
@@ -54,11 +57,13 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
     let mut screens = BTreeMap::new();
     let mut dirty = false;
     let mut node_ended = false;
+    let mut attach_error = None;
+    let mut detach_sent = false;
 
     'attached: loop {
         loop {
-            match read_message(&mut reader) {
-                Ok(Some(NodeMessage::Snapshot {
+            match messages.try_recv() {
+                Ok(ReaderEvent::Message(NodeMessage::Snapshot {
                     room_name,
                     layout,
                     screens: next_screens,
@@ -79,22 +84,23 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
                     )?;
                     dirty = true;
                 }
-                Ok(Some(NodeMessage::Update { .. })) | Ok(Some(NodeMessage::Error { .. })) => {}
-                Ok(Some(_)) => {}
-                Ok(None) => {
+                Ok(ReaderEvent::Message(NodeMessage::Update { .. }))
+                | Ok(ReaderEvent::Message(NodeMessage::Error { .. }))
+                | Ok(ReaderEvent::Message(_)) => {}
+                Ok(ReaderEvent::Ended) | Err(TryRecvError::Disconnected) => {
                     node_ended = true;
                     break 'attached;
                 }
-                Err(error)
-                    if error.kind() == io::ErrorKind::WouldBlock
-                        || error.kind() == io::ErrorKind::TimedOut =>
-                {
-                    break;
+                Ok(ReaderEvent::DecodeError(error)) => {
+                    attach_error = Some(error);
+                    break 'attached;
                 }
-                Err(_) => {
+                Ok(ReaderEvent::ReadError(error)) => {
+                    attach_error = Some(error);
                     node_ended = true;
                     break 'attached;
                 }
+                Err(TryRecvError::Empty) => break,
             }
         }
         if dirty {
@@ -122,6 +128,7 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
                 match tui.handle_key(key, terminal.size()?.into()) {
                     KeyHandling::Quit => {
                         write_message(&mut stream, &ClientMessage::Detach { generation })?;
+                        detach_sent = true;
                         break;
                     }
                     KeyHandling::Consumed(intents) => {
@@ -174,7 +181,15 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
             _ => {}
         }
     }
+    if !node_ended && !detach_sent {
+        let _ = write_message(&mut stream, &ClientMessage::Detach { generation });
+    }
+    let _ = stream.shutdown(Shutdown::Both);
+    let _ = reader_thread.join();
     guard.leave()?;
+    if let Some(error) = attach_error {
+        eprintln!("p2pmux attach error: {error}");
+    }
     if node_ended {
         println!("p2pmux node ended");
     } else {
@@ -255,17 +270,13 @@ fn send_intents(
 pub fn shutdown(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Error>> {
     let mut stream = UnixStream::connect(&descriptor.socket_path)?;
     let mut reader = BufReader::new(stream.try_clone()?);
-    write_message(&mut stream, &ClientMessage::Hello { cols: 0, rows: 0 })?;
-    let generation = match read_message(&mut reader)? {
-        Some(NodeMessage::AttachAccepted { generation }) => generation,
-        Some(NodeMessage::AttachRejected { reason }) => return Err(io::Error::other(reason).into()),
-        _ => return Err(io::Error::other("node did not accept attachment").into()),
-    };
-    write_message(&mut stream, &ClientMessage::Shutdown { generation })?;
+    // Shutdown is a control request, not an interactive attachment.  It must still work while a
+    // stale or live client holds the single-attachment gate.
+    write_message(&mut stream, &ClientMessage::Shutdown { generation: 0 })?;
     stream.set_read_timeout(Some(Duration::from_secs(1)))?;
     loop {
         match read_message(&mut reader)? {
-            Some(NodeMessage::ShutdownAck { generation: ack }) if ack == generation => break,
+            Some(NodeMessage::ShutdownAck { generation: 0 }) => break,
             Some(_) => continue,
             None => {
                 return Err(io::Error::other("node closed before shutdown acknowledgement").into());
@@ -281,15 +292,61 @@ fn write_message(stream: &mut UnixStream, message: &ClientMessage) -> io::Result
     stream.flush()
 }
 
-fn read_message(reader: &mut BufReader<UnixStream>) -> io::Result<Option<NodeMessage>> {
+/// Reads one complete newline-delimited local IPC frame.  This deliberately stays blocking: a
+/// Snapshot can be much larger than a single Unix-socket read.
+pub fn read_message(reader: &mut BufReader<UnixStream>) -> io::Result<Option<NodeMessage>> {
     let mut line = String::new();
     match reader.read_line(&mut line) {
         Ok(0) => Ok(None),
-        Ok(_) => serde_json::from_str(&line)
-            .map(Some)
-            .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "invalid node message")),
+        Ok(_) => serde_json::from_str(&line).map(Some).map_err(|error| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("invalid node message: {error}"),
+            )
+        }),
         Err(error) => Err(error),
     }
+}
+
+enum ReaderEvent {
+    Message(NodeMessage),
+    DecodeError(String),
+    ReadError(String),
+    Ended,
+}
+
+fn spawn_message_reader(
+    mut reader: BufReader<UnixStream>,
+) -> (Receiver<ReaderEvent>, thread::JoinHandle<()>) {
+    let (sender, receiver) = mpsc::channel();
+    let thread = thread::spawn(move || {
+        loop {
+            match read_message(&mut reader) {
+                Ok(Some(message)) => {
+                    if sender.send(ReaderEvent::Message(message)).is_err() {
+                        return;
+                    }
+                }
+                Ok(None) => {
+                    let _ = sender.send(ReaderEvent::Ended);
+                    return;
+                }
+                Err(error) if error.kind() == io::ErrorKind::InvalidData => {
+                    if sender
+                        .send(ReaderEvent::DecodeError(error.to_string()))
+                        .is_err()
+                    {
+                        return;
+                    }
+                }
+                Err(error) => {
+                    let _ = sender.send(ReaderEvent::ReadError(error.to_string()));
+                    return;
+                }
+            }
+        }
+    });
+    (receiver, thread)
 }
 
 fn client_key_bytes(code: KeyCode, modifiers: KeyModifiers) -> Option<Vec<u8>> {

--- a/src/client.rs
+++ b/src/client.rs
@@ -63,30 +63,30 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
     'attached: loop {
         loop {
             match messages.try_recv() {
-                Ok(ReaderEvent::Message(NodeMessage::Snapshot {
-                    room_name,
-                    layout,
-                    screens: next_screens,
-                    leases,
-                    tab_id,
-                    pane_id,
-                    ..
-                })) => {
-                    apply_snapshot(
-                        &mut tui,
-                        &mut screens,
+                Ok(ReaderEvent::Message(message)) => {
+                    if let NodeMessage::Snapshot {
                         room_name,
                         layout,
-                        next_screens,
+                        screens: next_screens,
                         leases,
                         tab_id,
                         pane_id,
-                    )?;
-                    dirty = true;
+                        ..
+                    } = *message
+                    {
+                        apply_snapshot(
+                            &mut tui,
+                            &mut screens,
+                            room_name,
+                            *layout,
+                            next_screens,
+                            leases,
+                            tab_id,
+                            pane_id,
+                        )?;
+                        dirty = true;
+                    }
                 }
-                Ok(ReaderEvent::Message(NodeMessage::Update { .. }))
-                | Ok(ReaderEvent::Message(NodeMessage::Error { .. }))
-                | Ok(ReaderEvent::Message(_)) => {}
                 Ok(ReaderEvent::Ended) | Err(TryRecvError::Disconnected) => {
                     node_ended = true;
                     break 'attached;
@@ -309,7 +309,7 @@ pub fn read_message(reader: &mut BufReader<UnixStream>) -> io::Result<Option<Nod
 }
 
 enum ReaderEvent {
-    Message(NodeMessage),
+    Message(Box<NodeMessage>),
     DecodeError(String),
     ReadError(String),
     Ended,
@@ -323,7 +323,10 @@ fn spawn_message_reader(
         loop {
             match read_message(&mut reader) {
                 Ok(Some(message)) => {
-                    if sender.send(ReaderEvent::Message(message)).is_err() {
+                    if sender
+                        .send(ReaderEvent::Message(Box::new(message)))
+                        .is_err()
+                    {
                         return;
                     }
                 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -48,6 +48,19 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
     Ok(())
 }
 
+pub fn shutdown(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Error>> {
+    let mut stream = UnixStream::connect(&descriptor.socket_path)?;
+    let mut reader = BufReader::new(stream.try_clone()?);
+    write_message(&mut stream, &ClientMessage::Hello { cols: 0, rows: 0 })?;
+    let generation = match read_message(&mut reader)? {
+        Some(NodeMessage::AttachAccepted { generation }) => generation,
+        Some(NodeMessage::AttachRejected { reason }) => return Err(io::Error::other(reason).into()),
+        _ => return Err(io::Error::other("node did not accept attachment").into()),
+    };
+    write_message(&mut stream, &ClientMessage::Shutdown { generation })?;
+    Ok(())
+}
+
 fn draw(name: &str, screen: &str) -> io::Result<()> {
     let mut stdout = io::stdout(); execute!(stdout, cursor::MoveTo(0, 0), Clear(ClearType::All))?;
     writeln!(stdout, "p2pmux ({name})")?; write!(stdout, "{screen}")?; stdout.flush()

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -1,5 +1,32 @@
 use std::collections::{BTreeMap, BTreeSet};
 
+use serde::{Deserialize, Serialize};
+
+mod pane_map {
+    use std::collections::BTreeMap;
+
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    use super::{Pane, PaneId};
+
+    pub fn serialize<S>(panes: &BTreeMap<PaneId, Pane>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        panes.values().collect::<Vec<_>>().serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<BTreeMap<PaneId, Pane>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(Vec::<Pane>::deserialize(deserializer)?
+            .into_iter()
+            .map(|pane| (pane.pane_id, pane))
+            .collect())
+    }
+}
+
 pub const MAX_MEMBERS: usize = 8;
 pub const MAX_TABS: usize = 9;
 pub const MAX_PANES_PER_TAB: usize = 8;
@@ -16,20 +43,23 @@ pub type PaneId = u64;
 pub type TabId = u64;
 pub type ReservationId = u64;
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum Axis {
     LeftRight,
     TopBottom,
 }
 
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum NewPanePosition {
     First,
     #[default]
     Second,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
 pub enum Node {
     Leaf {
         pane_id: PaneId,
@@ -42,14 +72,14 @@ pub enum Node {
     },
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Member {
     pub peer_id: Vec<u8>,
     pub endpoint_addr: Vec<u8>,
     pub display_name: String,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Pane {
     pub pane_id: PaneId,
     pub host_peer_id: Vec<u8>,
@@ -57,17 +87,18 @@ pub struct Pane {
     pub grid_cols: u16,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Tab {
     pub tab_id: TabId,
     pub root: Node,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct LayoutSnapshot {
     pub revision: u64,
     pub members: Vec<Member>,
     pub tabs: Vec<Tab>,
+    #[serde(with = "pane_map")]
     pub panes: BTreeMap<PaneId, Pane>,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod kitty_keyboard;
 pub mod layout;
 pub mod lease;
 pub mod local_ipc;
+pub mod node;
 pub mod protocol;
 pub mod pty_host;
 pub mod rendezvous;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod config;
 pub mod kitty_keyboard;
 pub mod layout;
 pub mod lease;
+pub mod local_ipc;
 pub mod protocol;
 pub mod pty_host;
 pub mod rendezvous;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub mod protocol;
 pub mod pty_host;
 pub mod rendezvous;
 pub mod screen;
+pub mod session_store;
 pub mod session;
 pub mod ticket;
 pub mod transport;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
 #![forbid(unsafe_code)]
 
 pub mod agent_detect;
-pub mod client;
 pub mod cli;
+pub mod client;
 pub mod config;
 pub mod kitty_keyboard;
 pub mod layout;
@@ -13,8 +13,8 @@ pub mod protocol;
 pub mod pty_host;
 pub mod rendezvous;
 pub mod screen;
-pub mod session_store;
 pub mod session;
+pub mod session_store;
 pub mod ticket;
 pub mod transport;
 pub mod tui;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![forbid(unsafe_code)]
 
 pub mod agent_detect;
+pub mod client;
 pub mod cli;
 pub mod config;
 pub mod kitty_keyboard;

--- a/src/local_ipc.rs
+++ b/src/local_ipc.rs
@@ -1,0 +1,103 @@
+//! Local node/client protocol. This is deliberately separate from the peer Iroh protocol.
+
+use std::{io, sync::{Arc, Mutex}};
+
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use tokio::{io::{AsyncBufReadExt, AsyncWriteExt, BufReader}, net::UnixStream, sync::mpsc};
+
+const MAX_FRAME: usize = 1024 * 1024;
+pub const OUTBOUND_QUEUE: usize = 64;
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ClientMessage {
+    Hello { cols: u16, rows: u16 },
+    Input { bytes: Vec<u8> },
+    StructuralIntent { intent: serde_json::Value },
+    Resize { cols: u16, rows: u16 },
+    Focus { tab_id: u64, pane_id: u64 },
+    Detach { generation: u64 },
+    Rename { name: String },
+    Shutdown { generation: u64 },
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum NodeMessage {
+    AttachAccepted { generation: u64 },
+    AttachRejected { reason: String },
+    Snapshot { room_name: String, role: String, summary: SessionSummary, layout: serde_json::Value, screens: serde_json::Value, leases: serde_json::Value, rosters: serde_json::Value, tab_id: u64, pane_id: u64 },
+    Update { state: serde_json::Value },
+    DetachAck { generation: u64 },
+    ShutdownAck { generation: u64 },
+    Error { message: String },
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+pub struct SessionSummary { pub tabs: u32, pub panes: u32, pub hosts: u32, pub coordinator_name: String }
+
+/// Single-client gate. A generation makes delayed disconnects harmless after a reattach.
+#[derive(Clone, Default)]
+pub struct AttachmentGate(Arc<Mutex<AttachmentState>>);
+#[derive(Default)]
+struct AttachmentState { generation: u64, attached: bool }
+
+impl AttachmentGate {
+    pub fn attach(&self) -> Result<u64, &'static str> {
+        let mut state = self.0.lock().expect("attachment gate poisoned");
+        if state.attached { return Err("already attached"); }
+        state.generation = state.generation.saturating_add(1).max(1);
+        state.attached = true;
+        Ok(state.generation)
+    }
+    pub fn detach(&self, generation: u64) -> bool {
+        let mut state = self.0.lock().expect("attachment gate poisoned");
+        if state.attached && state.generation == generation { state.attached = false; true } else { false }
+    }
+}
+
+pub async fn send<T: Serialize>(writer: &mut tokio::net::unix::OwnedWriteHalf, message: &T) -> io::Result<()> {
+    let mut bytes = serde_json::to_vec(message).map_err(io::Error::other)?;
+    bytes.push(b'\n');
+    writer.write_all(&bytes).await
+}
+
+pub async fn receive<T: DeserializeOwned>(reader: &mut BufReader<tokio::net::unix::OwnedReadHalf>) -> io::Result<Option<T>> {
+    let mut bytes = Vec::new();
+    let count = reader.read_until(b'\n', &mut bytes).await?;
+    if count == 0 { return Ok(None); }
+    if count > MAX_FRAME { return Err(io::Error::new(io::ErrorKind::InvalidData, "local IPC frame too large")); }
+    serde_json::from_slice(&bytes).map(Some).map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "invalid local IPC message"))
+}
+
+pub fn bounded_outbound() -> (mpsc::Sender<NodeMessage>, mpsc::Receiver<NodeMessage>) { mpsc::channel(OUTBOUND_QUEUE) }
+
+pub async fn split(stream: UnixStream) -> (BufReader<tokio::net::unix::OwnedReadHalf>, tokio::net::unix::OwnedWriteHalf) {
+    let (read, write) = stream.into_split(); (BufReader::new(read), write)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::{net::UnixListener, time::{timeout, Duration}};
+
+    #[tokio::test]
+    async fn messages_round_trip_and_gate_refuses_second_client() {
+        let path = std::env::temp_dir().join(format!("p2pmux-ipc-{}.sock", std::process::id()));
+        let _ = std::fs::remove_file(&path);
+        let listener = UnixListener::bind(&path).unwrap();
+        let gate = AttachmentGate::default(); let gate_for_task = gate.clone();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap(); let (mut reader, mut writer) = split(stream).await;
+            assert_eq!(receive::<ClientMessage>(&mut reader).await.unwrap(), Some(ClientMessage::Hello { cols: 80, rows: 24 }));
+            send(&mut writer, &NodeMessage::AttachAccepted { generation: gate_for_task.attach().unwrap() }).await.unwrap();
+        });
+        let stream = UnixStream::connect(&path).await.unwrap(); let (mut reader, mut writer) = split(stream).await;
+        send(&mut writer, &ClientMessage::Hello { cols: 80, rows: 24 }).await.unwrap();
+        assert_eq!(receive::<NodeMessage>(&mut reader).await.unwrap(), Some(NodeMessage::AttachAccepted { generation: 1 }));
+        timeout(Duration::from_secs(1), server).await.unwrap().unwrap();
+        assert_eq!(gate.attach(), Err("already attached"));
+        assert!(gate.detach(1)); assert!(gate.attach().is_ok());
+        let _ = std::fs::remove_file(path);
+    }
+}

--- a/src/local_ipc.rs
+++ b/src/local_ipc.rs
@@ -1,9 +1,16 @@
 //! Local node/client protocol. This is deliberately separate from the peer Iroh protocol.
 
-use std::{io, sync::{Arc, Mutex}};
+use std::{
+    io,
+    sync::{Arc, Mutex},
+};
 
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use tokio::{io::{AsyncBufReadExt, AsyncWriteExt, BufReader}, net::UnixStream, sync::mpsc};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use tokio::{
+    io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
+    net::UnixStream,
+    sync::mpsc,
+};
 
 const MAX_FRAME: usize = 1024 * 1024;
 pub const OUTBOUND_QUEUE: usize = 64;
@@ -11,6 +18,7 @@ pub const OUTBOUND_QUEUE: usize = 64;
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ClientMessage {
+    Probe,
     Hello { cols: u16, rows: u16 },
     Input { bytes: Vec<u8> },
     StructuralIntent { intent: serde_json::Value },
@@ -24,80 +32,165 @@ pub enum ClientMessage {
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum NodeMessage {
-    AttachAccepted { generation: u64 },
-    AttachRejected { reason: String },
-    Snapshot { room_name: String, role: String, summary: SessionSummary, layout: serde_json::Value, screens: serde_json::Value, leases: serde_json::Value, rosters: serde_json::Value, tab_id: u64, pane_id: u64 },
-    Update { state: serde_json::Value },
-    DetachAck { generation: u64 },
-    ShutdownAck { generation: u64 },
-    Error { message: String },
+    ProbeAck,
+    AttachAccepted {
+        generation: u64,
+    },
+    AttachRejected {
+        reason: String,
+    },
+    Snapshot {
+        room_name: String,
+        role: String,
+        summary: SessionSummary,
+        layout: serde_json::Value,
+        screens: serde_json::Value,
+        leases: serde_json::Value,
+        rosters: serde_json::Value,
+        tab_id: u64,
+        pane_id: u64,
+    },
+    Update {
+        state: serde_json::Value,
+    },
+    DetachAck {
+        generation: u64,
+    },
+    ShutdownAck {
+        generation: u64,
+    },
+    Error {
+        message: String,
+    },
 }
 
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
-pub struct SessionSummary { pub tabs: u32, pub panes: u32, pub hosts: u32, pub coordinator_name: String }
+pub struct SessionSummary {
+    pub tabs: u32,
+    pub panes: u32,
+    pub hosts: u32,
+    pub coordinator_name: String,
+}
 
 /// Single-client gate. A generation makes delayed disconnects harmless after a reattach.
 #[derive(Clone, Default)]
 pub struct AttachmentGate(Arc<Mutex<AttachmentState>>);
 #[derive(Default)]
-struct AttachmentState { generation: u64, attached: bool }
+struct AttachmentState {
+    generation: u64,
+    attached: bool,
+}
 
 impl AttachmentGate {
     pub fn attach(&self) -> Result<u64, &'static str> {
         let mut state = self.0.lock().expect("attachment gate poisoned");
-        if state.attached { return Err("already attached"); }
+        if state.attached {
+            return Err("already attached");
+        }
         state.generation = state.generation.saturating_add(1).max(1);
         state.attached = true;
         Ok(state.generation)
     }
     pub fn detach(&self, generation: u64) -> bool {
         let mut state = self.0.lock().expect("attachment gate poisoned");
-        if state.attached && state.generation == generation { state.attached = false; true } else { false }
+        if state.attached && state.generation == generation {
+            state.attached = false;
+            true
+        } else {
+            false
+        }
     }
 }
 
-pub async fn send<T: Serialize>(writer: &mut tokio::net::unix::OwnedWriteHalf, message: &T) -> io::Result<()> {
+pub async fn send<T: Serialize>(
+    writer: &mut tokio::net::unix::OwnedWriteHalf,
+    message: &T,
+) -> io::Result<()> {
     let mut bytes = serde_json::to_vec(message).map_err(io::Error::other)?;
     bytes.push(b'\n');
     writer.write_all(&bytes).await
 }
 
-pub async fn receive<T: DeserializeOwned>(reader: &mut BufReader<tokio::net::unix::OwnedReadHalf>) -> io::Result<Option<T>> {
+pub async fn receive<T: DeserializeOwned>(
+    reader: &mut BufReader<tokio::net::unix::OwnedReadHalf>,
+) -> io::Result<Option<T>> {
     let mut bytes = Vec::new();
     let count = reader.read_until(b'\n', &mut bytes).await?;
-    if count == 0 { return Ok(None); }
-    if count > MAX_FRAME { return Err(io::Error::new(io::ErrorKind::InvalidData, "local IPC frame too large")); }
-    serde_json::from_slice(&bytes).map(Some).map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "invalid local IPC message"))
+    if count == 0 {
+        return Ok(None);
+    }
+    if count > MAX_FRAME {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "local IPC frame too large",
+        ));
+    }
+    serde_json::from_slice(&bytes)
+        .map(Some)
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "invalid local IPC message"))
 }
 
-pub fn bounded_outbound() -> (mpsc::Sender<NodeMessage>, mpsc::Receiver<NodeMessage>) { mpsc::channel(OUTBOUND_QUEUE) }
+pub fn bounded_outbound() -> (mpsc::Sender<NodeMessage>, mpsc::Receiver<NodeMessage>) {
+    mpsc::channel(OUTBOUND_QUEUE)
+}
 
-pub async fn split(stream: UnixStream) -> (BufReader<tokio::net::unix::OwnedReadHalf>, tokio::net::unix::OwnedWriteHalf) {
-    let (read, write) = stream.into_split(); (BufReader::new(read), write)
+pub async fn split(
+    stream: UnixStream,
+) -> (
+    BufReader<tokio::net::unix::OwnedReadHalf>,
+    tokio::net::unix::OwnedWriteHalf,
+) {
+    let (read, write) = stream.into_split();
+    (BufReader::new(read), write)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tokio::{net::UnixListener, time::{timeout, Duration}};
+    use tokio::{
+        net::UnixListener,
+        time::{Duration, timeout},
+    };
 
     #[tokio::test]
     async fn messages_round_trip_and_gate_refuses_second_client() {
         let path = std::env::temp_dir().join(format!("p2pmux-ipc-{}.sock", std::process::id()));
         let _ = std::fs::remove_file(&path);
         let listener = UnixListener::bind(&path).unwrap();
-        let gate = AttachmentGate::default(); let gate_for_task = gate.clone();
+        let gate = AttachmentGate::default();
+        let gate_for_task = gate.clone();
         let server = tokio::spawn(async move {
-            let (stream, _) = listener.accept().await.unwrap(); let (mut reader, mut writer) = split(stream).await;
-            assert_eq!(receive::<ClientMessage>(&mut reader).await.unwrap(), Some(ClientMessage::Hello { cols: 80, rows: 24 }));
-            send(&mut writer, &NodeMessage::AttachAccepted { generation: gate_for_task.attach().unwrap() }).await.unwrap();
+            let (stream, _) = listener.accept().await.unwrap();
+            let (mut reader, mut writer) = split(stream).await;
+            assert_eq!(
+                receive::<ClientMessage>(&mut reader).await.unwrap(),
+                Some(ClientMessage::Hello { cols: 80, rows: 24 })
+            );
+            send(
+                &mut writer,
+                &NodeMessage::AttachAccepted {
+                    generation: gate_for_task.attach().unwrap(),
+                },
+            )
+            .await
+            .unwrap();
         });
-        let stream = UnixStream::connect(&path).await.unwrap(); let (mut reader, mut writer) = split(stream).await;
-        send(&mut writer, &ClientMessage::Hello { cols: 80, rows: 24 }).await.unwrap();
-        assert_eq!(receive::<NodeMessage>(&mut reader).await.unwrap(), Some(NodeMessage::AttachAccepted { generation: 1 }));
-        timeout(Duration::from_secs(1), server).await.unwrap().unwrap();
+        let stream = UnixStream::connect(&path).await.unwrap();
+        let (mut reader, mut writer) = split(stream).await;
+        send(&mut writer, &ClientMessage::Hello { cols: 80, rows: 24 })
+            .await
+            .unwrap();
+        assert_eq!(
+            receive::<NodeMessage>(&mut reader).await.unwrap(),
+            Some(NodeMessage::AttachAccepted { generation: 1 })
+        );
+        timeout(Duration::from_secs(1), server)
+            .await
+            .unwrap()
+            .unwrap();
         assert_eq!(gate.attach(), Err("already attached"));
-        assert!(gate.detach(1)); assert!(gate.attach().is_ok());
+        assert!(gate.detach(1));
+        assert!(gate.attach().is_ok());
         let _ = std::fs::remove_file(path);
     }
 }

--- a/src/local_ipc.rs
+++ b/src/local_ipc.rs
@@ -12,6 +12,8 @@ use tokio::{
     sync::mpsc,
 };
 
+use crate::{layout::LayoutSnapshot, tui::UiIntent};
+
 const MAX_FRAME: usize = 1024 * 1024;
 pub const OUTBOUND_QUEUE: usize = 64;
 
@@ -21,7 +23,7 @@ pub enum ClientMessage {
     Probe,
     Hello { cols: u16, rows: u16 },
     Input { bytes: Vec<u8> },
-    StructuralIntent { intent: serde_json::Value },
+    StructuralIntent { intent: UiIntent },
     Resize { cols: u16, rows: u16 },
     Focus { tab_id: u64, pane_id: u64 },
     Detach { generation: u64 },
@@ -43,9 +45,9 @@ pub enum NodeMessage {
         room_name: String,
         role: String,
         summary: SessionSummary,
-        layout: serde_json::Value,
-        screens: serde_json::Value,
-        leases: serde_json::Value,
+        layout: LayoutSnapshot,
+        screens: Vec<PaneScreenSnapshot>,
+        leases: Vec<PaneLeaseSnapshot>,
         rosters: serde_json::Value,
         tab_id: u64,
         pane_id: u64,
@@ -62,6 +64,25 @@ pub enum NodeMessage {
     Error {
         message: String,
     },
+}
+
+/// Complete screen state for one pane. Attachments replace their local `GuestScreen` from this
+/// payload, so reconnects do not depend on a delta history.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct PaneScreenSnapshot {
+    pub pane_id: u64,
+    pub sequence: u64,
+    pub snapshot: Vec<u8>,
+    pub kitty_keyboard_active: bool,
+}
+
+/// The subset of a pane lease needed by render chrome; lease authority stays in the node.
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+pub struct PaneLeaseSnapshot {
+    pub pane_id: u64,
+    pub ready: bool,
+    pub controller_peer_id: Option<Vec<u8>>,
+    pub controller_active: bool,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]

--- a/src/local_ipc.rs
+++ b/src/local_ipc.rs
@@ -45,7 +45,7 @@ pub enum NodeMessage {
         room_name: String,
         role: String,
         summary: SessionSummary,
-        layout: LayoutSnapshot,
+        layout: Box<LayoutSnapshot>,
         screens: Vec<PaneScreenSnapshot>,
         leases: Vec<PaneLeaseSnapshot>,
         rosters: serde_json::Value,

--- a/src/node.rs
+++ b/src/node.rs
@@ -4,7 +4,26 @@
 //! owns it without terminal I/O and exposes only node operations; the local socket client is the
 //! only component allowed to render a terminal.
 
-use std::{error::Error, time::Instant};
+use std::{
+    error::Error,
+    fs,
+    io::{self, BufRead, BufReader, Write},
+    net::Shutdown,
+    os::unix::{fs::OpenOptionsExt, net::{UnixListener, UnixStream}},
+    time::{Duration, Instant},
+};
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    local_ipc::{AttachmentGate, ClientMessage, NodeMessage, SessionSummary},
+    rendezvous::LocalRendezvous,
+    session::{HostSession, LayoutControlEvent, SharedLayoutHost, join_layout_with_display_name, layout_snapshot_from_state},
+    session_store::{SessionDescriptor, SessionRole, SessionStore},
+    ticket::JoinTicket,
+    transport::Transport,
+    tui::SharedLocalPane,
+};
 
 use crate::tui::SharedLayoutRuntime;
 
@@ -12,6 +31,149 @@ pub struct SharedLayoutNode {
     runtime: SharedLayoutRuntime,
     last_tab_id: u64,
     last_pane_id: u64,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum NodeBootstrapKind {
+    Create { display_name: String, cols: u16, rows: u16 },
+    Join { ticket: String, display_name: String, cols: u16, rows: u16 },
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct NodeBootstrap { pub descriptor: SessionDescriptor, pub kind: NodeBootstrapKind }
+
+pub fn write_bootstrap(path: &std::path::Path, bootstrap: &NodeBootstrap) -> io::Result<()> {
+    let bytes = serde_json::to_vec(bootstrap).map_err(io::Error::other)?;
+    let mut file = std::fs::OpenOptions::new().write(true).create_new(true).mode(0o600).open(path)?;
+    file.write_all(&bytes)?; file.sync_all()
+}
+
+pub fn read_bootstrap(path: &std::path::Path) -> io::Result<NodeBootstrap> {
+    let bootstrap = serde_json::from_slice(&fs::read(path)?).map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "invalid node bootstrap"))?;
+    let _ = fs::remove_file(path);
+    Ok(bootstrap)
+}
+
+/// Private child entrypoint. It owns the descriptor, rendezvous record, socket and every PTY.
+pub async fn run_background(bootstrap: NodeBootstrap) -> Result<(), Box<dyn Error>> {
+    let mut descriptor = bootstrap.descriptor.clone();
+    descriptor.node_pid = std::process::id();
+    let (mut node, dispatcher_task, rendezvous) = match bootstrap.kind {
+        NodeBootstrapKind::Create { display_name, cols, rows } => {
+            let (shell_rows, shell_cols) = crate::tui::initial_root_pane_grid(cols, rows);
+            let host = SharedLayoutHost::with_display_name(HostSession::create().await?, display_name, shell_rows, shell_cols)?;
+            let host_peer_id = host.ticket().endpoint_addr().id.as_bytes().to_vec();
+            let initial = SharedLocalPane::spawn(1, shell_rows, shell_cols, host_peer_id.clone())?;
+            let panes = host.pane_server();
+            panes.register_local_pane(crate::protocol::PaneDescriptor { pane_id: 1, host_peer_id, grid_rows: u32::from(shell_rows), grid_cols: u32::from(shell_cols) }, initial.channels())?;
+            let snapshot = host.session_snapshot()?;
+            let layout = layout_snapshot_from_state(snapshot.state.as_ref().ok_or("missing host layout")?)
+                .map_err(|error| io::Error::other(format!("invalid host layout: {error:?}")))?;
+            let dispatcher = host.incoming_dispatcher(panes.clone())?;
+            let dispatcher_task = tokio::spawn(async move { dispatcher.accept_loop().await });
+            let rendezvous = LocalRendezvous::for_current_user()?.publish(host.ticket())?;
+            let join_code = rendezvous.code().to_owned();
+            let handle = tokio::runtime::Handle::current();
+            let mut runtime = crate::tui::SharedLayoutRuntime::host(host, panes, layout, initial, join_code, handle)?;
+            runtime.set_session_id(descriptor.id.as_bytes().to_vec());
+            (SharedLayoutNode::new(runtime), dispatcher_task, Some(rendezvous))
+        }
+        NodeBootstrapKind::Join { ticket, display_name, cols: _, rows: _ } => {
+            let ticket = ticket.parse::<JoinTicket>().map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "invalid ticket"))?;
+            let transport = Transport::bind().await?;
+            let mut member = join_layout_with_display_name(transport, ticket.clone(), display_name).await?;
+            let state = match member.events.recv().await {
+                Some(LayoutControlEvent::Snapshot(snapshot)) => snapshot.state.ok_or("missing layout snapshot")?,
+                _ => return Err(io::Error::other("layout coordinator disconnected during join").into()),
+            };
+            let panes = member.pane_server(ticket.session_id().to_vec())?;
+            panes.replace_roster_from_layout(&state)?;
+            let acceptor = panes.clone(); let dispatcher_task = tokio::spawn(async move { acceptor.accept_loop().await });
+            let runtime = crate::tui::SharedLayoutRuntime::member_from_state(member, panes, ticket.session_id().to_vec(), state, tokio::runtime::Handle::current())?;
+            (SharedLayoutNode::new(runtime), dispatcher_task, None)
+        }
+    };
+    let store = SessionStore::for_current_user()?;
+    let _ = fs::remove_file(&descriptor.socket_path);
+    let listener = UnixListener::bind(&descriptor.socket_path)?;
+    listener.set_nonblocking(true)?;
+    store.write(&descriptor)?;
+    let result = run_socket_loop(&mut node, listener, &descriptor);
+    node.shutdown();
+    dispatcher_task.abort(); let _ = dispatcher_task.await;
+    if let Some(rendezvous) = rendezvous { let _ = rendezvous.remove(); }
+    let _ = fs::remove_file(&descriptor.socket_path); let _ = store.remove(&descriptor.id);
+    result.map_err(Into::into)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+    #[test]
+    fn bootstrap_is_private_and_round_trips() {
+        let path = std::env::temp_dir().join(format!("p2pmux-bootstrap-{}", std::process::id()));
+        let _ = fs::remove_file(&path);
+        let descriptor = SessionDescriptor::new("0123456789abcdef0123456789abcdef".into(), "amber-otter-01".into(), "/tmp/p2pmux-test.sock".into(), 1, SessionRole::Coordinator);
+        write_bootstrap(&path, &NodeBootstrap { descriptor: descriptor.clone(), kind: NodeBootstrapKind::Create { display_name: "A".into(), cols: 80, rows: 24 } }).unwrap();
+        assert_eq!(fs::metadata(&path).unwrap().permissions().mode() & 0o777, 0o600);
+        assert_eq!(read_bootstrap(&path).unwrap().descriptor, descriptor);
+        assert!(!path.exists());
+    }
+}
+
+fn run_socket_loop(node: &mut SharedLayoutNode, listener: UnixListener, descriptor: &SessionDescriptor) -> io::Result<()> {
+    let gate = AttachmentGate::default();
+    let mut client: Option<(UnixStream, u64)> = None;
+    loop {
+        loop {
+            match listener.accept() {
+                Ok((mut stream, _)) => {
+                    stream.set_read_timeout(Some(Duration::from_millis(1)))?;
+                    if let Ok(generation) = gate.attach() {
+                        let hello = read_message(&mut stream)?;
+                        if matches!(hello, Some(ClientMessage::Hello { .. })) {
+                            write_message(&mut stream, &NodeMessage::AttachAccepted { generation })?;
+                            write_snapshot(&mut stream, descriptor, node, generation)?;
+                            client = Some((stream, generation));
+                        } else { let _ = gate.detach(generation); }
+                    } else { let _ = write_message(&mut stream, &NodeMessage::AttachRejected { reason: "already attached".into() }); }
+                }
+                Err(error) if error.kind() == io::ErrorKind::WouldBlock => break,
+                Err(error) => return Err(error),
+            }
+        }
+        let changed = node.drain().map_err(|error| io::Error::other(error.to_string()))?;
+        let mut detached = false; let mut shutdown = false;
+        if let Some((stream, generation)) = client.as_mut() {
+            match read_message(stream) {
+                Ok(Some(ClientMessage::Input { bytes })) => node.input(bytes).map_err(|error| io::Error::other(error.to_string()))?,
+                Ok(Some(ClientMessage::Detach { generation: requested })) if requested == *generation => { node.release_all_local_control().map_err(|error| io::Error::other(error.to_string()))?; write_message(stream, &NodeMessage::DetachAck { generation: *generation })?; detached = true; }
+                Ok(Some(ClientMessage::Shutdown { generation: requested })) if requested == *generation => { write_message(stream, &NodeMessage::ShutdownAck { generation: *generation })?; shutdown = true; }
+                Ok(Some(ClientMessage::Rename { name })) => { if crate::session_store::valid_name(&name) { write_message(stream, &NodeMessage::Update { state: serde_json::json!({"name": name}) })?; } else { write_message(stream, &NodeMessage::Error { message: "invalid session name".into() })?; } }
+                Ok(Some(_)) => {}
+                Err(error) if error.kind() == io::ErrorKind::WouldBlock || error.kind() == io::ErrorKind::TimedOut => {}
+                Ok(None) => detached = true,
+                Err(_) => detached = true,
+            }
+            if changed { write_snapshot(stream, descriptor, node, *generation)?; }
+        }
+        if let Some((stream, generation)) = client.take().filter(|_| detached || shutdown) {
+            let _ = stream.shutdown(Shutdown::Both); let _ = gate.detach(generation); node.release_all_local_control().map_err(|error| io::Error::other(error.to_string()))?;
+        }
+        if shutdown { return Ok(()); }
+        std::thread::sleep(Duration::from_millis(16));
+    }
+}
+
+fn read_message(stream: &mut UnixStream) -> io::Result<Option<ClientMessage>> {
+    let mut reader = BufReader::new(stream.try_clone()?); let mut line = String::new();
+    match reader.read_line(&mut line) { Ok(0) => Ok(None), Ok(_) => serde_json::from_str(&line).map(Some).map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "invalid local IPC message")), Err(error) => Err(error) }
+}
+fn write_message(stream: &mut UnixStream, message: &NodeMessage) -> io::Result<()> { serde_json::to_writer(&mut *stream, message).map_err(io::Error::other)?; stream.write_all(b"\n")?; stream.flush() }
+fn write_snapshot(stream: &mut UnixStream, descriptor: &SessionDescriptor, node: &SharedLayoutNode, _generation: u64) -> io::Result<()> {
+    let (tab_id, pane_id) = node.local_focus();
+    write_message(stream, &NodeMessage::Snapshot { room_name: descriptor.name.clone(), role: match descriptor.role { SessionRole::Coordinator => "coordinator", SessionRole::Member => "member" }.into(), summary: SessionSummary { tabs: 1, panes: 1, hosts: 1, coordinator_name: String::new() }, layout: serde_json::json!({}), screens: serde_json::json!(node.screen_text()), leases: serde_json::json!({}), rosters: serde_json::json!({}), tab_id, pane_id })
 }
 
 impl SharedLayoutNode {

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,0 +1,37 @@
+//! Headless owner of a shared layout.
+//!
+//! `SharedLayoutRuntime` remains the temporary foreground adapter during the split.  The node
+//! owns it without terminal I/O and exposes only node operations; the local socket client is the
+//! only component allowed to render a terminal.
+
+use std::{error::Error, time::Instant};
+
+use crate::tui::SharedLayoutRuntime;
+
+pub struct SharedLayoutNode {
+    runtime: SharedLayoutRuntime,
+    last_tab_id: u64,
+    last_pane_id: u64,
+}
+
+impl SharedLayoutNode {
+    pub fn new(runtime: SharedLayoutRuntime) -> Self {
+        let (last_tab_id, last_pane_id) = runtime.local_focus();
+        Self { runtime, last_tab_id, last_pane_id }
+    }
+
+    /// Advances Iroh, pane servers, PTYs, leases, subscriptions and agent sampling without ever
+    /// touching terminal state.
+    pub fn drain(&mut self) -> Result<bool, Box<dyn Error>> {
+        let changed = self.runtime.drain_node()?;
+        (self.last_tab_id, self.last_pane_id) = self.runtime.local_focus();
+        Ok(changed)
+    }
+
+    pub fn input(&mut self, bytes: Vec<u8>) -> Result<(), Box<dyn Error>> { self.runtime.node_input(bytes) }
+    pub fn release_all_local_control(&mut self) -> Result<(), Box<dyn Error>> { self.runtime.release_all_local_control() }
+    pub fn local_focus(&self) -> (u64, u64) { (self.last_tab_id, self.last_pane_id) }
+    pub fn screen_text(&self) -> String { self.runtime.node_screen_text() }
+    pub fn tick_due(&self) -> Instant { Instant::now() }
+    pub fn shutdown(self) { self.runtime.shutdown_node(); }
+}

--- a/src/node.rs
+++ b/src/node.rs
@@ -13,13 +13,16 @@ use std::{
         fs::OpenOptionsExt,
         net::{UnixListener, UnixStream},
     },
-    time::{Duration, Instant},
+    time::Duration,
 };
 
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    local_ipc::{AttachmentGate, ClientMessage, NodeMessage, SessionSummary},
+    local_ipc::{
+        AttachmentGate, ClientMessage, NodeMessage, PaneLeaseSnapshot, PaneScreenSnapshot,
+        SessionSummary,
+    },
     rendezvous::LocalRendezvous,
     session::{
         HostSession, LayoutControlEvent, SharedLayoutHost, join_layout_with_display_name,
@@ -234,7 +237,9 @@ fn run_socket_loop(
                                 write_message(&mut stream, &NodeMessage::ProbeAck)?;
                                 let _ = gate.detach(generation);
                             }
-                            Ok(Some(ClientMessage::Hello { .. })) => {
+                            Ok(Some(ClientMessage::Hello { cols, rows })) => {
+                                node.resize(cols, rows)
+                                    .map_err(|error| io::Error::other(error.to_string()))?;
                                 write_message(
                                     &mut stream,
                                     &NodeMessage::AttachAccepted { generation },
@@ -285,7 +290,7 @@ fn run_socket_loop(
                 Err(error) => return Err(error),
             }
         }
-        let changed = node
+        let mut changed = node
             .drain()
             .map_err(|error| io::Error::other(error.to_string()))?;
         let mut detached = false;
@@ -295,6 +300,21 @@ fn run_socket_loop(
                 Ok(Some(ClientMessage::Input { bytes })) => node
                     .input(bytes)
                     .map_err(|error| io::Error::other(error.to_string()))?,
+                Ok(Some(ClientMessage::StructuralIntent { intent })) => {
+                    node.intent(intent)
+                        .map_err(|error| io::Error::other(error.to_string()))?;
+                    changed = true;
+                }
+                Ok(Some(ClientMessage::Resize { cols, rows })) => {
+                    node.resize(cols, rows)
+                        .map_err(|error| io::Error::other(error.to_string()))?;
+                    changed = true;
+                }
+                Ok(Some(ClientMessage::Focus { tab_id, pane_id })) => {
+                    node.focus(tab_id, pane_id)
+                        .map_err(|error| io::Error::other(error.to_string()))?;
+                    changed = true;
+                }
                 Ok(Some(ClientMessage::Detach {
                     generation: requested,
                 })) if requested == *generation => {
@@ -385,6 +405,18 @@ fn write_snapshot(
     _generation: u64,
 ) -> io::Result<()> {
     let (tab_id, pane_id) = node.local_focus();
+    let (layout, screens, leases) = node.snapshot();
+    let hosts = layout
+        .panes
+        .values()
+        .map(|pane| pane.host_peer_id.clone())
+        .collect::<std::collections::BTreeSet<_>>()
+        .len() as u32;
+    let coordinator_name = layout
+        .members
+        .first()
+        .map(|member| member.display_name.clone())
+        .unwrap_or_default();
     write_message(
         stream,
         &NodeMessage::Snapshot {
@@ -395,14 +427,34 @@ fn write_snapshot(
             }
             .into(),
             summary: SessionSummary {
-                tabs: 1,
-                panes: 1,
-                hosts: 1,
-                coordinator_name: String::new(),
+                tabs: layout.tabs.len() as u32,
+                panes: layout.panes.len() as u32,
+                hosts,
+                coordinator_name,
             },
-            layout: serde_json::json!({}),
-            screens: serde_json::json!(node.screen_text()),
-            leases: serde_json::json!({}),
+            layout,
+            screens: screens
+                .into_iter()
+                .map(
+                    |(pane_id, (sequence, snapshot, kitty_keyboard_active))| PaneScreenSnapshot {
+                        pane_id,
+                        sequence,
+                        snapshot,
+                        kitty_keyboard_active,
+                    },
+                )
+                .collect(),
+            leases: leases
+                .into_iter()
+                .map(
+                    |(pane_id, (ready, controller_peer_id, controller_active))| PaneLeaseSnapshot {
+                        pane_id,
+                        ready,
+                        controller_peer_id,
+                        controller_active,
+                    },
+                )
+                .collect(),
             rosters: serde_json::json!({}),
             tab_id,
             pane_id,
@@ -437,11 +489,23 @@ impl SharedLayoutNode {
     pub fn local_focus(&self) -> (u64, u64) {
         (self.last_tab_id, self.last_pane_id)
     }
-    pub fn screen_text(&self) -> String {
-        self.runtime.node_screen_text()
+    pub fn snapshot(
+        &self,
+    ) -> (
+        crate::layout::LayoutSnapshot,
+        std::collections::BTreeMap<u64, (u64, Vec<u8>, bool)>,
+        std::collections::BTreeMap<u64, (bool, Option<Vec<u8>>, bool)>,
+    ) {
+        self.runtime.node_snapshot()
     }
-    pub fn tick_due(&self) -> Instant {
-        Instant::now()
+    pub fn resize(&mut self, cols: u16, rows: u16) -> Result<(), Box<dyn Error>> {
+        self.runtime.node_resize(cols, rows)
+    }
+    pub fn focus(&mut self, tab_id: u64, pane_id: u64) -> Result<(), Box<dyn Error>> {
+        self.runtime.node_focus(tab_id, pane_id)
+    }
+    pub fn intent(&mut self, intent: crate::tui::UiIntent) -> Result<(), Box<dyn Error>> {
+        self.runtime.node_intent(intent)
     }
     pub fn shutdown(self) {
         self.runtime.shutdown_node();

--- a/src/node.rs
+++ b/src/node.rs
@@ -185,42 +185,6 @@ pub async fn run_background(bootstrap: NodeBootstrap) -> Result<(), Box<dyn Erro
     result.map_err(Into::into)
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::os::unix::fs::PermissionsExt;
-    #[test]
-    fn bootstrap_is_private_and_round_trips() {
-        let path = std::env::temp_dir().join(format!("p2pmux-bootstrap-{}", std::process::id()));
-        let _ = fs::remove_file(&path);
-        let descriptor = SessionDescriptor::new(
-            "0123456789abcdef0123456789abcdef".into(),
-            "amber-otter-01".into(),
-            "/tmp/p2pmux-test.sock".into(),
-            1,
-            SessionRole::Coordinator,
-        );
-        write_bootstrap(
-            &path,
-            &NodeBootstrap {
-                descriptor: descriptor.clone(),
-                kind: NodeBootstrapKind::Create {
-                    display_name: "A".into(),
-                    cols: 80,
-                    rows: 24,
-                },
-            },
-        )
-        .unwrap();
-        assert_eq!(
-            fs::metadata(&path).unwrap().permissions().mode() & 0o777,
-            0o600
-        );
-        assert_eq!(read_bootstrap(&path).unwrap().descriptor, descriptor);
-        assert!(!path.exists());
-    }
-}
-
 fn run_socket_loop(
     node: &mut SharedLayoutNode,
     listener: UnixListener,
@@ -371,10 +335,11 @@ fn run_socket_loop(
                 Ok(None) => detached = true,
                 Err(_) => detached = true,
             }
-            if changed && !detached {
-                if write_snapshot(stream, descriptor, node, *generation).is_err() {
-                    detached = true;
-                }
+            if changed
+                && !detached
+                && write_snapshot(stream, descriptor, node, *generation).is_err()
+            {
+                detached = true;
             }
         }
         if (detached || shutdown)
@@ -442,7 +407,7 @@ fn write_snapshot(
                 hosts,
                 coordinator_name,
             },
-            layout,
+            layout: Box::new(layout),
             screens: screens
                 .into_iter()
                 .map(
@@ -503,8 +468,8 @@ impl SharedLayoutNode {
         &self,
     ) -> (
         crate::layout::LayoutSnapshot,
-        std::collections::BTreeMap<u64, (u64, Vec<u8>, bool)>,
-        std::collections::BTreeMap<u64, (bool, Option<Vec<u8>>, bool)>,
+        crate::tui::NodeScreenSnapshots,
+        crate::tui::NodeLeaseSnapshots,
     ) {
         self.runtime.node_snapshot()
     }
@@ -519,5 +484,42 @@ impl SharedLayoutNode {
     }
     pub fn shutdown(self) {
         self.runtime.shutdown_node();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+
+    #[test]
+    fn bootstrap_is_private_and_round_trips() {
+        let path = std::env::temp_dir().join(format!("p2pmux-bootstrap-{}", std::process::id()));
+        let _ = fs::remove_file(&path);
+        let descriptor = SessionDescriptor::new(
+            "0123456789abcdef0123456789abcdef".into(),
+            "amber-otter-01".into(),
+            "/tmp/p2pmux-test.sock".into(),
+            1,
+            SessionRole::Coordinator,
+        );
+        write_bootstrap(
+            &path,
+            &NodeBootstrap {
+                descriptor: descriptor.clone(),
+                kind: NodeBootstrapKind::Create {
+                    display_name: "A".into(),
+                    cols: 80,
+                    rows: 24,
+                },
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+        assert_eq!(read_bootstrap(&path).unwrap().descriptor, descriptor);
+        assert!(!path.exists());
     }
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -129,14 +129,20 @@ fn run_socket_loop(node: &mut SharedLayoutNode, listener: UnixListener, descript
         loop {
             match listener.accept() {
                 Ok((mut stream, _)) => {
-                    stream.set_read_timeout(Some(Duration::from_millis(1)))?;
+                    stream.set_read_timeout(Some(Duration::from_millis(100)))?;
                     if let Ok(generation) = gate.attach() {
-                        let hello = read_message(&mut stream)?;
-                        if matches!(hello, Some(ClientMessage::Hello { .. })) {
-                            write_message(&mut stream, &NodeMessage::AttachAccepted { generation })?;
-                            write_snapshot(&mut stream, descriptor, node, generation)?;
-                            client = Some((stream, generation));
-                        } else { let _ = gate.detach(generation); }
+                        match read_message(&mut stream) {
+                            Ok(Some(ClientMessage::Hello { .. })) => {
+                                write_message(&mut stream, &NodeMessage::AttachAccepted { generation })?;
+                                write_snapshot(&mut stream, descriptor, node, generation)?;
+                                stream.set_read_timeout(Some(Duration::from_millis(1)))?;
+                                client = Some((stream, generation));
+                            }
+                            Ok(None) => { let _ = gate.detach(generation); }
+                            Err(error) if error.kind() == io::ErrorKind::WouldBlock || error.kind() == io::ErrorKind::TimedOut => { let _ = gate.detach(generation); }
+                            Err(error) => return Err(error),
+                            _ => { let _ = gate.detach(generation); }
+                        }
                     } else { let _ = write_message(&mut stream, &NodeMessage::AttachRejected { reason: "already attached".into() }); }
                 }
                 Err(error) if error.kind() == io::ErrorKind::WouldBlock => break,

--- a/src/node.rs
+++ b/src/node.rs
@@ -9,7 +9,10 @@ use std::{
     fs,
     io::{self, BufRead, BufReader, Write},
     net::Shutdown,
-    os::unix::{fs::OpenOptionsExt, net::{UnixListener, UnixStream}},
+    os::unix::{
+        fs::OpenOptionsExt,
+        net::{UnixListener, UnixStream},
+    },
     time::{Duration, Instant},
 };
 
@@ -18,7 +21,10 @@ use serde::{Deserialize, Serialize};
 use crate::{
     local_ipc::{AttachmentGate, ClientMessage, NodeMessage, SessionSummary},
     rendezvous::LocalRendezvous,
-    session::{HostSession, LayoutControlEvent, SharedLayoutHost, join_layout_with_display_name, layout_snapshot_from_state},
+    session::{
+        HostSession, LayoutControlEvent, SharedLayoutHost, join_layout_with_display_name,
+        layout_snapshot_from_state,
+    },
     session_store::{SessionDescriptor, SessionRole, SessionStore},
     ticket::JoinTicket,
     transport::Transport,
@@ -35,21 +41,39 @@ pub struct SharedLayoutNode {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum NodeBootstrapKind {
-    Create { display_name: String, cols: u16, rows: u16 },
-    Join { ticket: String, display_name: String, cols: u16, rows: u16 },
+    Create {
+        display_name: String,
+        cols: u16,
+        rows: u16,
+    },
+    Join {
+        ticket: String,
+        display_name: String,
+        cols: u16,
+        rows: u16,
+    },
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct NodeBootstrap { pub descriptor: SessionDescriptor, pub kind: NodeBootstrapKind }
+pub struct NodeBootstrap {
+    pub descriptor: SessionDescriptor,
+    pub kind: NodeBootstrapKind,
+}
 
 pub fn write_bootstrap(path: &std::path::Path, bootstrap: &NodeBootstrap) -> io::Result<()> {
     let bytes = serde_json::to_vec(bootstrap).map_err(io::Error::other)?;
-    let mut file = std::fs::OpenOptions::new().write(true).create_new(true).mode(0o600).open(path)?;
-    file.write_all(&bytes)?; file.sync_all()
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(path)?;
+    file.write_all(&bytes)?;
+    file.sync_all()
 }
 
 pub fn read_bootstrap(path: &std::path::Path) -> io::Result<NodeBootstrap> {
-    let bootstrap = serde_json::from_slice(&fs::read(path)?).map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "invalid node bootstrap"))?;
+    let bootstrap = serde_json::from_slice(&fs::read(path)?)
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "invalid node bootstrap"))?;
     let _ = fs::remove_file(path);
     Ok(bootstrap)
 }
@@ -59,37 +83,83 @@ pub async fn run_background(bootstrap: NodeBootstrap) -> Result<(), Box<dyn Erro
     let mut descriptor = bootstrap.descriptor.clone();
     descriptor.node_pid = std::process::id();
     let (mut node, dispatcher_task, rendezvous) = match bootstrap.kind {
-        NodeBootstrapKind::Create { display_name, cols, rows } => {
+        NodeBootstrapKind::Create {
+            display_name,
+            cols,
+            rows,
+        } => {
             let (shell_rows, shell_cols) = crate::tui::initial_root_pane_grid(cols, rows);
-            let host = SharedLayoutHost::with_display_name(HostSession::create().await?, display_name, shell_rows, shell_cols)?;
+            let host = SharedLayoutHost::with_display_name(
+                HostSession::create().await?,
+                display_name,
+                shell_rows,
+                shell_cols,
+            )?;
             let host_peer_id = host.ticket().endpoint_addr().id.as_bytes().to_vec();
             let initial = SharedLocalPane::spawn(1, shell_rows, shell_cols, host_peer_id.clone())?;
             let panes = host.pane_server();
-            panes.register_local_pane(crate::protocol::PaneDescriptor { pane_id: 1, host_peer_id, grid_rows: u32::from(shell_rows), grid_cols: u32::from(shell_cols) }, initial.channels())?;
+            panes.register_local_pane(
+                crate::protocol::PaneDescriptor {
+                    pane_id: 1,
+                    host_peer_id,
+                    grid_rows: u32::from(shell_rows),
+                    grid_cols: u32::from(shell_cols),
+                },
+                initial.channels(),
+            )?;
             let snapshot = host.session_snapshot()?;
-            let layout = layout_snapshot_from_state(snapshot.state.as_ref().ok_or("missing host layout")?)
-                .map_err(|error| io::Error::other(format!("invalid host layout: {error:?}")))?;
+            let layout =
+                layout_snapshot_from_state(snapshot.state.as_ref().ok_or("missing host layout")?)
+                    .map_err(|error| io::Error::other(format!("invalid host layout: {error:?}")))?;
             let dispatcher = host.incoming_dispatcher(panes.clone())?;
             let dispatcher_task = tokio::spawn(async move { dispatcher.accept_loop().await });
             let rendezvous = LocalRendezvous::for_current_user()?.publish(host.ticket())?;
             let join_code = rendezvous.code().to_owned();
+            let session_id = host.ticket().session_id().to_vec();
             let handle = tokio::runtime::Handle::current();
-            let mut runtime = crate::tui::SharedLayoutRuntime::host(host, panes, layout, initial, join_code, handle)?;
-            runtime.set_session_id(descriptor.id.as_bytes().to_vec());
-            (SharedLayoutNode::new(runtime), dispatcher_task, Some(rendezvous))
+            let mut runtime = crate::tui::SharedLayoutRuntime::host(
+                host, panes, layout, initial, join_code, handle,
+            )?;
+            runtime.set_session_id(session_id);
+            (
+                SharedLayoutNode::new(runtime),
+                dispatcher_task,
+                Some(rendezvous),
+            )
         }
-        NodeBootstrapKind::Join { ticket, display_name, cols: _, rows: _ } => {
-            let ticket = ticket.parse::<JoinTicket>().map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "invalid ticket"))?;
+        NodeBootstrapKind::Join {
+            ticket,
+            display_name,
+            cols: _,
+            rows: _,
+        } => {
+            let ticket = ticket
+                .parse::<JoinTicket>()
+                .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "invalid ticket"))?;
             let transport = Transport::bind().await?;
-            let mut member = join_layout_with_display_name(transport, ticket.clone(), display_name).await?;
+            let mut member =
+                join_layout_with_display_name(transport, ticket.clone(), display_name).await?;
             let state = match member.events.recv().await {
-                Some(LayoutControlEvent::Snapshot(snapshot)) => snapshot.state.ok_or("missing layout snapshot")?,
-                _ => return Err(io::Error::other("layout coordinator disconnected during join").into()),
+                Some(LayoutControlEvent::Snapshot(snapshot)) => {
+                    snapshot.state.ok_or("missing layout snapshot")?
+                }
+                _ => {
+                    return Err(
+                        io::Error::other("layout coordinator disconnected during join").into(),
+                    );
+                }
             };
             let panes = member.pane_server(ticket.session_id().to_vec())?;
             panes.replace_roster_from_layout(&state)?;
-            let acceptor = panes.clone(); let dispatcher_task = tokio::spawn(async move { acceptor.accept_loop().await });
-            let runtime = crate::tui::SharedLayoutRuntime::member_from_state(member, panes, ticket.session_id().to_vec(), state, tokio::runtime::Handle::current())?;
+            let acceptor = panes.clone();
+            let dispatcher_task = tokio::spawn(async move { acceptor.accept_loop().await });
+            let runtime = crate::tui::SharedLayoutRuntime::member_from_state(
+                member,
+                panes,
+                ticket.session_id().to_vec(),
+                state,
+                tokio::runtime::Handle::current(),
+            )?;
             (SharedLayoutNode::new(runtime), dispatcher_task, None)
         }
     };
@@ -100,9 +170,13 @@ pub async fn run_background(bootstrap: NodeBootstrap) -> Result<(), Box<dyn Erro
     store.write(&descriptor)?;
     let result = run_socket_loop(&mut node, listener, &descriptor);
     node.shutdown();
-    dispatcher_task.abort(); let _ = dispatcher_task.await;
-    if let Some(rendezvous) = rendezvous { let _ = rendezvous.remove(); }
-    let _ = fs::remove_file(&descriptor.socket_path); let _ = store.remove(&descriptor.id);
+    dispatcher_task.abort();
+    let _ = dispatcher_task.await;
+    if let Some(rendezvous) = rendezvous {
+        let _ = rendezvous.remove();
+    }
+    let _ = fs::remove_file(&descriptor.socket_path);
+    let _ = store.remove(&descriptor.id);
     result.map_err(Into::into)
 }
 
@@ -114,15 +188,39 @@ mod tests {
     fn bootstrap_is_private_and_round_trips() {
         let path = std::env::temp_dir().join(format!("p2pmux-bootstrap-{}", std::process::id()));
         let _ = fs::remove_file(&path);
-        let descriptor = SessionDescriptor::new("0123456789abcdef0123456789abcdef".into(), "amber-otter-01".into(), "/tmp/p2pmux-test.sock".into(), 1, SessionRole::Coordinator);
-        write_bootstrap(&path, &NodeBootstrap { descriptor: descriptor.clone(), kind: NodeBootstrapKind::Create { display_name: "A".into(), cols: 80, rows: 24 } }).unwrap();
-        assert_eq!(fs::metadata(&path).unwrap().permissions().mode() & 0o777, 0o600);
+        let descriptor = SessionDescriptor::new(
+            "0123456789abcdef0123456789abcdef".into(),
+            "amber-otter-01".into(),
+            "/tmp/p2pmux-test.sock".into(),
+            1,
+            SessionRole::Coordinator,
+        );
+        write_bootstrap(
+            &path,
+            &NodeBootstrap {
+                descriptor: descriptor.clone(),
+                kind: NodeBootstrapKind::Create {
+                    display_name: "A".into(),
+                    cols: 80,
+                    rows: 24,
+                },
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
         assert_eq!(read_bootstrap(&path).unwrap().descriptor, descriptor);
         assert!(!path.exists());
     }
 }
 
-fn run_socket_loop(node: &mut SharedLayoutNode, listener: UnixListener, descriptor: &SessionDescriptor) -> io::Result<()> {
+fn run_socket_loop(
+    node: &mut SharedLayoutNode,
+    listener: UnixListener,
+    descriptor: &SessionDescriptor,
+) -> io::Result<()> {
     let gate = AttachmentGate::default();
     let mut client: Option<(UnixStream, u64)> = None;
     loop {
@@ -132,60 +230,194 @@ fn run_socket_loop(node: &mut SharedLayoutNode, listener: UnixListener, descript
                     stream.set_read_timeout(Some(Duration::from_millis(100)))?;
                     if let Ok(generation) = gate.attach() {
                         match read_message(&mut stream) {
+                            Ok(Some(ClientMessage::Probe)) => {
+                                write_message(&mut stream, &NodeMessage::ProbeAck)?;
+                                let _ = gate.detach(generation);
+                            }
                             Ok(Some(ClientMessage::Hello { .. })) => {
-                                write_message(&mut stream, &NodeMessage::AttachAccepted { generation })?;
+                                write_message(
+                                    &mut stream,
+                                    &NodeMessage::AttachAccepted { generation },
+                                )?;
                                 write_snapshot(&mut stream, descriptor, node, generation)?;
                                 stream.set_read_timeout(Some(Duration::from_millis(1)))?;
                                 client = Some((stream, generation));
                             }
-                            Ok(None) => { let _ = gate.detach(generation); }
-                            Err(error) if error.kind() == io::ErrorKind::WouldBlock || error.kind() == io::ErrorKind::TimedOut => { let _ = gate.detach(generation); }
-                            Err(error) => return Err(error),
-                            _ => { let _ = gate.detach(generation); }
+                            Ok(None) => {
+                                let _ = gate.detach(generation);
+                            }
+                            Err(error)
+                                if matches!(
+                                    error.kind(),
+                                    io::ErrorKind::WouldBlock
+                                        | io::ErrorKind::TimedOut
+                                        | io::ErrorKind::ConnectionReset
+                                        | io::ErrorKind::BrokenPipe
+                                ) =>
+                            {
+                                let _ = gate.detach(generation);
+                            }
+                            Err(_) => {
+                                let _ = gate.detach(generation);
+                            }
+                            _ => {
+                                let _ = gate.detach(generation);
+                            }
                         }
-                    } else { let _ = write_message(&mut stream, &NodeMessage::AttachRejected { reason: "already attached".into() }); }
+                    } else {
+                        let _ = write_message(
+                            &mut stream,
+                            &NodeMessage::AttachRejected {
+                                reason: "already attached".into(),
+                            },
+                        );
+                    }
                 }
                 Err(error) if error.kind() == io::ErrorKind::WouldBlock => break,
+                Err(error)
+                    if matches!(
+                        error.kind(),
+                        io::ErrorKind::ConnectionAborted | io::ErrorKind::ConnectionReset
+                    ) =>
+                {
+                    continue;
+                }
                 Err(error) => return Err(error),
             }
         }
-        let changed = node.drain().map_err(|error| io::Error::other(error.to_string()))?;
-        let mut detached = false; let mut shutdown = false;
+        let changed = node
+            .drain()
+            .map_err(|error| io::Error::other(error.to_string()))?;
+        let mut detached = false;
+        let mut shutdown = false;
         if let Some((stream, generation)) = client.as_mut() {
             match read_message(stream) {
-                Ok(Some(ClientMessage::Input { bytes })) => node.input(bytes).map_err(|error| io::Error::other(error.to_string()))?,
-                Ok(Some(ClientMessage::Detach { generation: requested })) if requested == *generation => { node.release_all_local_control().map_err(|error| io::Error::other(error.to_string()))?; write_message(stream, &NodeMessage::DetachAck { generation: *generation })?; detached = true; }
-                Ok(Some(ClientMessage::Shutdown { generation: requested })) if requested == *generation => { write_message(stream, &NodeMessage::ShutdownAck { generation: *generation })?; shutdown = true; }
-                Ok(Some(ClientMessage::Rename { name })) => { if crate::session_store::valid_name(&name) { write_message(stream, &NodeMessage::Update { state: serde_json::json!({"name": name}) })?; } else { write_message(stream, &NodeMessage::Error { message: "invalid session name".into() })?; } }
+                Ok(Some(ClientMessage::Input { bytes })) => node
+                    .input(bytes)
+                    .map_err(|error| io::Error::other(error.to_string()))?,
+                Ok(Some(ClientMessage::Detach {
+                    generation: requested,
+                })) if requested == *generation => {
+                    node.release_all_local_control()
+                        .map_err(|error| io::Error::other(error.to_string()))?;
+                    write_message(
+                        stream,
+                        &NodeMessage::DetachAck {
+                            generation: *generation,
+                        },
+                    )?;
+                    detached = true;
+                }
+                Ok(Some(ClientMessage::Shutdown {
+                    generation: requested,
+                })) if requested == *generation => {
+                    write_message(
+                        stream,
+                        &NodeMessage::ShutdownAck {
+                            generation: *generation,
+                        },
+                    )?;
+                    shutdown = true;
+                }
+                Ok(Some(ClientMessage::Rename { name })) => {
+                    if crate::session_store::valid_name(&name) {
+                        write_message(
+                            stream,
+                            &NodeMessage::Update {
+                                state: serde_json::json!({"name": name}),
+                            },
+                        )?;
+                    } else {
+                        write_message(
+                            stream,
+                            &NodeMessage::Error {
+                                message: "invalid session name".into(),
+                            },
+                        )?;
+                    }
+                }
                 Ok(Some(_)) => {}
-                Err(error) if error.kind() == io::ErrorKind::WouldBlock || error.kind() == io::ErrorKind::TimedOut => {}
+                Err(error)
+                    if error.kind() == io::ErrorKind::WouldBlock
+                        || error.kind() == io::ErrorKind::TimedOut => {}
                 Ok(None) => detached = true,
                 Err(_) => detached = true,
             }
-            if changed { write_snapshot(stream, descriptor, node, *generation)?; }
+            if changed && !detached {
+                write_snapshot(stream, descriptor, node, *generation)?;
+            }
         }
-        if let Some((stream, generation)) = client.take().filter(|_| detached || shutdown) {
-            let _ = stream.shutdown(Shutdown::Both); let _ = gate.detach(generation); node.release_all_local_control().map_err(|error| io::Error::other(error.to_string()))?;
+        if (detached || shutdown)
+            && let Some((stream, generation)) = client.take()
+        {
+            let _ = stream.shutdown(Shutdown::Both);
+            let _ = gate.detach(generation);
+            node.release_all_local_control()
+                .map_err(|error| io::Error::other(error.to_string()))?;
         }
-        if shutdown { return Ok(()); }
+        if shutdown {
+            return Ok(());
+        }
         std::thread::sleep(Duration::from_millis(16));
     }
 }
 
 fn read_message(stream: &mut UnixStream) -> io::Result<Option<ClientMessage>> {
-    let mut reader = BufReader::new(stream.try_clone()?); let mut line = String::new();
-    match reader.read_line(&mut line) { Ok(0) => Ok(None), Ok(_) => serde_json::from_str(&line).map(Some).map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "invalid local IPC message")), Err(error) => Err(error) }
+    let mut reader = BufReader::new(stream.try_clone()?);
+    let mut line = String::new();
+    match reader.read_line(&mut line) {
+        Ok(0) => Ok(None),
+        Ok(_) => serde_json::from_str(&line)
+            .map(Some)
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "invalid local IPC message")),
+        Err(error) => Err(error),
+    }
 }
-fn write_message(stream: &mut UnixStream, message: &NodeMessage) -> io::Result<()> { serde_json::to_writer(&mut *stream, message).map_err(io::Error::other)?; stream.write_all(b"\n")?; stream.flush() }
-fn write_snapshot(stream: &mut UnixStream, descriptor: &SessionDescriptor, node: &SharedLayoutNode, _generation: u64) -> io::Result<()> {
+fn write_message(stream: &mut UnixStream, message: &NodeMessage) -> io::Result<()> {
+    serde_json::to_writer(&mut *stream, message).map_err(io::Error::other)?;
+    stream.write_all(b"\n")?;
+    stream.flush()
+}
+fn write_snapshot(
+    stream: &mut UnixStream,
+    descriptor: &SessionDescriptor,
+    node: &SharedLayoutNode,
+    _generation: u64,
+) -> io::Result<()> {
     let (tab_id, pane_id) = node.local_focus();
-    write_message(stream, &NodeMessage::Snapshot { room_name: descriptor.name.clone(), role: match descriptor.role { SessionRole::Coordinator => "coordinator", SessionRole::Member => "member" }.into(), summary: SessionSummary { tabs: 1, panes: 1, hosts: 1, coordinator_name: String::new() }, layout: serde_json::json!({}), screens: serde_json::json!(node.screen_text()), leases: serde_json::json!({}), rosters: serde_json::json!({}), tab_id, pane_id })
+    write_message(
+        stream,
+        &NodeMessage::Snapshot {
+            room_name: descriptor.name.clone(),
+            role: match descriptor.role {
+                SessionRole::Coordinator => "coordinator",
+                SessionRole::Member => "member",
+            }
+            .into(),
+            summary: SessionSummary {
+                tabs: 1,
+                panes: 1,
+                hosts: 1,
+                coordinator_name: String::new(),
+            },
+            layout: serde_json::json!({}),
+            screens: serde_json::json!(node.screen_text()),
+            leases: serde_json::json!({}),
+            rosters: serde_json::json!({}),
+            tab_id,
+            pane_id,
+        },
+    )
 }
 
 impl SharedLayoutNode {
     pub fn new(runtime: SharedLayoutRuntime) -> Self {
         let (last_tab_id, last_pane_id) = runtime.local_focus();
-        Self { runtime, last_tab_id, last_pane_id }
+        Self {
+            runtime,
+            last_tab_id,
+            last_pane_id,
+        }
     }
 
     /// Advances Iroh, pane servers, PTYs, leases, subscriptions and agent sampling without ever
@@ -196,10 +428,22 @@ impl SharedLayoutNode {
         Ok(changed)
     }
 
-    pub fn input(&mut self, bytes: Vec<u8>) -> Result<(), Box<dyn Error>> { self.runtime.node_input(bytes) }
-    pub fn release_all_local_control(&mut self) -> Result<(), Box<dyn Error>> { self.runtime.release_all_local_control() }
-    pub fn local_focus(&self) -> (u64, u64) { (self.last_tab_id, self.last_pane_id) }
-    pub fn screen_text(&self) -> String { self.runtime.node_screen_text() }
-    pub fn tick_due(&self) -> Instant { Instant::now() }
-    pub fn shutdown(self) { self.runtime.shutdown_node(); }
+    pub fn input(&mut self, bytes: Vec<u8>) -> Result<(), Box<dyn Error>> {
+        self.runtime.node_input(bytes)
+    }
+    pub fn release_all_local_control(&mut self) -> Result<(), Box<dyn Error>> {
+        self.runtime.release_all_local_control()
+    }
+    pub fn local_focus(&self) -> (u64, u64) {
+        (self.last_tab_id, self.last_pane_id)
+    }
+    pub fn screen_text(&self) -> String {
+        self.runtime.node_screen_text()
+    }
+    pub fn tick_due(&self) -> Instant {
+        Instant::now()
+    }
+    pub fn shutdown(self) {
+        self.runtime.shutdown_node();
+    }
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -172,7 +172,9 @@ pub async fn run_background(bootstrap: NodeBootstrap) -> Result<(), Box<dyn Erro
     listener.set_nonblocking(true)?;
     store.write(&descriptor)?;
     let result = run_socket_loop(&mut node, listener, &descriptor);
-    node.shutdown();
+    // `SharedLayoutRuntime` owns a Tokio handle for its asynchronous pane/control cleanup.
+    // The node itself runs on this runtime, so perform that blocking teardown outside its worker.
+    tokio::task::block_in_place(|| node.shutdown());
     dispatcher_task.abort();
     let _ = dispatcher_task.await;
     if let Some(rendezvous) = rendezvous {
@@ -227,55 +229,62 @@ fn run_socket_loop(
     let gate = AttachmentGate::default();
     let mut client: Option<(UnixStream, u64)> = None;
     loop {
+        let mut shutdown = false;
         loop {
             match listener.accept() {
                 Ok((mut stream, _)) => {
                     stream.set_read_timeout(Some(Duration::from_millis(100)))?;
-                    if let Ok(generation) = gate.attach() {
-                        match read_message(&mut stream) {
-                            Ok(Some(ClientMessage::Probe)) => {
-                                write_message(&mut stream, &NodeMessage::ProbeAck)?;
-                                let _ = gate.detach(generation);
-                            }
-                            Ok(Some(ClientMessage::Hello { cols, rows })) => {
+                    match read_message(&mut stream) {
+                        // Probes and shutdowns are control requests. They must not consume or
+                        // contend with the single interactive attachment slot.
+                        Ok(Some(ClientMessage::Probe)) => {
+                            let _ = write_message(&mut stream, &NodeMessage::ProbeAck);
+                        }
+                        Ok(Some(ClientMessage::Shutdown { generation })) => {
+                            let _ = write_message(
+                                &mut stream,
+                                &NodeMessage::ShutdownAck { generation },
+                            );
+                            shutdown = true;
+                            break;
+                        }
+                        Ok(Some(ClientMessage::Hello { cols, rows })) => {
+                            if let Ok(generation) = gate.attach() {
                                 node.resize(cols, rows)
                                     .map_err(|error| io::Error::other(error.to_string()))?;
-                                write_message(
+                                let attached = write_message(
                                     &mut stream,
                                     &NodeMessage::AttachAccepted { generation },
-                                )?;
-                                write_snapshot(&mut stream, descriptor, node, generation)?;
-                                stream.set_read_timeout(Some(Duration::from_millis(1)))?;
-                                client = Some((stream, generation));
-                            }
-                            Ok(None) => {
-                                let _ = gate.detach(generation);
-                            }
-                            Err(error)
-                                if matches!(
-                                    error.kind(),
-                                    io::ErrorKind::WouldBlock
-                                        | io::ErrorKind::TimedOut
-                                        | io::ErrorKind::ConnectionReset
-                                        | io::ErrorKind::BrokenPipe
-                                ) =>
-                            {
-                                let _ = gate.detach(generation);
-                            }
-                            Err(_) => {
-                                let _ = gate.detach(generation);
-                            }
-                            _ => {
-                                let _ = gate.detach(generation);
+                                )
+                                .and_then(|()| {
+                                    write_snapshot(&mut stream, descriptor, node, generation)
+                                })
+                                .is_ok();
+                                if attached {
+                                    stream.set_read_timeout(Some(Duration::from_millis(1)))?;
+                                    client = Some((stream, generation));
+                                } else {
+                                    let _ = gate.detach(generation);
+                                }
+                            } else {
+                                let _ = write_message(
+                                    &mut stream,
+                                    &NodeMessage::AttachRejected {
+                                        reason: "already attached".into(),
+                                    },
+                                );
                             }
                         }
-                    } else {
-                        let _ = write_message(
-                            &mut stream,
-                            &NodeMessage::AttachRejected {
-                                reason: "already attached".into(),
-                            },
-                        );
+                        Ok(None) => {}
+                        Err(error)
+                            if matches!(
+                                error.kind(),
+                                io::ErrorKind::WouldBlock
+                                    | io::ErrorKind::TimedOut
+                                    | io::ErrorKind::ConnectionReset
+                                    | io::ErrorKind::BrokenPipe
+                            ) => {}
+                        Err(_) | Ok(Some(_)) => {}
                     }
                 }
                 Err(error) if error.kind() == io::ErrorKind::WouldBlock => break,
@@ -294,8 +303,7 @@ fn run_socket_loop(
             .drain()
             .map_err(|error| io::Error::other(error.to_string()))?;
         let mut detached = false;
-        let mut shutdown = false;
-        if let Some((stream, generation)) = client.as_mut() {
+        if !shutdown && let Some((stream, generation)) = client.as_mut() {
             match read_message(stream) {
                 Ok(Some(ClientMessage::Input { bytes })) => node
                     .input(bytes)
@@ -320,12 +328,12 @@ fn run_socket_loop(
                 })) if requested == *generation => {
                     node.release_all_local_control()
                         .map_err(|error| io::Error::other(error.to_string()))?;
-                    write_message(
+                    let _ = write_message(
                         stream,
                         &NodeMessage::DetachAck {
                             generation: *generation,
                         },
-                    )?;
+                    );
                     detached = true;
                 }
                 Ok(Some(ClientMessage::Shutdown {
@@ -364,7 +372,9 @@ fn run_socket_loop(
                 Err(_) => detached = true,
             }
             if changed && !detached {
-                write_snapshot(stream, descriptor, node, *generation)?;
+                if write_snapshot(stream, descriptor, node, *generation).is_err() {
+                    detached = true;
+                }
             }
         }
         if (detached || shutdown)

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -221,7 +221,8 @@ impl GuestScreen {
     }
 }
 
-fn snapshot_payload(screen: &vt100::Screen) -> Result<Arc<[u8]>, ScreenError> {
+/// Encodes a complete fixed-grid screen for a fresh local or remote renderer.
+pub fn snapshot_payload(screen: &vt100::Screen) -> Result<Arc<[u8]>, ScreenError> {
     let (rows, cols) = screen.size();
     validate_dimensions(rows, cols)?;
     let state = screen.state_formatted();

--- a/src/session_store.rs
+++ b/src/session_store.rs
@@ -5,7 +5,7 @@
 
 use std::{
     fs::{self, OpenOptions},
-    io::{self, Read, Write},
+    io::{self, BufRead, Write},
     os::unix::{fs::OpenOptionsExt, net::UnixStream},
     path::{Path, PathBuf},
     time::{Duration, SystemTime, UNIX_EPOCH},
@@ -259,8 +259,12 @@ fn probe(path: &Path) -> bool {
     {
         return false;
     }
+    // Read one newline-delimited ack. Do not use read_to_string: the node keeps the
+    // connection open, so waiting for EOF falsely marks live sessions as dead and
+    // list_live would delete their descriptors.
+    let mut reader = io::BufReader::new(stream);
     let mut response = String::new();
-    stream.read_to_string(&mut response).is_ok() && response.contains("\"probe_ack\"")
+    matches!(reader.read_line(&mut response), Ok(n) if n > 0) && response.contains("\"probe_ack\"")
 }
 
 fn current_uid() -> io::Result<String> {
@@ -336,5 +340,40 @@ mod tests {
             .unwrap();
         assert!(store.list_live().unwrap().is_empty());
         assert!(store.read(&id).is_err());
+    }
+
+    #[test]
+    fn live_probe_reads_one_ack_without_waiting_for_eof() {
+        use std::os::unix::net::UnixListener;
+        use std::thread;
+
+        let store = store();
+        let id = generate_id().unwrap();
+        let socket = store.socket_path(&id).unwrap();
+        let _ = fs::remove_file(&socket);
+        let listener = UnixListener::bind(&socket).unwrap();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut line = String::new();
+            let mut reader = io::BufReader::new(stream.try_clone().unwrap());
+            reader.read_line(&mut line).unwrap();
+            assert!(line.contains("probe"));
+            stream.write_all(b"{\"type\":\"probe_ack\"}\n").unwrap();
+            // Keep the connection open briefly; a correct probe must not require EOF.
+            thread::sleep(Duration::from_millis(50));
+        });
+        store
+            .write(&SessionDescriptor::new(
+                id.clone(),
+                "amber-otter-01".into(),
+                socket,
+                42,
+                SessionRole::Coordinator,
+            ))
+            .unwrap();
+        let live = store.list_live().unwrap();
+        assert_eq!(live.len(), 1);
+        assert_eq!(live[0].id, id);
+        server.join().unwrap();
     }
 }

--- a/src/session_store.rs
+++ b/src/session_store.rs
@@ -1,0 +1,198 @@
+//! Small, durable finder records for locally running sessions.
+//!
+//! The record intentionally contains only enough information to find a live node.  Session
+//! state (PTYs, tickets, screens, and focus) belongs to the node process, never to disk.
+
+use std::{
+    fs::{self, OpenOptions},
+    io::{self, Write},
+    os::unix::{fs::OpenOptionsExt, net::UnixStream},
+    path::{Path, PathBuf},
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use getrandom::fill;
+use serde::{Deserialize, Serialize};
+
+const VERSION: u32 = 1;
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionRole {
+    Coordinator,
+    Member,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct SessionDescriptor {
+    pub version: u32,
+    pub id: String,
+    pub name: String,
+    pub socket_path: PathBuf,
+    pub node_pid: u32,
+    pub role: SessionRole,
+    pub created_at: u64,
+}
+
+impl SessionDescriptor {
+    pub fn new(id: String, name: String, socket_path: PathBuf, node_pid: u32, role: SessionRole) -> Self {
+        Self { version: VERSION, id, name, socket_path, node_pid, role, created_at: now_secs() }
+    }
+
+    fn validate(&self) -> io::Result<()> {
+        if self.version != VERSION || !valid_id(&self.id) || !valid_name(&self.name) || self.node_pid == 0 {
+            return Err(io::Error::new(io::ErrorKind::InvalidData, "malformed session descriptor"));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct SessionStore {
+    sessions_dir: PathBuf,
+    socket_dir: PathBuf,
+}
+
+impl SessionStore {
+    pub fn for_current_user() -> io::Result<Self> {
+        let home = std::env::var_os("HOME").ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "HOME is not set"))?;
+        let uid = unsafe_uid_not_needed();
+        Ok(Self::at(
+            PathBuf::from(home).join("Library/Application Support/p2pmux/sessions"),
+            PathBuf::from("/tmp").join(format!("p2pmux-{uid}")),
+        ))
+    }
+
+    /// Test-friendly constructor.  Directories are created lazily with private permissions.
+    pub fn at(sessions_dir: PathBuf, socket_dir: PathBuf) -> Self {
+        Self { sessions_dir, socket_dir }
+    }
+
+    pub fn socket_path(&self, id: &str) -> io::Result<PathBuf> {
+        if !valid_id(id) { return Err(io::Error::new(io::ErrorKind::InvalidInput, "invalid session id")); }
+        self.ensure_dirs()?;
+        Ok(self.socket_dir.join(format!("{id}.sock")))
+    }
+
+    pub fn write(&self, descriptor: &SessionDescriptor) -> io::Result<()> {
+        descriptor.validate()?;
+        self.ensure_dirs()?;
+        let destination = self.sessions_dir.join(format!("{}.json", descriptor.id));
+        let temporary = self.sessions_dir.join(format!(".{}.{}.tmp", descriptor.id, std::process::id()));
+        let bytes = serde_json::to_vec(descriptor).map_err(io::Error::other)?;
+        let mut file = OpenOptions::new().write(true).create_new(true).mode(0o600).open(&temporary)?;
+        file.write_all(&bytes)?;
+        file.sync_all()?;
+        fs::rename(temporary, destination)?;
+        Ok(())
+    }
+
+    pub fn read(&self, id: &str) -> io::Result<SessionDescriptor> {
+        let descriptor: SessionDescriptor = serde_json::from_slice(&fs::read(self.sessions_dir.join(format!("{id}.json")))?)
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "malformed session descriptor"))?;
+        descriptor.validate()?;
+        if descriptor.id != id { return Err(io::Error::new(io::ErrorKind::InvalidData, "malformed session descriptor")); }
+        Ok(descriptor)
+    }
+
+    pub fn remove(&self, id: &str) -> io::Result<()> {
+        match fs::remove_file(self.sessions_dir.join(format!("{id}.json"))) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error),
+        }
+    }
+
+    /// Returns only connectable descriptors. Failed probes are the sole condition under which a
+    /// finder record is removed, avoiding accidental deletion of a node that is merely starting.
+    pub fn list_live(&self) -> io::Result<Vec<SessionDescriptor>> {
+        let entries = match fs::read_dir(&self.sessions_dir) {
+            Ok(entries) => entries,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(error) => return Err(error),
+        };
+        let mut sessions = Vec::new();
+        for entry in entries {
+            let entry = entry?;
+            let path = entry.path();
+            if path.extension().and_then(|value| value.to_str()) != Some("json") { continue; }
+            let id = match path.file_stem().and_then(|value| value.to_str()) { Some(value) => value, None => continue };
+            match self.read(id) {
+                Ok(descriptor) if probe(&descriptor.socket_path) => sessions.push(descriptor),
+                Ok(_) | Err(_) => { let _ = fs::remove_file(path); }
+            }
+        }
+        sessions.sort_by(|left, right| left.created_at.cmp(&right.created_at));
+        Ok(sessions)
+    }
+
+    pub fn rename(&self, old: &str, new: &str) -> io::Result<SessionDescriptor> {
+        if !valid_name(new) { return Err(io::Error::new(io::ErrorKind::InvalidInput, "invalid session name")); }
+        let mut descriptor = self.read(old)?;
+        descriptor.name = new.to_owned();
+        self.write(&descriptor)?;
+        Ok(descriptor)
+    }
+
+    fn ensure_dirs(&self) -> io::Result<()> {
+        for directory in [&self.sessions_dir, &self.socket_dir] {
+            fs::create_dir_all(directory)?;
+            fs::set_permissions(directory, std::os::unix::fs::PermissionsExt::from_mode(0o700))?;
+        }
+        Ok(())
+    }
+}
+
+pub fn generate_id() -> io::Result<String> { random_hex(16) }
+
+pub fn generate_name() -> io::Result<String> {
+    const ADJECTIVES: &[&str] = &["amber", "brisk", "cobalt", "daring", "ember", "fuzzy", "golden", "lunar"];
+    const NOUNS: &[&str] = &["badger", "comet", "falcon", "harbor", "meadow", "otter", "pine", "river"];
+    let mut bytes = [0u8; 3];
+    fill(&mut bytes).map_err(|error| io::Error::other(error.to_string()))?;
+    Ok(format!("{}-{}-{:02x}", ADJECTIVES[usize::from(bytes[0]) % ADJECTIVES.len()], NOUNS[usize::from(bytes[1]) % NOUNS.len()], bytes[2]))
+}
+
+pub fn valid_name(name: &str) -> bool {
+    !name.is_empty() && name.len() <= 48 && !name.starts_with('-') && !name.ends_with('-')
+        && name.bytes().all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+}
+
+fn valid_id(id: &str) -> bool { id.len() == 32 && id.bytes().all(|byte| byte.is_ascii_hexdigit()) }
+fn random_hex(length: usize) -> io::Result<String> { let mut bytes = vec![0u8; length]; fill(&mut bytes).map_err(|error| io::Error::other(error.to_string()))?; Ok(bytes.iter().map(|byte| format!("{byte:02x}")).collect()) }
+fn now_secs() -> u64 { SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or(Duration::ZERO).as_secs() }
+fn probe(path: &Path) -> bool { UnixStream::connect(path).is_ok() }
+
+// libc is deliberately not a dependency. macOS always exports the POSIX uid through this env
+// in normal shells; tests can provide it. Falling back to the process id keeps socket names safe.
+fn unsafe_uid_not_needed() -> String { std::env::var("UID").unwrap_or_else(|_| std::process::id().to_string()) }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{os::unix::fs::PermissionsExt, time::{SystemTime, UNIX_EPOCH}};
+
+    fn store() -> SessionStore {
+        let root = std::env::temp_dir().join(format!("p2pmux-session-store-{}", SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos()));
+        SessionStore::at(root.join("sessions"), root.join("sockets"))
+    }
+
+    #[test]
+    fn writes_private_atomic_descriptor_and_validates_names() {
+        let store = store(); let id = generate_id().unwrap(); let socket = store.socket_path(&id).unwrap();
+        let descriptor = SessionDescriptor::new(id.clone(), "amber-otter-01".into(), socket, 42, SessionRole::Coordinator);
+        store.write(&descriptor).unwrap();
+        assert_eq!(store.read(&id).unwrap(), descriptor);
+        assert_eq!(fs::metadata(store.sessions_dir.join(format!("{id}.json"))).unwrap().permissions().mode() & 0o777, 0o600);
+        assert!(!valid_name("Nope") && !valid_name("-nope") && valid_name("good-name-2"));
+    }
+
+    #[test]
+    fn stale_records_are_removed_only_after_probe_fails() {
+        let store = store(); let id = generate_id().unwrap(); let socket = store.socket_path(&id).unwrap();
+        store.write(&SessionDescriptor::new(id.clone(), "amber-otter-01".into(), socket, 42, SessionRole::Coordinator)).unwrap();
+        assert!(store.list_live().unwrap().is_empty());
+        assert!(store.read(&id).is_err());
+    }
+}

--- a/src/session_store.rs
+++ b/src/session_store.rs
@@ -5,7 +5,7 @@
 
 use std::{
     fs::{self, OpenOptions},
-    io::{self, Write},
+    io::{self, Read, Write},
     os::unix::{fs::OpenOptionsExt, net::UnixStream},
     path::{Path, PathBuf},
     time::{Duration, SystemTime, UNIX_EPOCH},
@@ -36,13 +36,34 @@ pub struct SessionDescriptor {
 }
 
 impl SessionDescriptor {
-    pub fn new(id: String, name: String, socket_path: PathBuf, node_pid: u32, role: SessionRole) -> Self {
-        Self { version: VERSION, id, name, socket_path, node_pid, role, created_at: now_secs() }
+    pub fn new(
+        id: String,
+        name: String,
+        socket_path: PathBuf,
+        node_pid: u32,
+        role: SessionRole,
+    ) -> Self {
+        Self {
+            version: VERSION,
+            id,
+            name,
+            socket_path,
+            node_pid,
+            role,
+            created_at: now_secs(),
+        }
     }
 
     fn validate(&self) -> io::Result<()> {
-        if self.version != VERSION || !valid_id(&self.id) || !valid_name(&self.name) || self.node_pid == 0 {
-            return Err(io::Error::new(io::ErrorKind::InvalidData, "malformed session descriptor"));
+        if self.version != VERSION
+            || !valid_id(&self.id)
+            || !valid_name(&self.name)
+            || self.node_pid == 0
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "malformed session descriptor",
+            ));
         }
         Ok(())
     }
@@ -56,8 +77,9 @@ pub struct SessionStore {
 
 impl SessionStore {
     pub fn for_current_user() -> io::Result<Self> {
-        let home = std::env::var_os("HOME").ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "HOME is not set"))?;
-        let uid = unsafe_uid_not_needed();
+        let home = std::env::var_os("HOME")
+            .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "HOME is not set"))?;
+        let uid = current_uid()?;
         Ok(Self::at(
             PathBuf::from(home).join("Library/Application Support/p2pmux/sessions"),
             PathBuf::from("/tmp").join(format!("p2pmux-{uid}")),
@@ -66,11 +88,19 @@ impl SessionStore {
 
     /// Test-friendly constructor.  Directories are created lazily with private permissions.
     pub fn at(sessions_dir: PathBuf, socket_dir: PathBuf) -> Self {
-        Self { sessions_dir, socket_dir }
+        Self {
+            sessions_dir,
+            socket_dir,
+        }
     }
 
     pub fn socket_path(&self, id: &str) -> io::Result<PathBuf> {
-        if !valid_id(id) { return Err(io::Error::new(io::ErrorKind::InvalidInput, "invalid session id")); }
+        if !valid_id(id) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "invalid session id",
+            ));
+        }
         self.ensure_dirs()?;
         Ok(self.socket_dir.join(format!("{id}.sock")))
     }
@@ -79,9 +109,15 @@ impl SessionStore {
         descriptor.validate()?;
         self.ensure_dirs()?;
         let destination = self.sessions_dir.join(format!("{}.json", descriptor.id));
-        let temporary = self.sessions_dir.join(format!(".{}.{}.tmp", descriptor.id, std::process::id()));
+        let temporary =
+            self.sessions_dir
+                .join(format!(".{}.{}.tmp", descriptor.id, std::process::id()));
         let bytes = serde_json::to_vec(descriptor).map_err(io::Error::other)?;
-        let mut file = OpenOptions::new().write(true).create_new(true).mode(0o600).open(&temporary)?;
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(&temporary)?;
         file.write_all(&bytes)?;
         file.sync_all()?;
         fs::rename(temporary, destination)?;
@@ -89,10 +125,18 @@ impl SessionStore {
     }
 
     pub fn read(&self, id: &str) -> io::Result<SessionDescriptor> {
-        let descriptor: SessionDescriptor = serde_json::from_slice(&fs::read(self.sessions_dir.join(format!("{id}.json")))?)
-            .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "malformed session descriptor"))?;
+        let descriptor: SessionDescriptor =
+            serde_json::from_slice(&fs::read(self.sessions_dir.join(format!("{id}.json")))?)
+                .map_err(|_| {
+                    io::Error::new(io::ErrorKind::InvalidData, "malformed session descriptor")
+                })?;
         descriptor.validate()?;
-        if descriptor.id != id { return Err(io::Error::new(io::ErrorKind::InvalidData, "malformed session descriptor")); }
+        if descriptor.id != id {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "malformed session descriptor",
+            ));
+        }
         Ok(descriptor)
     }
 
@@ -116,11 +160,18 @@ impl SessionStore {
         for entry in entries {
             let entry = entry?;
             let path = entry.path();
-            if path.extension().and_then(|value| value.to_str()) != Some("json") { continue; }
-            let id = match path.file_stem().and_then(|value| value.to_str()) { Some(value) => value, None => continue };
+            if path.extension().and_then(|value| value.to_str()) != Some("json") {
+                continue;
+            }
+            let id = match path.file_stem().and_then(|value| value.to_str()) {
+                Some(value) => value,
+                None => continue,
+            };
             match self.read(id) {
                 Ok(descriptor) if probe(&descriptor.socket_path) => sessions.push(descriptor),
-                Ok(_) | Err(_) => { let _ = fs::remove_file(path); }
+                Ok(_) | Err(_) => {
+                    let _ = fs::remove_file(path);
+                }
             }
         }
         sessions.sort_by(|left, right| left.created_at.cmp(&right.created_at));
@@ -128,7 +179,12 @@ impl SessionStore {
     }
 
     pub fn rename(&self, old: &str, new: &str) -> io::Result<SessionDescriptor> {
-        if !valid_name(new) { return Err(io::Error::new(io::ErrorKind::InvalidInput, "invalid session name")); }
+        if !valid_name(new) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "invalid session name",
+            ));
+        }
         let mut descriptor = self.read(old)?;
         descriptor.name = new.to_owned();
         self.write(&descriptor)?;
@@ -138,60 +194,146 @@ impl SessionStore {
     fn ensure_dirs(&self) -> io::Result<()> {
         for directory in [&self.sessions_dir, &self.socket_dir] {
             fs::create_dir_all(directory)?;
-            fs::set_permissions(directory, std::os::unix::fs::PermissionsExt::from_mode(0o700))?;
+            fs::set_permissions(
+                directory,
+                std::os::unix::fs::PermissionsExt::from_mode(0o700),
+            )?;
         }
         Ok(())
     }
 }
 
-pub fn generate_id() -> io::Result<String> { random_hex(16) }
+pub fn generate_id() -> io::Result<String> {
+    random_hex(16)
+}
 
 pub fn generate_name() -> io::Result<String> {
-    const ADJECTIVES: &[&str] = &["amber", "brisk", "cobalt", "daring", "ember", "fuzzy", "golden", "lunar"];
-    const NOUNS: &[&str] = &["badger", "comet", "falcon", "harbor", "meadow", "otter", "pine", "river"];
+    const ADJECTIVES: &[&str] = &[
+        "amber", "brisk", "cobalt", "daring", "ember", "fuzzy", "golden", "lunar",
+    ];
+    const NOUNS: &[&str] = &[
+        "badger", "comet", "falcon", "harbor", "meadow", "otter", "pine", "river",
+    ];
     let mut bytes = [0u8; 3];
     fill(&mut bytes).map_err(|error| io::Error::other(error.to_string()))?;
-    Ok(format!("{}-{}-{:02x}", ADJECTIVES[usize::from(bytes[0]) % ADJECTIVES.len()], NOUNS[usize::from(bytes[1]) % NOUNS.len()], bytes[2]))
+    Ok(format!(
+        "{}-{}-{:02x}",
+        ADJECTIVES[usize::from(bytes[0]) % ADJECTIVES.len()],
+        NOUNS[usize::from(bytes[1]) % NOUNS.len()],
+        bytes[2]
+    ))
 }
 
 pub fn valid_name(name: &str) -> bool {
-    !name.is_empty() && name.len() <= 48 && !name.starts_with('-') && !name.ends_with('-')
-        && name.bytes().all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+    !name.is_empty()
+        && name.len() <= 48
+        && !name.starts_with('-')
+        && !name.ends_with('-')
+        && name
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
 }
 
-fn valid_id(id: &str) -> bool { id.len() == 32 && id.bytes().all(|byte| byte.is_ascii_hexdigit()) }
-fn random_hex(length: usize) -> io::Result<String> { let mut bytes = vec![0u8; length]; fill(&mut bytes).map_err(|error| io::Error::other(error.to_string()))?; Ok(bytes.iter().map(|byte| format!("{byte:02x}")).collect()) }
-fn now_secs() -> u64 { SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or(Duration::ZERO).as_secs() }
-fn probe(path: &Path) -> bool { UnixStream::connect(path).is_ok() }
+fn valid_id(id: &str) -> bool {
+    id.len() == 32 && id.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+fn random_hex(length: usize) -> io::Result<String> {
+    let mut bytes = vec![0u8; length];
+    fill(&mut bytes).map_err(|error| io::Error::other(error.to_string()))?;
+    Ok(bytes.iter().map(|byte| format!("{byte:02x}")).collect())
+}
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or(Duration::ZERO)
+        .as_secs()
+}
+fn probe(path: &Path) -> bool {
+    let Ok(mut stream) = UnixStream::connect(path) else {
+        return false;
+    };
+    if stream.write_all(b"{\"type\":\"probe\"}\n").is_err()
+        || stream
+            .set_read_timeout(Some(Duration::from_millis(250)))
+            .is_err()
+    {
+        return false;
+    }
+    let mut response = String::new();
+    stream.read_to_string(&mut response).is_ok() && response.contains("\"probe_ack\"")
+}
 
-// libc is deliberately not a dependency. macOS always exports the POSIX uid through this env
-// in normal shells; tests can provide it. Falling back to the process id keeps socket names safe.
-fn unsafe_uid_not_needed() -> String { std::env::var("UID").unwrap_or_else(|_| std::process::id().to_string()) }
+fn current_uid() -> io::Result<String> {
+    let output = std::process::Command::new("id").arg("-u").output()?;
+    if !output.status.success() {
+        return Err(io::Error::other("could not determine current uid"));
+    }
+    let uid = String::from_utf8(output.stdout).map_err(|_| io::Error::other("invalid uid"))?;
+    let uid = uid.trim();
+    if uid.is_empty() || !uid.bytes().all(|byte| byte.is_ascii_digit()) {
+        return Err(io::Error::other("invalid uid"));
+    }
+    Ok(uid.to_owned())
+}
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::{os::unix::fs::PermissionsExt, time::{SystemTime, UNIX_EPOCH}};
+    use std::{
+        os::unix::fs::PermissionsExt,
+        time::{SystemTime, UNIX_EPOCH},
+    };
 
     fn store() -> SessionStore {
-        let root = std::env::temp_dir().join(format!("p2pmux-session-store-{}", SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos()));
+        let root = std::env::temp_dir().join(format!(
+            "p2pmux-session-store-{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
         SessionStore::at(root.join("sessions"), root.join("sockets"))
     }
 
     #[test]
     fn writes_private_atomic_descriptor_and_validates_names() {
-        let store = store(); let id = generate_id().unwrap(); let socket = store.socket_path(&id).unwrap();
-        let descriptor = SessionDescriptor::new(id.clone(), "amber-otter-01".into(), socket, 42, SessionRole::Coordinator);
+        let store = store();
+        let id = generate_id().unwrap();
+        let socket = store.socket_path(&id).unwrap();
+        let descriptor = SessionDescriptor::new(
+            id.clone(),
+            "amber-otter-01".into(),
+            socket,
+            42,
+            SessionRole::Coordinator,
+        );
         store.write(&descriptor).unwrap();
         assert_eq!(store.read(&id).unwrap(), descriptor);
-        assert_eq!(fs::metadata(store.sessions_dir.join(format!("{id}.json"))).unwrap().permissions().mode() & 0o777, 0o600);
+        assert_eq!(
+            fs::metadata(store.sessions_dir.join(format!("{id}.json")))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o600
+        );
         assert!(!valid_name("Nope") && !valid_name("-nope") && valid_name("good-name-2"));
     }
 
     #[test]
     fn stale_records_are_removed_only_after_probe_fails() {
-        let store = store(); let id = generate_id().unwrap(); let socket = store.socket_path(&id).unwrap();
-        store.write(&SessionDescriptor::new(id.clone(), "amber-otter-01".into(), socket, 42, SessionRole::Coordinator)).unwrap();
+        let store = store();
+        let id = generate_id().unwrap();
+        let socket = store.socket_path(&id).unwrap();
+        store
+            .write(&SessionDescriptor::new(
+                id.clone(),
+                "amber-otter-01".into(),
+                socket,
+                42,
+                SessionRole::Coordinator,
+            ))
+            .unwrap();
         assert!(store.list_live().unwrap().is_empty());
         assert!(store.read(&id).is_err());
     }

--- a/src/session_store.rs
+++ b/src/session_store.rs
@@ -347,9 +347,13 @@ mod tests {
         use std::os::unix::net::UnixListener;
         use std::thread;
 
-        let store = store();
+        let root = PathBuf::from(format!("/tmp/p2pmux-t-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&root);
+        let store = SessionStore::at(root.join("s"), root.join("k"));
         let id = generate_id().unwrap();
-        let socket = store.socket_path(&id).unwrap();
+        // Keep the path short enough for sockaddr_un on macOS.
+        let socket = root.join("k").join(format!("{}.s", &id[..8]));
+        fs::create_dir_all(root.join("k")).unwrap();
         let _ = fs::remove_file(&socket);
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
@@ -366,7 +370,7 @@ mod tests {
             .write(&SessionDescriptor::new(
                 id.clone(),
                 "amber-otter-01".into(),
-                socket,
+                socket.clone(),
                 42,
                 SessionRole::Coordinator,
             ))
@@ -375,5 +379,6 @@ mod tests {
         assert_eq!(live.len(), 1);
         assert_eq!(live[0].id, id);
         server.join().unwrap();
+        let _ = fs::remove_dir_all(root);
     }
 }

--- a/src/session_store.rs
+++ b/src/session_store.rs
@@ -174,7 +174,7 @@ impl SessionStore {
                 }
             }
         }
-        sessions.sort_by(|left, right| left.created_at.cmp(&right.created_at));
+        sessions.sort_by_key(|session| session.created_at);
         Ok(sessions)
     }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -67,6 +67,9 @@ use crate::{
     transport::Transport,
 };
 
+pub(crate) type NodeScreenSnapshots = BTreeMap<PaneId, (u64, Vec<u8>, bool)>;
+pub(crate) type NodeLeaseSnapshots = BTreeMap<PaneId, (bool, Option<Vec<u8>>, bool)>;
+
 /// Kept as the module's public marker from the scaffold.
 pub struct Tui;
 
@@ -2216,9 +2219,11 @@ fn format_agent_overlay_card(
         &row.cwd,
         usize::from(width.saturating_sub(text_width(&first_prefix))),
     );
-    let card_style = selected
-        .then_some(Style::default().bg(AGENT_OVERLAY_SELECTED_BACKGROUND))
-        .unwrap_or_default();
+    let card_style = if selected {
+        Style::default().bg(AGENT_OVERLAY_SELECTED_BACKGROUND)
+    } else {
+        Style::default()
+    };
     let first_line = agent_overlay_line(
         vec![
             Span::styled(marker, Style::default().fg(AGENT_OVERLAY_CHROME)),
@@ -3175,13 +3180,7 @@ impl SharedLayoutRuntime {
 
     /// A complete node-owned view for a newly attached local renderer. Frames are deliberately
     /// snapshots: the client can always rebuild a `GuestScreen` without owning a PTY.
-    pub fn node_snapshot(
-        &self,
-    ) -> (
-        LayoutSnapshot,
-        BTreeMap<PaneId, (u64, Vec<u8>, bool)>,
-        BTreeMap<PaneId, (bool, Option<Vec<u8>>, bool)>,
-    ) {
+    pub fn node_snapshot(&self) -> (LayoutSnapshot, NodeScreenSnapshots, NodeLeaseSnapshots) {
         let mut screens = BTreeMap::new();
         let mut chrome = BTreeMap::new();
         for (pane_id, pane) in &self.local {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -17,6 +17,8 @@ use std::{
 };
 use tokio::sync::{mpsc, watch};
 
+use serde::{Deserialize, Serialize};
+
 use crossterm::{
     event::{
         self, DisableBracketedPaste, DisableMouseCapture, EnableMouseCapture, Event, KeyCode,
@@ -147,8 +149,23 @@ pub struct PaneViewState {
     scrollback: usize,
 }
 
+impl PaneViewState {
+    pub fn from_chrome(
+        ready: bool,
+        controller_peer_id: Option<Vec<u8>>,
+        controller_active: bool,
+    ) -> Self {
+        Self {
+            ready,
+            controller_peer_id,
+            controller_active,
+            scrollback: 0,
+        }
+    }
+}
+
 /// User operations emitted by the TUI. Session code owns all resulting mutations and PTYs.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub enum UiIntent {
     CreatePane {
         target_pane_id: PaneId,
@@ -275,6 +292,7 @@ impl PaneTextSelection {
 /// Pure local rendering and selection state for a revisioned shared layout.
 #[derive(Clone, Debug)]
 pub struct MultiPaneTui {
+    title: String,
     snapshot: LayoutSnapshot,
     current_tab: TabId,
     focused_pane: PaneId,
@@ -304,6 +322,7 @@ impl MultiPaneTui {
             .map(|pane_id| (*pane_id, PaneViewState::default()))
             .collect();
         Ok(Self {
+            title: TOP_BAR_BRAND.into(),
             snapshot,
             current_tab,
             focused_pane,
@@ -325,6 +344,15 @@ impl MultiPaneTui {
 
     pub fn snapshot(&self) -> &LayoutSnapshot {
         &self.snapshot
+    }
+
+    /// Local clients may decorate the shared chrome without changing layout state.
+    pub fn set_title(&mut self, title: impl Into<String>) {
+        self.title = title.into();
+    }
+
+    pub fn title(&self) -> &str {
+        &self.title
     }
 
     pub fn current_tab(&self) -> TabId {
@@ -579,6 +607,22 @@ impl MultiPaneTui {
         pane_at(&self.geometry(area).panes, column, row).unwrap_or(self.focused_pane)
     }
 
+    pub fn pane_at_or_focused_for_mouse(&self, column: u16, row: u16, area: Rect) -> PaneId {
+        self.pane_at_or_focused(column, row, area)
+    }
+
+    pub fn scroll_mouse_pane(
+        &mut self,
+        column: u16,
+        row: u16,
+        area: Rect,
+        scrollback_len: usize,
+        up: bool,
+    ) -> bool {
+        let pane_id = self.pane_at_or_focused(column, row, area);
+        self.scroll_pane(pane_id, scrollback_len, up)
+    }
+
     fn scroll_pane(&mut self, pane_id: PaneId, scrollback_len: usize, up: bool) -> bool {
         let Some(view) = self.pane_views.get_mut(&pane_id) else {
             return false;
@@ -737,7 +781,7 @@ impl MultiPaneTui {
     fn tab_label_rects(&self, tab_bar: Rect) -> BTreeMap<TabId, Rect> {
         let mut x = tab_bar
             .x
-            .saturating_add(text_width(TOP_BAR_BRAND))
+            .saturating_add(text_width(&self.title))
             .saturating_add(text_width(TOP_BAR_BRAND_SEPARATOR));
         let right = tab_bar.x.saturating_add(tab_bar.width);
         self.snapshot
@@ -820,6 +864,66 @@ impl MultiPaneTui {
             self.exit_chord_mode();
             KeyHandling::Forward
         }
+    }
+
+    /// Applies the local half of mouse interaction and returns mutations for the node.
+    pub fn handle_mouse(
+        &mut self,
+        mouse: crossterm::event::MouseEvent,
+        area: Rect,
+    ) -> Vec<UiIntent> {
+        match mouse.kind {
+            MouseEventKind::Moved if !self.overlay_open() => {
+                self.hover_pane_at(mouse.column, mouse.row, area);
+                Vec::new()
+            }
+            MouseEventKind::Down(MouseButton::Left) => {
+                if self.overlay_open() {
+                    return self.handle_agent_overlay_click(mouse.column, mouse.row, area);
+                }
+                self.clear_selection();
+                if self.begin_resize_drag(mouse.column, mouse.row, area) {
+                    return Vec::new();
+                }
+                if let Some(intent) = self.switch_tab_at(mouse.column, mouse.row, area) {
+                    return vec![intent];
+                }
+                let changed = self.focus_pane_at(mouse.column, mouse.row, area);
+                self.begin_selection_at(mouse.column, mouse.row, area);
+                changed
+                    .then_some(UiIntent::FocusPane {
+                        pane_id: self.focused_pane,
+                    })
+                    .into_iter()
+                    .collect()
+            }
+            MouseEventKind::Drag(MouseButton::Left) => {
+                if !self.extend_resize_drag(mouse.column, mouse.row) {
+                    self.extend_selection_at(mouse.column, mouse.row, area);
+                }
+                Vec::new()
+            }
+            MouseEventKind::Up(MouseButton::Left) => {
+                self.end_selection_drag();
+                self.end_resize_drag(mouse.column, mouse.row)
+                    .into_iter()
+                    .collect()
+            }
+            _ => Vec::new(),
+        }
+    }
+
+    /// Aligns a reattached client's local selection with the node-owned focus.
+    pub fn set_focus(&mut self, tab_id: TabId, pane_id: PaneId) -> Result<(), LayoutError> {
+        self.select_tab(tab_id)?;
+        if !self
+            .current_tab_layout()
+            .is_some_and(|tab| contains_leaf(&tab.root, pane_id))
+        {
+            return Err(LayoutError::UnknownPane { pane_id });
+        }
+        self.focused_pane = pane_id;
+        Ok(())
     }
 
     fn handle_agent_overlay_key(&mut self, key: KeyEvent) -> KeyHandling {
@@ -1788,7 +1892,7 @@ fn render_shared_multi_pane(
             .set_stringn(
                 geometry.tab_bar.x,
                 geometry.tab_bar.y,
-                TOP_BAR_BRAND,
+                tui.title(),
                 usize::from(geometry.tab_bar.width),
                 Style::default().fg(Color::White).bg(FOOTER_BACKGROUND),
             )
@@ -2786,18 +2890,72 @@ impl SharedLayoutRuntime {
         (self.tui.current_tab(), self.tui.focused_pane())
     }
 
-    pub fn node_screen_text(&self) -> String {
-        let pane_id = self.tui.focused_pane();
-        self.local
-            .get(&pane_id)
-            .map(|pane| pane.screen.screen().contents())
-            .or_else(|| {
-                self.remote
-                    .get(&pane_id)
-                    .and_then(|pane| pane.screen.screen())
-                    .map(vt100::Screen::contents)
-            })
-            .unwrap_or_default()
+    /// A complete node-owned view for a newly attached local renderer. Frames are deliberately
+    /// snapshots: the client can always rebuild a `GuestScreen` without owning a PTY.
+    pub fn node_snapshot(
+        &self,
+    ) -> (
+        LayoutSnapshot,
+        BTreeMap<PaneId, (u64, Vec<u8>, bool)>,
+        BTreeMap<PaneId, (bool, Option<Vec<u8>>, bool)>,
+    ) {
+        let mut screens = BTreeMap::new();
+        let mut chrome = BTreeMap::new();
+        for (pane_id, pane) in &self.local {
+            let frame = pane.screen.current_frame();
+            screens.insert(
+                *pane_id,
+                (
+                    frame.sequence,
+                    frame.snapshot.as_ref().to_vec(),
+                    frame.kitty_keyboard_active,
+                ),
+            );
+            let view = pane.view_state();
+            chrome.insert(
+                *pane_id,
+                (view.ready, view.controller_peer_id, view.controller_active),
+            );
+        }
+        for (pane_id, pane) in &self.remote {
+            if let Some(screen) = pane.screen.screen()
+                && let Ok(snapshot) = crate::screen::snapshot_payload(screen)
+            {
+                screens.insert(
+                    *pane_id,
+                    (
+                        pane.screen.sequence().unwrap_or(1),
+                        snapshot.as_ref().to_vec(),
+                        pane.screen.kitty_keyboard_active(),
+                    ),
+                );
+            }
+            let view = pane.view_state();
+            chrome.insert(
+                *pane_id,
+                (view.ready, view.controller_peer_id, view.controller_active),
+            );
+        }
+        (self.tui.snapshot().clone(), screens, chrome)
+    }
+
+    pub fn node_resize(&mut self, cols: u16, rows: u16) -> Result<(), Box<dyn Error>> {
+        if cols == 0 || rows == 0 {
+            return Ok(());
+        }
+        self.reflow_local_panes(Rect::new(0, 0, cols, rows))
+    }
+
+    pub fn node_focus(&mut self, tab_id: TabId, pane_id: PaneId) -> Result<(), Box<dyn Error>> {
+        let previous = self.tui.focused_pane();
+        self.tui
+            .set_focus(tab_id, pane_id)
+            .map_err(|error| io::Error::other(format!("invalid node focus: {error:?}")))?;
+        self.release_blurred_pane(previous)
+    }
+
+    pub fn node_intent(&mut self, intent: UiIntent) -> Result<(), Box<dyn Error>> {
+        self.handle_intent(intent)
     }
 
     pub fn shutdown_node(self) {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -2755,20 +2755,30 @@ impl SharedLayoutRuntime {
 
     /// Node-facing non-terminal operations. Kept small while the old foreground adapter is
     /// retired so pane/Iroh ownership has exactly one home.
-    pub fn drain_node(&mut self) -> Result<bool, Box<dyn Error>> { self.drain() }
+    pub fn drain_node(&mut self) -> Result<bool, Box<dyn Error>> {
+        self.drain()
+    }
 
     pub fn node_input(&mut self, bytes: Vec<u8>) -> Result<(), Box<dyn Error>> {
         let pane_id = self.tui.focused_pane();
-        if let Some(pane) = self.local.get_mut(&pane_id) { pane.input(bytes.clone())?; }
-        if let Some(pane) = self.remote.get_mut(&pane_id) { pane.input(bytes); }
+        if let Some(pane) = self.local.get_mut(&pane_id) {
+            pane.input(bytes.clone())?;
+        }
+        if let Some(pane) = self.remote.get_mut(&pane_id) {
+            pane.input(bytes);
+        }
         self.tui.reset_scrollback(pane_id);
         Ok(())
     }
 
     pub fn release_all_local_control(&mut self) -> Result<(), Box<dyn Error>> {
         let peer_id = self.control.peer_id();
-        for pane in self.local.values_mut() { pane.release_controller(&peer_id)?; }
-        for pane in self.remote.values_mut() { pane.release_controller(); }
+        for pane in self.local.values_mut() {
+            pane.release_controller(&peer_id)?;
+        }
+        for pane in self.remote.values_mut() {
+            pane.release_controller();
+        }
         Ok(())
     }
 
@@ -2778,12 +2788,21 @@ impl SharedLayoutRuntime {
 
     pub fn node_screen_text(&self) -> String {
         let pane_id = self.tui.focused_pane();
-        self.local.get(&pane_id).map(|pane| pane.screen.screen().contents())
-            .or_else(|| self.remote.get(&pane_id).and_then(|pane| pane.screen.screen()).map(vt100::Screen::contents))
+        self.local
+            .get(&pane_id)
+            .map(|pane| pane.screen.screen().contents())
+            .or_else(|| {
+                self.remote
+                    .get(&pane_id)
+                    .and_then(|pane| pane.screen.screen())
+                    .map(vt100::Screen::contents)
+            })
             .unwrap_or_default()
     }
 
-    pub fn shutdown_node(self) { self.shutdown(); }
+    pub fn shutdown_node(self) {
+        self.shutdown();
+    }
 
     fn clear_selection(&mut self) -> bool {
         let selection_cleared = self.tui.clear_selection();

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -2753,6 +2753,38 @@ impl SharedLayoutRuntime {
         self.session_id = session_id;
     }
 
+    /// Node-facing non-terminal operations. Kept small while the old foreground adapter is
+    /// retired so pane/Iroh ownership has exactly one home.
+    pub fn drain_node(&mut self) -> Result<bool, Box<dyn Error>> { self.drain() }
+
+    pub fn node_input(&mut self, bytes: Vec<u8>) -> Result<(), Box<dyn Error>> {
+        let pane_id = self.tui.focused_pane();
+        if let Some(pane) = self.local.get_mut(&pane_id) { pane.input(bytes.clone())?; }
+        if let Some(pane) = self.remote.get_mut(&pane_id) { pane.input(bytes); }
+        self.tui.reset_scrollback(pane_id);
+        Ok(())
+    }
+
+    pub fn release_all_local_control(&mut self) -> Result<(), Box<dyn Error>> {
+        let peer_id = self.control.peer_id();
+        for pane in self.local.values_mut() { pane.release_controller(&peer_id)?; }
+        for pane in self.remote.values_mut() { pane.release_controller(); }
+        Ok(())
+    }
+
+    pub fn local_focus(&self) -> (u64, u64) {
+        (self.tui.current_tab(), self.tui.focused_pane())
+    }
+
+    pub fn node_screen_text(&self) -> String {
+        let pane_id = self.tui.focused_pane();
+        self.local.get(&pane_id).map(|pane| pane.screen.screen().contents())
+            .or_else(|| self.remote.get(&pane_id).and_then(|pane| pane.screen.screen()).map(vt100::Screen::contents))
+            .unwrap_or_default()
+    }
+
+    pub fn shutdown_node(self) { self.shutdown(); }
+
     fn clear_selection(&mut self) -> bool {
         let selection_cleared = self.tui.clear_selection();
         let copy_feedback_cleared = self.copied_lines.take().is_some();

--- a/tests/detach_resume_node.rs
+++ b/tests/detach_resume_node.rs
@@ -1,5 +1,5 @@
 use std::{
-    io::{BufRead, BufReader, Write},
+    io::{BufReader, Write},
     os::unix::net::UnixStream,
     process::{Child, Command, Stdio},
     thread,
@@ -7,6 +7,7 @@ use std::{
 };
 
 use p2pmux::{
+    client,
     local_ipc::{ClientMessage, NodeMessage},
     node::{NodeBootstrap, NodeBootstrapKind, write_bootstrap},
     session_store::{SessionDescriptor, SessionRole, SessionStore, generate_id},
@@ -42,8 +43,8 @@ fn detached_node_serves_real_snapshots_and_accepts_a_new_attachment() {
             descriptor: descriptor.clone(),
             kind: NodeBootstrapKind::Create {
                 display_name: "Test User".into(),
-                cols: 80,
-                rows: 24,
+                cols: 320,
+                rows: 100,
             },
         },
     )
@@ -130,26 +131,27 @@ fn detached_node_serves_real_snapshots_and_accepts_a_new_attachment() {
     drop(reader);
     drop(stream);
 
-    let (mut stream, mut reader, generation) = attach(&socket_path);
+    let (_stream, mut reader, _generation) = attach(&socket_path);
     assert!(
         matches!(receive_until_snapshot(&mut reader), NodeMessage::Snapshot { layout, screens, .. }
         if layout.panes.contains_key(&1) && screens.iter().any(|frame| frame.pane_id == 1))
     );
-    send(&mut stream, &ClientMessage::Shutdown { generation });
-    loop {
-        if matches!(receive(&mut reader), NodeMessage::ShutdownAck { generation: ack } if ack == generation)
-        {
-            break;
-        }
-    }
+    // A shutdown control request must work even while this interactive attachment is live.
+    client::shutdown(&descriptor).unwrap();
+    drop(reader);
+    drop(_stream);
     let deadline = Instant::now() + Duration::from_secs(5);
     while child.0.try_wait().unwrap().is_none() && Instant::now() < deadline {
         thread::sleep(Duration::from_millis(20));
     }
-    assert!(
-        child.0.try_wait().unwrap().is_some(),
-        "node did not shut down"
-    );
+    let status = child.0.try_wait().unwrap();
+    assert!(status.is_some(), "node did not shut down");
+    assert!(status.unwrap().success(), "node exited unsuccessfully");
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while socket_path.exists() && Instant::now() < deadline {
+        thread::sleep(Duration::from_millis(20));
+    }
+    assert!(!socket_path.exists(), "node did not remove its socket");
 }
 
 fn attach(socket_path: &std::path::Path) -> (UnixStream, BufReader<UnixStream>, u64) {
@@ -182,7 +184,5 @@ fn send(stream: &mut UnixStream, message: &ClientMessage) {
 }
 
 fn receive(reader: &mut BufReader<UnixStream>) -> NodeMessage {
-    let mut line = String::new();
-    reader.read_line(&mut line).unwrap();
-    serde_json::from_str(&line).unwrap()
+    client::read_message(reader).unwrap().unwrap()
 }

--- a/tests/detach_resume_node.rs
+++ b/tests/detach_resume_node.rs
@@ -15,6 +15,8 @@ use p2pmux::{
 
 struct NodeChild(Child);
 
+const RECEIVE_TIMEOUT: Duration = Duration::from_secs(8);
+
 impl Drop for NodeChild {
     fn drop(&mut self) {
         if self.0.try_wait().ok().flatten().is_none() {
@@ -43,8 +45,8 @@ fn detached_node_serves_real_snapshots_and_accepts_a_new_attachment() {
             descriptor: descriptor.clone(),
             kind: NodeBootstrapKind::Create {
                 display_name: "Test User".into(),
-                cols: 320,
-                rows: 100,
+                cols: 80,
+                rows: 24,
             },
         },
     )
@@ -169,11 +171,13 @@ fn attach(socket_path: &std::path::Path) -> (UnixStream, BufReader<UnixStream>, 
 }
 
 fn receive_until_snapshot(reader: &mut BufReader<UnixStream>) -> NodeMessage {
+    let deadline = Instant::now() + RECEIVE_TIMEOUT;
     loop {
-        let message = receive(reader);
+        let message = receive_until_deadline(reader, deadline);
         if matches!(message, NodeMessage::Snapshot { .. }) {
             return message;
         }
+        assert!(Instant::now() < deadline, "timed out waiting for snapshot");
     }
 }
 
@@ -184,5 +188,31 @@ fn send(stream: &mut UnixStream, message: &ClientMessage) {
 }
 
 fn receive(reader: &mut BufReader<UnixStream>) -> NodeMessage {
-    client::read_message(reader).unwrap().unwrap()
+    receive_until_deadline(reader, Instant::now() + RECEIVE_TIMEOUT)
+}
+
+fn receive_until_deadline(reader: &mut BufReader<UnixStream>, deadline: Instant) -> NodeMessage {
+    loop {
+        match client::read_message(reader) {
+            Ok(Some(message)) => return message,
+            Ok(None) => panic!("node closed its socket"),
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+                ) && Instant::now() < deadline =>
+            {
+                thread::sleep(Duration::from_millis(10));
+            }
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+                ) =>
+            {
+                panic!("timed out waiting for node message: {error}")
+            }
+            Err(error) => panic!("failed to receive node message: {error}"),
+        }
+    }
 }

--- a/tests/detach_resume_node.rs
+++ b/tests/detach_resume_node.rs
@@ -1,0 +1,188 @@
+use std::{
+    io::{BufRead, BufReader, Write},
+    os::unix::net::UnixStream,
+    process::{Child, Command, Stdio},
+    thread,
+    time::{Duration, Instant},
+};
+
+use p2pmux::{
+    local_ipc::{ClientMessage, NodeMessage},
+    node::{NodeBootstrap, NodeBootstrapKind, write_bootstrap},
+    session_store::{SessionDescriptor, SessionRole, SessionStore, generate_id},
+};
+
+struct NodeChild(Child);
+
+impl Drop for NodeChild {
+    fn drop(&mut self) {
+        if self.0.try_wait().ok().flatten().is_none() {
+            let _ = self.0.kill();
+            let _ = self.0.wait();
+        }
+    }
+}
+
+#[test]
+fn detached_node_serves_real_snapshots_and_accepts_a_new_attachment() {
+    let store = SessionStore::for_current_user().unwrap();
+    let id = generate_id().unwrap();
+    let socket_path = store.socket_path(&id).unwrap();
+    let descriptor = SessionDescriptor::new(
+        id,
+        "amber-otter-01".into(),
+        socket_path.clone(),
+        1,
+        SessionRole::Coordinator,
+    );
+    let bootstrap_path = socket_path.with_extension("bootstrap");
+    write_bootstrap(
+        &bootstrap_path,
+        &NodeBootstrap {
+            descriptor: descriptor.clone(),
+            kind: NodeBootstrapKind::Create {
+                display_name: "Test User".into(),
+                cols: 80,
+                rows: 24,
+            },
+        },
+    )
+    .unwrap();
+    let mut child = NodeChild(
+        Command::new(env!("CARGO_BIN_EXE_p2pmux"))
+            .arg("__node")
+            .arg("--bootstrap")
+            .arg(&bootstrap_path)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .unwrap(),
+    );
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while !socket_path.exists() && Instant::now() < deadline {
+        thread::sleep(Duration::from_millis(20));
+    }
+    assert!(socket_path.exists(), "node did not create its socket");
+
+    let (mut stream, mut reader, generation) = attach(&socket_path);
+    let snapshot = receive_until_snapshot(&mut reader);
+    let NodeMessage::Snapshot {
+        summary,
+        layout,
+        screens,
+        leases,
+        ..
+    } = snapshot
+    else {
+        unreachable!()
+    };
+    assert_eq!((summary.tabs, summary.panes, summary.hosts), (1, 1, 1));
+    assert_eq!(summary.coordinator_name, "Test User");
+    assert_eq!(layout.tabs.len(), 1);
+    assert_eq!(layout.panes.len(), 1);
+    assert!(
+        screens
+            .iter()
+            .find(|frame| frame.pane_id == 1)
+            .is_some_and(|frame| !frame.snapshot.is_empty())
+    );
+    assert!(
+        leases
+            .iter()
+            .find(|lease| lease.pane_id == 1)
+            .is_some_and(|lease| lease.ready)
+    );
+
+    // A second live client is refused while the first holds the attachment gate.
+    let mut refused = UnixStream::connect(&socket_path).unwrap();
+    send(&mut refused, &ClientMessage::Hello { cols: 80, rows: 24 });
+    let mut refused_reader = BufReader::new(refused.try_clone().unwrap());
+    assert!(matches!(
+        receive(&mut refused_reader),
+        NodeMessage::AttachRejected { .. }
+    ));
+
+    send(
+        &mut stream,
+        &ClientMessage::Input {
+            bytes: b"printf p2pmux-detach-roundtrip\\r".to_vec(),
+        },
+    );
+    let updated = receive_until_snapshot(&mut reader);
+    let NodeMessage::Snapshot { screens, .. } = updated else {
+        unreachable!()
+    };
+    assert!(
+        screens
+            .iter()
+            .find(|frame| frame.pane_id == 1)
+            .is_some_and(|frame| !frame.snapshot.is_empty())
+    );
+
+    send(&mut stream, &ClientMessage::Detach { generation });
+    loop {
+        if matches!(receive(&mut reader), NodeMessage::DetachAck { generation: ack } if ack == generation)
+        {
+            break;
+        }
+    }
+    drop(reader);
+    drop(stream);
+
+    let (mut stream, mut reader, generation) = attach(&socket_path);
+    assert!(
+        matches!(receive_until_snapshot(&mut reader), NodeMessage::Snapshot { layout, screens, .. }
+        if layout.panes.contains_key(&1) && screens.iter().any(|frame| frame.pane_id == 1))
+    );
+    send(&mut stream, &ClientMessage::Shutdown { generation });
+    loop {
+        if matches!(receive(&mut reader), NodeMessage::ShutdownAck { generation: ack } if ack == generation)
+        {
+            break;
+        }
+    }
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while child.0.try_wait().unwrap().is_none() && Instant::now() < deadline {
+        thread::sleep(Duration::from_millis(20));
+    }
+    assert!(
+        child.0.try_wait().unwrap().is_some(),
+        "node did not shut down"
+    );
+}
+
+fn attach(socket_path: &std::path::Path) -> (UnixStream, BufReader<UnixStream>, u64) {
+    let mut stream = UnixStream::connect(socket_path).unwrap();
+    stream
+        .set_read_timeout(Some(Duration::from_secs(2)))
+        .unwrap();
+    send(&mut stream, &ClientMessage::Hello { cols: 80, rows: 24 });
+    let mut reader = BufReader::new(stream.try_clone().unwrap());
+    let generation = match receive(&mut reader) {
+        NodeMessage::AttachAccepted { generation } => generation,
+        message => panic!("unexpected attach response: {message:?}"),
+    };
+    (stream, reader, generation)
+}
+
+fn receive_until_snapshot(reader: &mut BufReader<UnixStream>) -> NodeMessage {
+    loop {
+        let message = receive(reader);
+        if matches!(message, NodeMessage::Snapshot { .. }) {
+            return message;
+        }
+    }
+}
+
+fn send(stream: &mut UnixStream, message: &ClientMessage) {
+    serde_json::to_writer(&mut *stream, message).unwrap();
+    stream.write_all(b"\n").unwrap();
+    stream.flush().unwrap();
+}
+
+fn receive(reader: &mut BufReader<UnixStream>) -> NodeMessage {
+    let mut line = String::new();
+    reader.read_line(&mut line).unwrap();
+    serde_json::from_str(&line).unwrap()
+}

--- a/tests/local_ipc.rs
+++ b/tests/local_ipc.rs
@@ -1,0 +1,13 @@
+use p2pmux::local_ipc::{AttachmentGate, ClientMessage, NodeMessage, SessionSummary};
+
+#[test]
+fn protocol_messages_are_tagged_and_attachment_is_generation_safe() {
+    let message = NodeMessage::Snapshot {
+        room_name: "amber-otter-01".into(), role: "coordinator".into(), summary: SessionSummary::default(),
+        layout: serde_json::json!({}), screens: serde_json::json!({}), leases: serde_json::json!({}), rosters: serde_json::json!({}), tab_id: 2, pane_id: 3,
+    };
+    assert_eq!(serde_json::to_value(message).unwrap()["type"], "snapshot");
+    assert_eq!(serde_json::to_value(ClientMessage::Detach { generation: 7 }).unwrap()["generation"], 7);
+    let gate = AttachmentGate::default(); let old = gate.attach().unwrap(); assert!(gate.detach(old));
+    let current = gate.attach().unwrap(); assert!(!gate.detach(old)); assert!(gate.detach(current));
+}

--- a/tests/local_ipc.rs
+++ b/tests/local_ipc.rs
@@ -9,12 +9,12 @@ fn protocol_messages_are_tagged_and_attachment_is_generation_safe() {
         room_name: "amber-otter-01".into(),
         role: "coordinator".into(),
         summary: SessionSummary::default(),
-        layout: LayoutSnapshot {
+        layout: Box::new(LayoutSnapshot {
             revision: 0,
             members: vec![],
             tabs: vec![],
             panes: Default::default(),
-        },
+        }),
         screens: Default::default(),
         leases: Default::default(),
         rosters: serde_json::json!({}),

--- a/tests/local_ipc.rs
+++ b/tests/local_ipc.rs
@@ -3,11 +3,25 @@ use p2pmux::local_ipc::{AttachmentGate, ClientMessage, NodeMessage, SessionSumma
 #[test]
 fn protocol_messages_are_tagged_and_attachment_is_generation_safe() {
     let message = NodeMessage::Snapshot {
-        room_name: "amber-otter-01".into(), role: "coordinator".into(), summary: SessionSummary::default(),
-        layout: serde_json::json!({}), screens: serde_json::json!({}), leases: serde_json::json!({}), rosters: serde_json::json!({}), tab_id: 2, pane_id: 3,
+        room_name: "amber-otter-01".into(),
+        role: "coordinator".into(),
+        summary: SessionSummary::default(),
+        layout: serde_json::json!({}),
+        screens: serde_json::json!({}),
+        leases: serde_json::json!({}),
+        rosters: serde_json::json!({}),
+        tab_id: 2,
+        pane_id: 3,
     };
     assert_eq!(serde_json::to_value(message).unwrap()["type"], "snapshot");
-    assert_eq!(serde_json::to_value(ClientMessage::Detach { generation: 7 }).unwrap()["generation"], 7);
-    let gate = AttachmentGate::default(); let old = gate.attach().unwrap(); assert!(gate.detach(old));
-    let current = gate.attach().unwrap(); assert!(!gate.detach(old)); assert!(gate.detach(current));
+    assert_eq!(
+        serde_json::to_value(ClientMessage::Detach { generation: 7 }).unwrap()["generation"],
+        7
+    );
+    let gate = AttachmentGate::default();
+    let old = gate.attach().unwrap();
+    assert!(gate.detach(old));
+    let current = gate.attach().unwrap();
+    assert!(!gate.detach(old));
+    assert!(gate.detach(current));
 }

--- a/tests/local_ipc.rs
+++ b/tests/local_ipc.rs
@@ -1,4 +1,7 @@
-use p2pmux::local_ipc::{AttachmentGate, ClientMessage, NodeMessage, SessionSummary};
+use p2pmux::{
+    layout::LayoutSnapshot,
+    local_ipc::{AttachmentGate, ClientMessage, NodeMessage, SessionSummary},
+};
 
 #[test]
 fn protocol_messages_are_tagged_and_attachment_is_generation_safe() {
@@ -6,9 +9,14 @@ fn protocol_messages_are_tagged_and_attachment_is_generation_safe() {
         room_name: "amber-otter-01".into(),
         role: "coordinator".into(),
         summary: SessionSummary::default(),
-        layout: serde_json::json!({}),
-        screens: serde_json::json!({}),
-        leases: serde_json::json!({}),
+        layout: LayoutSnapshot {
+            revision: 0,
+            members: vec![],
+            tabs: vec![],
+            panes: Default::default(),
+        },
+        screens: Default::default(),
+        leases: Default::default(),
         rosters: serde_json::json!({}),
         tab_id: 2,
         pane_id: 3,


### PR DESCRIPTION
## Summary
- Split p2pmux into a session-scoped background **node** (PTYs/Iroh/layout) and a local **TUI client** over a Unix socket, so `Ctrl+Q` detaches without killing shells.
- Add memorable session names, `p2pmux --resume` picker, `attach` / `kill` / `rename`, and top-bar chrome `p2pmux (<name>)`.
- Persist only a tiny local finder descriptor; live layout/screens stay in the node. Offline-host placeholders/grace are explicitly deferred to a follow-up.

## Test plan
- [x] `cargo test` green on `feat/detach-resume`
- [x] Manual expect dogfood: `create --session-name dogfood-otter` → stay attached → `Ctrl+Q` prints resume/attach/kill hints → socket stays live → `attach dogfood-otter` → detach again → `kill --yes` cleans descriptor and leaves no `__node`
- [ ] Dogfood two-Mac join while one peer is detached (optional follow-up)
- [ ] Confirm `--resume` picker filtering with multiple live sessions

## Notes / follow-ups
- Offline grey `host offline` panes + shared grace countdown: deferred (separate PR).
- Resume picker still shows placeholder tab/pane/host counts in some rows; enrich from live node summary next.
- Bare `p2pmux` with no live sessions errors with a create hint rather than launching onboarding interactively.


Made with [Cursor](https://cursor.com)