### PR TITLE
feat: rename panes and tabs with Ctrl+P/T e

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2472,6 +2472,7 @@ dependencies = [
  "sysinfo",
  "tokio",
  "toml",
+ "unicode-width",
  "vt100",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,4 @@ sysinfo = "0.37"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "time", "sync", "net", "io-util"] }
 toml = "0.8"
 vt100 = "0.16"
+unicode-width = "0.2"

--- a/README.md
+++ b/README.md
@@ -130,9 +130,13 @@ hosts then resize their own PTY and VT screen and publish their local grids.
 - `Ctrl+P`, then `r` / `l` / `d` / `u` — create the new pane right / left / down / up of the
   focused pane.
 - `Ctrl+P`, then `X` — delete the focused pane. Only that pane’s host may delete it.
+- `Ctrl+P`, then `e` — rename the focused pane for every admitted member. Enter saves; Esc
+  cancels; a blank title restores `Pane #N`.
 - `Ctrl+P`, then arrows — move focus.
 - `Ctrl+T`, then `N` — create a tab with a local PTY on the requester’s Mac.
 - `Ctrl+T`, then `X` — delete the current tab only when the requester hosts every pane in it.
+- `Ctrl+T`, then `e` — rename the current tab for every admitted member. Enter saves; Esc
+  cancels; a blank title restores `Tab #N`.
 - `Ctrl+T`, then left/right — switch tabs.
 
 The final pane in a tab must be removed by deleting its tab; the final tab cannot be deleted.

--- a/docs/MVP_DESIGN.md
+++ b/docs/MVP_DESIGN.md
@@ -111,9 +111,11 @@ The last pane in a tab must be removed by deleting the tab; the final tab is ret
 
 ### Spike 3 controls
 
-`Ctrl+P` then `N` splits; `Ctrl+P` then `X` requests focused-pane deletion; `Ctrl+P` plus arrows
-moves focus. `Ctrl+T` then `N` creates a tab; `Ctrl+T` then `X` requests tab deletion; `Ctrl+T`
-plus left/right switches tabs; `Esc` cancels. These mux chords are consumed locally. Ctrl+Q detaches
+`Ctrl+P` then `N` splits; `Ctrl+P` then `X` requests focused-pane deletion; `Ctrl+P` then `e`
+renames the focused pane for all admitted members. `Ctrl+P` plus arrows moves focus. `Ctrl+T` then
+`N` creates a tab; `Ctrl+T` then `X` requests tab deletion; `Ctrl+T` then `e` renames the current
+tab for all admitted members; `Ctrl+T` plus left/right switches tabs. Rename uses Enter to save and
+Esc to cancel; a blank title restores the ordinal label. These mux chords are consumed locally. Ctrl+Q detaches
 the local view while the session node remains live; F9 and F10 reach the focused PTY. Pane grids never resize.
 
 ### Disconnect grace (any member)

--- a/docs/superpowers/plans/2026-07-26-pane-tab-rename.md
+++ b/docs/superpowers/plans/2026-07-26-pane-tab-rename.md
@@ -4,7 +4,7 @@
 
 **Goal:** Ship shared, persistent pane and tab chrome titles through `Ctrl+P e` and `Ctrl+T e`, with a non-expiring modal prompt and ordinal fallback labels.
 
-**Architecture:** `layout::SessionState` is the sole title authority and includes `Option<String>` on its `Pane`/`Tab` snapshot model. Protocol v6 carries titles in descriptors plus one-action rename requests. The coordinator validates/serializes mutations and broadcasts normal `LayoutCommit`s. TUI owns the local prompt state, chord dispatch, input editing, and width-safe chrome rendering. No title is stored in local finder records; the live node snapshot is the persistence boundary.
+**Architecture:** `layout::SessionState` is the sole title authority and includes `Option<String>` on its `Pane`/`Tab` snapshot model. Protocol v6 carries titles in descriptors plus one-action rename requests. The coordinator validates/serializes mutations and broadcasts normal `LayoutCommit`s. TUI owns the local prompt state, chord dispatch, input editing, and width-safe chrome rendering, including the agents-overlay location labels. No title is stored in local finder records: the live `SharedLayoutRuntime` snapshot flows through `SharedLayoutNode::snapshot()` and `node::write_snapshot()` to a reattached local renderer, while `SessionStore` records only locate that node.
 
 **Tech Stack:** Rust 2024; existing serde layout model, Prost protocol, Tokio coordinator/session transport, Ratatui + Crossterm TUI, existing unit/integration test suites.
 
@@ -22,6 +22,7 @@
 | `src/protocol.rs` | Protocol v6, descriptor fields, rename messages/action tags, bounded validation |
 | `src/session.rs` | Descriptor ↔ layout conversion and coordinator rename dispatch/rejection mapping |
 | `src/tui.rs` | Rename modal, `e` chords/footer, intent/request plumbing, chrome truncation/rendering |
+| `Cargo.toml` | Direct `unicode-width` dependency for terminal-cell-width-safe chrome allocation |
 | `tests/protocol.rs` | Wire/tag/version/validation coverage |
 | `tests/session_layout.rs` | Pure coordinator rename/late-snapshot coverage |
 | `tests/session_layout_control.rs` | Shared-layout control-stream commit/rejection coverage |
@@ -37,13 +38,18 @@
 - `docs/superpowers/specs/2026-07-26-pane-tab-rename-design.md`
 - `docs/superpowers/plans/2026-07-26-pane-tab-rename.md`
 
-- [ ] Verify the documents match the locked product decisions, especially lowercase `e`, empty-clears, modal behavior, and protocol v6.
-- [ ] Commit docs only.
+- [x] Verify the documents match the locked product decisions, especially lowercase `e`, empty-clears, modal behavior, and protocol v6. Completed in `d12aa60`.
+- [x] Commit docs only. Completed in `d12aa60` (`docs: specify pane and tab rename`).
 
 ```bash
 git add docs/superpowers/specs/2026-07-26-pane-tab-rename-design.md docs/superpowers/plans/2026-07-26-pane-tab-rename.md
 git commit -m "docs: specify pane and tab rename"
 ```
+
+---
+
+Implementation begins at Task 2. Keep Task 1's docs-only commit intact; this review pass is a
+separate docs commit.
 
 ---
 
@@ -55,8 +61,8 @@ git commit -m "docs: specify pane and tab rename"
 
 - [ ] Add `title: Option<String>` to `Pane` and `Tab`; update every fixture/construction site deliberately rather than defaulting silently.
 - [ ] Add a layout-owned normalization helper returning `Result<Option<String>, LayoutError>`: trim Unicode whitespace; empty => `None`; otherwise enforce ≤32 Unicode scalars and no controls. Snapshot validation additionally rejects non-normalized values (`Some("")` and values whose trim changes them).
-- [ ] Add `SessionState::rename_pane(requester, base_revision, pane_id, title)` and `rename_tab(...)`. Both must call `check_mutation`, `require_member`, and `ensure_no_reservation`; lookup IDs; normalize/store; then `advance_revision` exactly once. Do not require target hosting.
-- [ ] Write focused failing/passing tests for any-member authorization, remote-host rename, clear, whitespace clear, bounds/control failures, unknown IDs, stale revision, snapshot round-trip/invalid snapshot, and unchanged roots/grids/hosts.
+- [ ] Add `SessionState::rename_pane(requester, base_revision, pane_id, title)` and `rename_tab(...)`. Both must call `check_mutation`, `require_member`, and `ensure_no_reservation`; lookup IDs; normalize/store; then `advance_revision` exactly once. Do not require target hosting. Keep the reservation gate: `reserve_*` captures a base revision that its later `PaneReady` must still match, so allowing a title-only commit during a pending reservation would falsely stale that ready. Rename may proceed after the reservation commits, cancels, fails, or expires.
+- [ ] Write focused failing/passing tests for any-member authorization, remote-host rename, clear, whitespace clear, bounds/control failures, unknown IDs, stale revision, pending-reservation rejection, snapshot round-trip/invalid snapshot, and unchanged roots/grids/hosts.
 - [ ] Run:
 
 ```bash
@@ -140,10 +146,10 @@ git commit -m "feat: replicate pane and tab title changes"
 - Modify: `src/tui.rs`
 - Modify/add: TUI unit tests in `src/tui.rs`
 
-- [ ] Refactor modal state enough to make agents overlay and rename mutually exclusive (an enum is preferred over independent booleans); preserve the overlay's current behavior.
+- [ ] Refactor modal state enough to make agents overlay and rename mutually exclusive (an enum is preferred over independent booleans). Preserve all existing agents-overlay behavior and its tests (including Ctrl+A double-tap, navigation, click/Enter selection, scrolling, and rendering); do not make drive-by overlay UX changes while adding rename.
 - [ ] Add a rename state with target kind/ID, editable `String`, and local validation error. On `Ctrl+P e` capture `focused_pane`; on `Ctrl+T e` capture `current_tab`; exit chord mode when opening.
 - [ ] Add lowercase `e` to `handle_pane_chord`, `handle_tab_chord`, `is_chord_command`, and contextual footer segments/text. Keep lowercase `r` exclusively the pane right-split action.
-- [ ] Process active rename before `expire_chord_mode`, normal chords, overlay toggle, mouse focus/selection/resize, and PTY forwarding. Implement printable input, Backspace, Enter normalization/validation → `UiIntent::RenamePane`/`RenameTab`, Esc cancel, and Ctrl+Q global detach precedence. Consume unsupported input.
+- [ ] Process active rename before `expire_chord_mode`, normal chords, overlay toggle, mouse focus/selection/resize, and PTY forwarding. Implement printable input, Backspace, Enter normalization/validation → `UiIntent::RenamePane`/`RenameTab`, Esc cancel, and Ctrl+Q global detach precedence. Consume unsupported input. Route global Ctrl+Q ahead of either modal as necessary, but otherwise retain the agents overlay's present key semantics.
 - [ ] Emit intents to the existing session runner; construct one-action `LayoutRequest`s with title fields and all non-rename action fields `None`. Ensure a prompt closes before a request/rejection is handled and never silently retargets after a layout update.
 - [ ] Render the centered `Clear`/bordered prompt plus edit field, prompt-local error, and `Enter save · Esc cancel`; it must be non-idle-expiring.
 - [ ] Test chord target capture and `e` recognition/footer; prefill; printable/shifted Unicode and Backspace; Enter sends expected intent including empty clear; invalid stays open; Esc has no intent; timeout does not close; Ctrl+P/Ctrl+T/Ctrl+A/arrows/mouse do not escape the modal; Ctrl+Q wins; no PTY forwarding; and overlay/rename exclusion.
@@ -166,13 +172,14 @@ git commit -m "feat: add modal pane and tab rename prompts"
 ## Task 6: Render custom chrome safely and finish documentation
 
 **Files:**
+- Modify: `Cargo.toml`
 - Modify: `src/tui.rs`
 - Modify: `README.md` (if controls documentation is user-facing there)
 - Modify: `docs/MVP_DESIGN.md` (if its locked controls/chrome paragraph must name `e`)
 - Modify/add: TUI rendering tests in `src/tui.rs`
 
-- [ ] Replace ordinal-only `tab_label`/`pane_title` inputs with title-aware helpers: use custom title exactly when `Some`, otherwise `Tab #N` / `Pane #N`; retain existing host/control pane chrome and active-tab styling.
-- [ ] Add display-width-aware single-line ellipsis truncation at tab and pane render allocation boundaries. Test narrow widths, Unicode-width characters, and no border/tab overlap. Do not alter the canonical stored title while truncating.
+- [ ] Replace ordinal-only `tab_label`/`pane_title` inputs with title-aware helpers: use custom title exactly when `Some`, otherwise `Tab #N` / `Pane #N`; retain existing host/control pane chrome and active-tab styling. Carry the resolved tab/pane labels into `AgentOverlayRow` and render those labels in its location line under the same custom-title/ordinal-fallback rule; rows remain selected by `pane_id` and do not append an ordinal beside a custom title.
+- [ ] Add `unicode-width` as a direct dependency and replace scalar-count width calculations on these render paths with terminal-cell-width-aware helpers. Add display-width-aware single-line ellipsis truncation at tab, pane, and agents-overlay render allocation boundaries. For pane chrome, allocate/protect the title first (custom or ordinal), ellipsize it within the block-title width, and only then append host/control from leftover width; host/control may clip or disappear before title does. Test narrow widths, Unicode-width characters, the title-versus-host/control precedence, overlay custom-title/fallback labels, and no border/tab overlap. Do not alter the canonical stored title while truncating.
 - [ ] Update README/MVP controls text only where necessary: document `Ctrl+P e` / `Ctrl+T e`, all-member label authority, Enter/Esc, and blank-to-ordinal behavior; explicitly do not describe the unrelated session CLI `rename` as pane/tab rename.
 - [ ] Run the complete quality gate:
 
@@ -185,12 +192,13 @@ cargo test
 - [ ] Commit:
 
 ```bash
-git add src/tui.rs README.md docs/MVP_DESIGN.md
-git commit -m "docs: document shared pane and tab rename"
+git add Cargo.toml Cargo.lock src/tui.rs README.md docs/MVP_DESIGN.md
+git commit -m "feat: render shared pane and tab titles"
 ```
 
 If no README/MVP change is warranted, omit those paths from `git add` but retain the render/tests
-commit under the same message.
+commit under the same message. If user-facing docs changed, commit them separately as a small
+`docs:` follow-up after the rendering feature commit.
 
 ---
 

--- a/docs/superpowers/plans/2026-07-26-pane-tab-rename.md
+++ b/docs/superpowers/plans/2026-07-26-pane-tab-rename.md
@@ -59,18 +59,18 @@ separate docs commit.
 - Modify: `src/layout.rs`
 - Modify/add: layout unit tests in `src/layout.rs`
 
-- [ ] Add `title: Option<String>` to `Pane` and `Tab`; update every fixture/construction site deliberately rather than defaulting silently.
-- [ ] Add a layout-owned normalization helper returning `Result<Option<String>, LayoutError>`: trim Unicode whitespace; empty => `None`; otherwise enforce ≤32 Unicode scalars and no controls. Snapshot validation additionally rejects non-normalized values (`Some("")` and values whose trim changes them).
-- [ ] Add `SessionState::rename_pane(requester, base_revision, pane_id, title)` and `rename_tab(...)`. Both must call `check_mutation`, `require_member`, and `ensure_no_reservation`; lookup IDs; normalize/store; then `advance_revision` exactly once. Do not require target hosting. Keep the reservation gate: `reserve_*` captures a base revision that its later `PaneReady` must still match, so allowing a title-only commit during a pending reservation would falsely stale that ready. Rename may proceed after the reservation commits, cancels, fails, or expires.
-- [ ] Write focused failing/passing tests for any-member authorization, remote-host rename, clear, whitespace clear, bounds/control failures, unknown IDs, stale revision, pending-reservation rejection, snapshot round-trip/invalid snapshot, and unchanged roots/grids/hosts.
-- [ ] Run:
+- [x] Add `title: Option<String>` to `Pane` and `Tab`; update every fixture/construction site deliberately rather than defaulting silently.
+- [x] Add a layout-owned normalization helper returning `Result<Option<String>, LayoutError>`: trim Unicode whitespace; empty => `None`; otherwise enforce ≤32 Unicode scalars and no controls. Snapshot validation additionally rejects non-normalized values (`Some("")` and values whose trim changes them).
+- [x] Add `SessionState::rename_pane(requester, base_revision, pane_id, title)` and `rename_tab(...)`. Both must call `check_mutation`, `require_member`, and `ensure_no_reservation`; lookup IDs; normalize/store; then `advance_revision` exactly once. Do not require target hosting. Keep the reservation gate: `reserve_*` captures a base revision that its later `PaneReady` must still match, so allowing a title-only commit during a pending reservation would falsely stale that ready. Rename may proceed after the reservation commits, cancels, fails, or expires.
+- [x] Write focused failing/passing tests for any-member authorization, remote-host rename, clear, whitespace clear, bounds/control failures, unknown IDs, stale revision, pending-reservation rejection, snapshot round-trip/invalid snapshot, and unchanged roots/grids/hosts.
+- [x] Run:
 
 ```bash
 cargo test --lib layout -- --nocapture
 cargo fmt --check
 ```
 
