### PR TITLE
feat: random city names for sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ Set a peer-visible display name once with `p2pmux config set name pelazas`; insp
 `~/.config/p2pmux/config.toml`). `create` and `join` accept `--name <name>` to override and save
 the value for that run and future sessions.
 
+Every `create` and `join` automatically receives a memorable world-city session name such as
+`tokyo` or `cape-town`; no session name is required. `create --session-name <name>` remains
+available when you want to choose a name explicitly. Automatically chosen names avoid live local
+session names, adding `-2`, `-3`, and so on if every city name is already in use.
+
 `create` and `join` start a session-scoped background node, then attach the local TUI client.
 Ctrl+Q detaches that client without stopping shells, Iroh, rendezvous, or hosted panes. It prints
 the exact `--resume`, `attach`, and `kill` commands needed to return. Use `p2pmux --resume` for

--- a/docs/superpowers/plans/2026-07-26-city-session-names.md
+++ b/docs/superpowers/plans/2026-07-26-city-session-names.md
@@ -1,0 +1,16 @@
+# City session names
+
+Replace adjective-noun session names with random world cities. Auto-pick on every create/join; `--session-name` remains an optional override.
+
+## Commits
+
+1. `feat: add world-city session name list` — curated kebab-case city list + `generate_name()` picks one at random; keep `valid_name` rules.
+2. `feat: avoid colliding with live session names` — if picked city is already live locally, retry other cities; if exhausted, append `-2`, `-3`, …
+3. `test: cover city name generation and collisions` — unit tests for format, uniqueness retries, collision suffix.
+4. `docs: describe auto city session names` — README note that create picks a city; `--session-name` optional.
+
+## Constraints
+- Work only in `/Users/pelazas/Desktop/p2pmux-city-names`
+- One commit per task above
+- `cargo fmt`, `clippy -D warnings`, `cargo test` green
+- Do not require users to pass a session name

