### PR TITLE
fix: restore agents overlay on attach client

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -22,9 +22,10 @@ use ratatui::{Terminal, TerminalOptions, Viewport, backend::CrosstermBackend, la
 
 use crate::{
     local_ipc::{ClientMessage, NodeMessage},
+    protocol::AgentRosterState,
     screen::GuestScreen,
     session_store::SessionDescriptor,
-    tui::{KeyHandling, MultiPaneTui, PaneViewState, render_multi_pane},
+    tui::{AgentOverlayRow, KeyHandling, MultiPaneTui, PaneViewState, render_multi_pane},
 };
 
 pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Error>> {
@@ -69,6 +70,7 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
                         layout,
                         screens: next_screens,
                         leases,
+                        rosters,
                         tab_id,
                         pane_id,
                         ..
@@ -81,6 +83,7 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
                             *layout,
                             next_screens,
                             leases,
+                            rosters,
                             tab_id,
                             pane_id,
                         )?;
@@ -209,6 +212,7 @@ fn apply_snapshot(
     layout: crate::layout::LayoutSnapshot,
     next_screens: Vec<crate::local_ipc::PaneScreenSnapshot>,
     leases: Vec<crate::local_ipc::PaneLeaseSnapshot>,
+    rosters: Vec<crate::local_ipc::AgentOverlaySnapshotRow>,
     tab_id: u64,
     pane_id: u64,
 ) -> Result<(), Box<dyn std::error::Error>> {
@@ -242,6 +246,24 @@ fn apply_snapshot(
             ),
         );
     }