-- [ ] Commit:
+- [x] Commit:
 
 ```bash
 git add src/layout.rs

--- a/docs/superpowers/plans/2026-07-26-pane-tab-rename.md
+++ b/docs/superpowers/plans/2026-07-26-pane-tab-rename.md
@@ -1,0 +1,229 @@
+# Mid-session pane and tab rename Implementation Plan
+
+> **For agentic workers:** Execute only in `/Users/pelazas/Desktop/p2pmux-pane-tab-rename` on branch `feat/pane-tab-rename`. Make one local commit per completed task. Do **not** push or open a PR during implementation unless an explicit handoff asks for it; the eventual PR target is `main`.
+
+**Goal:** Ship shared, persistent pane and tab chrome titles through `Ctrl+P e` and `Ctrl+T e`, with a non-expiring modal prompt and ordinal fallback labels.
+
+**Architecture:** `layout::SessionState` is the sole title authority and includes `Option<String>` on its `Pane`/`Tab` snapshot model. Protocol v6 carries titles in descriptors plus one-action rename requests. The coordinator validates/serializes mutations and broadcasts normal `LayoutCommit`s. TUI owns the local prompt state, chord dispatch, input editing, and width-safe chrome rendering. No title is stored in local finder records; the live node snapshot is the persistence boundary.
+
+**Tech Stack:** Rust 2024; existing serde layout model, Prost protocol, Tokio coordinator/session transport, Ratatui + Crossterm TUI, existing unit/integration test suites.
+
+**Spec:** `docs/superpowers/specs/2026-07-26-pane-tab-rename-design.md` (authoritative).
+
+---
+
+## File map
+
+| File | Responsibility |
+|---|---|
+| `docs/superpowers/specs/2026-07-26-pane-tab-rename-design.md` | Authoritative UX, state, and wire contract |
+| `docs/superpowers/plans/2026-07-26-pane-tab-rename.md` | This ordered implementation plan |
+| `src/layout.rs` | `Pane.title` / `Tab.title`, normalized title validation, rename mutations, snapshot validation |
+| `src/protocol.rs` | Protocol v6, descriptor fields, rename messages/action tags, bounded validation |
+| `src/session.rs` | Descriptor ↔ layout conversion and coordinator rename dispatch/rejection mapping |
+| `src/tui.rs` | Rename modal, `e` chords/footer, intent/request plumbing, chrome truncation/rendering |
+| `tests/protocol.rs` | Wire/tag/version/validation coverage |
+| `tests/session_layout.rs` | Pure coordinator rename/late-snapshot coverage |
+| `tests/session_layout_control.rs` | Shared-layout control-stream commit/rejection coverage |
+| `tests/module_surface.rs` | Protocol-version assertion |
+| `README.md` | User-facing rename key/behavior documentation, if needed |
+| `docs/MVP_DESIGN.md` | Locked controls/chrome text, if needed |
+
+---
+
+## Task 1: Commit the design and plan
+
+**Files:**
+- `docs/superpowers/specs/2026-07-26-pane-tab-rename-design.md`
+- `docs/superpowers/plans/2026-07-26-pane-tab-rename.md`
+
+- [ ] Verify the documents match the locked product decisions, especially lowercase `e`, empty-clears, modal behavior, and protocol v6.
+- [ ] Commit docs only.
+
+```bash
+git add docs/superpowers/specs/2026-07-26-pane-tab-rename-design.md docs/superpowers/plans/2026-07-26-pane-tab-rename.md
+git commit -m "docs: specify pane and tab rename"
+```
+
+---
+
+## Task 2: Add authoritative title state and pure layout mutations
+
+**Files:**
+- Modify: `src/layout.rs`
+- Modify/add: layout unit tests in `src/layout.rs`
+
+- [ ] Add `title: Option<String>` to `Pane` and `Tab`; update every fixture/construction site deliberately rather than defaulting silently.
+- [ ] Add a layout-owned normalization helper returning `Result<Option<String>, LayoutError>`: trim Unicode whitespace; empty => `None`; otherwise enforce ≤32 Unicode scalars and no controls. Snapshot validation additionally rejects non-normalized values (`Some("")` and values whose trim changes them).
+- [ ] Add `SessionState::rename_pane(requester, base_revision, pane_id, title)` and `rename_tab(...)`. Both must call `check_mutation`, `require_member`, and `ensure_no_reservation`; lookup IDs; normalize/store; then `advance_revision` exactly once. Do not require target hosting.
+- [ ] Write focused failing/passing tests for any-member authorization, remote-host rename, clear, whitespace clear, bounds/control failures, unknown IDs, stale revision, snapshot round-trip/invalid snapshot, and unchanged roots/grids/hosts.
+- [ ] Run:
+
+```bash
+cargo test --lib layout -- --nocapture
+cargo fmt --check
+```
+
+- [ ] Commit:
+
+```bash
+git add src/layout.rs
+git commit -m "feat: store shared pane and tab titles"
+```
+
+---
+
+## Task 3: Define protocol v6 rename messages and validation
+
+**Files:**
+- Modify: `src/protocol.rs`
+- Modify: `tests/protocol.rs`
+- Modify: `tests/module_surface.rs`
+
+- [ ] Bump `PROTOCOL_VERSION` from 5 to 6, including explicit test names/assertions and all expected envelopes.
+- [ ] Add `PaneDescriptor.title: Option<String>` at Prost tag 5 and `TabDescriptor.title: Option<String>` at tag 3.
+- [ ] Add `RenamePane { pane_id: u64 tag 1, title: String tag 2 }` and `RenameTab { tab_id: u64 tag 1, title: String tag 2 }`.
+- [ ] Add `LayoutRequest.rename_pane` tag 9 and `rename_tab` tag 10. Extend the exact-one-action count from six to eight, including every request fixture/default.
+- [ ] Define `MAX_LAYOUT_TITLE_BYTES: usize = 128`; protocol validation accepts empty title (clear), rejects zero IDs and title byte lengths above the cap. Keep scalar/control/normalization authority in `layout.rs` as specified.
+- [ ] Ensure layout-state decode/conversion reaches layout snapshot validation so descriptor `Some("")`, overlong, control-containing, or untrimmed titles cannot render locally.
+- [ ] Test byte cap; v6 encode/decode; descriptor optional-title round trip; both exact message tags/actions; empty clear; zero target; multiple action; malformed title; and v5/v7 rejection.
+- [ ] Run:
+
+```bash
+cargo test --test protocol
+cargo test --test module_surface
+cargo fmt --check
+```
+
+- [ ] Commit:
+
+```bash
+git add src/protocol.rs tests/protocol.rs tests/module_surface.rs
+git commit -m "feat: add rename layout actions in protocol v6"
+```
+
+---
+
+## Task 4: Plumb titles through the coordinator and shared sessions
+
+**Files:**
+- Modify: `src/session.rs`
+- Modify: `tests/session_layout.rs`
+- Modify: `tests/session_layout_control.rs`
+- Modify any session fixtures made exhaustive by descriptor/request fields
+
+- [ ] Map title fields in `protocol_layout_state` and `layout_snapshot_from_state`.
+- [ ] Import/dispatch `RenamePane` and `RenameTab` in `LayoutCoordinator::handle_request_at`; include both in action counting and call the Task 2 mutations.
+- [ ] Preserve existing reject mapping: unknown target → `UnknownId`, invalid title/multiple action → `Malformed`, stale → `Stale`, and non-member → `NotHost`. Do not add title ACLs.
+- [ ] Add coordinator tests for remote-member rename of both kinds, commit revision/state contents, stale/unknown/invalid rejections, and a joining member receiving title-bearing `SessionSnapshot`.
+- [ ] Add shared-layout control tests proving a member-issued rename reaches peers as `LayoutControlEvent::Commit`; verify a rejection does not mutate title.
+- [ ] Run:
+
+```bash
+cargo test --test session_layout
+cargo test --test session_layout_control
+cargo fmt --check
+```
+
+- [ ] Commit:
+
+```bash
+git add src/session.rs tests/session_layout.rs tests/session_layout_control.rs
+git commit -m "feat: replicate pane and tab title changes"
+```
+
+---
+
+## Task 5: Implement the modal rename prompt and commands
+
+**Files:**
+- Modify: `src/tui.rs`
+- Modify/add: TUI unit tests in `src/tui.rs`
+
+- [ ] Refactor modal state enough to make agents overlay and rename mutually exclusive (an enum is preferred over independent booleans); preserve the overlay's current behavior.
+- [ ] Add a rename state with target kind/ID, editable `String`, and local validation error. On `Ctrl+P e` capture `focused_pane`; on `Ctrl+T e` capture `current_tab`; exit chord mode when opening.
+- [ ] Add lowercase `e` to `handle_pane_chord`, `handle_tab_chord`, `is_chord_command`, and contextual footer segments/text. Keep lowercase `r` exclusively the pane right-split action.
+- [ ] Process active rename before `expire_chord_mode`, normal chords, overlay toggle, mouse focus/selection/resize, and PTY forwarding. Implement printable input, Backspace, Enter normalization/validation → `UiIntent::RenamePane`/`RenameTab`, Esc cancel, and Ctrl+Q global detach precedence. Consume unsupported input.
+- [ ] Emit intents to the existing session runner; construct one-action `LayoutRequest`s with title fields and all non-rename action fields `None`. Ensure a prompt closes before a request/rejection is handled and never silently retargets after a layout update.
+- [ ] Render the centered `Clear`/bordered prompt plus edit field, prompt-local error, and `Enter save · Esc cancel`; it must be non-idle-expiring.
+- [ ] Test chord target capture and `e` recognition/footer; prefill; printable/shifted Unicode and Backspace; Enter sends expected intent including empty clear; invalid stays open; Esc has no intent; timeout does not close; Ctrl+P/Ctrl+T/Ctrl+A/arrows/mouse do not escape the modal; Ctrl+Q wins; no PTY forwarding; and overlay/rename exclusion.
+- [ ] Run:
+
+```bash
+cargo test --lib tui -- --nocapture
+cargo fmt --check
+```
+
+- [ ] Commit:
+
+```bash
+git add src/tui.rs
+git commit -m "feat: add modal pane and tab rename prompts"
+```
+
+---
+
+## Task 6: Render custom chrome safely and finish documentation
+
+**Files:**
+- Modify: `src/tui.rs`
+- Modify: `README.md` (if controls documentation is user-facing there)
+- Modify: `docs/MVP_DESIGN.md` (if its locked controls/chrome paragraph must name `e`)
+- Modify/add: TUI rendering tests in `src/tui.rs`
+
+- [ ] Replace ordinal-only `tab_label`/`pane_title` inputs with title-aware helpers: use custom title exactly when `Some`, otherwise `Tab #N` / `Pane #N`; retain existing host/control pane chrome and active-tab styling.
+- [ ] Add display-width-aware single-line ellipsis truncation at tab and pane render allocation boundaries. Test narrow widths, Unicode-width characters, and no border/tab overlap. Do not alter the canonical stored title while truncating.
+- [ ] Update README/MVP controls text only where necessary: document `Ctrl+P e` / `Ctrl+T e`, all-member label authority, Enter/Esc, and blank-to-ordinal behavior; explicitly do not describe the unrelated session CLI `rename` as pane/tab rename.
+- [ ] Run the complete quality gate:
+
+```bash
+cargo fmt --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test
+```
+
+- [ ] Commit:
+
+```bash
+git add src/tui.rs README.md docs/MVP_DESIGN.md
+git commit -m "docs: document shared pane and tab rename"
+```
+
+If no README/MVP change is warranted, omit those paths from `git add` but retain the render/tests
+commit under the same message.
+
+---
+
+## Manual acceptance
+
+1. Create or join with two admitted members; have either member focus a pane hosted by the other,
+   press `Ctrl+P` then `e`, type `build logs`, and Enter. Both clients show `build logs` as that
+   pane's border label while host/control metadata remains correct.
+2. Press `Ctrl+T` then `e` on a tab, replace its prefilled custom title, and Enter. All clients
+   see the updated tab label and active styling.
+3. Reopen either prompt, erase its contents (or enter whitespace), press Enter, and verify exactly
+   `Pane #N` / `Tab #N` returns.
+4. Leave a prompt open longer than two seconds; it remains open. Esc closes without sending title
+   text to the focused shell. Ctrl+Q detaches rather than writing to the prompt/PTY.
+5. While open, try Ctrl+P, Ctrl+T, Ctrl+A, arrows, clicking panes/tabs, and typing arbitrary
+   commands; none navigate, toggle overlay, resize, or reach a PTY.
+6. Attempt a 33-scalar title and a control character path; the prompt keeps focus and shows a
+   validation error. Confirm the coordinator rejects stale/removed targets without corrupting
+   state.
+7. Attach/rejoin a second client after the commits; it receives both custom titles. Detach and
+   resume the local client while the node stays alive; titles remain.
+8. Check narrow terminal widths: tab/pane chrome ellipsizes cleanly without overwriting borders or
+   adjacent labels.
+
+## Success criteria
+
+- Protocol v6 is the only interoperable wire version and carries normalized optional titles in all
+  layout snapshots/commits.
+- Every admitted member can rename any pane/tab; permissions and PTY/control behavior otherwise do
+  not change.
+- Rename prompt modality, timeout, Enter/Esc, overlay interaction, and Ctrl+Q behavior match the
+  authoritative spec.
+- Empty custom titles reliably restore ordinal labels, and all layers have focused regression
+  coverage plus a green full suite.
+- All implementation commits are local, one per task, and no push/PR occurs without explicit
+  handoff.

--- a/docs/superpowers/plans/2026-07-26-pane-tab-rename.md
+++ b/docs/superpowers/plans/2026-07-26-pane-tab-rename.md
@@ -86,14 +86,14 @@ git commit -m "feat: store shared pane and tab titles"
 - Modify: `tests/protocol.rs`
 - Modify: `tests/module_surface.rs`
 
-- [ ] Bump `PROTOCOL_VERSION` from 5 to 6, including explicit test names/assertions and all expected envelopes.
-- [ ] Add `PaneDescriptor.title: Option<String>` at Prost tag 5 and `TabDescriptor.title: Option<String>` at tag 3.
-- [ ] Add `RenamePane { pane_id: u64 tag 1, title: String tag 2 }` and `RenameTab { tab_id: u64 tag 1, title: String tag 2 }`.
-- [ ] Add `LayoutRequest.rename_pane` tag 9 and `rename_tab` tag 10. Extend the exact-one-action count from six to eight, including every request fixture/default.
-- [ ] Define `MAX_LAYOUT_TITLE_BYTES: usize = 128`; protocol validation accepts empty title (clear), rejects zero IDs and title byte lengths above the cap. Keep scalar/control/normalization authority in `layout.rs` as specified.
-- [ ] Ensure layout-state decode/conversion reaches layout snapshot validation so descriptor `Some("")`, overlong, control-containing, or untrimmed titles cannot render locally.
-- [ ] Test byte cap; v6 encode/decode; descriptor optional-title round trip; both exact message tags/actions; empty clear; zero target; multiple action; malformed title; and v5/v7 rejection.
-- [ ] Run:
+- [x] Bump `PROTOCOL_VERSION` from 5 to 6, including explicit test names/assertions and all expected envelopes.
+- [x] Add `PaneDescriptor.title: Option<String>` at Prost tag 5 and `TabDescriptor.title: Option<String>` at tag 3.
+- [x] Add `RenamePane { pane_id: u64 tag 1, title: String tag 2 }` and `RenameTab { tab_id: u64 tag 1, title: String tag 2 }`.
+- [x] Add `LayoutRequest.rename_pane` tag 9 and `rename_tab` tag 10. Extend the exact-one-action count from six to eight, including every request fixture/default.
+- [x] Define `MAX_LAYOUT_TITLE_BYTES: usize = 128`; protocol validation accepts empty title (clear), rejects zero IDs and title byte lengths above the cap. Keep scalar/control/normalization authority in `layout.rs` as specified.
+- [x] Ensure layout-state decode/conversion reaches layout snapshot validation so descriptor `Some("")`, overlong, control-containing, or untrimmed titles cannot render locally.
+- [x] Test byte cap; v6 encode/decode; descriptor optional-title round trip; both exact message tags/actions; empty clear; zero target; multiple action; malformed title; and v5/v7 rejection.
+- [x] Run:
 
 ```bash
 cargo test --test protocol
@@ -101,7 +101,7 @@ cargo test --test module_surface
 cargo fmt --check
 ```
 
-- [ ] Commit:
+- [x] Commit:
 
 ```bash
 git add src/protocol.rs tests/protocol.rs tests/module_surface.rs
@@ -118,12 +118,12 @@ git commit -m "feat: add rename layout actions in protocol v6"
 - Modify: `tests/session_layout_control.rs`
 - Modify any session fixtures made exhaustive by descriptor/request fields
 
-- [ ] Map title fields in `protocol_layout_state` and `layout_snapshot_from_state`.
-- [ ] Import/dispatch `RenamePane` and `RenameTab` in `LayoutCoordinator::handle_request_at`; include both in action counting and call the Task 2 mutations.
-- [ ] Preserve existing reject mapping: unknown target → `UnknownId`, invalid title/multiple action → `Malformed`, stale → `Stale`, and non-member → `NotHost`. Do not add title ACLs.
-- [ ] Add coordinator tests for remote-member rename of both kinds, commit revision/state contents, stale/unknown/invalid rejections, and a joining member receiving title-bearing `SessionSnapshot`.
-- [ ] Add shared-layout control tests proving a member-issued rename reaches peers as `LayoutControlEvent::Commit`; verify a rejection does not mutate title.
-- [ ] Run:
+- [x] Map title fields in `protocol_layout_state` and `layout_snapshot_from_state`.
+- [x] Import/dispatch `RenamePane` and `RenameTab` in `LayoutCoordinator::handle_request_at`; include both in action counting and call the Task 2 mutations.
+- [x] Preserve existing reject mapping: unknown target → `UnknownId`, invalid title/multiple action → `Malformed`, stale → `Stale`, and non-member → `NotHost`. Do not add title ACLs.
+- [x] Add coordinator tests for remote-member rename of both kinds, commit revision/state contents, stale/unknown/invalid rejections, and a joining member receiving title-bearing `SessionSnapshot`.
+- [x] Add shared-layout control tests proving a member-issued rename reaches peers as `LayoutControlEvent::Commit`; verify a rejection does not mutate title.
+- [x] Run:
 
 ```bash
 cargo test --test session_layout