--- a/src/node.rs
+++ b/src/node.rs
@@ -498,7 +498,7 @@ mod tests {
         let _ = fs::remove_file(&path);
         let descriptor = SessionDescriptor::new(
             "0123456789abcdef0123456789abcdef".into(),
-            "amber-otter-01".into(),
+            "lisbon".into(),
             "/tmp/p2pmux-test.sock".into(),
             1,
             SessionRole::Coordinator,

--- a/src/session_store.rs
+++ b/src/session_store.rs
@@ -4,6 +4,7 @@
 //! state (PTYs, tickets, screens, and focus) belongs to the node process, never to disk.
 
 use std::{
+    collections::HashSet,
     fs::{self, OpenOptions},
     io::{self, BufRead, Write},
     os::unix::{fs::OpenOptionsExt, net::UnixStream},
@@ -309,10 +310,37 @@ pub fn generate_id() -> io::Result<String> {
 }
 
 pub fn generate_name() -> io::Result<String> {
+    generate_name_from_store(&SessionStore::for_current_user()?)
+}
+
+fn generate_name_from_store(store: &SessionStore) -> io::Result<String> {
+    let live_names = store
+        .list_live()?
+        .into_iter()
+        .map(|session| session.name)
+        .collect();
     let mut bytes = [0u8; 8];
     fill(&mut bytes).map_err(|error| io::Error::other(error.to_string()))?;
     let index = u64::from_le_bytes(bytes) as usize % CITY_NAMES.len();
-    Ok(CITY_NAMES[index].to_owned())
+    Ok(available_city_name(&live_names, index))
+}
+
+fn available_city_name(live_names: &HashSet<String>, start: usize) -> String {
+    for offset in 0..CITY_NAMES.len() {
+        let city = CITY_NAMES[(start + offset) % CITY_NAMES.len()];
+        if !live_names.contains(city) {
+            return city.to_owned();
+        }
+    }
+
+    let city = CITY_NAMES[start % CITY_NAMES.len()];
+    for suffix in 2.. {
+        let name = format!("{city}-{suffix}");
+        if !live_names.contains(&name) {
+            return name;
+        }
+    }
+    unreachable!("an unbounded suffix range always yields a name")
 }
 
 pub fn valid_name(name: &str) -> bool {

--- a/src/session_store.rs
+++ b/src/session_store.rs
@@ -16,6 +16,107 @@ use serde::{Deserialize, Serialize};
 
 const VERSION: u32 = 1;
 
+const CITY_NAMES: &[&str] = &[
+    "abu-dhabi",
+    "accra",
+    "amsterdam",
+    "ankara",
+    "athens",
+    "auckland",
+    "bangkok",
+    "barcelona",
+    "beijing",
+    "beirut",
+    "belgrade",
+    "berlin",
+    "bogota",
+    "boston",
+    "brasilia",
+    "brussels",
+    "buenos-aires",
+    "cairo",
+    "calgary",
+    "cape-town",
+    "caracas",
+    "chicago",
+    "copenhagen",
+    "dakar",
+    "dallas",
+    "delhi",
+    "denver",
+    "dhaka",
+    "doha",
+    "dublin",
+    "edinburgh",
+    "firenze",
+    "frankfurt",
+    "geneva",
+    "guangzhou",
+    "guatemala-city",
+    "hanoi",
+    "helsinki",
+    "hong-kong",
+    "honolulu",
+    "houston",
+    "istanbul",
+    "jakarta",
+    "jerusalem",
+    "johannesburg",
+    "kathmandu",
+    "kuala-lumpur",
+    "kyiv",
+    "lagos",
+    "lima",
+    "lisbon",
+    "london",
+    "los-angeles",
+    "madrid",
+    "manila",
+    "melbourne",
+    "mexico-city",
+    "miami",
+    "milan",
+    "montreal",
+    "mumbai",
+    "munich",
+    "nairobi",
+    "new-york",
+    "osaka",
+    "oslo",
+    "ottawa",
+    "paris",
+    "perth",
+    "philadelphia",
+    "prague",
+    "reykjavik",
+    "rio-de-janeiro",
+    "riyadh",
+    "rome",
+    "san-diego",
+    "san-francisco",
+    "san-jose",
+    "santiago",
+    "sao-paulo",
+    "seattle",
+    "seoul",
+    "shanghai",
+    "singapore",
+    "stockholm",
+    "sydney",
+    "taipei",
+    "tallinn",
+    "tehran",
+    "tel-aviv",
+    "tokyo",
+    "toronto",
+    "vancouver",
+    "vienna",
+    "warsaw",
+    "washington",
+    "wellington",
+    "zurich",
+];
+
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SessionRole {
@@ -208,20 +309,10 @@ pub fn generate_id() -> io::Result<String> {
 }
 
 pub fn generate_name() -> io::Result<String> {
-    const ADJECTIVES: &[&str] = &[
-        "amber", "brisk", "cobalt", "daring", "ember", "fuzzy", "golden", "lunar",
-    ];
-    const NOUNS: &[&str] = &[
-        "badger", "comet", "falcon", "harbor", "meadow", "otter", "pine", "river",
-    ];
-    let mut bytes = [0u8; 3];
+    let mut bytes = [0u8; 8];
     fill(&mut bytes).map_err(|error| io::Error::other(error.to_string()))?;
-    Ok(format!(
-        "{}-{}-{:02x}",
-        ADJECTIVES[usize::from(bytes[0]) % ADJECTIVES.len()],
-        NOUNS[usize::from(bytes[1]) % NOUNS.len()],
-        bytes[2]
-    ))
+    let index = u64::from_le_bytes(bytes) as usize % CITY_NAMES.len();
+    Ok(CITY_NAMES[index].to_owned())
 }
 
 pub fn valid_name(name: &str) -> bool {

--- a/src/session_store.rs
+++ b/src/session_store.rs
@@ -425,7 +425,7 @@ mod tests {
         let socket = store.socket_path(&id).unwrap();
         let descriptor = SessionDescriptor::new(
             id.clone(),
-            "amber-otter-01".into(),
+            "lisbon".into(),
             socket,
             42,
             SessionRole::Coordinator,
@@ -451,7 +451,7 @@ mod tests {
         store
             .write(&SessionDescriptor::new(
                 id.clone(),
-                "amber-otter-01".into(),
+                "lisbon".into(),
                 socket,
                 42,
                 SessionRole::Coordinator,
@@ -488,7 +488,7 @@ mod tests {
         store
             .write(&SessionDescriptor::new(
                 id.clone(),
-                "amber-otter-01".into(),
+                "lisbon".into(),
                 socket.clone(),
                 42,
                 SessionRole::Coordinator,
@@ -499,5 +499,36 @@ mod tests {
         assert_eq!(live[0].id, id);
         server.join().unwrap();
         let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn generated_names_are_valid_world_cities() {
+        let name = generate_name_from_store(&store()).unwrap();
+
+        assert!((80..=150).contains(&CITY_NAMES.len()));
+        assert!(CITY_NAMES.iter().all(|city| valid_name(city)));
+        assert!(CITY_NAMES.contains(&name.as_str()));
+    }
+
+    #[test]
+    fn city_name_skips_live_names() {
+        let live_names = HashSet::from([CITY_NAMES[0].to_owned()]);
+
+        assert_eq!(available_city_name(&live_names, 0), CITY_NAMES[1]);
+    }
+
+    #[test]
+    fn city_name_adds_suffix_after_all_cities_are_live() {
+        let mut live_names: HashSet<_> = CITY_NAMES.iter().map(|city| (*city).to_owned()).collect();
+
+        assert_eq!(
+            available_city_name(&live_names, 0),
+            format!("{}-2", CITY_NAMES[0])
+        );
+        live_names.insert(format!("{}-2", CITY_NAMES[0]));
+        assert_eq!(
+            available_city_name(&live_names, 0),
+            format!("{}-3", CITY_NAMES[0])
+        );
     }
 }

--- a/tests/detach_resume_node.rs
+++ b/tests/detach_resume_node.rs
@@ -33,7 +33,7 @@ fn detached_node_serves_real_snapshots_and_accepts_a_new_attachment() {
     let socket_path = store.socket_path(&id).unwrap();
     let descriptor = SessionDescriptor::new(
         id,
-        "amber-otter-01".into(),
+        "lisbon".into(),
         socket_path.clone(),
         1,
         SessionRole::Coordinator,

--- a/tests/local_ipc.rs
+++ b/tests/local_ipc.rs
@@ -6,7 +6,7 @@ use p2pmux::{
 #[test]
 fn protocol_messages_are_tagged_and_attachment_is_generation_safe() {
     let message = NodeMessage::Snapshot {
-        room_name: "amber-otter-01".into(),
+        room_name: "lisbon".into(),
         role: "coordinator".into(),
         summary: SessionSummary::default(),
         layout: Box::new(LayoutSnapshot {


### PR DESCRIPTION
## Summary
- Auto-name each new local session from a curated world-city list (kebab-case), so users never have to pass `--session-name`.
- Skip cities that collide with live local sessions; if the list is exhausted, append `-2`, `-3`, …
- Keep optional `--session-name` override for explicit naming.

## Test plan
- [x] `cargo fmt --check`, `clippy -D warnings`, `cargo test --all-features`
- [ ] `cargo run -- create` → top bar shows a city like `p2pmux (lisbon)` with no `--session-name`
- [ ] Detach / `attach <city>` / `kill <city>` use that name
- [ ] Second create while first is live picks a different city (or suffix if needed)


Made with [Cursor](https://cursor.com)