+    view.set_agent_rows(
+        rosters
+            .into_iter()
+            .filter_map(|row| {
+                Some(AgentOverlayRow {
+                    pane_id: row.pane_id,
+                    tab_ordinal: 0,
+                    pane_ordinal: 0,
+                    kind: row.kind,
+                    cwd: row.cwd,
+                    state: AgentRosterState::try_from(row.state).ok()?,
+                    working_since_unix_ms: row.working_since_unix_ms,
+                    host: row.host,
+                    controller: row.controller,
+                })
+            })
+            .collect(),
+    );
     Ok(())
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -114,16 +114,7 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
             }
         }
         if let Some(tui) = tui.as_mut() {
-            let now = Instant::now();
-            dirty |= tui.expire_chord_mode(now);
-            dirty |= tui.expire_agent_toggle(now);
-            if tui.agent_overlay_has_working_rows()
-                && now.duration_since(last_agent_overlay_animation)
-                    >= AGENT_OVERLAY_ANIMATION_INTERVAL
-            {
-                last_agent_overlay_animation = now;
-                dirty = true;
-            }
+            dirty |= refresh_tui_timers(tui, Instant::now(), &mut last_agent_overlay_animation);
         }
         if dirty {
             if let Some(tui) = tui.as_ref() {
@@ -165,7 +156,7 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
                 }
             }
             Event::Paste(text) => {
-                if !tui.overlay_open() {
+                if should_forward_paste(tui) {
                     write_message(
                         &mut stream,
                         &ClientMessage::Input {
@@ -240,6 +231,25 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
         );
     }
     Ok(())
+}
+
+fn refresh_tui_timers(
+    tui: &mut MultiPaneTui,
+    now: Instant,
+    last_agent_overlay_animation: &mut Instant,
+) -> bool {
+    let mut dirty = tui.expire_chord_mode(now) || tui.expire_agent_toggle(now);
+    if tui.agent_overlay_has_working_rows()
+        && now.duration_since(*last_agent_overlay_animation) >= AGENT_OVERLAY_ANIMATION_INTERVAL
+    {
+        *last_agent_overlay_animation = now;
+        dirty = true;
+    }
+    dirty
+}
+
+fn should_forward_paste(tui: &MultiPaneTui) -> bool {
+    !tui.overlay_open()
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -490,7 +500,83 @@ impl Drop for ClientTerminalGuard {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
+    use crate::{
+        layout::{LayoutSnapshot, Member, Node, Pane, Tab},
+        local_ipc::AgentOverlaySnapshotRow,
+        tui::UiIntent,
+    };
+
     use super::*;
+
+    fn layout(pane_ids: &[u64]) -> LayoutSnapshot {
+        let root = pane_ids
+            .iter()
+            .copied()
+            .map(|pane_id| Node::Leaf { pane_id })
+            .reduce(|first, second| Node::Split {
+                axis: crate::layout::Axis::LeftRight,
+                first_share_bps: 5_000,
+                first: Box::new(first),
+                second: Box::new(second),
+            })
+            .expect("at least one pane");
+        LayoutSnapshot {
+            revision: 1,
+            members: vec![Member {
+                peer_id: b"host".to_vec(),
+                endpoint_addr: b"endpoint".to_vec(),
+                display_name: String::from("Host"),
+            }],
+            tabs: vec![Tab { tab_id: 1, root }],
+            panes: pane_ids
+                .iter()
+                .map(|pane_id| {
+                    (
+                        *pane_id,
+                        Pane {
+                            pane_id: *pane_id,
+                            host_peer_id: b"host".to_vec(),
+                            grid_rows: 2,
+                            grid_cols: 8,
+                        },
+                    )
+                })
+                .collect::<BTreeMap<_, _>>(),
+        }
+    }
+
+    fn roster_row(pane_id: u64, state: i32) -> AgentOverlaySnapshotRow {
+        AgentOverlaySnapshotRow {
+            pane_id,
+            kind: String::from("codex"),
+            cwd: String::from("/repo"),
+            state,
+            working_since_unix_ms: 1,
+            host: String::from("Host"),
+            controller: String::from("free"),
+        }
+    }
+
+    fn apply_rows(
+        tui: &mut Option<MultiPaneTui>,
+        pane_ids: &[u64],
+        rows: Vec<AgentOverlaySnapshotRow>,
+    ) {
+        apply_snapshot(
+            tui,
+            &mut BTreeMap::new(),
+            String::from("room"),
+            layout(pane_ids),
+            vec![],
+            vec![],
+            rows,
+            1,
+            pane_ids[0],
+        )
+        .unwrap();
+    }
     #[test]
     fn ctrl_q_is_reserved_for_detach() {
         assert_eq!(
@@ -501,5 +587,115 @@ mod tests {
             client_key_bytes(KeyCode::Char('q'), KeyModifiers::CONTROL),
             Some(vec![17])
         );
+    }
+
+    #[test]
+    fn attach_client_timer_opens_overlay_and_double_tap_forwards_ctrl_a() {
+        let mut tui = Some(MultiPaneTui::new(layout(&[1])).unwrap());
+        let tui = tui.as_mut().unwrap();
+        let area = Rect::new(0, 0, 80, 24);
+        let ctrl_a = crossterm::event::KeyEvent::new(KeyCode::Char('a'), KeyModifiers::CONTROL);
+        let mut animation = Instant::now();
+
+        assert_eq!(tui.handle_key(ctrl_a, area), KeyHandling::Consumed(vec![]));
+        assert!(refresh_tui_timers(
+            tui,
+            Instant::now() + Duration::from_millis(400),
+            &mut animation,
+        ));
+        assert!(tui.overlay_open());
+        assert_eq!(
+            tui.handle_key(
+                crossterm::event::KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
+                area
+            ),
+            KeyHandling::Consumed(vec![])
+        );
+        assert_eq!(tui.handle_key(ctrl_a, area), KeyHandling::Consumed(vec![]));
+        assert_eq!(tui.handle_key(ctrl_a, area), KeyHandling::Forward);
+    }
+
+    #[test]
+    fn snapshot_rosters_populate_rows_and_ignore_invalid_or_unknown_panes() {
+        let mut tui = None;
+        apply_rows(
+            &mut tui,
+            &[1],
+            vec![
+                roster_row(1, AgentRosterState::Working as i32),
+                roster_row(2, AgentRosterState::Working as i32),
+                roster_row(1, 99),
+            ],
+        );
+        let area = Rect::new(0, 0, 80, 24);
+        {
+            let tui = tui.as_mut().unwrap();
+            tui.handle_key(
+                crossterm::event::KeyEvent::new(KeyCode::Char('a'), KeyModifiers::CONTROL),
+                area,
+            );
+            let mut animation = Instant::now();
+            refresh_tui_timers(
+                tui,
+                Instant::now() + Duration::from_millis(400),
+                &mut animation,
+            );
+            assert_eq!(
+                tui.handle_key(
+                    crossterm::event::KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+                    area
+                ),
+                KeyHandling::Consumed(vec![UiIntent::FocusPane { pane_id: 1 }]),
+            );
+        }
+        apply_rows(&mut tui, &[1], vec![]);
+        let tui = tui.as_mut().unwrap();
+        tui.handle_key(
+            crossterm::event::KeyEvent::new(KeyCode::Char('a'), KeyModifiers::CONTROL),
+            area,
+        );
+        let mut animation = Instant::now();
+        refresh_tui_timers(
+            tui,
+            Instant::now() + Duration::from_millis(400),
+            &mut animation,
+        );
+        assert_eq!(
+            tui.handle_key(
+                crossterm::event::KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+                area
+            ),
+            KeyHandling::Consumed(vec![]),
+        );
+    }
+
+    #[test]
+    fn modal_overlay_blocks_paste_and_resize_before_open_sets_scroll_bounds() {
+        let mut tui = None;
+        apply_rows(
+            &mut tui,
+            &[1, 2, 3],
+            vec![
+                roster_row(1, AgentRosterState::Working as i32),
+                roster_row(2, AgentRosterState::Working as i32),
+                roster_row(3, AgentRosterState::Working as i32),
+            ],
+        );
+        let tui = tui.as_mut().unwrap();
+        let area = Rect::new(0, 0, 24, 8);
+        tui.set_agent_overlay_viewport(area);
+        tui.handle_key(
+            crossterm::event::KeyEvent::new(KeyCode::Char('a'), KeyModifiers::CONTROL),
+            area,
+        );
+        let mut animation = Instant::now();
+        refresh_tui_timers(
+            tui,
+            Instant::now() + Duration::from_millis(400),
+            &mut animation,
+        );
+
+        assert!(!should_forward_paste(tui));
+        assert!(tui.scroll_agent_overlay(area, false));
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -7,7 +7,7 @@ use std::{
     os::unix::net::UnixStream,
     sync::mpsc::{self, Receiver, TryRecvError},
     thread,
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use crossterm::{
@@ -25,7 +25,10 @@ use crate::{
     protocol::AgentRosterState,
     screen::GuestScreen,
     session_store::SessionDescriptor,
-    tui::{AgentOverlayRow, KeyHandling, MultiPaneTui, PaneViewState, render_multi_pane},
+    tui::{
+        AGENT_OVERLAY_ANIMATION_INTERVAL, AgentOverlayRow, KeyHandling, MultiPaneTui,
+        PaneViewState, render_multi_pane,
+    },
 };
 
 pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Error>> {
@@ -60,6 +63,7 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
     let mut node_ended = false;
     let mut attach_error = None;
     let mut detach_sent = false;
+    let mut last_agent_overlay_animation = Instant::now();
 
     'attached: loop {
         loop {
@@ -87,6 +91,9 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
                             tab_id,
                             pane_id,
                         )?;
+                        if let Some(tui) = tui.as_mut() {
+                            tui.set_agent_overlay_viewport(terminal.size()?.into());
+                        }
                         dirty = true;
                     }
                 }
@@ -104,6 +111,18 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
                     break 'attached;
                 }
                 Err(TryRecvError::Empty) => break,
+            }
+        }
+        if let Some(tui) = tui.as_mut() {
+            let now = Instant::now();
+            dirty |= tui.expire_chord_mode(now);
+            dirty |= tui.expire_agent_toggle(now);
+            if tui.agent_overlay_has_working_rows()
+                && now.duration_since(last_agent_overlay_animation)
+                    >= AGENT_OVERLAY_ANIMATION_INTERVAL
+            {
+                last_agent_overlay_animation = now;
+                dirty = true;
             }
         }
         if dirty {
@@ -145,15 +164,33 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
                     }
                 }
             }
-            Event::Paste(text) => write_message(
-                &mut stream,
-                &ClientMessage::Input {
-                    bytes: text.into_bytes(),
-                },
-            )?,
+            Event::Paste(text) => {
+                if !tui.overlay_open() {
+                    write_message(
+                        &mut stream,
+                        &ClientMessage::Input {
+                            bytes: text.into_bytes(),
+                        },
+                    )?;
+                }
+                dirty = true;
+            }
             Event::Mouse(mouse) => {
                 let area = terminal.size()?.into();
-                if matches!(
+                if tui.overlay_open() {
+                    if matches!(
+                        mouse.kind,
+                        MouseEventKind::ScrollUp | MouseEventKind::ScrollDown
+                    ) {
+                        tui.scroll_agent_overlay(
+                            area,
+                            matches!(mouse.kind, MouseEventKind::ScrollUp),
+                        );
+                    } else if matches!(mouse.kind, MouseEventKind::Down(_)) {
+                        let intents = tui.handle_mouse(mouse, area);
+                        send_intents(&mut stream, tui, intents)?;
+                    }
+                } else if matches!(
                     mouse.kind,
                     MouseEventKind::ScrollUp | MouseEventKind::ScrollDown
                 ) {
@@ -178,6 +215,7 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
             }
             Event::Resize(cols, rows) => {
                 terminal.resize(Rect::new(0, 0, cols, rows))?;
+                tui.set_agent_overlay_viewport(Rect::new(0, 0, cols, rows));
                 write_message(&mut stream, &ClientMessage::Resize { cols, rows })?;
                 dirty = true;
             }

--- a/src/local_ipc.rs
+++ b/src/local_ipc.rs
@@ -48,7 +48,7 @@ pub enum NodeMessage {
         layout: Box<LayoutSnapshot>,
         screens: Vec<PaneScreenSnapshot>,
         leases: Vec<PaneLeaseSnapshot>,
-        rosters: serde_json::Value,
+        rosters: Vec<AgentOverlaySnapshotRow>,
         tab_id: u64,
         pane_id: u64,
     },
@@ -64,6 +64,32 @@ pub enum NodeMessage {
     Error {
         message: String,
     },
+}
+
+/// Render-ready agent data included atomically with an attachment snapshot.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct AgentOverlaySnapshotRow {
+    pub pane_id: u64,
+    pub kind: String,
+    pub cwd: String,
+    pub state: i32,
+    pub working_since_unix_ms: u64,
+    pub host: String,
+    pub controller: String,
+}
+
+impl From<&crate::tui::AgentOverlayRow> for AgentOverlaySnapshotRow {
+    fn from(row: &crate::tui::AgentOverlayRow) -> Self {
+        Self {
+            pane_id: row.pane_id,
+            kind: row.kind.clone(),
+            cwd: row.cwd.clone(),
+            state: row.state as i32,
+            working_since_unix_ms: row.working_since_unix_ms,
+            host: row.host.clone(),
+            controller: row.controller.clone(),
+        }
+    }
 }
 
 /// Complete screen state for one pane. Attachments replace their local `GuestScreen` from this

--- a/src/node.rs
+++ b/src/node.rs
@@ -20,8 +20,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     local_ipc::{
-        AttachmentGate, ClientMessage, NodeMessage, PaneLeaseSnapshot, PaneScreenSnapshot,
-        SessionSummary,
+        AgentOverlaySnapshotRow, AttachmentGate, ClientMessage, NodeMessage, PaneLeaseSnapshot,
+        PaneScreenSnapshot, SessionSummary,
     },
     rendezvous::LocalRendezvous,
     session::{
@@ -383,7 +383,7 @@ fn write_snapshot(
     _generation: u64,
 ) -> io::Result<()> {
     let (tab_id, pane_id) = node.local_focus();
-    let (layout, screens, leases) = node.snapshot();
+    let (layout, screens, leases, rosters) = node.snapshot();
     let hosts = layout
         .panes
         .values()
@@ -433,7 +433,7 @@ fn write_snapshot(
                     },
                 )
                 .collect(),
-            rosters: serde_json::json!({}),
+            rosters,
             tab_id,
             pane_id,
         },
@@ -473,6 +473,7 @@ impl SharedLayoutNode {
         crate::layout::LayoutSnapshot,
         crate::tui::NodeScreenSnapshots,
         crate::tui::NodeLeaseSnapshots,
+        Vec<AgentOverlaySnapshotRow>,
     ) {
         self.runtime.node_snapshot()
     }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -93,7 +93,7 @@ fn unix_ms_now() -> u64 {
 }
 const AGENT_SAMPLE_INTERVAL: Duration = Duration::from_secs(1);
 const AGENT_TOGGLE_WINDOW: Duration = Duration::from_millis(400);
-const AGENT_OVERLAY_ANIMATION_INTERVAL: Duration = Duration::from_millis(100);
+pub(crate) const AGENT_OVERLAY_ANIMATION_INTERVAL: Duration = Duration::from_millis(100);
 const AGENT_OVERLAY_CARD_LINES: usize = 3;
 const AGENT_OVERLAY_CHROME: Color = Color::Rgb(255, 69, 0);
 const AGENT_OVERLAY_SELECTED_BACKGROUND: Color = Color::DarkGray;
@@ -424,7 +424,7 @@ impl MultiPaneTui {
         true
     }
 
-    fn set_agent_overlay_viewport(&mut self, area: Rect) {
+    pub(crate) fn set_agent_overlay_viewport(&mut self, area: Rect) {
         self.agent_overlay_viewport_lines = agents_overlay_inner(area).height;
         self.clamp_agent_overlay_scroll();
     }
@@ -477,7 +477,7 @@ impl MultiPaneTui {
         self.clamp_agent_overlay_scroll();
     }
 
-    fn scroll_agent_overlay(&mut self, area: Rect, up: bool) -> bool {
+    pub(crate) fn scroll_agent_overlay(&mut self, area: Rect, up: bool) -> bool {
         self.set_agent_overlay_viewport(area);
         let previous = self.agent_overlay_scroll_line;
         if up {
@@ -493,7 +493,7 @@ impl MultiPaneTui {
         self.agent_overlay_scroll_line != previous
     }
 
-    fn agent_overlay_has_working_rows(&self) -> bool {
+    pub(crate) fn agent_overlay_has_working_rows(&self) -> bool {
         self.agent_overlay_open
             && self
                 .agent_rows
@@ -514,7 +514,7 @@ impl MultiPaneTui {
             })
     }
 
-    fn expire_agent_toggle(&mut self, now: Instant) -> bool {
+    pub(crate) fn expire_agent_toggle(&mut self, now: Instant) -> bool {
         if self
             .pending_agent_toggle
             .is_some_and(|then| now.duration_since(then) >= AGENT_TOGGLE_WINDOW)
@@ -544,7 +544,7 @@ impl MultiPaneTui {
     }
 
     /// Clears sticky pane/tab mode after [`CHORD_IDLE_TIMEOUT`] without a key.
-    fn expire_chord_mode(&mut self, now: Instant) -> bool {
+    pub(crate) fn expire_chord_mode(&mut self, now: Instant) -> bool {
         let Some(last) = self.chord_last_activity else {
             return false;
         };

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -3672,8 +3672,7 @@ impl SharedLayoutRuntime {
                     )
                 })
                 .collect::<BTreeMap<_, _>>();
-        let rows = self
-            .agent_rosters
+        self.agent_rosters
             .values()
             .flat_map(|roster| {
                 roster.entries.iter().filter_map(|entry| {
@@ -3705,8 +3704,7 @@ impl SharedLayoutRuntime {
                     })
                 })
             })
-            .collect();
-        rows
+            .collect()
     }
 
     fn handle_control_event(&mut self, event: LayoutControlEvent) -> Result<(), Box<dyn Error>> {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -51,6 +51,7 @@ use crate::{
     kitty_keyboard::KittyKeyboardTracker,
     layout::{Axis, LayoutError, LayoutSnapshot, NewPanePosition, Node, PaneId, TabId},
     lease::{IDLE_AFTER, LeaseDecision, LeaseManager, LeaseState},
+    local_ipc::AgentOverlaySnapshotRow,
     protocol::{
         AgentRoster, AgentRosterEntry, AgentRosterState, CreatePane, CreateTab, DeletePane,
         DeleteTab, LayoutRequest, NewPanePosition as ProtocolNewPanePosition, PaneDescriptor,
@@ -3180,7 +3181,14 @@ impl SharedLayoutRuntime {
 
     /// A complete node-owned view for a newly attached local renderer. Frames are deliberately
     /// snapshots: the client can always rebuild a `GuestScreen` without owning a PTY.
-    pub fn node_snapshot(&self) -> (LayoutSnapshot, NodeScreenSnapshots, NodeLeaseSnapshots) {
+    pub fn node_snapshot(
+        &self,
+    ) -> (
+        LayoutSnapshot,
+        NodeScreenSnapshots,
+        NodeLeaseSnapshots,
+        Vec<AgentOverlaySnapshotRow>,
+    ) {
         let mut screens = BTreeMap::new();
         let mut chrome = BTreeMap::new();
         for (pane_id, pane) in &self.local {
@@ -3218,7 +3226,15 @@ impl SharedLayoutRuntime {
                 (view.ready, view.controller_peer_id, view.controller_active),
             );
         }
-        (self.tui.snapshot().clone(), screens, chrome)
+        (
+            self.tui.snapshot().clone(),
+            screens,
+            chrome,
+            self.agent_overlay_rows()
+                .iter()
+                .map(AgentOverlaySnapshotRow::from)
+                .collect(),
+        )
     }
 
     pub fn node_resize(&mut self, cols: u16, rows: u16) -> Result<(), Box<dyn Error>> {
@@ -3640,6 +3656,10 @@ impl SharedLayoutRuntime {
     }
 
     fn refresh_agent_rows(&mut self) -> bool {
+        self.tui.set_agent_rows(self.agent_overlay_rows())
+    }
+
+    pub fn agent_overlay_rows(&self) -> Vec<AgentOverlayRow> {
         let pane_locations =
             self.tui
                 .snapshot()
@@ -3686,7 +3706,7 @@ impl SharedLayoutRuntime {
                 })
             })
             .collect();
-        self.tui.set_agent_rows(rows)
+        rows
     }
 
     fn handle_control_event(&mut self, event: LayoutControlEvent) -> Result<(), Box<dyn Error>> {

--- a/tests/local_ipc.rs
+++ b/tests/local_ipc.rs
@@ -17,7 +17,7 @@ fn protocol_messages_are_tagged_and_attachment_is_generation_safe() {
         }),
         screens: Default::default(),
         leases: Default::default(),
-        rosters: serde_json::json!({}),
+        rosters: vec![],
         tab_id: 2,
         pane_id: 3,
     };


### PR DESCRIPTION
## Summary
- Ship typed agent overlay rows on local IPC `Snapshot.rosters` from the node runtime (no more empty `{}`).
- Restore attach-client Ctrl+A timer, animation redraw, overlay viewport on resize, and modal paste/mouse handling so the overlay works without `P2PMUX_LEGACY_FOREGROUND`.
- Add regression coverage for open-after-wait, double-tap pass-through, paste blocking, and roster apply.

## Test plan
- [ ] `cargo test`
- [ ] Attach to a live session (default path, not legacy foreground)
- [ ] Press Ctrl+A once, wait ~400ms → Agents overlay opens
- [ ] Press Ctrl+A twice quickly → beginning-of-line reaches the PTY, overlay stays closed
- [ ] With an allowlisted agent in a pane → row appears with correct state/location; Enter jumps; Esc closes
- [ ] While overlay open → paste is not forwarded; mouse wheel scrolls the list
- [ ] Detach/reattach → overlay still works and rows refresh from snapshots


Made with [Cursor](https://cursor.com)