@@ -131,7 +131,7 @@ cargo test --test session_layout_control
 cargo fmt --check
 ```
 
-- [ ] Commit:
+- [x] Commit:
 
 ```bash
 git add src/session.rs tests/session_layout.rs tests/session_layout_control.rs
@@ -146,21 +146,21 @@ git commit -m "feat: replicate pane and tab title changes"
 - Modify: `src/tui.rs`
 - Modify/add: TUI unit tests in `src/tui.rs`
 
-- [ ] Refactor modal state enough to make agents overlay and rename mutually exclusive (an enum is preferred over independent booleans). Preserve all existing agents-overlay behavior and its tests (including Ctrl+A double-tap, navigation, click/Enter selection, scrolling, and rendering); do not make drive-by overlay UX changes while adding rename.
-- [ ] Add a rename state with target kind/ID, editable `String`, and local validation error. On `Ctrl+P e` capture `focused_pane`; on `Ctrl+T e` capture `current_tab`; exit chord mode when opening.
-- [ ] Add lowercase `e` to `handle_pane_chord`, `handle_tab_chord`, `is_chord_command`, and contextual footer segments/text. Keep lowercase `r` exclusively the pane right-split action.
-- [ ] Process active rename before `expire_chord_mode`, normal chords, overlay toggle, mouse focus/selection/resize, and PTY forwarding. Implement printable input, Backspace, Enter normalization/validation → `UiIntent::RenamePane`/`RenameTab`, Esc cancel, and Ctrl+Q global detach precedence. Consume unsupported input. Route global Ctrl+Q ahead of either modal as necessary, but otherwise retain the agents overlay's present key semantics.
-- [ ] Emit intents to the existing session runner; construct one-action `LayoutRequest`s with title fields and all non-rename action fields `None`. Ensure a prompt closes before a request/rejection is handled and never silently retargets after a layout update.
-- [ ] Render the centered `Clear`/bordered prompt plus edit field, prompt-local error, and `Enter save · Esc cancel`; it must be non-idle-expiring.
-- [ ] Test chord target capture and `e` recognition/footer; prefill; printable/shifted Unicode and Backspace; Enter sends expected intent including empty clear; invalid stays open; Esc has no intent; timeout does not close; Ctrl+P/Ctrl+T/Ctrl+A/arrows/mouse do not escape the modal; Ctrl+Q wins; no PTY forwarding; and overlay/rename exclusion.
-- [ ] Run:
+- [x] Refactor modal state enough to make agents overlay and rename mutually exclusive (an enum is preferred over independent booleans). Preserve all existing agents-overlay behavior and its tests (including Ctrl+A double-tap, navigation, click/Enter selection, scrolling, and rendering); do not make drive-by overlay UX changes while adding rename.
+- [x] Add a rename state with target kind/ID, editable `String`, and local validation error. On `Ctrl+P e` capture `focused_pane`; on `Ctrl+T e` capture `current_tab`; exit chord mode when opening.
+- [x] Add lowercase `e` to `handle_pane_chord`, `handle_tab_chord`, `is_chord_command`, and contextual footer segments/text. Keep lowercase `r` exclusively the pane right-split action.
+- [x] Process active rename before `expire_chord_mode`, normal chords, overlay toggle, mouse focus/selection/resize, and PTY forwarding. Implement printable input, Backspace, Enter normalization/validation → `UiIntent::RenamePane`/`RenameTab`, Esc cancel, and Ctrl+Q global detach precedence. Consume unsupported input. Route global Ctrl+Q ahead of either modal as necessary, but otherwise retain the agents overlay's present key semantics.
+- [x] Emit intents to the existing session runner; construct one-action `LayoutRequest`s with title fields and all non-rename action fields `None`. Ensure a prompt closes before a request/rejection is handled and never silently retargets after a layout update.
+- [x] Render the centered `Clear`/bordered prompt plus edit field, prompt-local error, and `Enter save · Esc cancel`; it must be non-idle-expiring.
+- [x] Test chord target capture and `e` recognition/footer; prefill; printable/shifted Unicode and Backspace; Enter sends expected intent including empty clear; invalid stays open; Esc has no intent; timeout does not close; Ctrl+P/Ctrl+T/Ctrl+A/arrows/mouse do not escape the modal; Ctrl+Q wins; no PTY forwarding; and overlay/rename exclusion.
+- [x] Run:
 
 ```bash
 cargo test --lib tui -- --nocapture
 cargo fmt --check
 ```
 
-- [ ] Commit:
+- [x] Commit:
 
 ```bash
 git add src/tui.rs
@@ -178,10 +178,10 @@ git commit -m "feat: add modal pane and tab rename prompts"
 - Modify: `docs/MVP_DESIGN.md` (if its locked controls/chrome paragraph must name `e`)
 - Modify/add: TUI rendering tests in `src/tui.rs`
 
-- [ ] Replace ordinal-only `tab_label`/`pane_title` inputs with title-aware helpers: use custom title exactly when `Some`, otherwise `Tab #N` / `Pane #N`; retain existing host/control pane chrome and active-tab styling. Carry the resolved tab/pane labels into `AgentOverlayRow` and render those labels in its location line under the same custom-title/ordinal-fallback rule; rows remain selected by `pane_id` and do not append an ordinal beside a custom title.
-- [ ] Add `unicode-width` as a direct dependency and replace scalar-count width calculations on these render paths with terminal-cell-width-aware helpers. Add display-width-aware single-line ellipsis truncation at tab, pane, and agents-overlay render allocation boundaries. For pane chrome, allocate/protect the title first (custom or ordinal), ellipsize it within the block-title width, and only then append host/control from leftover width; host/control may clip or disappear before title does. Test narrow widths, Unicode-width characters, the title-versus-host/control precedence, overlay custom-title/fallback labels, and no border/tab overlap. Do not alter the canonical stored title while truncating.
-- [ ] Update README/MVP controls text only where necessary: document `Ctrl+P e` / `Ctrl+T e`, all-member label authority, Enter/Esc, and blank-to-ordinal behavior; explicitly do not describe the unrelated session CLI `rename` as pane/tab rename.
-- [ ] Run the complete quality gate:
+- [x] Replace ordinal-only `tab_label`/`pane_title` inputs with title-aware helpers: use custom title exactly when `Some`, otherwise `Tab #N` / `Pane #N`; retain existing host/control pane chrome and active-tab styling. Carry the resolved tab/pane labels into `AgentOverlayRow` and render those labels in its location line under the same custom-title/ordinal-fallback rule; rows remain selected by `pane_id` and do not append an ordinal beside a custom title.
+- [x] Add `unicode-width` as a direct dependency and replace scalar-count width calculations on these render paths with terminal-cell-width-aware helpers. Add display-width-aware single-line ellipsis truncation at tab, pane, and agents-overlay render allocation boundaries. For pane chrome, allocate/protect the title first (custom or ordinal), ellipsize it within the block-title width, and only then append host/control from leftover width; host/control may clip or disappear before title does. Test narrow widths, Unicode-width characters, the title-versus-host/control precedence, overlay custom-title/fallback labels, and no border/tab overlap. Do not alter the canonical stored title while truncating.
+- [x] Update README/MVP controls text only where necessary: document `Ctrl+P e` / `Ctrl+T e`, all-member label authority, Enter/Esc, and blank-to-ordinal behavior; explicitly do not describe the unrelated session CLI `rename` as pane/tab rename.
+- [x] Run the complete quality gate:
 
 ```bash
 cargo fmt --check
@@ -189,7 +189,7 @@ cargo clippy --all-targets --all-features -- -D warnings
 cargo test
 ```
 
-- [ ] Commit:
+- [x] Commit:
 
 ```bash
 git add Cargo.toml Cargo.lock src/tui.rs README.md docs/MVP_DESIGN.md

--- a/docs/superpowers/specs/2026-07-26-pane-tab-rename-design.md
+++ b/docs/superpowers/specs/2026-07-26-pane-tab-rename-design.md
@@ -1,0 +1,206 @@
+# Mid-session pane and tab rename
+
+## Goal
+
+Allow any admitted member to give the focused pane or current tab a shared, persistent chrome
+title without changing session-room names or control authority.
+
+- `Ctrl+P`, then lowercase `e`, opens a modal rename prompt for the focused pane.
+- `Ctrl+T`, then lowercase `e`, opens a modal rename prompt for the current tab.
+- The title is shared layout metadata. It appears in layout commits and snapshots, so every member,
+  including late joiners and a reattached local client, renders the same chrome.
+
+## Non-goals
+
+- Changing the CLI `rename` command, which names a session room and is unrelated.
+- Titles as authentication, authorization, ownership, or a control-lease capability.
+- Per-member/private titles, title history, undo, filesystem persistence, or a title list UI.
+- Renaming panes/tabs while disconnected from the coordinator.
+
+## Product rules
+
+Titles are labels only. Every admitted member may rename every pane and tab, including panes they
+do not host. Existing host-only pane deletion and all-host tab deletion rules do not apply.
+
+The authoritative stored value is `Option<String>`:
+
+- `None` means no custom title and renders the ordinal fallback: `Pane #N` or `Tab #N`.
+- `Some(title)` is a normalized, non-empty custom title and replaces that ordinal label in chrome.
+- On confirm, trim leading/trailing Unicode whitespace. An empty result clears the custom title
+  (`None`). This means a blank or whitespace-only submission restores the ordinal fallback.
+- A non-empty title is at most 32 Unicode scalar values and contains no control characters.
+
+This deliberately mirrors the existing display-name length/control-character safety boundary while
+giving title input its distinct empty-means-clear behavior. It does not reuse
+`config::validate_display_name`, because that helper rejects empty values and lives in a CLI config
+module rather than the shared layout model.
+
+## Interaction model
+
+### Entering rename
+
+Pane mode gains `e` and tab mode gains `e`; `r` remains the pane-mode right split command.
+
+| Sequence | Result |
+|---|---|
+| `Ctrl+P`, `e` | Rename the pane focused when `e` is pressed. |
+| `Ctrl+T`, `e` | Rename the tab current when `e` is pressed. |
+
+Opening the prompt consumes `e`, exits sticky chord mode, clears any text selection/resize drag as
+appropriate, and snapshots the target ID. Later local focus/tab changes must not retarget an open
+prompt.
+
+### Rename prompt
+
+Rename is a first-class TUI modal mode, mutually exclusive with the agents overlay and chord modes.
+Render a small centered floating `Clear` + bordered panel over the current layout, rather than
+overloading the footer. It contains a target-specific title (`Rename pane` / `Rename tab`), a
+single-line editable field, and concise help: `Enter save · Esc cancel`. The underlying layout
+remains visible but cannot receive interaction.
+
+- Prefill the field with the target's existing custom title; an untitled target starts empty. Do
+  not prefill `Pane #N` or `Tab #N`, because those are generated fallback labels rather than saved
+  data.
+- `Char` input with no control/alt modifier appends the typed Unicode character (including shifted
+  printable characters). Backspace removes one Unicode scalar. `Delete`, cursor movement, paste,
+  selection, and multiline editing are out of scope for v1; unsupported keys are consumed.
+- Enter normalizes and validates the field. If valid, close the prompt immediately and emit one
+  rename intent/request. Empty is valid and clears. If invalid, keep the prompt open, do not send
+  a request, and render a local message (max 32 characters / no control characters).
+- Esc closes and discards all edits, with no request and no PTY forwarding.
+- The prompt never expires. The two-second `CHORD_IDLE_TIMEOUT` applies only to `ChordMode::Pane`
+  and `ChordMode::Tab`, never to rename.
+
+### Modal precedence and global keys
+
+The event dispatcher must handle the active modal before sticky chords, focus navigation, mouse
+selection, or normal PTY forwarding.
+
+- While rename is open, all keys are consumed. `Ctrl+P` and `Ctrl+T` do not switch modes; `Ctrl+A`
+  does not open/toggle the agents overlay; arrows and mouse do not navigate/focus/select/resize.
+- `Ctrl+Q` retains its existing global detach/quit priority. It closes/discards the prompt, clears
+  chord state, and is never sent to a PTY.
+- If the agents overlay is open, it remains modal and no rename chord can start. A rename prompt
+  cannot be opened over it. Conversely, once rename is open, overlay toggling is disabled until
+  the prompt closes.
+- A layout commit may arrive while the prompt is open. Keep its target ID; on Enter the coordinator
+  is the authority. If the target disappeared or the revision became stale, the request is rejected
+  and normal rejection status is shown after the prompt closes.
+
+## Chrome and layout behavior
+
+`Pane.title` and `Tab.title` live in the authoritative `SessionState` snapshot, not in local TUI
+state. Pane and tab order remains the source of ordinal fallback numbering. A title mutation only
+changes the title and revision; it never changes roots, pane hosting, PTY grids, leases, focus, or
+membership.
+
+- Tab bar label: custom title when present, otherwise `Tab #N`. Keep the current active-tab color
+  treatment and clickable tab hit-testing.
+- Pane border label: custom title when present, otherwise `Pane #N`, followed by the existing
+  `host: … control: …` metadata.
+- Apply a display-width-aware, single-line ellipsis helper at each render boundary. Never emit
+  controls/newlines (the model already rejects controls). Tab labels are clipped to their allocated
+  tab-bar width; reserve the active-tab padding and show an ellipsis when it fits. Pane labels are
+  clipped to the block title's available width after reserving host/control text; if chrome is too
+  narrow, host/control may clip normally but title rendering must not overflow adjacent borders.
+- Titles in snapshots naturally survive a client detach/resume while the headless session lives.
+  They are intentionally not written to finder records and cannot restore a dead session.
+
+## Wire contract and compatibility
+
+This changes both `LayoutState` descriptors and `LayoutRequest` wire shape. Bump
+`PROTOCOL_VERSION` from **5 to 6**; mixed v5/v6 peers fail the existing version handshake instead
+of silently ignoring titles/actions.
+
+Use the following Prost fields. Tags are additive and must never be renumbered or reused.
+
+```rust
+pub struct PaneDescriptor {
+    // existing tags 1..=4
+    #[prost(string, optional, tag = "5")]
+    pub title: Option<String>,
+}
+
+pub struct TabDescriptor {
+    // existing tags 1..=2
+    #[prost(string, optional, tag = "3")]
+    pub title: Option<String>,
+}
+
+pub struct LayoutRequest {
+    // existing tags 1..=8
+    #[prost(message, optional, tag = "9")]
+    pub rename_pane: Option<RenamePane>,
+    #[prost(message, optional, tag = "10")]
+    pub rename_tab: Option<RenameTab>,
+}
+
+pub struct RenamePane {
+    #[prost(uint64, tag = "1")]
+    pub pane_id: u64,
+    #[prost(string, tag = "2")]
+    pub title: String, // empty clears
+}
+
+pub struct RenameTab {
+    #[prost(uint64, tag = "1")]
+    pub tab_id: u64,
+    #[prost(string, tag = "2")]
+    pub title: String, // empty clears
+}
+```
+
+`Option<String>` on descriptors preserves the semantic distinction between an absent custom title
+and a present custom title. Requests use a required string because empty is the explicit clear
+operation. The coordinator/layout normalization converts that empty string to `None` before
+committing, so committed descriptors never carry `Some("")`.
+
+Protocol validation must count exactly one of all eight layout actions; validate nonzero target IDs
+and title byte length no greater than a new `MAX_LAYOUT_TITLE_BYTES = 128` before allocation/use.
+The layout authority then applies the normative Unicode scalar-count (≤32), control-character, and
+trim/empty normalization rule. Descriptor/snapshot validation applies the same title validation:
+`None` is valid, `Some` must already be normalized, non-empty, ≤32 scalars, and control-free.
+This two-layer split keeps hostile wire inputs bounded while one pure layout helper defines the
+product rule.
+
+No new reject enum is needed. Coordinator outcomes are:
+
+| Case | Result |
+|---|---|
+| Unknown pane/tab ID | `LayoutRejectReason::UnknownId` |
+| Sender not an admitted member | existing `NotHost` mapping for `LayoutError::NotMember` |
+| Invalid title or malformed/multiple action request | `Malformed` |
+| Request revision does not equal state revision | `Stale` |
+| Valid rename | authoritative revision advances and `LayoutCommit` broadcasts title-bearing state |
+
+Unlike delete/grid operations, rename performs no pane-host/tab-host authorization check. A pending
+creation reservation should use the existing `ensure_no_reservation` structural-mutation gate so
+rename ordering/revision behavior stays consistent with other layout requests.
+
+## Testing
+
+- Layout: normalization; empty/whitespace clear; 32-scalar boundary; overlong/control rejection;
+  any admitted member can rename a remote-hosted pane/tab; unknown IDs and stale revisions reject;
+  snapshot validation rejects `Some("")` and invalid titles; commits preserve titles.
+- Protocol: v6 assertion; descriptor encode/decode preserves optional titles; rename action tags 9
+  and 10 round-trip; empty clear is valid; zero IDs, over-128-byte titles, and mixed actions fail.
+- Session: coordinator dispatches both actions, maps each rejection correctly, broadcasts commits,
+  and a late join snapshot carries pane/tab titles.
+- TUI: `Ctrl+P e` / `Ctrl+T e` target the expected IDs and expose `e` in chord recognition/footer;
+  prefill; character and Backspace editing; Enter request; blank clear; invalid stays open; Esc
+  cancel; no chord timeout; modal key/mouse/PTY suppression; Ctrl+Q priority; overlay mutual
+  exclusion; title/fallback render and narrow-width ellipsis.
+
+Run `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and
+`cargo test` after the implementation tasks.
+
+## Success criteria
+
+1. Any member can share-rename the focused pane or current tab using lowercase `e` in the matching
+   sticky chord, while `r` remains right split.
+2. Rename is an accessible, non-expiring modal; Enter commits, Esc cancels, and no prompt keys
+   leak to a PTY.
+3. Blank confirmation restores exactly the ordinal pane/tab labels.
+4. Titles converge through coordinator commits, late join snapshots, and local detach/resume.
+5. Invalid, stale, or missing targets fail safely without partial local mutation.
+6. v5 and v6 peers never interoperate silently; all tests and quality gates pass.

--- a/docs/superpowers/specs/2026-07-26-pane-tab-rename-design.md
+++ b/docs/superpowers/specs/2026-07-26-pane-tab-rename-design.md
@@ -98,13 +98,23 @@ membership.
   treatment and clickable tab hit-testing.
 - Pane border label: custom title when present, otherwise `Pane #N`, followed by the existing
   `host: … control: …` metadata.
