### PR TITLE
feat: local UI theme config for mux chrome

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2472,6 +2472,7 @@ dependencies = [
  "sysinfo",
  "tokio",
  "toml",
+ "toml_edit 0.22.27",
  "unicode-width",
  "vt100",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,6 @@ serde_json = "1"
 sysinfo = "0.37"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "time", "sync", "net", "io-util"] }
 toml = "0.8"
+toml_edit = "0.22"
 vt100 = "0.16"
 unicode-width = "0.2"

--- a/README.md
+++ b/README.md
@@ -70,6 +70,13 @@ Set a peer-visible display name once with `p2pmux config set name pelazas`; insp
 `~/.config/p2pmux/config.toml`). `create` and `join` accept `--name <name>` to override and save
 the value for that run and future sessions.
 
+Run `p2pmux config init` to create a fully commented configuration template; it refuses to
+overwrite an existing file. Local TUI chrome colors live under `[ui.theme]`. Every theme key is
+optional, and omitted keys retain today's built-in colors; the template documents every key and
+its default. Colors accept lowercase named values (`white`, `yellow`, `gray`, `dark_gray`) or
+case-insensitive `#RRGGBB` values. The theme is client-local and is never synchronized over P2P;
+detach and reattach after editing the file to reload it.
+
 Every `create` and `join` automatically receives a memorable world-city session name such as
 `tokyo` or `cape-town`; no session name is required. `create --session-name <name>` remains
 available when you want to choose a name explicitly. Automatically chosen names avoid live local

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -76,6 +76,7 @@ enum Command {
 enum ConfigCommand {
     Set { key: String, value: String },
     Get { key: String },
+    Init,
 }
 
 const TRUST_WARNING: &str = "TRUST WARNING: This is a fully trusted shared-shell session. Anyone with the join ticket can see every pane and may obtain interactive control of available terminals (run commands, see output, touch files reachable to that macOS user).
@@ -111,6 +112,10 @@ async fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
         }
         Some(Command::Local) => crate::tui::run_local(),
         Some(Command::Config { command }) => match command {
+            ConfigCommand::Init => {
+                crate::config::init()?;
+                Ok(())
+            }
             ConfigCommand::Set { key, value } if key == "name" => {
                 crate::config::save(&value)?;
                 Ok(())

--- a/src/client.rs
+++ b/src/client.rs
@@ -32,6 +32,16 @@ use crate::{
 };
 
 pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Error>> {
+    let config_path = crate::config::config_path()?;
+    let theme = crate::config::load_config_from(&config_path)
+        .map_err(|error| {
+            io::Error::other(format!(
+                "could not load config {}: {error}",
+                config_path.display()
+            ))
+        })?
+        .ui
+        .theme;
     let mut stream = UnixStream::connect(&descriptor.socket_path)?;
     let read_stream = stream.try_clone()?;
     let mut reader = BufReader::new(read_stream);
@@ -82,6 +92,7 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
                     {
                         apply_snapshot(
                             &mut tui,
+                            theme,
                             &mut screens,
                             room_name,
                             *layout,
@@ -255,6 +266,7 @@ fn should_forward_paste(tui: &MultiPaneTui) -> bool {
 #[allow(clippy::too_many_arguments)]
 fn apply_snapshot(
     tui: &mut Option<MultiPaneTui>,
+    theme: crate::config::UiTheme,
     screens: &mut BTreeMap<u64, GuestScreen>,
     room_name: String,
     layout: crate::layout::LayoutSnapshot,
@@ -271,7 +283,7 @@ fn apply_snapshot(
             view
         }
         None => tui
-            .insert(MultiPaneTui::new(layout).map_err(|error| {
+            .insert(MultiPaneTui::with_theme(layout, theme).map_err(|error| {
                 io::Error::other(format!("invalid layout snapshot: {error:?}"))
             })?),
     };

--- a/src/client.rs
+++ b/src/client.rs
@@ -585,6 +585,7 @@ mod tests {
     ) {
         apply_snapshot(
             tui,
+            crate::config::UiTheme::default(),
             &mut BTreeMap::new(),
             String::from("room"),
             layout(pane_ids),

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,12 +3,14 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use ratatui::style::Color;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug)]
 pub enum ConfigError {
     MissingHome,
     InvalidName(&'static str),
+    InvalidColor { key: &'static str, value: String },
     Io(io::Error),
     Parse(toml::de::Error),
     Serialize(toml::ser::Error),
@@ -19,6 +21,7 @@ impl fmt::Display for ConfigError {
         match self {
             Self::MissingHome => f.write_str("could not resolve config directory"),
             Self::InvalidName(message) => f.write_str(message),
+            Self::InvalidColor { key, value } => write!(f, "invalid color for {key}: {value}"),
             Self::Io(error) => error.fmt(f),
             Self::Parse(error) => error.fmt(f),
             Self::Serialize(error) => error.fmt(f),
@@ -34,9 +37,117 @@ impl From<io::Error> for ConfigError {
     }
 }
 
-#[derive(Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+pub struct Config {
+    pub display_name: Option<String>,
+    pub ui: UiConfig,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            display_name: None,
+            ui: UiConfig::default(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct UiConfig {
+    pub theme: UiTheme,
+}
+
+impl Default for UiConfig {
+    fn default() -> Self {
+        Self {
+            theme: UiTheme::default(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct UiTheme {
+    pub footer_background: Color,
+    pub footer_muted: Color,
+    pub footer_accent: Color,
+    pub footer_orange: Color,
+    pub tab_active_background: Color,
+    pub tab_foreground: Color,
+    pub tab_separator: Color,
+    pub copy_feedback_accent: Color,
+    pub agent_overlay_chrome: Color,
+    pub agent_overlay_selected_background: Color,
+    pub agent_overlay_muted: Color,
+    pub agent_overlay_warm: Color,
+    pub agent_overlay_foreground: Color,
+    pub agent_overlay_secondary: Color,
+    pub pane_border_free_focused: Color,
+    pub pane_border_unknown_focused: Color,
+    pub pane_border_hovered: Color,
+    pub pane_border_idle: Color,
+    pub pane_border_remote_control: Color,
+}
+
+impl Default for UiTheme {
+    fn default() -> Self {
+        Self {
+            footer_background: Color::Rgb(30, 30, 30),
+            footer_muted: Color::White,
+            footer_accent: Color::Rgb(220, 50, 47),
+            footer_orange: Color::Rgb(255, 120, 70),
+            tab_active_background: Color::Rgb(220, 50, 47),
+            tab_foreground: Color::White,
+            tab_separator: Color::DarkGray,
+            copy_feedback_accent: Color::Rgb(255, 69, 0),
+            agent_overlay_chrome: Color::Rgb(255, 69, 0),
+            agent_overlay_selected_background: Color::DarkGray,
+            agent_overlay_muted: Color::Rgb(145, 157, 180),
+            agent_overlay_warm: Color::Rgb(255, 184, 77),
+            agent_overlay_foreground: Color::White,
+            agent_overlay_secondary: Color::Gray,
+            pane_border_free_focused: Color::White,
+            pane_border_unknown_focused: Color::Yellow,
+            pane_border_hovered: Color::Gray,
+            pane_border_idle: Color::DarkGray,
+            pane_border_remote_control: Color::Rgb(255, 69, 0),
+        }
+    }
+}
+
+#[derive(Debug, Default, Deserialize)]
 struct ConfigFile {
     display_name: Option<String>,
+    #[serde(default)]
+    ui: UiConfigFile,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct UiConfigFile {
+    #[serde(default)]
+    theme: UiThemeFile,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct UiThemeFile {
+    footer_background: Option<String>,
+    footer_muted: Option<String>,
+    footer_accent: Option<String>,
+    footer_orange: Option<String>,
+    tab_active_background: Option<String>,
+    tab_foreground: Option<String>,
+    tab_separator: Option<String>,
+    copy_feedback_accent: Option<String>,
+    agent_overlay_chrome: Option<String>,
+    agent_overlay_selected_background: Option<String>,
+    agent_overlay_muted: Option<String>,
+    agent_overlay_warm: Option<String>,
+    agent_overlay_foreground: Option<String>,
+    agent_overlay_secondary: Option<String>,
+    pane_border_free_focused: Option<String>,
+    pane_border_unknown_focused: Option<String>,
+    pane_border_hovered: Option<String>,
+    pane_border_idle: Option<String>,
+    pane_border_remote_control: Option<String>,
 }
 
 pub fn config_path() -> Result<PathBuf, ConfigError> {
@@ -66,23 +177,159 @@ pub fn validate_display_name(name: &str) -> Result<String, ConfigError> {
 }
 
 pub fn load_from(path: &Path) -> Result<Option<String>, ConfigError> {
+    Ok(load_config_from(path)?.display_name)
+}
+
+pub fn load_config_from(path: &Path) -> Result<Config, ConfigError> {
     let text = match fs::read_to_string(path) {
         Ok(text) => text,
-        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(Config::default()),
         Err(error) => return Err(error.into()),
     };
     let config: ConfigFile = toml::from_str(&text).map_err(ConfigError::Parse)?;
-    config
+    let display_name = config
         .display_name
         .map(|name| validate_display_name(&name))
-        .transpose()
+        .transpose()?;
+    let mut theme = UiTheme::default();
+    apply_color(
+        &mut theme.footer_background,
+        config.ui.theme.footer_background,
+        "footer_background",
+    )?;
+    apply_color(
+        &mut theme.footer_muted,
+        config.ui.theme.footer_muted,
+        "footer_muted",
+    )?;
+    apply_color(
+        &mut theme.footer_accent,
+        config.ui.theme.footer_accent,
+        "footer_accent",
+    )?;
+    apply_color(
+        &mut theme.footer_orange,
+        config.ui.theme.footer_orange,
+        "footer_orange",
+    )?;
+    apply_color(
+        &mut theme.tab_active_background,
+        config.ui.theme.tab_active_background,
+        "tab_active_background",
+    )?;
+    apply_color(
+        &mut theme.tab_foreground,
+        config.ui.theme.tab_foreground,
+        "tab_foreground",
+    )?;
+    apply_color(
+        &mut theme.tab_separator,
+        config.ui.theme.tab_separator,
+        "tab_separator",
+    )?;
+    apply_color(
+        &mut theme.copy_feedback_accent,
+        config.ui.theme.copy_feedback_accent,
+        "copy_feedback_accent",
+    )?;
+    apply_color(
+        &mut theme.agent_overlay_chrome,
+        config.ui.theme.agent_overlay_chrome,
+        "agent_overlay_chrome",
+    )?;
+    apply_color(
+        &mut theme.agent_overlay_selected_background,
+        config.ui.theme.agent_overlay_selected_background,
+        "agent_overlay_selected_background",
+    )?;
+    apply_color(
+        &mut theme.agent_overlay_muted,
+        config.ui.theme.agent_overlay_muted,
+        "agent_overlay_muted",
+    )?;
+    apply_color(
+        &mut theme.agent_overlay_warm,
+        config.ui.theme.agent_overlay_warm,
+        "agent_overlay_warm",
+    )?;
+    apply_color(
+        &mut theme.agent_overlay_foreground,
+        config.ui.theme.agent_overlay_foreground,
+        "agent_overlay_foreground",
+    )?;
+    apply_color(
+        &mut theme.agent_overlay_secondary,
+        config.ui.theme.agent_overlay_secondary,
+        "agent_overlay_secondary",
+    )?;
+    apply_color(
+        &mut theme.pane_border_free_focused,
+        config.ui.theme.pane_border_free_focused,
+        "pane_border_free_focused",
+    )?;
+    apply_color(
+        &mut theme.pane_border_unknown_focused,
+        config.ui.theme.pane_border_unknown_focused,
+        "pane_border_unknown_focused",
+    )?;
+    apply_color(
+        &mut theme.pane_border_hovered,
+        config.ui.theme.pane_border_hovered,
+        "pane_border_hovered",
+    )?;
+    apply_color(
+        &mut theme.pane_border_idle,
+        config.ui.theme.pane_border_idle,
+        "pane_border_idle",
+    )?;
+    apply_color(
+        &mut theme.pane_border_remote_control,
+        config.ui.theme.pane_border_remote_control,
+        "pane_border_remote_control",
+    )?;
+    Ok(Config {
+        display_name,
+        ui: UiConfig { theme },
+    })
+}
+
+fn apply_color(
+    color: &mut Color,
+    value: Option<String>,
+    key: &'static str,
+) -> Result<(), ConfigError> {
+    if let Some(value) = value {
+        *color = parse_color(&value).ok_or_else(|| ConfigError::InvalidColor { key, value })?;
+    }
+    Ok(())
+}
+
+fn parse_color(value: &str) -> Option<Color> {
+    match value {
+        "white" => Some(Color::White),
+        "yellow" => Some(Color::Yellow),
+        "gray" => Some(Color::Gray),
+        "dark_gray" => Some(Color::DarkGray),
+        _ => {
+            let hex = value.strip_prefix('#')?;
+            if hex.len() != 6 {
+                return None;
+            }
+            Some(Color::Rgb(
+                u8::from_str_radix(&hex[0..2], 16).ok()?,
+                u8::from_str_radix(&hex[2..4], 16).ok()?,
+                u8::from_str_radix(&hex[4..6], 16).ok()?,
+            ))
+        }
+    }
 }
 
 pub fn save_to(path: &Path, name: &str) -> Result<String, ConfigError> {
     let display_name = validate_display_name(name)?;
-    let config = ConfigFile {
-        display_name: Some(display_name.clone()),
-    };
+    let config = toml::map::Map::from_iter([(
+        "display_name".into(),
+        toml::Value::String(display_name.clone()),
+    )]);
     let text = toml::to_string_pretty(&config).map_err(ConfigError::Serialize)?;
     let parent = path.parent().ok_or(ConfigError::MissingHome)?;
     fs::create_dir_all(parent)?;
@@ -94,6 +341,89 @@ pub fn load() -> Result<Option<String>, ConfigError> {
     load_from(&config_path()?)
 }
 
+pub fn load_config() -> Result<Config, ConfigError> {
+    load_config_from(&config_path()?)
+}
+
 pub fn save(name: &str) -> Result<String, ConfigError> {
     save_to(&config_path()?, name)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        fs,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    use ratatui::style::Color;
+
+    use super::*;
+
+    fn temp_config_path() -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        std::env::temp_dir()
+            .join(format!("p2pmux-config-{unique}"))
+            .join("config.toml")
+    }
+
+    #[test]
+    fn absent_file_uses_defaults() {
+        let path = temp_config_path();
+        assert_eq!(load_config_from(&path).unwrap(), Config::default());
+    }
+
+    #[test]
+    fn partial_theme_override_keeps_other_defaults() {
+        let path = temp_config_path();
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, "[ui.theme]\nfooter_background = \"#010203\"\n").unwrap();
+
+        let config = load_config_from(&path).unwrap();
+        assert_eq!(config.ui.theme.footer_background, Color::Rgb(1, 2, 3));
+        assert_eq!(
+            config.ui.theme.footer_accent,
+            UiTheme::default().footer_accent
+        );
+
+        fs::remove_dir_all(path.parent().unwrap()).unwrap();
+    }
+
+    #[test]
+    fn named_and_hex_colors_parse() {
+        let path = temp_config_path();
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(
+            &path,
+            "[ui.theme]\nfooter_muted = \"white\"\nfooter_accent = \"#aBcDeF\"\n",
+        )
+        .unwrap();
+
+        let config = load_config_from(&path).unwrap();
+        assert_eq!(config.ui.theme.footer_muted, Color::White);
+        assert_eq!(config.ui.theme.footer_accent, Color::Rgb(171, 205, 239));
+
+        fs::remove_dir_all(path.parent().unwrap()).unwrap();
+    }
+
+    #[test]
+    fn invalid_color_names_its_key() {
+        let path = temp_config_path();
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, "[ui.theme]\nfooter_background = \"blue\"\n").unwrap();
+
+        let error = load_config_from(&path).unwrap_err();
+        assert!(error.to_string().contains("footer_background"));
+
+        fs::remove_dir_all(path.parent().unwrap()).unwrap();
+    }
+
+    #[test]
+    fn display_name_validation_still_works() {
+        assert_eq!(validate_display_name("  pelazas  ").unwrap(), "pelazas");
+        assert!(validate_display_name("\n").is_err());
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -40,32 +40,15 @@ impl From<io::Error> for ConfigError {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct Config {
     pub display_name: Option<String>,
     pub ui: UiConfig,
 }
 
-impl Default for Config {
-    fn default() -> Self {
-        Self {
-            display_name: None,
-            ui: UiConfig::default(),
-        }
-    }
-}
-
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct UiConfig {
     pub theme: UiTheme,
-}
-
-impl Default for UiConfig {
-    fn default() -> Self {
-        Self {
-            theme: UiTheme::default(),
-        }
-    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -302,7 +285,7 @@ fn apply_color(
     key: &'static str,
 ) -> Result<(), ConfigError> {
     if let Some(value) = value {
-        *color = parse_color(&value).ok_or_else(|| ConfigError::InvalidColor { key, value })?;
+        *color = parse_color(&value).ok_or(ConfigError::InvalidColor { key, value })?;
     }
     Ok(())
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,10 +1,15 @@
 use std::{
     env, fmt, fs, io,
     path::{Path, PathBuf},
+    sync::atomic::{AtomicUsize, Ordering},
 };
 
 use ratatui::style::Color;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
+
+static CONFIG_WRITE_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+const DEFAULT_CONFIG_TEMPLATE: &str = "# p2pmux local configuration\n#\n# display_name is visible to peers.\n# display_name = \"your-name\"\n\n# UI chrome is local to this client and is never shared with session peers.\n[ui.theme]\n# Named colors: white, yellow, gray, dark_gray\n# Hex colors: #RRGGBB\n#\n# footer_background = \"#1e1e1e\"\n# footer_muted = \"white\"\n# footer_accent = \"#dc322f\"\n# footer_orange = \"#ff7846\"\n# tab_active_background = \"#dc322f\"\n# tab_foreground = \"white\"\n# tab_separator = \"dark_gray\"\n# copy_feedback_accent = \"#ff4500\"\n# agent_overlay_chrome = \"#ff4500\"\n# agent_overlay_selected_background = \"dark_gray\"\n# agent_overlay_muted = \"#919db4\"\n# agent_overlay_warm = \"#ffb84d\"\n# agent_overlay_foreground = \"white\"\n# agent_overlay_secondary = \"gray\"\n# pane_border_free_focused = \"white\"\n# pane_border_unknown_focused = \"yellow\"\n# pane_border_hovered = \"gray\"\n# pane_border_idle = \"dark_gray\"\n# pane_border_remote_control = \"#ff4500\"\n";
 
 #[derive(Debug)]
 pub enum ConfigError {
@@ -13,7 +18,6 @@ pub enum ConfigError {
     InvalidColor { key: &'static str, value: String },
     Io(io::Error),
     Parse(toml::de::Error),
-    Serialize(toml::ser::Error),
 }
 
 impl fmt::Display for ConfigError {
@@ -24,7 +28,6 @@ impl fmt::Display for ConfigError {
             Self::InvalidColor { key, value } => write!(f, "invalid color for {key}: {value}"),
             Self::Io(error) => error.fmt(f),
             Self::Parse(error) => error.fmt(f),
-            Self::Serialize(error) => error.fmt(f),
         }
     }
 }
@@ -326,15 +329,34 @@ fn parse_color(value: &str) -> Option<Color> {
 
 pub fn save_to(path: &Path, name: &str) -> Result<String, ConfigError> {
     let display_name = validate_display_name(name)?;
-    let config = toml::map::Map::from_iter([(
-        "display_name".into(),
-        toml::Value::String(display_name.clone()),
-    )]);
-    let text = toml::to_string_pretty(&config).map_err(ConfigError::Serialize)?;
+    let mut document = match fs::read_to_string(path) {
+        Ok(text) => text
+            .parse::<toml_edit::DocumentMut>()
+            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => toml_edit::DocumentMut::new(),
+        Err(error) => return Err(error.into()),
+    };
+    document["display_name"] = toml_edit::value(display_name.as_str());
+    atomic_write(path, &document.to_string())?;
+    Ok(display_name)
+}
+
+fn atomic_write(path: &Path, text: &str) -> Result<(), ConfigError> {
     let parent = path.parent().ok_or(ConfigError::MissingHome)?;
     fs::create_dir_all(parent)?;
-    fs::write(path, text)?;
-    Ok(display_name)
+    let file_name = path.file_name().ok_or(ConfigError::MissingHome)?;
+    let temporary = parent.join(format!(
+        ".{}.{}.{}",
+        file_name.to_string_lossy(),
+        std::process::id(),
+        CONFIG_WRITE_COUNTER.fetch_add(1, Ordering::Relaxed),
+    ));
+    fs::write(&temporary, text)?;
+    if let Err(error) = fs::rename(&temporary, path) {
+        let _ = fs::remove_file(&temporary);
+        return Err(error.into());
+    }
+    Ok(())
 }
 
 pub fn load() -> Result<Option<String>, ConfigError> {
@@ -347,6 +369,21 @@ pub fn load_config() -> Result<Config, ConfigError> {
 
 pub fn save(name: &str) -> Result<String, ConfigError> {
     save_to(&config_path()?, name)
+}
+
+pub fn init() -> Result<(), ConfigError> {
+    init_to(&config_path()?)
+}
+
+pub fn init_to(path: &Path) -> Result<(), ConfigError> {
+    if path.exists() {
+        return Err(io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            format!("config file already exists: {}", path.display()),
+        )
+        .into());
+    }
+    atomic_write(path, DEFAULT_CONFIG_TEMPLATE)
 }
 
 #[cfg(test)]
@@ -425,5 +462,44 @@ mod tests {
     fn display_name_validation_still_works() {
         assert_eq!(validate_display_name("  pelazas  ").unwrap(), "pelazas");
         assert!(validate_display_name("\n").is_err());
+    }
+
+    #[test]
+    fn save_name_preserves_theme_and_comments() {
+        let path = temp_config_path();
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(
+            &path,
+            "# keep this comment\n[ui.theme]\nfooter_background = \"#010203\"\nunknown = \"value\"\n",
+        )
+        .unwrap();
+
+        save_to(&path, "pelazas").unwrap();
+        let text = fs::read_to_string(&path).unwrap();
+        assert!(text.contains("# keep this comment"));
+        assert!(text.contains("[ui.theme]"));
+        assert!(text.contains("footer_background = \"#010203\""));
+        assert!(text.contains("unknown = \"value\""));
+
+        fs::remove_dir_all(path.parent().unwrap()).unwrap();
+    }
+
+    #[test]
+    fn init_creates_default_template_only_when_missing() {
+        let path = temp_config_path();
+
+        init_to(&path).unwrap();
+        assert_eq!(load_config_from(&path).unwrap(), Config::default());
+        let text = fs::read_to_string(&path).unwrap();
+        assert!(text.contains("# footer_background"));
+
+        let error = init_to(&path).unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            format!("config file already exists: {}", path.display())
+        );
+        assert_eq!(fs::read_to_string(&path).unwrap(), text);
+
+        fs::remove_dir_all(path.parent().unwrap()).unwrap();
     }
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -2349,7 +2349,7 @@ fn render_shared_multi_pane(
         render_agents_overlay(frame, tui, unix_ms_now());
     }
     if let ModalState::Rename(prompt) = &tui.modal {
-        render_rename_prompt(frame, prompt);
+        render_rename_prompt(frame, prompt, &tui.theme);
     }
 }
 
@@ -2419,7 +2419,7 @@ fn agents_overlay_inner(area: Rect) -> Rect {
     Block::bordered().inner(agents_overlay_panel(area))
 }
 
-fn render_rename_prompt(frame: &mut Frame<'_>, prompt: &RenamePrompt) {
+fn render_rename_prompt(frame: &mut Frame<'_>, prompt: &RenamePrompt, theme: &UiTheme) {
     let area = frame.area();
     let width = area.width.saturating_sub(8).clamp(28, 64).min(area.width);
     let height = 7_u16.min(area.height);
@@ -2441,7 +2441,7 @@ fn render_rename_prompt(frame: &mut Frame<'_>, prompt: &RenamePrompt) {
                 title,
                 Style::default().add_modifier(Modifier::BOLD),
             ))
-            .border_style(Style::default().fg(FOOTER_ACCENT)),
+            .border_style(Style::default().fg(theme.footer_accent)),
         panel,
     );
     let inner = Block::bordered().inner(panel);
@@ -2454,7 +2454,7 @@ fn render_rename_prompt(frame: &mut Frame<'_>, prompt: &RenamePrompt) {
     }
     lines.push(Line::styled(
         "Enter save · Esc cancel",
-        Style::default().fg(FOOTER_MUTED),
+        Style::default().fg(theme.footer_muted),
     ));
     frame.render_widget(Paragraph::new(lines), inner);
 }
@@ -7399,6 +7399,7 @@ mod tests {
                 vec![Tab {
                     tab_id: 1,
                     root: Node::Leaf { pane_id: 1 },
+                    title: None,
                 }],
                 &[(1, 2, 2)],
             ),

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -2106,6 +2106,7 @@ fn mid_footer_flash_width(copied_lines: Option<usize>, footer_notice: Option<&st
     0
 }
 
+#[allow(clippy::too_many_arguments)]
 fn render_contextual_footer(
     buffer: &mut Buffer,
     theme: &UiTheme,
@@ -6599,8 +6600,10 @@ mod tests {
             Color::Rgb(255, 69, 0)
         );
 
-        let mut themed = UiTheme::default();
-        themed.pane_border_remote_control = Color::Rgb(1, 2, 3);
+        let themed = UiTheme {
+            pane_border_remote_control: Color::Rgb(1, 2, 3),
+            ..Default::default()
+        };
         assert_eq!(
             pane_border_color(&themed, Some(b"guest"), false, false, false),
             Color::Rgb(1, 2, 3)
@@ -7386,9 +7389,11 @@ mod tests {
 
     #[test]
     fn themed_tui_overrides_footer_chrome() {
-        let mut theme = UiTheme::default();
-        theme.footer_background = Color::Rgb(1, 2, 3);
-        theme.footer_orange = Color::Rgb(4, 5, 6);
+        let theme = UiTheme {
+            footer_background: Color::Rgb(1, 2, 3),
+            footer_orange: Color::Rgb(4, 5, 6),
+            ..Default::default()
+        };
         let tui = MultiPaneTui::with_theme(
             layout(
                 vec![Tab {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -49,6 +49,7 @@ use crate::{
         PaneAgentTracker, ProcessSnapshot, SysinfoSampler, classify_pane_tree,
         sample_global_snapshot,
     },
+    config::UiTheme,
     kitty_keyboard::KittyKeyboardTracker,
     layout::{
         Axis, LayoutError, LayoutSnapshot, NewPanePosition, Node, PaneId, TabId, normalize_title,
@@ -77,10 +78,6 @@ pub(crate) type NodeLeaseSnapshots = BTreeMap<PaneId, (bool, Option<Vec<u8>>, bo
 /// Kept as the module's public marker from the scaffold.
 pub struct Tui;
 
-const FOOTER_BACKGROUND: Color = Color::Rgb(30, 30, 30);
-const FOOTER_MUTED: Color = Color::White;
-const FOOTER_ACCENT: Color = Color::Rgb(220, 50, 47);
-const FOOTER_ORANGE: Color = Color::Rgb(255, 120, 70);
 const TOP_BAR_BRAND: &str = "p2pmux";
 const TOP_BAR_BRAND_SEPARATOR: &str = " │ ";
 const TAB_BAR_SEPARATOR: &str = " · ";
@@ -98,10 +95,6 @@ const AGENT_SAMPLE_INTERVAL: Duration = Duration::from_secs(1);
 const AGENT_TOGGLE_WINDOW: Duration = Duration::from_millis(400);
 pub(crate) const AGENT_OVERLAY_ANIMATION_INTERVAL: Duration = Duration::from_millis(100);
 const AGENT_OVERLAY_CARD_LINES: usize = 3;
-const AGENT_OVERLAY_CHROME: Color = Color::Rgb(255, 69, 0);
-const AGENT_OVERLAY_SELECTED_BACKGROUND: Color = Color::DarkGray;
-const AGENT_OVERLAY_MUTED: Color = Color::Rgb(145, 157, 180);
-const AGENT_OVERLAY_WARM: Color = Color::Rgb(255, 184, 77);
 
 enum FooterSegment {
     Text(&'static str),
@@ -351,6 +344,7 @@ impl PaneTextSelection {
 #[derive(Clone, Debug)]
 pub struct MultiPaneTui {
     title: String,
+    theme: UiTheme,
     snapshot: LayoutSnapshot,
     current_tab: TabId,
     focused_pane: PaneId,
@@ -374,6 +368,10 @@ pub struct MultiPaneTui {
 
 impl MultiPaneTui {
     pub fn new(snapshot: LayoutSnapshot) -> Result<Self, LayoutError> {
+        Self::with_theme(snapshot, UiTheme::default())
+    }
+
+    pub fn with_theme(snapshot: LayoutSnapshot, theme: UiTheme) -> Result<Self, LayoutError> {
         crate::layout::SessionState::validate_snapshot(&snapshot)?;
         let current_tab = snapshot.tabs[0].tab_id;
         let focused_pane = first_leaf(&snapshot.tabs[0].root).expect("validated layout has a leaf");
@@ -384,6 +382,7 @@ impl MultiPaneTui {
             .collect();
         Ok(Self {
             title: TOP_BAR_BRAND.into(),
+            theme,
             snapshot,
             current_tab,
             focused_pane,
@@ -1627,17 +1626,18 @@ fn pane_title(
 }
 
 fn pane_border_color(
+    theme: &UiTheme,
     controller_peer_id: Option<&[u8]>,
     _controller_active: bool,
     focused: bool,
     hovered: bool,
 ) -> Color {
     match controller_peer_id {
-        Some([]) if focused => Color::White,
-        None if focused => Color::Yellow,
-        Some([]) | None if hovered => Color::Gray,
-        Some([]) | None => Color::DarkGray,
-        Some(_) => Color::Rgb(255, 69, 0),
+        Some([]) if focused => theme.pane_border_free_focused,
+        None if focused => theme.pane_border_unknown_focused,
+        Some([]) | None if hovered => theme.pane_border_hovered,
+        Some([]) | None => theme.pane_border_idle,
+        Some(_) => theme.pane_border_remote_control,
     }
 }
 
@@ -1992,6 +1992,7 @@ fn contextual_footer(chord_mode: ChordMode) -> (&'static str, &'static [FooterSe
 
 fn render_footer_segments(
     buffer: &mut Buffer,
+    theme: &UiTheme,
     mut x: u16,
     y: u16,
     end_x: u16,
@@ -2001,20 +2002,22 @@ fn render_footer_segments(
         let (text, style) = match segment {
             FooterSegment::Text(text) => (
                 *text,
-                Style::default().fg(FOOTER_MUTED).bg(FOOTER_BACKGROUND),
+                Style::default()
+                    .fg(theme.footer_muted)
+                    .bg(theme.footer_background),
             ),
             FooterSegment::Key(text) => (
                 *text,
                 Style::default()
-                    .fg(FOOTER_ACCENT)
-                    .bg(FOOTER_BACKGROUND)
+                    .fg(theme.footer_accent)
+                    .bg(theme.footer_background)
                     .add_modifier(Modifier::BOLD),
             ),
             FooterSegment::OrangeKey(text) => (
                 *text,
                 Style::default()
-                    .fg(FOOTER_ORANGE)
-                    .bg(FOOTER_BACKGROUND)
+                    .fg(theme.footer_orange)
+                    .bg(theme.footer_background)
                     .add_modifier(Modifier::BOLD),
             ),
         };
@@ -2025,14 +2028,23 @@ fn render_footer_segments(
     x
 }
 
-fn render_copy_feedback(buffer: &mut Buffer, mut x: u16, y: u16, end_x: u16, lines: usize) {
+fn render_copy_feedback(
+    buffer: &mut Buffer,
+    theme: &UiTheme,
+    mut x: u16,
+    y: u16,
+    end_x: u16,
+    lines: usize,
+) {
     x = buffer
         .set_stringn(
             x,
             y,
             "  copied ",
             usize::from(end_x.saturating_sub(x)),
-            Style::default().fg(FOOTER_MUTED).bg(FOOTER_BACKGROUND),
+            Style::default()
+                .fg(theme.footer_muted)
+                .bg(theme.footer_background),
         )
         .0;
     buffer.set_stringn(
@@ -2041,20 +2053,27 @@ fn render_copy_feedback(buffer: &mut Buffer, mut x: u16, y: u16, end_x: u16, lin
         format!("{lines} line{}", if lines == 1 { "" } else { "s" }),
         usize::from(end_x.saturating_sub(x)),
         Style::default()
-            .fg(Color::Rgb(255, 69, 0))
-            .bg(FOOTER_BACKGROUND),
+            .fg(theme.copy_feedback_accent)
+            .bg(theme.footer_background),
     );
 }
 
-fn render_footer_notice(buffer: &mut Buffer, x: u16, y: u16, end_x: u16, notice: &str) {
+fn render_footer_notice(
+    buffer: &mut Buffer,
+    theme: &UiTheme,
+    x: u16,
+    y: u16,
+    end_x: u16,
+    notice: &str,
+) {
     buffer.set_stringn(
         x,
         y,
         format!("  {notice}"),
         usize::from(end_x.saturating_sub(x)),
         Style::default()
-            .fg(FOOTER_ORANGE)
-            .bg(FOOTER_BACKGROUND)
+            .fg(theme.footer_orange)
+            .bg(theme.footer_background)
             .add_modifier(Modifier::BOLD),
     );
 }
@@ -2089,6 +2108,7 @@ fn mid_footer_flash_width(copied_lines: Option<usize>, footer_notice: Option<&st
 
 fn render_contextual_footer(
     buffer: &mut Buffer,
+    theme: &UiTheme,
     area: Rect,
     status: &str,
     copied_lines: Option<usize>,
@@ -2101,7 +2121,7 @@ fn render_contextual_footer(
         area.y,
         " ".repeat(usize::from(area.width)),
         usize::from(area.width),
-        Style::default().bg(FOOTER_BACKGROUND),
+        Style::default().bg(theme.footer_background),
     );
 
     let end_x = area.right();
@@ -2113,7 +2133,9 @@ fn render_contextual_footer(
                 area.y,
                 format!("{status}  "),
                 usize::from(end_x.saturating_sub(x)),
-                Style::default().fg(FOOTER_MUTED).bg(FOOTER_BACKGROUND),
+                Style::default()
+                    .fg(theme.footer_muted)
+                    .bg(theme.footer_background),
             )
             .0;
     }
@@ -2138,15 +2160,15 @@ fn render_contextual_footer(
     };
     let help_end = join_x.saturating_sub(flash_width);
     let (_, segments) = contextual_footer(chord_mode);
-    let x = render_footer_segments(buffer, x, area.y, help_end, segments);
+    let x = render_footer_segments(buffer, theme, x, area.y, help_end, segments);
     // Mid-bar flash messages sit after chord help and before the join code.
     if let Some(notice) = footer_notice {
-        render_footer_notice(buffer, x, area.y, join_x, notice);
+        render_footer_notice(buffer, theme, x, area.y, join_x, notice);
     } else if status.is_empty()
         && chord_mode == ChordMode::None
         && let Some(lines) = copied_lines
     {
-        render_copy_feedback(buffer, x, area.y, join_x, lines);
+        render_copy_feedback(buffer, theme, x, area.y, join_x, lines);
     }
     if let Some(text) = join_text {
         buffer.set_stringn(
@@ -2154,7 +2176,9 @@ fn render_contextual_footer(
             area.y,
             text,
             usize::from(end_x.saturating_sub(join_x)),
-            Style::default().fg(FOOTER_MUTED).bg(FOOTER_BACKGROUND),
+            Style::default()
+                .fg(theme.footer_muted)
+                .bg(theme.footer_background),
         );
     }
 }
@@ -2168,6 +2192,7 @@ fn render_shared_multi_pane(
     footer_notice: Option<&str>,
     join_code: Option<&str>,
 ) {
+    let theme = &tui.theme;
     let geometry = tui.geometry(frame.area());
     if geometry.tab_bar.width > 0 && geometry.tab_bar.height > 0 {
         let buffer = frame.buffer_mut();
@@ -2176,7 +2201,7 @@ fn render_shared_multi_pane(
             geometry.tab_bar.y,
             " ".repeat(usize::from(geometry.tab_bar.width)),
             usize::from(geometry.tab_bar.width),
-            Style::default().bg(FOOTER_BACKGROUND),
+            Style::default().bg(theme.footer_background),
         );
         let mut x = buffer
             .set_stringn(
@@ -2184,7 +2209,9 @@ fn render_shared_multi_pane(
                 geometry.tab_bar.y,
                 tui.title(),
                 usize::from(geometry.tab_bar.width),
-                Style::default().fg(Color::White).bg(FOOTER_BACKGROUND),
+                Style::default()
+                    .fg(theme.tab_foreground)
+                    .bg(theme.footer_background),
             )
             .0;
         x = buffer
@@ -2193,7 +2220,9 @@ fn render_shared_multi_pane(
                 geometry.tab_bar.y,
                 TOP_BAR_BRAND_SEPARATOR,
                 usize::from(geometry.tab_bar.right().saturating_sub(x)),
-                Style::default().fg(Color::DarkGray).bg(FOOTER_BACKGROUND),
+                Style::default()
+                    .fg(theme.tab_separator)
+                    .bg(theme.footer_background),
             )
             .0;
         for (index, tab) in tui.snapshot.tabs.iter().enumerate() {
@@ -2204,18 +2233,22 @@ fn render_shared_multi_pane(
                         geometry.tab_bar.y,
                         TAB_BAR_SEPARATOR,
                         usize::from(geometry.tab_bar.right().saturating_sub(x)),
-                        Style::default().fg(Color::DarkGray).bg(FOOTER_BACKGROUND),
+                        Style::default()
+                            .fg(theme.tab_separator)
+                            .bg(theme.footer_background),
                     )
                     .0;
             }
             let active = tab.tab_id == tui.current_tab;
             let style = if active {
                 Style::default()
-                    .fg(Color::White)
-                    .bg(Color::Rgb(220, 50, 47))
+                    .fg(theme.tab_foreground)
+                    .bg(theme.tab_active_background)
                     .add_modifier(Modifier::BOLD)
             } else {
-                Style::default().fg(Color::White).bg(FOOTER_BACKGROUND)
+                Style::default()
+                    .fg(theme.tab_foreground)
+                    .bg(theme.footer_background)
             };
             let label = truncate_trailing(
                 &tab_label(tab.title.as_deref(), index + 1, active),
@@ -2238,6 +2271,7 @@ fn render_shared_multi_pane(
     if geometry.footer.width > 0 && geometry.footer.height > 0 {
         render_contextual_footer(
             frame.buffer_mut(),
+            theme,
             geometry.footer,
             status,
             copied_lines,
@@ -2269,6 +2303,7 @@ fn render_shared_multi_pane(
         title.spans.insert(0, Span::raw(" "));
         title.spans.push(Span::raw(" "));
         let border_color = pane_border_color(
+            theme,
             view.controller_peer_id.as_deref(),
             view.controller_active,
             focused,
@@ -2325,17 +2360,17 @@ fn render_agents_overlay(frame: &mut Frame<'_>, tui: &MultiPaneTui, now_unix_ms:
         .title(Line::styled(
             " Agents ",
             Style::default()
-                .fg(AGENT_OVERLAY_CHROME)
+                .fg(tui.theme.agent_overlay_chrome)
                 .add_modifier(Modifier::BOLD),
         ))
-        .border_style(Style::default().fg(AGENT_OVERLAY_CHROME));
+        .border_style(Style::default().fg(tui.theme.agent_overlay_chrome));
     let inner = agents_overlay_inner(area);
     frame.render_widget(block, panel);
     if tui.agent_rows.is_empty() {
         frame.render_widget(
             Paragraph::new(Line::styled(
                 "No agents running",
-                Style::default().fg(AGENT_OVERLAY_MUTED),
+                Style::default().fg(tui.theme.agent_overlay_muted),
             )),
             inner,
         );
@@ -2350,6 +2385,7 @@ fn render_agents_overlay(frame: &mut Frame<'_>, tui: &MultiPaneTui, now_unix_ms:
             inner.width,
             now_unix_ms,
             animation_phase,
+            &tui.theme,
         ));
         if index + 1 < tui.agent_rows.len() {
             lines.push(Line::raw(""));
@@ -2428,6 +2464,7 @@ fn format_agent_overlay_card(
     width: u16,
     now_unix_ms: u64,
     animation_phase: usize,
+    theme: &UiTheme,
 ) -> [Line<'static>; 2] {
     let marker = if selected { "›" } else { " " };
     let kind = overlay_kind_label(&row.kind);
@@ -2437,22 +2474,22 @@ fn format_agent_overlay_card(
         usize::from(width.saturating_sub(text_width(&first_prefix))),
     );
     let card_style = if selected {
-        Style::default().bg(AGENT_OVERLAY_SELECTED_BACKGROUND)
+        Style::default().bg(theme.agent_overlay_selected_background)
     } else {
         Style::default()
     };
     let first_line = agent_overlay_line(
         vec![
-            Span::styled(marker, Style::default().fg(AGENT_OVERLAY_CHROME)),
+            Span::styled(marker, Style::default().fg(theme.agent_overlay_chrome)),
             Span::raw(" "),
             Span::styled(
                 kind,
                 Style::default()
-                    .fg(Color::White)
+                    .fg(theme.agent_overlay_foreground)
                     .add_modifier(Modifier::BOLD),
             ),
-            Span::styled(" · ", Style::default().fg(AGENT_OVERLAY_MUTED)),
-            Span::styled(cwd, Style::default().fg(Color::Gray)),
+            Span::styled(" · ", Style::default().fg(theme.agent_overlay_muted)),
+            Span::styled(cwd, Style::default().fg(theme.agent_overlay_secondary)),
         ],
         card_style,
         selected,
@@ -2490,18 +2527,18 @@ fn format_agent_overlay_card(
         Span::styled(
             glyph,
             Style::default().fg(if row.state == AgentRosterState::Working {
-                AGENT_OVERLAY_CHROME
+                theme.agent_overlay_chrome
             } else {
-                AGENT_OVERLAY_MUTED
+                theme.agent_overlay_muted
             }),
         ),
         Span::raw(" "),
         Span::styled(
             state,
             Style::default().fg(if row.state == AgentRosterState::Working {
-                Color::White
+                theme.agent_overlay_foreground
             } else {
-                AGENT_OVERLAY_MUTED
+                theme.agent_overlay_muted
             }),
         ),
     ];
@@ -2509,19 +2546,22 @@ fn format_agent_overlay_card(
         second_spans.push(Span::raw(" "));
         second_spans.push(Span::styled(
             elapsed,
-            Style::default().fg(AGENT_OVERLAY_WARM),
+            Style::default().fg(theme.agent_overlay_warm),
         ));
     }
     second_spans.push(Span::styled(
         location,
-        Style::default().fg(AGENT_OVERLAY_MUTED),
+        Style::default().fg(theme.agent_overlay_muted),
     ));
     if let Some(controller) = controller {
         second_spans.push(Span::styled(
             controller_prefix,
-            Style::default().fg(AGENT_OVERLAY_MUTED),
+            Style::default().fg(theme.agent_overlay_muted),
         ));
-        second_spans.push(Span::styled(controller, Style::default().fg(Color::Gray)));
+        second_spans.push(Span::styled(
+            controller,
+            Style::default().fg(theme.agent_overlay_secondary),
+        ));
     }
     [
         first_line,
@@ -5206,6 +5246,7 @@ mod tests {
         style::{Color, Modifier},
     };
 
+    use crate::config::UiTheme;
     use crate::layout::{Axis, LayoutSnapshot, NewPanePosition, Node, Pane, Tab};
     use crate::lease::{IDLE_AFTER, LeaseManager, LeaseState};
     use crate::screen::{GuestScreen, HostScreen};
@@ -5217,15 +5258,14 @@ mod tests {
     use iroh::{Endpoint, RelayMode, endpoint::presets};
 
     use super::{
-        AGENT_TOGGLE_WINDOW, CHORD_IDLE_TIMEOUT, ChordMode, ESC_PREFIX_WINDOW, FOOTER_ACCENT,
-        FOOTER_BACKGROUND, FOOTER_MUTED, FOOTER_ORANGE, FooterSegment, HostControlEvent,
-        HostPaneChannels, HostPaneRuntime, KeyHandling, LayoutControlEvent, MultiPaneTui,
-        PaneTextSelection, PaneViewState, PendingEscape, RemoteSubscriptionState, ScreenCell,
-        SharedLayoutRuntime, SharedLocalPane, UiIntent, VtScreen, allocate_node_with_preview,
-        area_from_terminal_size, contextual_footer, copied_line_count, encode_key, encode_paste,
-        grid_for_pane, initial_root_pane_grid, is_chord_command, lease_allows_held_input,
-        member_label, mouse_to_screen_cell, pane_border_color, pane_title, pane_wire_id,
-        reconcile_remote_control_attempt, render_guest_screen, render_multi_pane,
+        AGENT_TOGGLE_WINDOW, CHORD_IDLE_TIMEOUT, ChordMode, ESC_PREFIX_WINDOW, FooterSegment,
+        HostControlEvent, HostPaneChannels, HostPaneRuntime, KeyHandling, LayoutControlEvent,
+        MultiPaneTui, PaneTextSelection, PaneViewState, PendingEscape, RemoteSubscriptionState,
+        ScreenCell, SharedLayoutRuntime, SharedLocalPane, UiIntent, VtScreen,
+        allocate_node_with_preview, area_from_terminal_size, contextual_footer, copied_line_count,
+        encode_key, encode_paste, grid_for_pane, initial_root_pane_grid, is_chord_command,
+        lease_allows_held_input, member_label, mouse_to_screen_cell, pane_border_color, pane_title,
+        pane_wire_id, reconcile_remote_control_attempt, render_guest_screen, render_multi_pane,
         render_shared_multi_pane, selection_text, text_width, viewed_screen, visible_leaf_panes,
     };
 
@@ -5381,7 +5421,14 @@ mod tests {
     fn agents_overlay_cards_show_state_elapsed_and_location() {
         let row = agent_row(2, 2, 1);
 
-        let rendered = super::format_agent_overlay_card(&row, true, 120, 1_725_000_084_123, 0);
+        let rendered = super::format_agent_overlay_card(
+            &row,
+            true,
+            120,
+            1_725_000_084_123,
+            0,
+            &UiTheme::default(),
+        );
 
         assert!(rendered[0].to_string().starts_with("› Codex · "));
         assert!(
@@ -5399,16 +5446,37 @@ mod tests {
     fn agents_overlay_cards_distinguish_idle_done_and_future_work() {
         let mut row = agent_row(2, 2, 1);
         row.state = crate::protocol::AgentRosterState::Idle;
-        let idle = super::format_agent_overlay_card(&row, false, 120, 1_725_000_000_123, 0);
+        let idle = super::format_agent_overlay_card(
+            &row,
+            false,
+            120,
+            1_725_000_000_123,
+            0,
+            &UiTheme::default(),
+        );
         assert!(idle[1].to_string().starts_with("○ idle"));
 
         row.state = crate::protocol::AgentRosterState::Done;
-        let done = super::format_agent_overlay_card(&row, false, 120, 1_725_000_000_123, 0);
+        let done = super::format_agent_overlay_card(
+            &row,
+            false,
+            120,
+            1_725_000_000_123,
+            0,
+            &UiTheme::default(),
+        );
         assert!(done[1].to_string().starts_with("✓ done"));
 
         row.state = crate::protocol::AgentRosterState::Working;
         row.working_since_unix_ms = 1_725_000_001_123;
-        let future = super::format_agent_overlay_card(&row, false, 120, 1_725_000_000_123, 0);
+        let future = super::format_agent_overlay_card(
+            &row,
+            false,
+            120,
+            1_725_000_000_123,
+            0,
+            &UiTheme::default(),
+        );
         assert!(future[1].to_string().starts_with("◐ working 0s"));
     }
 
@@ -5460,9 +5528,16 @@ mod tests {
             vec![(8, 1, 1), (6, 1, 2), (3, 2, 1)]
         );
         assert!(
-            super::format_agent_overlay_card(&tui.agent_rows[2], false, 120, 0, 0)[1]
-                .to_string()
-                .contains("Tab #2 · Pane #1")
+            super::format_agent_overlay_card(
+                &tui.agent_rows[2],
+                false,
+                120,
+                0,
+                0,
+                &UiTheme::default(),
+            )[1]
+            .to_string()
+            .contains("Tab #2 · Pane #1")
         );
     }
 
@@ -5894,7 +5969,7 @@ mod tests {
         assert!(notice < join, "notice sits before join code");
         assert_eq!(
             terminal.backend().buffer()[(notice as u16, 4)].fg,
-            FOOTER_ORANGE
+            UiTheme::default().footer_orange
         );
         assert!(
             !footer.trim_start().starts_with("layout request"),
@@ -6490,31 +6565,45 @@ mod tests {
 
     #[test]
     fn free_panes_use_a_mid_gray_border_when_hovered_unfocused() {
+        let theme = UiTheme::default();
         assert_eq!(
-            pane_border_color(Some(b""), false, true, false),
+            pane_border_color(&theme, Some(b""), false, true, false),
             Color::White
         );
         assert_eq!(
-            pane_border_color(Some(b""), false, false, true),
+            pane_border_color(&theme, Some(b""), false, false, true),
             Color::Gray
         );
         assert_eq!(
-            pane_border_color(Some(b""), false, false, false),
-            Color::DarkGray
-        );
-        assert_eq!(pane_border_color(None, false, true, false), Color::Yellow);
-        assert_eq!(pane_border_color(None, false, false, true), Color::Gray);
-        assert_eq!(
-            pane_border_color(None, false, false, false),
+            pane_border_color(&theme, Some(b""), false, false, false),
             Color::DarkGray
         );
         assert_eq!(
-            pane_border_color(Some(b"guest"), true, true, true),
+            pane_border_color(&theme, None, false, true, false),
+            Color::Yellow
+        );
+        assert_eq!(
+            pane_border_color(&theme, None, false, false, true),
+            Color::Gray
+        );
+        assert_eq!(
+            pane_border_color(&theme, None, false, false, false),
+            Color::DarkGray
+        );
+        assert_eq!(
+            pane_border_color(&theme, Some(b"guest"), true, true, true),
             Color::Rgb(255, 69, 0)
         );
         assert_eq!(
-            pane_border_color(Some(b"guest"), false, false, true),
+            pane_border_color(&theme, Some(b"guest"), false, false, true),
             Color::Rgb(255, 69, 0)
+        );
+
+        let mut themed = UiTheme::default();
+        themed.pane_border_remote_control = Color::Rgb(1, 2, 3);
+        assert_eq!(
+            pane_border_color(&themed, Some(b"guest"), false, false, false),
+            Color::Rgb(1, 2, 3)
         );
     }
 
@@ -7247,6 +7336,7 @@ mod tests {
 
     #[test]
     fn shared_footer_accents_key_glyphs_on_a_dark_background() {
+        let theme = UiTheme::default();
         let mut tui = MultiPaneTui::new(layout(
             vec![Tab {
                 tab_id: 1,
@@ -7270,10 +7360,14 @@ mod tests {
             let mut x = 0;
             for segment in segments {
                 let (text, fg, bg, bold) = match segment {
-                    FooterSegment::Text(text) => (*text, FOOTER_MUTED, FOOTER_BACKGROUND, false),
-                    FooterSegment::Key(text) => (*text, FOOTER_ACCENT, FOOTER_BACKGROUND, true),
+                    FooterSegment::Text(text) => {
+                        (*text, theme.footer_muted, theme.footer_background, false)
+                    }
+                    FooterSegment::Key(text) => {
+                        (*text, theme.footer_accent, theme.footer_background, true)
+                    }
                     FooterSegment::OrangeKey(text) => {
-                        (*text, FOOTER_ORANGE, FOOTER_BACKGROUND, true)
+                        (*text, theme.footer_orange, theme.footer_background, true)
                     }
                 };
                 for key in text.chars() {
@@ -7288,6 +7382,32 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn themed_tui_overrides_footer_chrome() {
+        let mut theme = UiTheme::default();
+        theme.footer_background = Color::Rgb(1, 2, 3);
+        theme.footer_orange = Color::Rgb(4, 5, 6);
+        let tui = MultiPaneTui::with_theme(
+            layout(
+                vec![Tab {
+                    tab_id: 1,
+                    root: Node::Leaf { pane_id: 1 },
+                }],
+                &[(1, 2, 2)],
+            ),
+            theme,
+        )
+        .expect("valid layout");
+        let mut terminal = Terminal::new(TestBackend::new(120, 4)).expect("test terminal");
+
+        terminal
+            .draw(|frame| render_multi_pane(frame, &tui, &BTreeMap::new()))
+            .expect("render");
+        let footer = terminal.backend().buffer();
+        assert_eq!(footer[(0, 3)].bg, theme.footer_background);
+        assert_eq!(footer[(0, 3)].fg, theme.footer_orange);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Make p2pmux chrome colors (footer, tabs, pane borders, agent overlay, copy feedback) configurable via `~/.config/p2pmux/config.toml` `[ui.theme]`, with defaults identical to today’s hardcoded UI.
- Add `p2pmux config init` (non-destructive commented template) and make `config set name` preserve existing sections/comments via `toml_edit`.
- Theme is client-local only (loaded on attach); not synced over P2P. No layout blueprints or notifications in this PR.

## Test plan
- [x] `cargo test` green on `feat/ui-theme-config` (after rebase onto main)
- [ ] `p2pmux config init` creates `~/.config/p2pmux/config.toml` when missing; refuses overwrite when present
- [ ] Absent/partial theme → same look as before; override one color (e.g. `pane_border_free_focused`) and confirm only that chrome changes
- [ ] `p2pmux config set name …` does not wipe `[ui.theme]`
- [ ] Invalid color fails before entering the TUI with path + key name


Made with [Cursor](https://cursor.com)