### PR TITLE
Polish agents overlay chrome to match pane styling

### DIFF
--- a/src/tui.rs
+++ b/src/tui.rs
@@ -94,7 +94,7 @@ const AGENT_SAMPLE_INTERVAL: Duration = Duration::from_secs(1);
 const AGENT_TOGGLE_WINDOW: Duration = Duration::from_millis(400);
 const AGENT_OVERLAY_ANIMATION_INTERVAL: Duration = Duration::from_millis(100);
 const AGENT_OVERLAY_CARD_LINES: usize = 3;
-const AGENT_OVERLAY_CHROME: Color = Color::Rgb(56, 132, 255);
+const AGENT_OVERLAY_CHROME: Color = Color::Rgb(255, 69, 0);
 const AGENT_OVERLAY_BACKGROUND: Color = Color::Rgb(10, 18, 35);
 const AGENT_OVERLAY_SELECTED_BACKGROUND: Color = Color::Rgb(31, 74, 142);
 const AGENT_OVERLAY_MUTED: Color = Color::Rgb(145, 157, 180);
@@ -2148,7 +2148,9 @@ fn render_agents_overlay(frame: &mut Frame<'_>, tui: &MultiPaneTui, now_unix_ms:
     let block = Block::bordered()
         .title(Line::styled(
             " Agents ",
-            Style::default().fg(AGENT_OVERLAY_CHROME),
+            Style::default()
+                .fg(AGENT_OVERLAY_CHROME)
+                .add_modifier(Modifier::BOLD),
         ))
         .border_style(Style::default().fg(AGENT_OVERLAY_CHROME))
         .style(Style::default().bg(AGENT_OVERLAY_BACKGROUND));
@@ -5164,7 +5166,7 @@ mod tests {
     }
 
     #[test]
-    fn agents_overlay_uses_blue_chrome_and_selected_card_background() {
+    fn agents_overlay_uses_orange_red_chrome_and_selected_card_background() {
         let mut tui = MultiPaneTui::new(layout(
             vec![Tab {
                 tab_id: 1,
@@ -5183,7 +5185,11 @@ mod tests {
         let inner = super::agents_overlay_inner(Rect::new(0, 0, 80, 24));
         let buffer = terminal.backend().buffer();
 
-        assert_eq!(buffer[(panel.x, panel.y)].fg, super::AGENT_OVERLAY_CHROME);
+        assert_eq!(buffer[(panel.x, panel.y)].fg, Color::Rgb(255, 69, 0));
+        assert_eq!(
+            buffer[(panel.x.saturating_add(1), panel.y)].modifier,
+            Modifier::BOLD
+        );
         assert_eq!(
             buffer[(inner.x, inner.y)].bg,
             super::AGENT_OVERLAY_SELECTED_BACKGROUND

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -95,8 +95,7 @@ const AGENT_TOGGLE_WINDOW: Duration = Duration::from_millis(400);
 const AGENT_OVERLAY_ANIMATION_INTERVAL: Duration = Duration::from_millis(100);
 const AGENT_OVERLAY_CARD_LINES: usize = 3;
 const AGENT_OVERLAY_CHROME: Color = Color::Rgb(255, 69, 0);
-const AGENT_OVERLAY_BACKGROUND: Color = Color::Rgb(10, 18, 35);
-const AGENT_OVERLAY_SELECTED_BACKGROUND: Color = Color::Rgb(31, 74, 142);
+const AGENT_OVERLAY_SELECTED_BACKGROUND: Color = Color::DarkGray;
 const AGENT_OVERLAY_MUTED: Color = Color::Rgb(145, 157, 180);
 const AGENT_OVERLAY_WARM: Color = Color::Rgb(255, 184, 77);
 
@@ -2152,8 +2151,7 @@ fn render_agents_overlay(frame: &mut Frame<'_>, tui: &MultiPaneTui, now_unix_ms:
                 .fg(AGENT_OVERLAY_CHROME)
                 .add_modifier(Modifier::BOLD),
         ))
-        .border_style(Style::default().fg(AGENT_OVERLAY_CHROME))
-        .style(Style::default().bg(AGENT_OVERLAY_BACKGROUND));
+        .border_style(Style::default().fg(AGENT_OVERLAY_CHROME));
     let inner = agents_overlay_inner(area);
     frame.render_widget(block, panel);
     if tui.agent_rows.is_empty() {
@@ -5166,7 +5164,7 @@ mod tests {
     }
 
     #[test]
-    fn agents_overlay_uses_orange_red_chrome_and_selected_card_background() {
+    fn agents_overlay_uses_orange_red_chrome_gray_selection_and_pane_background() {
         let mut tui = MultiPaneTui::new(layout(
             vec![Tab {
                 tab_id: 1,
@@ -5192,15 +5190,19 @@ mod tests {
         );
         assert_eq!(
             buffer[(inner.x, inner.y)].bg,
-            super::AGENT_OVERLAY_SELECTED_BACKGROUND
+            Color::DarkGray
         );
         assert_eq!(
             buffer[(inner.x, inner.y.saturating_add(1))].bg,
-            super::AGENT_OVERLAY_SELECTED_BACKGROUND
+            Color::DarkGray
         );
         assert_eq!(
             buffer[(inner.x.saturating_add(50), inner.y)].bg,
-            super::AGENT_OVERLAY_SELECTED_BACKGROUND
+            Color::DarkGray
+        );
+        assert_eq!(
+            buffer[(inner.x, inner.y.saturating_add(3))].bg,
+            Color::Reset
         );
     }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -5188,10 +5188,7 @@ mod tests {
             buffer[(panel.x.saturating_add(1), panel.y)].modifier,
             Modifier::BOLD
         );
-        assert_eq!(
-            buffer[(inner.x, inner.y)].bg,
-            Color::DarkGray
-        );
+        assert_eq!(buffer[(inner.x, inner.y)].bg, Color::DarkGray);
         assert_eq!(
             buffer[(inner.x, inner.y.saturating_add(1))].bg,
             Color::DarkGray

--- a/tests/detach_resume_node.rs
+++ b/tests/detach_resume_node.rs
@@ -1,7 +1,9 @@
 use std::{
-    io::{BufReader, Write},
+    any::Any,
+    io::{BufReader, Read, Write},
     os::unix::net::UnixStream,
-    process::{Child, Command, Stdio},
+    process::{Child, Command, ExitStatus, Stdio},
+    sync::{Arc, Mutex},
     thread,
     time::{Duration, Instant},
 };
@@ -13,15 +15,67 @@ use p2pmux::{
     session_store::{SessionDescriptor, SessionRole, SessionStore, generate_id},
 };
 
-struct NodeChild(Child);
+struct NodeChild {
+    child: Child,
+    stderr: Arc<Mutex<Vec<u8>>>,
+    stderr_reader: Option<thread::JoinHandle<std::io::Result<()>>>,
+}
 
 const RECEIVE_TIMEOUT: Duration = Duration::from_secs(8);
 
 impl Drop for NodeChild {
     fn drop(&mut self) {
-        if self.0.try_wait().ok().flatten().is_none() {
-            let _ = self.0.kill();
-            let _ = self.0.wait();
+        if self.child.try_wait().ok().flatten().is_none() {
+            let _ = self.child.kill();
+            let _ = self.child.wait();
+        }
+        self.join_stderr_reader();
+    }
+}
+
+impl NodeChild {
+    fn spawn(bootstrap_path: &std::path::Path) -> Self {
+        let mut child = Command::new(env!("CARGO_BIN_EXE_p2pmux"))
+            .arg("__node")
+            .arg("--bootstrap")
+            .arg(bootstrap_path)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap();
+        let stderr = Arc::new(Mutex::new(Vec::new()));
+        let captured_stderr = Arc::clone(&stderr);
+        let mut child_stderr = child.stderr.take().unwrap();
+        let stderr_reader = thread::spawn(move || {
+            let mut output = Vec::new();
+            child_stderr.read_to_end(&mut output)?;
+            captured_stderr.lock().unwrap().extend(output);
+            Ok(())
+        });
+        Self {
+            child,
+            stderr,
+            stderr_reader: Some(stderr_reader),
+        }
+    }
+
+    fn try_wait(&mut self) -> std::io::Result<Option<ExitStatus>> {
+        self.child.try_wait()
+    }
+
+    fn failure_context(&mut self) -> String {
+        let status = self.child.try_wait().ok().flatten();
+        if status.is_some() {
+            self.join_stderr_reader();
+        }
+        let stderr = String::from_utf8_lossy(&self.stderr.lock().unwrap()).into_owned();
+        format!("node status: {status:?}; node stderr:\n{stderr}")
+    }
+
+    fn join_stderr_reader(&mut self) {
+        if let Some(reader) = self.stderr_reader.take() {
+            let _ = reader.join();
         }
     }
 }
@@ -51,25 +105,35 @@ fn detached_node_serves_real_snapshots_and_accepts_a_new_attachment() {
         },
     )
     .unwrap();
-    let mut child = NodeChild(
-        Command::new(env!("CARGO_BIN_EXE_p2pmux"))
-            .arg("__node")
-            .arg("--bootstrap")
-            .arg(&bootstrap_path)
-            .stdin(Stdio::null())
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .spawn()
-            .unwrap(),
-    );
+    let mut child = NodeChild::spawn(&bootstrap_path);
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        run_detach_resume_round_trip(&socket_path, &descriptor, &mut child);
+    }));
+    if let Err(payload) = result {
+        panic!(
+            "detach-resume node test failed: {}; {}",
+            panic_message(payload),
+            child.failure_context(),
+        );
+    }
+}
+
+fn run_detach_resume_round_trip(
+    socket_path: &std::path::Path,
+    descriptor: &SessionDescriptor,
+    child: &mut NodeChild,
+) {
     let deadline = Instant::now() + Duration::from_secs(5);
     while !socket_path.exists() && Instant::now() < deadline {
+        if let Some(status) = child.try_wait().unwrap() {
+            panic!("node exited before creating its socket: {status}");
+        }
         thread::sleep(Duration::from_millis(20));
     }
     assert!(socket_path.exists(), "node did not create its socket");
 
-    let (mut stream, mut reader, generation) = attach(&socket_path);
-    let snapshot = receive_until_snapshot(&mut reader);
+    let (mut stream, mut reader, generation) = attach(socket_path, "initial attach");
+    let snapshot = receive_until_snapshot(&mut reader, "initial snapshot");
     let NodeMessage::Snapshot {
         summary,
         layout,
@@ -98,11 +162,11 @@ fn detached_node_serves_real_snapshots_and_accepts_a_new_attachment() {
     );
 
     // A second live client is refused while the first holds the attachment gate.
-    let mut refused = UnixStream::connect(&socket_path).unwrap();
+    let mut refused = UnixStream::connect(socket_path).unwrap();
     send(&mut refused, &ClientMessage::Hello { cols: 80, rows: 24 });
     let mut refused_reader = BufReader::new(refused.try_clone().unwrap());
     assert!(matches!(
-        receive(&mut refused_reader),
+        receive(&mut refused_reader, "second client rejection"),
         NodeMessage::AttachRejected { .. }
     ));
 
@@ -112,7 +176,7 @@ fn detached_node_serves_real_snapshots_and_accepts_a_new_attachment() {
             bytes: b"printf p2pmux-detach-roundtrip\\r".to_vec(),
         },
     );
-    let updated = receive_until_snapshot(&mut reader);
+    let updated = receive_until_snapshot(&mut reader, "snapshot after input");
     let NodeMessage::Snapshot { screens, .. } = updated else {
         unreachable!()
     };
@@ -125,17 +189,18 @@ fn detached_node_serves_real_snapshots_and_accepts_a_new_attachment() {
 
     send(&mut stream, &ClientMessage::Detach { generation });
     loop {
-        if matches!(receive(&mut reader), NodeMessage::DetachAck { generation: ack } if ack == generation)
+        if matches!(receive(&mut reader, "detach acknowledgement"), NodeMessage::DetachAck { generation: ack } if ack == generation)
         {
             break;
         }
     }
+    wait_for_detach(&mut reader);
     drop(reader);
     drop(stream);
 
-    let (_stream, mut reader, _generation) = attach(&socket_path);
+    let (_stream, mut reader, _generation) = attach(socket_path, "reattach after detach");
     assert!(
-        matches!(receive_until_snapshot(&mut reader), NodeMessage::Snapshot { layout, screens, .. }
+        matches!(receive_until_snapshot(&mut reader, "snapshot after reattach"), NodeMessage::Snapshot { layout, screens, .. }
         if layout.panes.contains_key(&1) && screens.iter().any(|frame| frame.pane_id == 1))
     );
     // A shutdown control request must work even while this interactive attachment is live.
@@ -143,10 +208,10 @@ fn detached_node_serves_real_snapshots_and_accepts_a_new_attachment() {
     drop(reader);
     drop(_stream);
     let deadline = Instant::now() + Duration::from_secs(5);
-    while child.0.try_wait().unwrap().is_none() && Instant::now() < deadline {
+    while child.try_wait().unwrap().is_none() && Instant::now() < deadline {
         thread::sleep(Duration::from_millis(20));
     }
-    let status = child.0.try_wait().unwrap();
+    let status = child.try_wait().unwrap();
     assert!(status.is_some(), "node did not shut down");
     assert!(status.unwrap().success(), "node exited unsuccessfully");
     let deadline = Instant::now() + Duration::from_secs(2);
@@ -156,24 +221,24 @@ fn detached_node_serves_real_snapshots_and_accepts_a_new_attachment() {
     assert!(!socket_path.exists(), "node did not remove its socket");
 }
 
-fn attach(socket_path: &std::path::Path) -> (UnixStream, BufReader<UnixStream>, u64) {
+fn attach(socket_path: &std::path::Path, phase: &str) -> (UnixStream, BufReader<UnixStream>, u64) {
     let mut stream = UnixStream::connect(socket_path).unwrap();
     stream
         .set_read_timeout(Some(Duration::from_secs(2)))
         .unwrap();
     send(&mut stream, &ClientMessage::Hello { cols: 80, rows: 24 });
     let mut reader = BufReader::new(stream.try_clone().unwrap());
-    let generation = match receive(&mut reader) {
+    let generation = match receive(&mut reader, phase) {
         NodeMessage::AttachAccepted { generation } => generation,
         message => panic!("unexpected attach response: {message:?}"),
     };
     (stream, reader, generation)
 }
 
-fn receive_until_snapshot(reader: &mut BufReader<UnixStream>) -> NodeMessage {
+fn receive_until_snapshot(reader: &mut BufReader<UnixStream>, phase: &str) -> NodeMessage {
     let deadline = Instant::now() + RECEIVE_TIMEOUT;
     loop {
-        let message = receive_until_deadline(reader, deadline);
+        let message = receive_until_deadline(reader, deadline, phase);
         if matches!(message, NodeMessage::Snapshot { .. }) {
             return message;
         }
@@ -182,20 +247,25 @@ fn receive_until_snapshot(reader: &mut BufReader<UnixStream>) -> NodeMessage {
 }
 
 fn send(stream: &mut UnixStream, message: &ClientMessage) {
-    serde_json::to_writer(&mut *stream, message).unwrap();
-    stream.write_all(b"\n").unwrap();
+    let mut frame = serde_json::to_vec(message).unwrap();
+    frame.push(b'\n');
+    stream.write_all(&frame).unwrap();
     stream.flush().unwrap();
 }
 
-fn receive(reader: &mut BufReader<UnixStream>) -> NodeMessage {
-    receive_until_deadline(reader, Instant::now() + RECEIVE_TIMEOUT)
+fn receive(reader: &mut BufReader<UnixStream>, phase: &str) -> NodeMessage {
+    receive_until_deadline(reader, Instant::now() + RECEIVE_TIMEOUT, phase)
 }
 
-fn receive_until_deadline(reader: &mut BufReader<UnixStream>, deadline: Instant) -> NodeMessage {
+fn receive_until_deadline(
+    reader: &mut BufReader<UnixStream>,
+    deadline: Instant,
+    phase: &str,
+) -> NodeMessage {
     loop {
         match client::read_message(reader) {
             Ok(Some(message)) => return message,
-            Ok(None) => panic!("node closed its socket"),
+            Ok(None) => panic!("node closed its socket while waiting for {phase}"),
             Err(error)
                 if matches!(
                     error.kind(),
@@ -210,9 +280,47 @@ fn receive_until_deadline(reader: &mut BufReader<UnixStream>, deadline: Instant)
                     std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
                 ) =>
             {
-                panic!("timed out waiting for node message: {error}")
+                panic!("timed out waiting for node message during {phase}: {error}")
             }
-            Err(error) => panic!("failed to receive node message: {error}"),
+            Err(error) => panic!("failed to receive node message during {phase}: {error}"),
         }
+    }
+}
+
+fn wait_for_detach(reader: &mut BufReader<UnixStream>) {
+    reader.get_mut().set_nonblocking(true).unwrap();
+    let deadline = Instant::now() + RECEIVE_TIMEOUT;
+    loop {
+        match client::read_message(reader) {
+            Ok(None) => return,
+            Ok(Some(message)) => panic!("unexpected node message while detaching: {message:?}"),
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+                ) && Instant::now() < deadline =>
+            {
+                thread::sleep(Duration::from_millis(10));
+            }
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+                ) =>
+            {
+                panic!("timed out waiting for node to finish detaching: {error}")
+            }
+            Err(error) => panic!("failed while waiting for node to detach: {error}"),
+        }
+    }
+}
+
+fn panic_message(payload: Box<dyn Any + Send>) -> String {
+    if let Some(message) = payload.downcast_ref::<String>() {
+        message.clone()
+    } else if let Some(message) = payload.downcast_ref::<&str>() {
+        (*message).into()
+    } else {
+        "non-string panic payload".into()
     }
 }

--- a/tests/detach_resume_node.rs
+++ b/tests/detach_resume_node.rs
@@ -188,9 +188,18 @@ fn run_detach_resume_round_trip(
     );
 
     send(&mut stream, &ClientMessage::Detach { generation });
+    let detach_deadline = Instant::now() + RECEIVE_TIMEOUT;
     loop {
-        if matches!(receive(&mut reader, "detach acknowledgement"), NodeMessage::DetachAck { generation: ack } if ack == generation)
-        {
+        assert!(
+            Instant::now() < detach_deadline,
+            "timed out waiting for detach acknowledgement"
+        );
+        if matches!(
+            receive_until_deadline(&mut reader, detach_deadline, "detach acknowledgement"),
+            NodeMessage::DetachAck {
+                generation: ack
+            } if ack == generation
+        ) {
             break;
         }
     }

--- a/tests/detach_resume_node.rs
+++ b/tests/detach_resume_node.rs
@@ -204,7 +204,7 @@ fn run_detach_resume_round_trip(
         if layout.panes.contains_key(&1) && screens.iter().any(|frame| frame.pane_id == 1))
     );
     // A shutdown control request must work even while this interactive attachment is live.
-    client::shutdown(&descriptor).unwrap();
+    client::shutdown(descriptor).unwrap();
     drop(reader);
     drop(_stream);
     let deadline = Instant::now() + Duration::from_secs(5);


### PR DESCRIPTION
## Summary
- Swap the Ctrl+A agents overlay border/title chrome from vivid blue to the same orange-red used for typing/control pane borders, and bold the `Agents` title.
- Use a gray selected-card background and drop the custom navy panel fill so the overlay sits on the same background as normal panes.

## Test plan
- [ ] `cargo test --lib -- agents_overlay`
- [ ] Open Ctrl+A: confirm orange-red border, bold Agents title
- [ ] Move selection: selected card is gray, not blue
- [ ] Confirm overlay panel background matches surrounding panes


Made with [Cursor](https://cursor.com)