+- Agents overlay location chrome follows the same title rule: show the tab's custom title when
+  present (otherwise `Tab #N`) and the pane's custom title when present (otherwise `Pane #N`).
+  The selected row is still keyed by `pane_id` and Enter still selects that pane, so using a title
+  does not make selection ambiguous; no extra ordinal is appended when a custom title exists.
 - Apply a display-width-aware, single-line ellipsis helper at each render boundary. Never emit
   controls/newlines (the model already rejects controls). Tab labels are clipped to their allocated
   tab-bar width; reserve the active-tab padding and show an ellipsis when it fits. Pane labels are
-  clipped to the block title's available width after reserving host/control text; if chrome is too
-  narrow, host/control may clip normally but title rendering must not overflow adjacent borders.
-- Titles in snapshots naturally survive a client detach/resume while the headless session lives.
-  They are intentionally not written to finder records and cannot restore a dead session.
+  title-first: protect a single-line, ellipsized custom/fallback title within the block-title
+  width, then append `host`/`control` metadata only from remaining width. Host/control may clip or
+  disappear at narrow widths, but title rendering must not overflow adjacent borders. The same
+  single-line clipping rule applies to agents-overlay location chrome.
+- A local detach does not serialize a separate layout store. The live
+  `SharedLayoutRuntime` owns the current `LayoutSnapshot`; `SharedLayoutNode::snapshot()` returns
+  it and `node::write_snapshot()` sends it to a later local attachment. `SessionStore` finder
+  records contain only connection/identity data for locating that live node. Therefore titles ride
+  in the existing in-memory node snapshot and are not added to finder records; they cannot restore
+  a dead session.
 
 ## Wire contract and compatibility
 
@@ -171,17 +181,22 @@ No new reject enum is needed. Coordinator outcomes are:
 | Sender not an admitted member | existing `NotHost` mapping for `LayoutError::NotMember` |
 | Invalid title or malformed/multiple action request | `Malformed` |
 | Request revision does not equal state revision | `Stale` |
+| Create reservation is pending | existing `ReservationFailure` mapping |
 | Valid rename | authoritative revision advances and `LayoutCommit` broadcasts title-bearing state |
 
-Unlike delete/grid operations, rename performs no pane-host/tab-host authorization check. A pending
-creation reservation should use the existing `ensure_no_reservation` structural-mutation gate so
-rename ordering/revision behavior stays consistent with other layout requests.
+Unlike delete/grid operations, rename performs no pane-host/tab-host authorization check. Rename
+*does* wait behind the existing `ensure_no_reservation` gate. A create reservation records its
+creator's base revision and its later `PaneReady` must commit at that same revision; a rename in
+between would advance the revision and turn a valid ready into `Stale`. Blocking rename until the
+reservation is committed, cancelled, failed, or expired preserves that create protocol without a
+second reservation/rebase mechanism. This is ordering protection, not title authorization.
 
 ## Testing
 
 - Layout: normalization; empty/whitespace clear; 32-scalar boundary; overlong/control rejection;
-  any admitted member can rename a remote-hosted pane/tab; unknown IDs and stale revisions reject;
-  snapshot validation rejects `Some("")` and invalid titles; commits preserve titles.
+  any admitted member can rename a remote-hosted pane/tab; unknown IDs, stale revisions, and a
+  pending reservation reject; snapshot validation rejects `Some("")` and invalid titles; commits
+  preserve titles.
 - Protocol: v6 assertion; descriptor encode/decode preserves optional titles; rename action tags 9
   and 10 round-trip; empty clear is valid; zero IDs, over-128-byte titles, and mixed actions fail.
 - Session: coordinator dispatches both actions, maps each rejection correctly, broadcasts commits,
@@ -189,7 +204,8 @@ rename ordering/revision behavior stays consistent with other layout requests.
 - TUI: `Ctrl+P e` / `Ctrl+T e` target the expected IDs and expose `e` in chord recognition/footer;
   prefill; character and Backspace editing; Enter request; blank clear; invalid stays open; Esc
   cancel; no chord timeout; modal key/mouse/PTY suppression; Ctrl+Q priority; overlay mutual
-  exclusion; title/fallback render and narrow-width ellipsis.
+  exclusion without changing existing overlay behavior; title/fallback render in tab, pane, and
+  agents-overlay chrome; title-first narrow-width ellipsis.
 
 Run `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and
 `cargo test` after the implementation tasks.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -167,6 +167,8 @@ async fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
                     host_peer_id,
                     grid_rows: u32::from(shell_rows),
                     grid_cols: u32::from(shell_cols),
+
+                    title: None,
                 },
                 initial.channels(),
             )?;

--- a/src/client.rs
+++ b/src/client.rs
@@ -302,6 +302,8 @@ fn apply_snapshot(
                     pane_id: row.pane_id,
                     tab_ordinal: 0,
                     pane_ordinal: 0,
+                    tab_label: String::new(),
+                    pane_label: String::new(),
                     kind: row.kind,
                     cwd: row.cwd,
                     state: AgentRosterState::try_from(row.state).ok()?,
@@ -529,7 +531,11 @@ mod tests {
                 endpoint_addr: b"endpoint".to_vec(),
                 display_name: String::from("Host"),
             }],
-            tabs: vec![Tab { tab_id: 1, root }],
+            tabs: vec![Tab {
+                tab_id: 1,
+                root,
+                title: None,
+            }],
             panes: pane_ids
                 .iter()
                 .map(|pane_id| {
@@ -540,6 +546,7 @@ mod tests {
                             host_peer_id: b"host".to_vec(),
                             grid_rows: 2,
                             grid_cols: 8,
+                            title: None,
                         },
                     )
                 })

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -85,12 +85,14 @@ pub struct Pane {
     pub host_peer_id: Vec<u8>,
     pub grid_rows: u16,
     pub grid_cols: u16,
+    pub title: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Tab {
     pub tab_id: TabId,
     pub root: Node,
+    pub title: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -169,6 +171,7 @@ pub enum LayoutError {
     InvalidPeerId,
     InvalidEndpointAddress,
     InvalidDisplayName,
+    InvalidTitle,
     TabLimit,
     PaneLimit,
     SplitDepthLimit,
@@ -221,6 +224,7 @@ impl SessionState {
             host_peer_id: initial_host.clone(),
             grid_rows,
             grid_cols,
+            title: None,
         };
         let mut panes = BTreeMap::new();
         panes.insert(1, initial_pane);
@@ -234,6 +238,7 @@ impl SessionState {
             tabs: vec![Tab {
                 tab_id: 1,
                 root: Node::Leaf { pane_id: 1 },
+                title: None,
             }],
             panes,
             next_tab_id: 2,
@@ -294,7 +299,7 @@ impl SessionState {
         let mut tab_ids = BTreeSet::new();
         let mut pane_ids = BTreeSet::new();
         for tab in &snapshot.tabs {
-            if tab.tab_id == 0 || !tab_ids.insert(tab.tab_id) {
+            if tab.tab_id == 0 || !tab_ids.insert(tab.tab_id) || !is_normalized_title(&tab.title) {
                 return Err(LayoutError::InvalidSnapshot);
             }
             let before = pane_ids.len();
@@ -317,6 +322,7 @@ impl SessionState {
                 || !pane_ids.contains(pane_id)
                 || validate_grid(pane.grid_rows, pane.grid_cols).is_err()
                 || !peer_ids.contains(&pane.host_peer_id)
+                || !is_normalized_title(&pane.title)
             {
                 return Err(LayoutError::InvalidSnapshot);
             }
@@ -406,6 +412,7 @@ impl SessionState {
                 tabs.push(Tab {
                     tab_id: tab.tab_id,
                     root,
+                    title: tab.title,
                 });
             }
         }
@@ -577,6 +584,7 @@ impl SessionState {
                         host_peer_id: creator.to_vec(),
                         grid_rows,
                         grid_cols,
+                        title: None,
                     },
                 );
                 self.pending_reservation = None;
@@ -595,6 +603,7 @@ impl SessionState {
                 self.tabs.push(Tab {
                     tab_id,
                     root: Node::Leaf { pane_id },
+                    title: None,
                 });
                 self.panes.insert(
                     pane_id,
@@ -603,6 +612,7 @@ impl SessionState {
                         host_peer_id: creator.to_vec(),
                         grid_rows,
                         grid_cols,
+                        title: None,
                     },
                 );
                 self.pending_reservation = None;
@@ -833,6 +843,47 @@ impl SessionState {
             pane.grid_rows = rows;
             pane.grid_cols = cols;
         }
+        self.advance_revision();
+        Ok(())
+    }
+
+    pub fn rename_pane(
+        &mut self,
+        requester: &[u8],
+        base_revision: u64,
+        pane_id: PaneId,
+        title: String,
+    ) -> Result<(), LayoutError> {
+        self.check_mutation(base_revision)?;
+        self.require_member(requester)?;
+        self.ensure_no_reservation()?;
+        let title = normalize_title(&title)?;
+        let pane = self
+            .panes
+            .get_mut(&pane_id)
+            .ok_or(LayoutError::UnknownPane { pane_id })?;
+        pane.title = title;
+        self.advance_revision();
+        Ok(())
+    }
+
+    pub fn rename_tab(
+        &mut self,
+        requester: &[u8],
+        base_revision: u64,
+        tab_id: TabId,
+        title: String,
+    ) -> Result<(), LayoutError> {
+        self.check_mutation(base_revision)?;
+        self.require_member(requester)?;
+        self.ensure_no_reservation()?;
+        let title = normalize_title(&title)?;
+        let tab = self
+            .tabs
+            .iter_mut()
+            .find(|tab| tab.tab_id == tab_id)
+            .ok_or(LayoutError::UnknownTab { tab_id })?;
+        tab.title = title;
         self.advance_revision();
         Ok(())
     }
@@ -1121,6 +1172,26 @@ fn validate_display_name(display_name: &str) -> Result<(), LayoutError> {
     Ok(())
 }
 
+pub fn normalize_title(title: &str) -> Result<Option<String>, LayoutError> {
+    let normalized = title.trim();
+    if normalized.is_empty() {
+        return Ok(None);
+    }
+    if normalized.chars().count() > 32 || normalized.chars().any(char::is_control) {
+        return Err(LayoutError::InvalidTitle);
+    }
+    Ok(Some(normalized.to_owned()))
+}
+
+fn is_normalized_title(title: &Option<String>) -> bool {
+    match title {
+        None => true,
+        Some(title) => {
+            normalize_title(title).is_ok_and(|normalized| normalized.as_deref() == Some(title))
+        }
+    }
+}
+
 fn validate_endpoint_addr(endpoint_addr: &[u8]) -> Result<(), LayoutError> {
     (!endpoint_addr.is_empty() && endpoint_addr.len() <= MAX_ENDPOINT_ADDR_BYTES)
         .then_some(())
@@ -1131,4 +1202,115 @@ fn validate_peer_id(peer_id: &[u8]) -> Result<(), LayoutError> {
     (!peer_id.is_empty() && peer_id.len() <= MAX_PEER_ID_BYTES)
         .then_some(())
         .ok_or(LayoutError::InvalidPeerId)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const HOST_A: &[u8] = b"host-a";
+    const HOST_B: &[u8] = b"host-b";
+
+    fn state() -> SessionState {
+        SessionState::new(HOST_A.to_vec(), b"endpoint-a".to_vec(), 24, 80).unwrap()
+    }
+
+    #[test]
+    fn titles_normalize_and_validate_at_the_layout_boundary() {
+        assert_eq!(
+            normalize_title("  build logs\u{2003}").unwrap(),
+            Some("build logs".into())
+        );
+        assert_eq!(normalize_title(" \t ").unwrap(), None);
+        assert_eq!(
+            normalize_title(&"x".repeat(32)).unwrap(),
+            Some("x".repeat(32))
+        );
+        assert_eq!(
+            normalize_title(&"x".repeat(33)),
+            Err(LayoutError::InvalidTitle)
+        );
+        assert_eq!(
+            normalize_title("line\nbreak"),
+            Err(LayoutError::InvalidTitle)
+        );
+    }
+
+    #[test]
+    fn any_member_can_rename_remote_panes_and_tabs_or_clear_them() {
+        let mut state = state();
+        state
+            .add_member(state.revision(), HOST_B.to_vec(), b"endpoint-b".to_vec())
+            .unwrap();
+        let roots = state.tabs().to_vec();
+        let hosts = state
+            .panes()
+            .map(|pane| (pane.pane_id, pane.host_peer_id.clone()))
+            .collect::<Vec<_>>();
+
+        state
+            .rename_pane(HOST_B, state.revision(), 1, " remote pane ".into())
+            .unwrap();
+        assert_eq!(state.pane(1).unwrap().title.as_deref(), Some("remote pane"));
+        assert_eq!(state.tabs(), roots.as_slice());
+        assert_eq!(
+            state
+                .panes()
+                .map(|pane| (pane.pane_id, pane.host_peer_id.clone()))
+                .collect::<Vec<_>>(),
+            hosts
+        );
+
+        let tab_id = state.create_tab(HOST_B, state.revision(), 24, 80).unwrap();
+        state
+            .rename_tab(HOST_A, state.revision(), tab_id, "tab title".into())
+            .unwrap();
+        assert_eq!(
+            state
+                .tabs()
+                .iter()
+                .find(|tab| tab.tab_id == tab_id)
+                .unwrap()
+                .title
+                .as_deref(),
+            Some("tab title")
+        );
+        state
+            .rename_pane(HOST_A, state.revision(), 1, "  ".into())
+            .unwrap();
+        assert_eq!(state.pane(1).unwrap().title, None);
+    }
+
+    #[test]
+    fn title_renames_reject_invalid_targets_stale_revisions_and_reservations() {
+        let mut state = state();
+        assert_eq!(
+            state.rename_pane(HOST_A, state.revision(), 99, "missing".into()),
+            Err(LayoutError::UnknownPane { pane_id: 99 })
+        );
+        assert_eq!(
+            state.rename_tab(HOST_A, 0, 1, "stale".into()),
+            Err(LayoutError::StaleRevision {
+                expected: 1,
+                got: 0
+            })
+        );
+        state.reserve_tab(HOST_A, state.revision(), 24, 80).unwrap();
+        assert_eq!(
+            state.rename_tab(HOST_A, state.revision(), 1, "blocked".into()),
+            Err(LayoutError::ReservationPending)
+        );
+
+        let mut snapshot = state.snapshot();
+        snapshot.tabs[0].title = Some(String::new());
+        assert_eq!(
+            SessionState::validate_snapshot(&snapshot),
+            Err(LayoutError::InvalidSnapshot)
+        );
+        snapshot.tabs[0].title = Some(" untrimmed ".into());
+        assert_eq!(
+            SessionState::validate_snapshot(&snapshot),
+            Err(LayoutError::InvalidSnapshot)
+        );
+    }
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -107,6 +107,8 @@ pub async fn run_background(bootstrap: NodeBootstrap) -> Result<(), Box<dyn Erro
                     host_peer_id,
                     grid_rows: u32::from(shell_rows),
                     grid_cols: u32::from(shell_cols),
+
+                    title: None,
                 },
                 initial.channels(),
             )?;

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -3,7 +3,7 @@
 use prost::Message;
 use std::{collections::HashSet, fmt};
 
-pub const PROTOCOL_VERSION: u32 = 5;
+pub const PROTOCOL_VERSION: u32 = 6;
 pub const MAX_FRAME_BYTES: usize = 1_048_576;
 pub const MAX_ENVELOPE_BYTES: usize = 1_048_560;
 pub const MAX_PEER_ID_BYTES: usize = 64;
@@ -16,6 +16,7 @@ pub const MAX_DELTA_BYTES: usize = 64 * 1024;
 pub const MAX_AGENT_ROSTER_ENTRIES: usize = 32;
 pub const MAX_AGENT_KIND_BYTES: usize = 32;
 pub const MAX_AGENT_CWD_BYTES: usize = 512;
+pub const MAX_LAYOUT_TITLE_BYTES: usize = 128;
 
 #[derive(Debug)]
 pub enum ProtocolError {
@@ -282,6 +283,8 @@ pub struct PaneDescriptor {
     pub grid_rows: u32,
     #[prost(uint32, tag = "4")]
     pub grid_cols: u32,
+    #[prost(string, optional, tag = "5")]
+    pub title: Option<String>,
 }
 
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -290,6 +293,8 @@ pub struct TabDescriptor {
     pub tab_id: u64,
     #[prost(message, optional, tag = "2")]
     pub root: Option<LayoutNode>,
+    #[prost(string, optional, tag = "3")]
+    pub title: Option<String>,
 }
 
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -344,6 +349,26 @@ pub struct LayoutRequest {
     pub set_split_ratio: Option<SetSplitRatio>,
     #[prost(message, optional, tag = "8")]
     pub update_pane_grids: Option<UpdatePaneGrids>,
+    #[prost(message, optional, tag = "9")]
+    pub rename_pane: Option<RenamePane>,
+    #[prost(message, optional, tag = "10")]
+    pub rename_tab: Option<RenameTab>,
+}
+
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RenamePane {
+    #[prost(uint64, tag = "1")]
+    pub pane_id: u64,
+    #[prost(string, tag = "2")]
+    pub title: String,
+}
+
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RenameTab {
+    #[prost(uint64, tag = "1")]
+    pub tab_id: u64,
+    #[prost(string, tag = "2")]
+    pub title: String,
 }
 
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -875,7 +900,9 @@ fn validate_layout_request(request: &LayoutRequest) -> Result<(), ProtocolError>
         + usize::from(request.create_tab.is_some())
         + usize::from(request.delete_tab.is_some())
         + usize::from(request.set_split_ratio.is_some())
-        + usize::from(request.update_pane_grids.is_some());
+        + usize::from(request.update_pane_grids.is_some())
+        + usize::from(request.rename_pane.is_some())
+        + usize::from(request.rename_tab.is_some());
     if actions != 1 {
         return Err(ProtocolError::InvalidLayout("layout_request.action"));
     }
@@ -936,6 +963,22 @@ fn validate_layout_request(request: &LayoutRequest) -> Result<(), ProtocolError>
             }
         }
     }
+    if let Some(rename) = &request.rename_pane {
+        validate_nonzero("layout_request.rename_pane.pane_id", rename.pane_id)?;
+        validate_field_size(
+            "layout_request.rename_pane.title",
+            rename.title.len(),
+            MAX_LAYOUT_TITLE_BYTES,
+        )?;
+    }
+    if let Some(rename) = &request.rename_tab {
+        validate_nonzero("layout_request.rename_tab.tab_id", rename.tab_id)?;
+        validate_field_size(
+            "layout_request.rename_tab.title",
+            rename.title.len(),
+            MAX_LAYOUT_TITLE_BYTES,
+        )?;
+    }
     Ok(())
 }
 
@@ -977,6 +1020,13 @@ fn validate_layout_state(state: &LayoutState) -> Result<(), ProtocolError> {
             MAX_PEER_ID_BYTES,
         )?;
         validate_grid("layout_state.pane.grid", pane.grid_rows, pane.grid_cols)?;
+        if let Some(title) = &pane.title {
+            validate_field_size(
+                "layout_state.pane.title",
+                title.len(),
+                MAX_LAYOUT_TITLE_BYTES,
+            )?;
+        }
         if !pane_ids.insert(pane.pane_id) {
             return Err(ProtocolError::InvalidLayout("layout_state.pane.pane_id"));
         }
@@ -991,6 +1041,13 @@ fn validate_layout_state(state: &LayoutState) -> Result<(), ProtocolError> {
     let mut leaf_pane_ids = HashSet::with_capacity(state.panes.len());
     for tab in &state.tabs {
         validate_nonzero("layout_state.tab.tab_id", tab.tab_id)?;
+        if let Some(title) = &tab.title {
+            validate_field_size(
+                "layout_state.tab.title",
+                title.len(),
+                MAX_LAYOUT_TITLE_BYTES,
+            )?;
+        }
         if !tab_ids.insert(tab.tab_id) {
             return Err(ProtocolError::InvalidLayout("layout_state.tab.tab_id"));
         }

--- a/src/session.rs
+++ b/src/session.rs
@@ -33,8 +33,8 @@ use crate::{
         Input, Join, LayoutCommit, LayoutNode, LayoutReject, LayoutRejectReason, LayoutRequest,
         LayoutSplit, LayoutState, MemberDescriptor, NewPanePosition as ProtocolNewPanePosition,
         PROTOCOL_VERSION, PaneDescriptor, PaneFailed, PaneReady, PaneReservation, PaneSubscribe,
-        ReleaseControl, SessionSnapshot, SetSplitRatio, Snapshot, SplitAxis, TabDescriptor,
-        TakeControl, UpdatePaneGrids, Welcome, envelope,
+        ReleaseControl, RenamePane, RenameTab, SessionSnapshot, SetSplitRatio, Snapshot, SplitAxis,
+        TabDescriptor, TakeControl, UpdatePaneGrids, Welcome, envelope,
     },
     screen::ScreenFrame,
     ticket::{JoinTicket, TicketError},
@@ -308,6 +308,9 @@ impl LayoutCoordinator {
             + usize::from(request.delete_tab.is_some())
             + usize::from(request.set_split_ratio.is_some())
             + usize::from(request.update_pane_grids.is_some());
+        let action_count = action_count
+            + usize::from(request.rename_pane.is_some())
+            + usize::from(request.rename_tab.is_some());
         if request_id == 0 || request.base_revision == 0 || action_count != 1 {
             return reject(request_id, LayoutRejectReason::Malformed);
         }
@@ -336,6 +339,10 @@ impl LayoutCoordinator {
             self.set_split_ratio(authenticated_peer_id, request.base_revision, ratio)
         } else if let Some(grids) = request.update_pane_grids {
             self.update_pane_grids(authenticated_peer_id, request.base_revision, grids)
+        } else if let Some(rename) = request.rename_pane {
+            self.rename_pane(authenticated_peer_id, request.base_revision, rename)
+        } else if let Some(rename) = request.rename_tab {
+            self.rename_tab(authenticated_peer_id, request.base_revision, rename)
         } else {
             Err(LayoutError::InvalidSnapshot)
         };
@@ -618,6 +625,38 @@ impl LayoutCoordinator {
         ))
     }
 
+    fn rename_pane(
+        &mut self,
+        peer: &[u8],
+        revision: u64,
+        rename: RenamePane,
+    ) -> Result<CoordinatorResponse, LayoutError> {
+        if rename.pane_id == 0 {
+            return Err(LayoutError::InvalidSnapshot);
+        }
+        self.state
+            .rename_pane(peer, revision, rename.pane_id, rename.title)?;
+        Ok(CoordinatorResponse::Commit(
+            self.layout_commit().map_err(layout_error)?,
+        ))
+    }
+
+    fn rename_tab(
+        &mut self,
+        peer: &[u8],
+        revision: u64,
+        rename: RenameTab,
+    ) -> Result<CoordinatorResponse, LayoutError> {
+        if rename.tab_id == 0 {
+            return Err(LayoutError::InvalidSnapshot);
+        }
+        self.state
+            .rename_tab(peer, revision, rename.tab_id, rename.title)?;
+        Ok(CoordinatorResponse::Commit(
+            self.layout_commit().map_err(layout_error)?,
+        ))
+    }
+
     fn layout_commit(&self) -> Result<LayoutCommit, CoordinatorError> {
         let state = self.protocol_layout_state()?;
         Ok(LayoutCommit {
@@ -767,8 +806,7 @@ fn protocol_layout_state(snapshot: LayoutSnapshot) -> LayoutState {
                 host_peer_id: pane.host_peer_id,
                 grid_rows: u32::from(pane.grid_rows),
                 grid_cols: u32::from(pane.grid_cols),
-
-                title: None,
+                title: pane.title,
             })
             .collect(),
         tabs: snapshot
@@ -777,8 +815,7 @@ fn protocol_layout_state(snapshot: LayoutSnapshot) -> LayoutState {
             .map(|tab| TabDescriptor {
                 tab_id: tab.tab_id,
                 root: Some(protocol_node(tab.root)),
-
-                title: None,
+                title: tab.title,
             })
             .collect(),
     }
@@ -810,7 +847,7 @@ pub fn layout_snapshot_from_state(state: &LayoutState) -> Result<LayoutSnapshot,
                     host_peer_id: pane.host_peer_id.clone(),
                     grid_rows,
                     grid_cols,
-                    title: None,
+                    title: pane.title.clone(),
                 },
             ))
         })
@@ -824,7 +861,7 @@ pub fn layout_snapshot_from_state(state: &LayoutState) -> Result<LayoutSnapshot,
                 root: layout_node_from_protocol(
                     tab.root.as_ref().ok_or(LayoutError::InvalidSnapshot)?,
                 )?,
-                title: None,
+                title: tab.title.clone(),
             })
         })
         .collect::<Result<_, LayoutError>>()?;

--- a/src/session.rs
+++ b/src/session.rs
@@ -806,6 +806,7 @@ pub fn layout_snapshot_from_state(state: &LayoutState) -> Result<LayoutSnapshot,
                     host_peer_id: pane.host_peer_id.clone(),
                     grid_rows,
                     grid_cols,
+                    title: None,
                 },
             ))
         })
@@ -819,6 +820,7 @@ pub fn layout_snapshot_from_state(state: &LayoutState) -> Result<LayoutSnapshot,
                 root: layout_node_from_protocol(
                     tab.root.as_ref().ok_or(LayoutError::InvalidSnapshot)?,
                 )?,
+                title: None,
             })
         })
         .collect::<Result<_, LayoutError>>()?;
@@ -911,6 +913,7 @@ fn reject_reason(error: &LayoutError) -> LayoutRejectReason {
         LayoutError::InvalidPeerId
         | LayoutError::InvalidEndpointAddress
         | LayoutError::InvalidDisplayName
+        | LayoutError::InvalidTitle
         | LayoutError::InvalidGrid
         | LayoutError::InvalidSplitRatio
         | LayoutError::AlreadyMember

--- a/src/session.rs
+++ b/src/session.rs
@@ -767,6 +767,8 @@ fn protocol_layout_state(snapshot: LayoutSnapshot) -> LayoutState {
                 host_peer_id: pane.host_peer_id,
                 grid_rows: u32::from(pane.grid_rows),
                 grid_cols: u32::from(pane.grid_cols),
+
+                title: None,
             })
             .collect(),
         tabs: snapshot
@@ -775,6 +777,8 @@ fn protocol_layout_state(snapshot: LayoutSnapshot) -> LayoutState {
             .map(|tab| TabDescriptor {
                 tab_id: tab.tab_id,
                 root: Some(protocol_node(tab.root)),
+
+                title: None,
             })
             .collect(),
     }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -49,13 +49,15 @@ use crate::{
         sample_global_snapshot,
     },
     kitty_keyboard::KittyKeyboardTracker,
-    layout::{Axis, LayoutError, LayoutSnapshot, NewPanePosition, Node, PaneId, TabId},
+    layout::{
+        Axis, LayoutError, LayoutSnapshot, NewPanePosition, Node, PaneId, TabId, normalize_title,
+    },
     lease::{IDLE_AFTER, LeaseDecision, LeaseManager, LeaseState},
     local_ipc::AgentOverlaySnapshotRow,
     protocol::{
         AgentRoster, AgentRosterEntry, AgentRosterState, CreatePane, CreateTab, DeletePane,
         DeleteTab, LayoutRequest, NewPanePosition as ProtocolNewPanePosition, PaneDescriptor,
-        PaneFailed, PaneReady, SplitAxis,
+        PaneFailed, PaneReady, RenamePane, RenameTab, SplitAxis,
     },
     pty_host::PtyHost,
     screen::{GuestScreen, HostScreen, SCROLLBACK_LINES, ScreenFrame},
@@ -127,6 +129,8 @@ const PANE_FOOTER: &[FooterSegment] = &[
     FooterSegment::Text("Pane  <"),
     FooterSegment::Key("←↓↑→"),
     FooterSegment::Text("> FOCUS   <"),
+    FooterSegment::Key("e"),
+    FooterSegment::Text("> RENAME   <"),
     FooterSegment::Key("n"),
     FooterSegment::Text("> NEW   <"),
     FooterSegment::Key("r/l/d/u"),
@@ -140,6 +144,8 @@ const TAB_FOOTER: &[FooterSegment] = &[
     FooterSegment::Text("Tab  <"),
     FooterSegment::Key("←→"),
     FooterSegment::Text("> SWITCH   <"),
+    FooterSegment::Key("e"),
+    FooterSegment::Text("> RENAME   <"),
     FooterSegment::Key("n"),
     FooterSegment::Text("> NEW   <"),
     FooterSegment::Key("x"),
@@ -213,6 +219,14 @@ pub enum UiIntent {
         first_share_bps: u16,
         base_revision: u64,
     },
+    RenamePane {
+        pane_id: PaneId,
+        title: String,
+    },
+    RenameTab {
+        tab_id: TabId,
+        title: String,
+    },
 }
 
 /// Whether a terminal key belongs to the mux or should later be offered to the focused pane.
@@ -234,6 +248,27 @@ pub struct AgentOverlayRow {
     pub working_since_unix_ms: u64,
     pub host: String,
     pub controller: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum RenameTarget {
+    Pane(PaneId),
+    Tab(TabId),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct RenamePrompt {
+    target: RenameTarget,
+    value: String,
+    error: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+enum ModalState {
+    #[default]
+    None,
+    Agents,
+    Rename(RenamePrompt),
 }
 
 /// Rectangles for one rendered terminal frame.
@@ -325,7 +360,7 @@ pub struct MultiPaneTui {
     selection: Option<PaneTextSelection>,
     selection_dragging: bool,
     agent_rows: Vec<AgentOverlayRow>,
-    agent_overlay_open: bool,
+    modal: ModalState,
     agent_selected_pane: Option<PaneId>,
     /// Terminal-line offset into the cards (two card lines plus one spacer each).
     agent_overlay_scroll_line: usize,
@@ -358,7 +393,7 @@ impl MultiPaneTui {
             selection: None,
             selection_dragging: false,
             agent_rows: Vec::new(),
-            agent_overlay_open: false,
+            modal: ModalState::None,
             agent_selected_pane: None,
             agent_overlay_scroll_line: 0,
             agent_overlay_viewport_lines: 0,
@@ -393,7 +428,7 @@ impl MultiPaneTui {
     }
 
     pub fn overlay_open(&self) -> bool {
-        self.agent_overlay_open
+        matches!(self.modal, ModalState::Agents)
     }
 
     pub fn set_agent_rows(&mut self, mut rows: Vec<AgentOverlayRow>) -> bool {
@@ -494,7 +529,7 @@ impl MultiPaneTui {
     }
 
     pub(crate) fn agent_overlay_has_working_rows(&self) -> bool {
-        self.agent_overlay_open
+        self.overlay_open()
             && self
                 .agent_rows
                 .iter()
@@ -520,7 +555,7 @@ impl MultiPaneTui {
             .is_some_and(|then| now.duration_since(then) >= AGENT_TOGGLE_WINDOW)
         {
             self.pending_agent_toggle = None;
-            self.agent_overlay_open = true;
+            self.modal = ModalState::Agents;
             self.exit_chord_mode();
             return true;
         }
@@ -917,7 +952,15 @@ impl MultiPaneTui {
     }
 
     pub fn handle_key(&mut self, key: KeyEvent, area: Rect) -> KeyHandling {
-        if self.agent_overlay_open {
+        if is_quit(key) {
+            self.modal = ModalState::None;
+            self.exit_chord_mode();
+            return KeyHandling::Quit;
+        }
+        if matches!(self.modal, ModalState::Rename(_)) {
+            return self.handle_rename_key(key);
+        }
+        if self.overlay_open() {
             self.set_agent_overlay_viewport(area);
             return self.handle_agent_overlay_key(key);
         }
@@ -931,10 +974,6 @@ impl MultiPaneTui {
             }
             self.pending_agent_toggle = Some(Instant::now());
             return KeyHandling::Consumed(vec![]);
-        }
-        if is_quit(key) {
-            self.exit_chord_mode();
-            return KeyHandling::Quit;
         }
         if key.code == KeyCode::Esc
             && key.modifiers.is_empty()
@@ -988,6 +1027,9 @@ impl MultiPaneTui {
         mouse: crossterm::event::MouseEvent,
         area: Rect,
     ) -> Vec<UiIntent> {
+        if matches!(self.modal, ModalState::Rename(_)) {
+            return Vec::new();
+        }
         match mouse.kind {
             MouseEventKind::Moved if !self.overlay_open() => {
                 self.hover_pane_at(mouse.column, mouse.row, area);
@@ -1045,7 +1087,7 @@ impl MultiPaneTui {
     fn handle_agent_overlay_key(&mut self, key: KeyEvent) -> KeyHandling {
         match key.code {
             KeyCode::Esc => {
-                self.agent_overlay_open = false;
+                self.modal = ModalState::None;
                 KeyHandling::Consumed(vec![])
             }
             KeyCode::Up | KeyCode::Char('k') => {
@@ -1061,6 +1103,71 @@ impl MultiPaneTui {
                     return KeyHandling::Consumed(vec![]);
                 };
                 KeyHandling::Consumed(self.jump_to_agent_pane(pane_id))
+            }
+            _ => KeyHandling::Consumed(vec![]),
+        }
+    }
+
+    fn open_rename(&mut self, target: RenameTarget) {
+        let value = match target {
+            RenameTarget::Pane(pane_id) => self
+                .snapshot
+                .panes
+                .get(&pane_id)
+                .and_then(|pane| pane.title.clone()),
+            RenameTarget::Tab(tab_id) => self
+                .snapshot
+                .tabs
+                .iter()
+                .find(|tab| tab.tab_id == tab_id)
+                .and_then(|tab| tab.title.clone()),
+        }
+        .unwrap_or_default();
+        self.modal = ModalState::Rename(RenamePrompt {
+            target,
+            value,
+            error: None,
+        });
+        self.exit_chord_mode();
+        self.clear_selection();
+        self.cancel_resize_drag();
+    }
+
+    fn handle_rename_key(&mut self, key: KeyEvent) -> KeyHandling {
+        let ModalState::Rename(prompt) = &mut self.modal else {
+            unreachable!("rename handler requires an active rename prompt");
+        };
+        match key.code {
+            KeyCode::Esc if key.modifiers.is_empty() => {
+                self.modal = ModalState::None;
+                KeyHandling::Consumed(vec![])
+            }
+            KeyCode::Backspace if key.modifiers.is_empty() => {
+                prompt.value.pop();
+                prompt.error = None;
+                KeyHandling::Consumed(vec![])
+            }
+            KeyCode::Enter if key.modifiers.is_empty() => match normalize_title(&prompt.value) {
+                Ok(normalized) => {
+                    let title = normalized.unwrap_or_default();
+                    let intent = match prompt.target {
+                        RenameTarget::Pane(pane_id) => UiIntent::RenamePane { pane_id, title },
+                        RenameTarget::Tab(tab_id) => UiIntent::RenameTab { tab_id, title },
+                    };
+                    self.modal = ModalState::None;
+                    KeyHandling::Consumed(vec![intent])
+                }
+                Err(_) => {
+                    prompt.error = Some(String::from("Max 32 characters; no controls"));
+                    KeyHandling::Consumed(vec![])
+                }
+            },
+            KeyCode::Char(character)
+                if key.modifiers.is_empty() || key.modifiers == KeyModifiers::SHIFT =>
+            {
+                prompt.value.push(character);
+                prompt.error = None;
+                KeyHandling::Consumed(vec![])
             }
             _ => KeyHandling::Consumed(vec![]),
         }
@@ -1100,7 +1207,7 @@ impl MultiPaneTui {
         };
         self.current_tab = tab.tab_id;
         self.focused_pane = pane_id;
-        self.agent_overlay_open = false;
+        self.modal = ModalState::None;
         vec![UiIntent::FocusPane { pane_id }]
     }
 
@@ -1125,6 +1232,10 @@ impl MultiPaneTui {
 
     fn handle_pane_chord(&mut self, key: KeyEvent, area: Rect) -> Option<UiIntent> {
         match key.code {
+            KeyCode::Char('e') if key.modifiers.is_empty() => {
+                self.open_rename(RenameTarget::Pane(self.focused_pane));
+                None
+            }
             KeyCode::Char('n') if key.modifiers.is_empty() => {
                 let rect = self.geometry(area).panes.get(&self.focused_pane).copied()?;
                 self.create_pane(
@@ -1175,6 +1286,10 @@ impl MultiPaneTui {
 
     fn handle_tab_chord(&mut self, key: KeyEvent, area: Rect) -> Option<UiIntent> {
         match key.code {
+            KeyCode::Char('e') if key.modifiers.is_empty() => {
+                self.open_rename(RenameTarget::Tab(self.current_tab));
+                None
+            }
             KeyCode::Char('n') if key.modifiers.is_empty() => {
                 let (grid_rows, grid_cols) = grid_for_pane(self.geometry(area).content);
                 Some(UiIntent::CreateTab {
@@ -1333,7 +1448,8 @@ fn is_chord_command(mode: ChordMode, key: KeyEvent) -> bool {
     match mode {
         ChordMode::Pane => matches!(
             key.code,
-            KeyCode::Char('n')
+            KeyCode::Char('e')
+                | KeyCode::Char('n')
                 | KeyCode::Char('r')
                 | KeyCode::Char('l')
                 | KeyCode::Char('d')
@@ -1346,7 +1462,11 @@ fn is_chord_command(mode: ChordMode, key: KeyEvent) -> bool {
         ),
         ChordMode::Tab => matches!(
             key.code,
-            KeyCode::Char('n') | KeyCode::Char('x') | KeyCode::Left | KeyCode::Right
+            KeyCode::Char('e')
+                | KeyCode::Char('n')
+                | KeyCode::Char('x')
+                | KeyCode::Left
+                | KeyCode::Right
         ),
         ChordMode::None => false,
     }
@@ -1812,11 +1932,11 @@ fn contextual_footer(chord_mode: ChordMode) -> (&'static str, &'static [FooterSe
     match chord_mode {
         ChordMode::None => (CONTROL_HELP, NORMAL_FOOTER),
         ChordMode::Pane => (
-            "Pane  <←↓↑→> FOCUS   <n> NEW   <r/l/d/u> SPLIT   <x> CLOSE   <Esc> BACK",
+            "Pane  <←↓↑→> FOCUS   <e> RENAME   <n> NEW   <r/l/d/u> SPLIT   <x> CLOSE   <Esc> BACK",
             PANE_FOOTER,
         ),
         ChordMode::Tab => (
-            "Tab  <←→> SWITCH   <n> NEW   <x> CLOSE   <Esc> BACK",
+            "Tab  <←→> SWITCH   <e> RENAME   <n> NEW   <x> CLOSE   <Esc> BACK",
             TAB_FOOTER,
         ),
     }
@@ -2136,8 +2256,11 @@ fn render_shared_multi_pane(
             frame.render_widget(Paragraph::new("waiting for pane snapshot/lease"), content);
         }
     }
-    if tui.agent_overlay_open {
+    if tui.overlay_open() {
         render_agents_overlay(frame, tui, unix_ms_now());
+    }
+    if let ModalState::Rename(prompt) = &tui.modal {
+        render_rename_prompt(frame, prompt);
     }
 }
 
@@ -2204,6 +2327,46 @@ fn agents_overlay_panel(area: Rect) -> Rect {
 
 fn agents_overlay_inner(area: Rect) -> Rect {
     Block::bordered().inner(agents_overlay_panel(area))
+}
+
+fn render_rename_prompt(frame: &mut Frame<'_>, prompt: &RenamePrompt) {
+    let area = frame.area();
+    let width = area.width.saturating_sub(8).clamp(28, 64).min(area.width);
+    let height = 7_u16.min(area.height);
+    let panel = Rect::new(
+        area.x.saturating_add(area.width.saturating_sub(width) / 2),
+        area.y
+            .saturating_add(area.height.saturating_sub(height) / 2),
+        width,
+        height,
+    );
+    let title = match prompt.target {
+        RenameTarget::Pane(_) => " Rename pane ",
+        RenameTarget::Tab(_) => " Rename tab ",
+    };
+    frame.render_widget(Clear, panel);
+    frame.render_widget(
+        Block::bordered()
+            .title(Line::styled(
+                title,
+                Style::default().add_modifier(Modifier::BOLD),
+            ))
+            .border_style(Style::default().fg(FOOTER_ACCENT)),
+        panel,
+    );
+    let inner = Block::bordered().inner(panel);
+    let field = truncate_trailing(&prompt.value, usize::from(inner.width));
+    let mut lines = vec![Line::raw(field)];
+    if let Some(error) = &prompt.error {
+        lines.push(Line::styled(error.clone(), Style::default().fg(Color::Red)));
+    } else {
+        lines.push(Line::raw(""));
+    }
+    lines.push(Line::styled(
+        "Enter save · Esc cancel",
+        Style::default().fg(FOOTER_MUTED),
+    ));
+    frame.render_widget(Paragraph::new(lines), inner);
 }
 
 fn format_agent_overlay_card(
@@ -3948,6 +4111,36 @@ impl SharedLayoutRuntime {
                     rename_tab: None,
                 })?;
             }
+            UiIntent::RenamePane { pane_id, title } => {
+                let request_id = self.next_id();
+                self.send_request(LayoutRequest {
+                    request_id,
+                    base_revision: self.tui.snapshot().revision,
+                    create_pane: None,
+                    delete_pane: None,
+                    create_tab: None,
+                    delete_tab: None,
+                    set_split_ratio: None,
+                    update_pane_grids: None,
+                    rename_pane: Some(RenamePane { pane_id, title }),
+                    rename_tab: None,
+                })?;
+            }
+            UiIntent::RenameTab { tab_id, title } => {
+                let request_id = self.next_id();
+                self.send_request(LayoutRequest {
+                    request_id,
+                    base_revision: self.tui.snapshot().revision,
+                    create_pane: None,
+                    delete_pane: None,
+                    create_tab: None,
+                    delete_tab: None,
+                    set_split_ratio: None,
+                    update_pane_grids: None,
+                    rename_pane: None,
+                    rename_tab: Some(RenameTab { tab_id, title }),
+                })?;
+            }
             UiIntent::FocusPane { .. } | UiIntent::SwitchTab { .. } => {}
         }
         Ok(())
@@ -5036,7 +5229,7 @@ mod tests {
                 .map(|pane_id| agent_row(pane_id, pane_id as usize, 1))
                 .collect(),
         );
-        tui.agent_overlay_open = true;
+        tui.modal = super::ModalState::Agents;
         tui
     }
 
@@ -6124,6 +6317,91 @@ mod tests {
     }
 
     #[test]
+    fn rename_prompt_captures_chord_target_edits_and_consumes_modal_input() {
+        let area = Rect::new(0, 0, 80, 24);
+        let mut tui = MultiPaneTui::new(layout(
+            vec![Tab {
+                tab_id: 1,
+                root: Node::Leaf { pane_id: 1 },
+                title: None,
+            }],
+            &[(1, 2, 8)],
+        ))
+        .unwrap();
+        tui.snapshot.panes.get_mut(&1).unwrap().title = Some(String::from("old"));
+
+        assert_eq!(
+            tui.handle_key(
+                KeyEvent::new(KeyCode::Char('p'), KeyModifiers::CONTROL),
+                area
+            ),
+            KeyHandling::Consumed(vec![])
+        );
+        assert_eq!(
+            tui.handle_key(KeyEvent::new(KeyCode::Char('e'), KeyModifiers::NONE), area),
+            KeyHandling::Consumed(vec![])
+        );
+        assert_eq!(tui.chord_mode(), ChordMode::None);
+        assert!(matches!(
+            &tui.modal,
+            super::ModalState::Rename(prompt) if prompt.value == "old"
+        ));
+        assert_eq!(
+            tui.handle_key(
+                KeyEvent::new(KeyCode::Char('🙂'), KeyModifiers::SHIFT),
+                area
+            ),
+            KeyHandling::Consumed(vec![])
+        );
+        assert_eq!(
+            tui.handle_key(KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE), area),
+            KeyHandling::Consumed(vec![])
+        );
+        assert_eq!(
+            tui.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE), area),
+            KeyHandling::Consumed(vec![UiIntent::RenamePane {
+                pane_id: 1,
+                title: String::from("old"),
+            }])
+        );
+        assert!(!tui.overlay_open());
+    }
+
+    #[test]
+    fn rename_prompt_rejects_invalid_input_and_ctrl_q_wins() {
+        let area = Rect::new(0, 0, 80, 24);
+        let mut tui = MultiPaneTui::new(layout(
+            vec![Tab {
+                tab_id: 1,
+                root: Node::Leaf { pane_id: 1 },
+                title: None,
+            }],
+            &[(1, 2, 8)],
+        ))
+        .unwrap();
+        tui.open_rename(super::RenameTarget::Tab(1));
+        for character in "x".repeat(33).chars() {
+            tui.handle_key(
+                KeyEvent::new(KeyCode::Char(character), KeyModifiers::NONE),
+                area,
+            );
+        }
+        assert_eq!(
+            tui.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE), area),
+            KeyHandling::Consumed(vec![])
+        );
+        assert!(matches!(tui.modal, super::ModalState::Rename(_)));
+        assert_eq!(
+            tui.handle_key(
+                KeyEvent::new(KeyCode::Char('q'), KeyModifiers::CONTROL),
+                area
+            ),
+            KeyHandling::Quit
+        );
+        assert!(matches!(tui.modal, super::ModalState::None));
+    }
+
+    #[test]
     fn free_panes_use_a_mid_gray_border_when_hovered_unfocused() {
         assert_eq!(
             pane_border_color(Some(b""), false, true, false),
@@ -6856,11 +7134,11 @@ mod tests {
             ),
             (
                 ChordMode::Pane,
-                "Pane  <←↓↑→> FOCUS   <n> NEW   <r/l/d/u> SPLIT   <x> CLOSE   <Esc> BACK",
+                "Pane  <←↓↑→> FOCUS   <e> RENAME   <n> NEW   <r/l/d/u> SPLIT   <x> CLOSE   <Esc> BACK",
             ),
             (
                 ChordMode::Tab,
-                "Tab  <←→> SWITCH   <n> NEW   <x> CLOSE   <Esc> BACK",
+                "Tab  <←→> SWITCH   <e> RENAME   <n> NEW   <x> CLOSE   <Esc> BACK",
             ),
         ] {
             tui.chord_mode = mode;

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -16,6 +16,7 @@ use std::{
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 use tokio::sync::{mpsc, watch};
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use serde::{Deserialize, Serialize};
 
@@ -242,6 +243,8 @@ pub struct AgentOverlayRow {
     pub pane_id: PaneId,
     pub tab_ordinal: usize,
     pub pane_ordinal: usize,
+    pub tab_label: String,
+    pub pane_label: String,
     pub kind: String,
     pub cwd: String,
     pub state: AgentRosterState,
@@ -438,6 +441,19 @@ impl MultiPaneTui {
             };
             row.tab_ordinal = tab_ordinal;
             row.pane_ordinal = pane_ordinal;
+            row.tab_label = self
+                .snapshot
+                .tabs
+                .iter()
+                .find(|tab| contains_leaf(&tab.root, row.pane_id))
+                .and_then(|tab| tab.title.clone())
+                .unwrap_or_else(|| format!("Tab #{tab_ordinal}"));
+            row.pane_label = self
+                .snapshot
+                .panes
+                .get(&row.pane_id)
+                .and_then(|pane| pane.title.clone())
+                .unwrap_or_else(|| format!("Pane #{pane_ordinal}"));
             true
         });
         rows.sort_by_key(|row| (row.tab_ordinal, row.pane_ordinal, row.pane_id));
@@ -942,7 +958,11 @@ impl MultiPaneTui {
                 if index > 0 {
                     x = x.saturating_add(text_width(TAB_BAR_SEPARATOR));
                 }
-                let label_width = text_width(&tab_label(index + 1, tab.tab_id == self.current_tab));
+                let label_width = text_width(&tab_label(
+                    tab.title.as_deref(),
+                    index + 1,
+                    tab.tab_id == self.current_tab,
+                ));
                 let width = right.saturating_sub(x).min(label_width);
                 let rect = Rect::new(x, tab_bar.y, width, tab_bar.height);
                 x = x.saturating_add(label_width);
@@ -1547,34 +1567,62 @@ fn rect_contains(rect: Rect, column: u16, row: u16) -> bool {
 }
 
 fn text_width(text: &str) -> u16 {
-    text.chars().count() as u16
+    u16::try_from(UnicodeWidthStr::width(text)).unwrap_or(u16::MAX)
 }
 
-fn tab_label(index: usize, active: bool) -> String {
-    let label = format!("Tab #{index}");
+fn truncate_trailing(value: &str, width: usize) -> String {
+    if UnicodeWidthStr::width(value) <= width {
+        return value.into();
+    }
+    if width == 0 {
+        return String::new();
+    }
+    if width == 1 {
+        return "…".into();
+    }
+    let mut result = String::new();
+    for character in value.chars() {
+        if UnicodeWidthStr::width(result.as_str()).saturating_add(character.width().unwrap_or(0))
+            > width - 1
+        {
+            break;
+        }
+        result.push(character);
+    }
+    result.push('…');
+    result
+}
+
+fn tab_label(title: Option<&str>, index: usize, active: bool) -> String {
+    let label = title.map_or_else(|| format!("Tab #{index}"), str::to_owned);
     if active { format!(" {label} ") } else { label }
 }
 
 fn pane_title(
+    custom_title: Option<&str>,
     index: usize,
     host_peer_id: &[u8],
     controller_peer_id: Option<&[u8]>,
     members: &[crate::layout::Member],
+    available_width: usize,
 ) -> Line<'static> {
     let control = match controller_peer_id {
         Some([]) => "free".to_owned(),
         Some(peer_id) => member_label(peer_id, members),
         None => "…".to_owned(),
     };
+    let label = truncate_trailing(
+        &custom_title.map_or_else(|| format!("Pane #{index}"), str::to_owned),
+        available_width,
+    );
+    let metadata = format!(
+        " host: {} control: {control}",
+        member_label(host_peer_id, members)
+    );
+    let metadata_width = available_width.saturating_sub(UnicodeWidthStr::width(label.as_str()));
     Line::from(vec![
-        Span::styled(
-            format!("Pane #{index}"),
-            Style::default().add_modifier(Modifier::BOLD),
-        ),
-        Span::raw(format!(
-            " host: {} control: {control}",
-            member_label(host_peer_id, members)
-        )),
+        Span::styled(label, Style::default().add_modifier(Modifier::BOLD)),
+        Span::raw(truncate_trailing(&metadata, metadata_width)),
     ])
 }
 
@@ -2169,7 +2217,10 @@ fn render_shared_multi_pane(
             } else {
                 Style::default().fg(Color::White).bg(FOOTER_BACKGROUND)
             };
-            let label = tab_label(index + 1, active);
+            let label = truncate_trailing(
+                &tab_label(tab.title.as_deref(), index + 1, active),
+                usize::from(geometry.tab_labels[&tab.tab_id].width),
+            );
             let label_rect = geometry.tab_labels[&tab.tab_id];
             if label_rect.width == 0 {
                 continue;
@@ -2208,10 +2259,12 @@ fn render_shared_multi_pane(
         let view = tui.pane_views.get(&pane_id).cloned().unwrap_or_default();
         let focused = pane_id == tui.focused_pane;
         let mut title = pane_title(
+            pane.title.as_deref(),
             index + 1,
             &pane.host_peer_id,
             view.controller_peer_id.as_deref(),
             &tui.snapshot.members,
+            usize::from(rect.width.saturating_sub(2).saturating_sub(2)),
         );
         title.spans.insert(0, Span::raw(" "));
         title.spans.push(Span::raw(" "));
@@ -2416,8 +2469,10 @@ fn format_agent_overlay_card(
         AgentRosterState::Done => ("✓", "done", None),
     };
     let location = format!(
-        " · Tab #{} · Pane #{} · host: {}",
-        row.tab_ordinal, row.pane_ordinal, row.host
+        " · {} · {} · host: {}",
+        truncate_trailing(&row.tab_label, usize::from(width / 3)),
+        truncate_trailing(&row.pane_label, usize::from(width / 3)),
+        row.host
     );
     let state_prefix = match elapsed.as_deref() {
         Some(elapsed) => format!("{glyph} {state} {elapsed}"),
@@ -2529,29 +2584,26 @@ fn format_agent_elapsed(working_since_unix_ms: u64, now_unix_ms: u64) -> String 
     }
 }
 
-fn truncate_trailing(value: &str, width: usize) -> String {
-    let count = value.chars().count();
-    if count <= width {
-        return value.into();
-    }
-    if width <= 1 {
-        return "…".into();
-    }
-    format!("{}…", value.chars().take(width - 1).collect::<String>())
-}
-
 fn truncate_leading(value: &str, width: usize) -> String {
-    let count = value.chars().count();
-    if count <= width {
+    if UnicodeWidthStr::width(value) <= width {
         return value.into();
     }
-    if width <= 1 {
+    if width == 0 {
+        return String::new();
+    }
+    if width == 1 {
         return "…".into();
     }
-    format!(
-        "…{}",
-        value.chars().skip(count - width + 1).collect::<String>()
-    )
+    let mut result = String::new();
+    for character in value.chars().rev() {
+        if UnicodeWidthStr::width(result.as_str()).saturating_add(character.width().unwrap_or(0))
+            > width - 1
+        {
+            break;
+        }
+        result.insert(0, character);
+    }
+    format!("…{result}")
 }
 
 fn sanitize_single_line(value: &str) -> String {
@@ -3842,6 +3894,12 @@ impl SharedLayoutRuntime {
                     let pane = self.tui.snapshot().panes.get(&entry.pane_id)?;
                     let view = self.tui.pane_view(entry.pane_id)?;
                     let &(tab_ordinal, pane_ordinal) = pane_locations.get(&entry.pane_id)?;
+                    let tab = self
+                        .tui
+                        .snapshot()
+                        .tabs
+                        .iter()
+                        .find(|tab| contains_leaf(&tab.root, entry.pane_id))?;
                     let host = sanitize_single_line(&member_label(
                         &pane.host_peer_id,
                         &self.tui.snapshot().members,
@@ -3858,6 +3916,14 @@ impl SharedLayoutRuntime {
                         pane_id: entry.pane_id,
                         tab_ordinal,
                         pane_ordinal,
+                        tab_label: tab
+                            .title
+                            .clone()
+                            .unwrap_or_else(|| format!("Tab #{tab_ordinal}")),
+                        pane_label: pane
+                            .title
+                            .clone()
+                            .unwrap_or_else(|| format!("Pane #{pane_ordinal}")),
                         kind: sanitize_single_line(&entry.agent_kind),
                         cwd: sanitize_single_line(&entry.cwd),
                         state: AgentRosterState::try_from(entry.state).ok()?,
@@ -5203,6 +5269,8 @@ mod tests {
             pane_id,
             tab_ordinal,
             pane_ordinal,
+            tab_label: format!("Tab #{tab_ordinal}"),
+            pane_label: format!("Pane #{pane_ordinal}"),
             kind: String::from("codex"),
             cwd: String::from("/very/long/repository/path"),
             state: crate::protocol::AgentRosterState::Working,
@@ -6303,16 +6371,35 @@ mod tests {
 
         assert_eq!(visible_leaf_panes(&snapshot.tabs[0].root), vec![8, 3]);
         assert_eq!(
-            pane_title(1, b"host", Some(b""), &members).to_string(),
+            pane_title(None, 1, b"host", Some(b""), &members, 80).to_string(),
             "Pane #1 host: Host control: free"
         );
         assert_eq!(
-            pane_title(2, b"host", Some(b"guest"), &members).to_string(),
+            pane_title(None, 2, b"host", Some(b"guest"), &members, 80).to_string(),
             "Pane #2 host: Host control: Guest"
         );
         assert_eq!(
-            pane_title(2, b"host", None, &members).to_string(),
+            pane_title(None, 2, b"host", None, &members, 80).to_string(),
             "Pane #2 host: Host control: …"
+        );
+    }
+
+    #[test]
+    fn title_chrome_uses_custom_labels_and_cell_width_ellipsis() {
+        assert_eq!(super::tab_label(Some("build logs"), 1, false), "build logs");
+        assert_eq!(super::tab_label(None, 2, false), "Tab #2");
+        assert_eq!(super::truncate_trailing("界界", 3), "界…");
+        assert_eq!(super::truncate_trailing("界", 1), "…");
+        assert_eq!(super::truncate_trailing("title", 0), "");
+
+        let members = vec![crate::layout::Member {
+            peer_id: b"host".to_vec(),
+            endpoint_addr: b"endpoint".to_vec(),
+            display_name: String::from("Host"),
+        }];
+        assert_eq!(
+            pane_title(Some("build logs"), 1, b"host", Some(b""), &members, 12).to_string(),
+            "build logs …"
         );
     }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -4982,6 +4982,7 @@ mod tests {
                             host_peer_id: b"host".to_vec(),
                             grid_rows: *rows,
                             grid_cols: *cols,
+                            title: None,
                         },
                     )
                 })
@@ -5008,6 +5009,7 @@ mod tests {
             .map(|pane_id| Tab {
                 tab_id: pane_id,
                 root: Node::Leaf { pane_id },
+                title: None,
             })
             .collect();
         let panes = (1..=count)
@@ -5029,6 +5031,7 @@ mod tests {
             vec![Tab {
                 tab_id: 1,
                 root: Node::Leaf { pane_id: 1 },
+                title: None,
             }],
             &[(1, 2, 8)],
         ))
@@ -5066,10 +5069,12 @@ mod tests {
                 Tab {
                     tab_id: 1,
                     root: Node::Leaf { pane_id: 1 },
+                    title: None,
                 },
                 Tab {
                     tab_id: 2,
                     root: Node::Leaf { pane_id: 2 },
+                    title: None,
                 },
             ],
             &[(1, 2, 8), (2, 2, 8)],
@@ -5151,10 +5156,14 @@ mod tests {
                         first: Box::new(Node::Leaf { pane_id: 8 }),
                         second: Box::new(Node::Leaf { pane_id: 6 }),
                     },
+
+                    title: None,
                 },
                 Tab {
                     tab_id: 20,
                     root: Node::Leaf { pane_id: 3 },
+
+                    title: None,
                 },
             ],
             &[(8, 2, 8), (6, 2, 8), (3, 2, 8)],
@@ -5187,6 +5196,8 @@ mod tests {
             vec![Tab {
                 tab_id: 1,
                 root: Node::Leaf { pane_id: 1 },
+
+                title: None,
             }],
             &[(1, 2, 8)],
         ))
@@ -5228,10 +5239,14 @@ mod tests {
                 Tab {
                     tab_id: 1,
                     root: Node::Leaf { pane_id: 1 },
+
+                    title: None,
                 },
                 Tab {
                     tab_id: 2,
                     root: Node::Leaf { pane_id: 2 },
+
+                    title: None,
                 },
             ],
             &[(1, 2, 8), (2, 2, 8)],
@@ -5567,6 +5582,8 @@ mod tests {
             vec![Tab {
                 tab_id: 1,
                 root: Node::Leaf { pane_id: 1 },
+
+                title: None,
             }],
             &[(1, 1, 1)],
         );
@@ -5611,6 +5628,8 @@ mod tests {
             vec![Tab {
                 tab_id: 1,
                 root: Node::Leaf { pane_id: 1 },
+
+                title: None,
             }],
             &[(1, 1, 1)],
         );
@@ -5638,6 +5657,8 @@ mod tests {
             vec![Tab {
                 tab_id: 1,
                 root: Node::Leaf { pane_id: 1 },
+
+                title: None,
             }],
             &[(1, 1, 1)],
         );
@@ -5673,6 +5694,8 @@ mod tests {
             vec![Tab {
                 tab_id: 1,
                 root: Node::Leaf { pane_id: 1 },
+
+                title: None,
             }],
             &[(1, 1, 1)],
         );
@@ -5905,6 +5928,8 @@ mod tests {
                         second: Box::new(Node::Leaf { pane_id: 3 }),
                     }),
                 },
+
+                title: None,
             }],
             &[(1, 4, 10), (2, 4, 10), (3, 4, 10)],
         )
@@ -6051,6 +6076,8 @@ mod tests {
                     first: Box::new(Node::Leaf { pane_id: 8 }),
                     second: Box::new(Node::Leaf { pane_id: 3 }),
                 },
+
+                title: None,
             }],
             &[(3, 1, 1), (8, 1, 1)],
         );
@@ -6167,6 +6194,8 @@ mod tests {
             vec![Tab {
                 tab_id: 1,
                 root: Node::Leaf { pane_id: 1 },
+
+                title: None,
             }],
             &[(1, 19, 78)],
         ))
@@ -6262,10 +6291,14 @@ mod tests {
                 Tab {
                     tab_id: 1,
                     root: Node::Leaf { pane_id: 1 },
+
+                    title: None,
                 },
                 Tab {
                     tab_id: 2,
                     root: Node::Leaf { pane_id: 2 },
+
+                    title: None,
                 },
             ],
             &[(1, 2, 2), (2, 2, 2)],
@@ -6312,10 +6345,14 @@ mod tests {
                 Tab {
                     tab_id: 1,
                     root: Node::Leaf { pane_id: 1 },
+
+                    title: None,
                 },
                 Tab {
                     tab_id: 2,
                     root: Node::Leaf { pane_id: 2 },
+
+                    title: None,
                 },
             ],
             &[(1, 2, 2), (2, 2, 2)],
@@ -6327,6 +6364,8 @@ mod tests {
             vec![Tab {
                 tab_id: 1,
                 root: Node::Leaf { pane_id: 1 },
+
+                title: None,
             }],
             &[(1, 2, 2)],
         ))
@@ -6342,6 +6381,8 @@ mod tests {
             vec![Tab {
                 tab_id: 1,
                 root: Node::Leaf { pane_id: 1 },
+
+                title: None,
             }],
             &[(1, 2, 2)],
         ))
@@ -6377,6 +6418,8 @@ mod tests {
             vec![Tab {
                 tab_id: 1,
                 root: Node::Leaf { pane_id: 1 },
+
+                title: None,
             }],
             &[(1, 2, 2)],
         ))
@@ -6411,6 +6454,8 @@ mod tests {
             vec![Tab {
                 tab_id: 1,
                 root: Node::Leaf { pane_id: 1 },
+
+                title: None,
             }],
             &[(1, 1, 3)],
         ))
@@ -6443,6 +6488,8 @@ mod tests {
                 vec![Tab {
                     tab_id: 1,
                     root: Node::Leaf { pane_id: 1 },
+
+                    title: None,
                 }],
                 &[(1, 1, 3)],
             ))
@@ -6475,6 +6522,8 @@ mod tests {
             vec![Tab {
                 tab_id: 1,
                 root: Node::Leaf { pane_id: 1 },
+
+                title: None,
             }],
             &[(1, 3, 6)],
         ))
@@ -6496,6 +6545,8 @@ mod tests {
             vec![Tab {
                 tab_id: 1,
                 root: Node::Leaf { pane_id: 1 },
+
+                title: None,
             }],
             &[(1, 1, 5)],
         ))
@@ -6771,6 +6822,8 @@ mod tests {
             vec![Tab {
                 tab_id: 1,
                 root: Node::Leaf { pane_id: 1 },
+
+                title: None,
             }],
             &[(1, 2, 2)],
         ))
@@ -6814,6 +6867,8 @@ mod tests {
             vec![Tab {
                 tab_id: 1,
                 root: Node::Leaf { pane_id: 1 },
+
+                title: None,
             }],
             &[(1, 2, 2)],
         ))
@@ -6858,10 +6913,14 @@ mod tests {
                 Tab {
                     tab_id: 10,
                     root: Node::Leaf { pane_id: 1 },
+
+                    title: None,
                 },
                 Tab {
                     tab_id: 20,
                     root: Node::Leaf { pane_id: 2 },
+
+                    title: None,
                 },
             ],
             &[(1, 2, 2), (2, 2, 2)],
@@ -6919,6 +6978,8 @@ mod tests {
             vec![Tab {
                 tab_id: 1,
                 root: Node::Leaf { pane_id: 1 },
+
+                title: None,
             }],
             &[(1, 1, 1)],
         ))
@@ -6940,6 +7001,8 @@ mod tests {
             vec![Tab {
                 tab_id: 1,
                 root: Node::Leaf { pane_id: 1 },
+
+                title: None,
             }],
             &[(1, 1, 1)],
         ))
@@ -6989,6 +7052,8 @@ mod tests {
             vec![Tab {
                 tab_id: 1,
                 root: Node::Leaf { pane_id: 1 },
+
+                title: None,
             }],
             &[(1, 2, 2)],
         ))
@@ -7113,6 +7178,8 @@ mod tests {
             vec![Tab {
                 tab_id: 1,
                 root: Node::Leaf { pane_id: 1 },
+
+                title: None,
             }],
             &[(1, 2, 2)],
         ))
@@ -7124,10 +7191,14 @@ mod tests {
                 Tab {
                     tab_id: 1,
                     root: Node::Leaf { pane_id: 1 },
+
+                    title: None,
                 },
                 Tab {
                     tab_id: 3,
                     root: Node::Leaf { pane_id: 3 },
+
+                    title: None,
                 },
             ],
             &[(1, 2, 2), (3, 2, 2)],
@@ -7140,14 +7211,20 @@ mod tests {
                 Tab {
                     tab_id: 1,
                     root: Node::Leaf { pane_id: 1 },
+
+                    title: None,
                 },
                 Tab {
                     tab_id: 3,
                     root: Node::Leaf { pane_id: 3 },
+
+                    title: None,
                 },
                 Tab {
                     tab_id: 2,
                     root: Node::Leaf { pane_id: 2 },
+
+                    title: None,
                 },
             ],
             &[(1, 2, 2), (2, 2, 2), (3, 2, 2)],
@@ -7165,10 +7242,14 @@ mod tests {
                 Tab {
                     tab_id: 1,
                     root: Node::Leaf { pane_id: 1 },
+
+                    title: None,
                 },
                 Tab {
                     tab_id: 2,
                     root: Node::Leaf { pane_id: 2 },
+
+                    title: None,
                 },
             ],
             &[(1, 2, 2), (2, 2, 2)],
@@ -7216,14 +7297,20 @@ mod tests {
                 Tab {
                     tab_id: 1,
                     root: Node::Leaf { pane_id: 1 },
+
+                    title: None,
                 },
                 Tab {
                     tab_id: 2,
                     root: Node::Leaf { pane_id: 2 },
+
+                    title: None,
                 },
                 Tab {
                     tab_id: 3,
                     root: Node::Leaf { pane_id: 3 },
+
+                    title: None,
                 },
             ],
             &[(1, 2, 2), (2, 2, 2), (3, 2, 2)],

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -3845,6 +3845,9 @@ impl SharedLayoutRuntime {
                 delete_tab: None,
                 set_split_ratio: None,
                 update_pane_grids: Some(crate::protocol::UpdatePaneGrids { panes: updates }),
+
+                rename_pane: None,
+                rename_tab: None,
             })?;
         }
         Ok(())
@@ -3897,6 +3900,9 @@ impl SharedLayoutRuntime {
                     delete_tab: None,
                     set_split_ratio: None,
                     update_pane_grids: None,
+
+                    rename_pane: None,
+                    rename_tab: None,
                 })?
             }
             UiIntent::DeleteTab { tab_id } => {
@@ -3910,6 +3916,9 @@ impl SharedLayoutRuntime {
                     delete_tab: Some(DeleteTab { tab_id }),
                     set_split_ratio: None,
                     update_pane_grids: None,
+
+                    rename_pane: None,
+                    rename_tab: None,
                 })?
             }
             UiIntent::SetSplitRatio {
@@ -3935,6 +3944,8 @@ impl SharedLayoutRuntime {
                         first_share_bps: u32::from(first_share_bps),
                     }),
                     update_pane_grids: None,
+                    rename_pane: None,
+                    rename_tab: None,
                 })?;
             }
             UiIntent::FocusPane { .. } | UiIntent::SwitchTab { .. } => {}
@@ -3984,6 +3995,8 @@ impl SharedLayoutRuntime {
             delete_tab: None,
             set_split_ratio: None,
             update_pane_grids: None,
+            rename_pane: None,
+            rename_tab: None,
         })
     }
 
@@ -4033,6 +4046,8 @@ impl SharedLayoutRuntime {
             host_peer_id,
             grid_rows: u32::from(pending.grid_rows),
             grid_cols: u32::from(pending.grid_cols),
+
+            title: None,
         };
         if let Err(error) = self.panes.register_local_pane(descriptor, pane.channels()) {
             let _ = self.control.try_failed(PaneFailed {
@@ -5382,6 +5397,8 @@ mod tests {
                     host_peer_id: host_id,
                     grid_rows: 2,
                     grid_cols: 8,
+
+                    title: None,
                 },
                 initial.channels(),
             )
@@ -5482,6 +5499,8 @@ mod tests {
             host_peer_id: host_id.clone(),
             grid_rows: 1,
             grid_cols: 1,
+
+            title: None,
         };
         host_panes
             .register_local_pane(

--- a/tests/module_surface.rs
+++ b/tests/module_surface.rs
@@ -17,5 +17,5 @@ fn exposes_the_scaffold_module_boundaries() {
     let _: Option<JoinTicket> = None;
     let _: Option<HostSession> = None;
     let _: Option<Envelope> = None;
-    assert_eq!(PROTOCOL_VERSION, 5);
+    assert_eq!(PROTOCOL_VERSION, 6);
 }

--- a/tests/protocol.rs
+++ b/tests/protocol.rs
@@ -28,7 +28,7 @@ fn envelope(body: envelope::Body) -> Envelope {
 
 #[test]
 fn protocol_version_is_v5() {
-    assert_eq!(PROTOCOL_VERSION, 5);
+    assert_eq!(PROTOCOL_VERSION, 6);
 }
 
 #[test]
@@ -46,6 +46,9 @@ fn ratio_and_grid_actions_validate_strictly() {
             first_share_bps: 7_500,
         }),
         update_pane_grids: None,
+
+        rename_pane: None,
+        rename_tab: None,
     };
     let encoded = encode_frame(&envelope(envelope::Body::LayoutRequest(request.clone())))
         .expect("valid request");
@@ -70,6 +73,8 @@ fn ratio_and_grid_actions_validate_strictly() {
                 delete_tab: None,
                 set_split_ratio: None,
                 update_pane_grids: None,
+                rename_pane: None,
+                rename_tab: None,
             }
         };
         assert!(encode_frame(&envelope(envelope::Body::LayoutRequest(invalid))).is_err());
@@ -90,6 +95,9 @@ fn ratio_and_grid_actions_validate_strictly() {
                 grid_cols: 80,
             }],
         }),
+
+        rename_pane: None,
+        rename_tab: None,
     };
     assert!(
         decode_frame(
@@ -419,10 +427,14 @@ fn layout_state(root: LayoutNode) -> LayoutState {
             host_peer_id: b"peer-a".to_vec(),
             grid_rows: 24,
             grid_cols: 80,
+
+            title: None,
         }],
         tabs: vec![TabDescriptor {
             tab_id: 1,
             root: Some(root),
+
+            title: None,
         }],
     }
 }
@@ -448,6 +460,9 @@ fn v2_envelopes() -> Vec<Envelope> {
             delete_tab: None,
             set_split_ratio: None,
             update_pane_grids: None,
+
+            rename_pane: None,
+            rename_tab: None,
         })),
         envelope(envelope::Body::PaneReservation(PaneReservation {
             reservation_id: 1,
@@ -532,6 +547,9 @@ fn layout_messages_reject_invalid_shapes_and_bounds() {
         delete_tab: None,
         set_split_ratio: None,
         update_pane_grids: None,
+
+        rename_pane: None,
+        rename_tab: None,
     };
     let multiple_actions = LayoutRequest {
         create_pane: Some(CreatePane {
@@ -551,6 +569,8 @@ fn layout_messages_reject_invalid_shapes_and_bounds() {
                 leaf_pane_id: None,
                 split: None,
             }),
+
+            title: None,
         }],
         ..state.clone()
     };
@@ -566,6 +586,8 @@ fn layout_messages_reject_invalid_shapes_and_bounds() {
                     first_share_bps: None,
                 })),
             }),
+
+            title: None,
         }],
         ..state.clone()
     };
@@ -586,6 +608,7 @@ fn layout_messages_reject_invalid_shapes_and_bounds() {
                 host_peer_id: b"peer-a".to_vec(),
                 grid_rows: 24,
                 grid_cols: 80,
+                title: None,
             })
             .collect(),
         ..state.clone()
@@ -595,6 +618,7 @@ fn layout_messages_reject_invalid_shapes_and_bounds() {
             .map(|tab_id| TabDescriptor {
                 tab_id,
                 root: Some(leaf(1)),
+                title: None,
             })
             .collect(),
         ..state.clone()
@@ -605,6 +629,8 @@ fn layout_messages_reject_invalid_shapes_and_bounds() {
             host_peer_id: b"peer-a".to_vec(),
             grid_rows: 0,
             grid_cols: 80,
+
+            title: None,
         }],
         ..state.clone()
     };
@@ -742,6 +768,9 @@ fn create_pane_axis_and_position_are_validated() {
             delete_tab: None,
             set_split_ratio: None,
             update_pane_grids: None,
+
+            rename_pane: None,
+            rename_tab: None,
         }))
     }
 
@@ -753,12 +782,16 @@ fn create_pane_axis_and_position_are_validated() {
                     host_peer_id: b"peer-a".to_vec(),
                     grid_rows: 24,
                     grid_cols: 80,
+
+                    title: None,
                 },
                 PaneDescriptor {
                     pane_id: 2,
                     host_peer_id: b"peer-a".to_vec(),
                     grid_rows: 24,
                     grid_cols: 80,
+
+                    title: None,
                 },
             ],
             tabs: vec![TabDescriptor {
@@ -772,6 +805,8 @@ fn create_pane_axis_and_position_are_validated() {
                         first_share_bps: None,
                     })),
                 }),
+
+                title: None,
             }],
             ..layout_state(leaf(1))
         };
@@ -841,6 +876,9 @@ fn layout_grids_must_fit_the_reducer_u16_grid() {
         delete_tab: None,
         set_split_ratio: None,
         update_pane_grids: None,
+
+        rename_pane: None,
+        rename_tab: None,
     };
 
     for valid in [
@@ -1047,6 +1085,8 @@ fn layout_state_rejects_empty_duplicate_and_dangling_references() {
                     first_share_bps: None,
                 })),
             }),
+
+            title: None,
         }],
         ..state.clone()
     };
@@ -1054,6 +1094,8 @@ fn layout_state_rejects_empty_duplicate_and_dangling_references() {
         tabs: vec![TabDescriptor {
             tab_id: 1,
             root: Some(leaf(2)),
+
+            title: None,
         }],
         ..state.clone()
     };
@@ -1061,6 +1103,8 @@ fn layout_state_rejects_empty_duplicate_and_dangling_references() {
         tabs: vec![TabDescriptor {
             tab_id: 1,
             root: Some(leaf(0)),
+
+            title: None,
         }],
         ..state.clone()
     };
@@ -1072,6 +1116,7 @@ fn layout_state_rejects_empty_duplicate_and_dangling_references() {
                 host_peer_id: b"peer-a".to_vec(),
                 grid_rows: 24,
                 grid_cols: 80,
+                title: None,
             },
         ],
         ..state
@@ -1121,6 +1166,8 @@ fn layout_state_wire_shape_includes_all_nested_fields() {
             host_peer_id: b"peer-a".to_vec(),
             grid_rows: 24,
             grid_cols: 80,
+
+            title: None,
         }],
         tabs: vec![TabDescriptor {
             tab_id: 13,
@@ -1133,6 +1180,8 @@ fn layout_state_wire_shape_includes_all_nested_fields() {
                     first_share_bps: None,
                 })),
             }),
+
+            title: None,
         }],
     };
     let state_fields = parse_fields(&state.encode_to_vec());
@@ -1206,6 +1255,8 @@ fn layout_messages_reject_deep_or_wide_trees_and_oversize_join_endpoint() {
         tabs: vec![TabDescriptor {
             tab_id: 1,
             root: Some(wide_tree),
+
+            title: None,
         }],
         ..layout_state(leaf(1))
     };
@@ -1213,6 +1264,8 @@ fn layout_messages_reject_deep_or_wide_trees_and_oversize_join_endpoint() {
         tabs: vec![TabDescriptor {
             tab_id: 1,
             root: Some(deep_tree),
+
+            title: None,
         }],
         ..layout_state(leaf(1))
     };

--- a/tests/session_layout.rs
+++ b/tests/session_layout.rs
@@ -44,6 +44,8 @@ fn request(request_id: u64, base_revision: u64) -> LayoutRequest {
         delete_tab: None,
         set_split_ratio: None,
         update_pane_grids: None,
+        rename_pane: None,
+        rename_tab: None,
     }
 }
 

--- a/tests/session_layout_control.rs
+++ b/tests/session_layout_control.rs
@@ -87,6 +87,8 @@ fn create_request(request_id: u64, base_revision: u64) -> LayoutRequest {
         delete_tab: None,
         set_split_ratio: None,
         update_pane_grids: None,
+        rename_pane: None,
+        rename_tab: None,
     }
 }
 

--- a/tests/session_layout_control.rs
+++ b/tests/session_layout_control.rs
@@ -243,6 +243,8 @@ async fn late_joiner_subscribes_after_snapshot_without_preloaded_host_roster() {
         host_peer_id: host_id.clone(),
         grid_rows: 1,
         grid_cols: 1,
+
+        title: None,
     };
     let screen = HostScreen::new(1, 1).expect("screen");
     let (_screen_tx, screen_rx) = tokio::sync::watch::channel(screen.current_frame().clone());
@@ -318,6 +320,8 @@ async fn departed_member_loses_direct_pane_access_while_healthy_member_receives_
         host_peer_id: host_id.clone(),
         grid_rows: 1,
         grid_cols: 1,
+
+        title: None,
     };
     let screen = HostScreen::new(1, 1).expect("screen");
     let (_screen_tx, screen_rx) = tokio::sync::watch::channel(screen.current_frame().clone());
@@ -476,6 +480,9 @@ async fn forged_post_welcome_sender_is_rejected_without_a_layout_mutation() {
                 delete_tab: None,
                 set_split_ratio: None,
                 update_pane_grids: None,
+
+                rename_pane: None,
+                rename_tab: None,
             })),
         })
         .await
@@ -543,6 +550,9 @@ async fn deleting_a_member_owned_tab_broadcasts_the_full_commit() {
             delete_tab: None,
             set_split_ratio: None,
             update_pane_grids: None,
+
+            rename_pane: None,
+            rename_tab: None,
         })
         .expect("queue tab request");
     let reservation = match next_event(&mut second).await {
@@ -576,6 +586,9 @@ async fn deleting_a_member_owned_tab_broadcasts_the_full_commit() {
             }),
             set_split_ratio: None,
             update_pane_grids: None,
+
+            rename_pane: None,
+            rename_tab: None,
         })
         .expect("queue tab delete");
     for member in [&mut first, &mut second] {
@@ -655,6 +668,9 @@ async fn reservation_is_targeted_and_ready_broadcasts_the_commit() {
             delete_tab: None,
             set_split_ratio: None,
             update_pane_grids: None,
+
+            rename_pane: None,
+            rename_tab: None,
         })
         .expect("queue deletion");
     assert!(
@@ -674,6 +690,9 @@ async fn reservation_is_targeted_and_ready_broadcasts_the_commit() {
             delete_tab: None,
             set_split_ratio: None,
             update_pane_grids: None,
+
+            rename_pane: None,
+            rename_tab: None,
         })
         .expect("queue foreign deletion");
     assert!(matches!(

--- a/tests/session_stream.rs
+++ b/tests/session_stream.rs
@@ -105,6 +105,7 @@ async fn direct_subscription_streams_a_registered_non_default_pane_without_synth
         host_peer_id: host_id.clone(),
         grid_rows: 1,
         grid_cols: 3,
+        title: None,
     };
     let mut screen = HostScreen::new(1, 3).expect("screen");
     let (screen_tx, screen_rx) = tokio::sync::watch::channel(screen.current_frame().clone());

--- a/tests/session_stream.rs
+++ b/tests/session_stream.rs
@@ -217,12 +217,16 @@ async fn one_viewer_subscribes_to_panes_owned_by_two_different_hosts() {
         host_peer_id: first_id.clone(),
         grid_rows: 1,
         grid_cols: 1,
+
+        title: None,
     };
     let second_descriptor = PaneDescriptor {
         pane_id: 12,
         host_peer_id: second_id.clone(),
         grid_rows: 1,
         grid_cols: 1,
+
+        title: None,
     };
     let first_screen = HostScreen::new(1, 1).expect("first screen");
     let second_screen = HostScreen::new(1, 1).expect("second screen");
@@ -346,6 +350,8 @@ async fn direct_subscriptions_reject_unknown_nonmember_and_mismatched_hosts() {
         host_peer_id: host_id.clone(),
         grid_rows: 1,
         grid_cols: 1,
+
+        title: None,
     };
     let unknown_task = {
         let server = server.clone();
@@ -382,6 +388,8 @@ async fn direct_subscriptions_reject_unknown_nonmember_and_mismatched_hosts() {
         host_peer_id: host_id.clone(),
         grid_rows: 1,
         grid_cols: 1,
+
+        title: None,
     };
     server
         .register_pane(
@@ -463,6 +471,8 @@ async fn rejected_direct_subscriber_cannot_inject_control_into_a_registered_pane
                 host_peer_id: host_id.clone(),
                 grid_rows: 1,
                 grid_cols: 1,
+
+                title: None,
             },
             HostPaneChannels {
                 pane_id: pane_wire_id(101),
@@ -564,6 +574,8 @@ async fn pane_server_accept_loop_serves_two_viewers_without_waiting_for_the_firs
         host_peer_id: host_id.clone(),
         grid_rows: 1,
         grid_cols: 1,
+
+        title: None,
     };
     server
         .register_pane(
@@ -649,6 +661,8 @@ async fn pane_server_retries_an_idle_accept_timeout_before_serving_a_later_conne
         host_peer_id: host_id.clone(),
         grid_rows: 1,
         grid_cols: 1,
+
+        title: None,
     };
     server
         .register_pane(
@@ -723,6 +737,8 @@ async fn removing_a_pane_disconnects_subscribers_and_blocks_later_control_delive
         host_peer_id: host_id.clone(),
         grid_rows: 1,
         grid_cols: 1,
+
+        title: None,
     };
     server
         .register_pane(


### PR DESCRIPTION
## Summary
- Add shared, persistent pane/tab titles via sticky chords: `Ctrl+P` then `e`, `Ctrl+T` then `e`
- Protocol v6 carries optional titles on descriptors plus `RenamePane` / `RenameTab` layout actions; any admitted member can rename (labels only)
- Modal non-expiring rename prompt (Enter saves, Esc cancels, blank clears to `Pane #N` / `Tab #N`); chrome and agents overlay use custom titles with title-first ellipsis

## Test plan
- [ ] `Ctrl+P` `e` renames focused pane for both members; host/control metadata unchanged
- [ ] `Ctrl+T` `e` renames current tab for both members; active-tab styling still works
- [ ] Blank/whitespace Enter restores ordinal labels
- [ ] Prompt stays open past chord idle timeout; Esc does not leak into PTY; Ctrl+Q still detaches
- [ ] While prompt open: Ctrl+P/T/A, arrows, mouse do not navigate/toggle overlay/forward to PTY
- [ ] Late join / detach-resume still shows custom titles
- [ ] `cargo fmt --check && cargo clippy --all-targets --all-features -- -D warnings && cargo test`


Made with [Cursor](https://cursor.com)