### PR TITLE
fix: snappier attach focus and instant Agents overlay

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -708,9 +708,10 @@ mod tests {
         let mut animation = Instant::now();
 
         assert_eq!(tui.handle_key(ctrl_a, area), KeyHandling::Consumed(vec![]));
-        assert!(refresh_tui_timers(
+        assert!(tui.overlay_open());
+        assert!(!refresh_tui_timers(
             tui,
-            Instant::now() + Duration::from_millis(400),
+            Instant::now() + Duration::from_secs(1),
             &mut animation,
         ));
         assert!(tui.overlay_open());

--- a/src/client.rs
+++ b/src/client.rs
@@ -74,6 +74,7 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
     let mut attach_error = None;
     let mut detach_sent = false;
     let mut last_agent_overlay_animation = Instant::now();
+    let mut pending_focus = None;
 
     'attached: loop {
         loop {
@@ -101,6 +102,7 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
                             rosters,
                             tab_id,
                             pane_id,
+                            &mut pending_focus,
                         )?;
                         if let Some(tui) = tui.as_mut() {
                             tui.set_agent_overlay_viewport(terminal.size()?.into());
@@ -156,7 +158,7 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
                         break;
                     }
                     KeyHandling::Consumed(intents) => {
-                        send_intents(&mut stream, tui, intents)?;
+                        send_intents(&mut stream, tui, intents, &mut pending_focus)?;
                         dirty = true;
                     }
                     KeyHandling::Forward => {
@@ -190,7 +192,7 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
                         );
                     } else if matches!(mouse.kind, MouseEventKind::Down(_)) {
                         let intents = tui.handle_mouse(mouse, area);
-                        send_intents(&mut stream, tui, intents)?;
+                        send_intents(&mut stream, tui, intents, &mut pending_focus)?;
                     }
                 } else if matches!(
                     mouse.kind,
@@ -211,7 +213,7 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
                     );
                 } else {
                     let intents = tui.handle_mouse(mouse, area);
-                    send_intents(&mut stream, tui, intents)?;
+                    send_intents(&mut stream, tui, intents, &mut pending_focus)?;
                 }
                 dirty = true;
             }
@@ -275,6 +277,7 @@ fn apply_snapshot(
     rosters: Vec<crate::local_ipc::AgentOverlaySnapshotRow>,
     tab_id: u64,
     pane_id: u64,
+    pending_focus: &mut Option<(u64, u64)>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let view = match tui {
         Some(view) => {
@@ -288,8 +291,6 @@ fn apply_snapshot(
             })?),
     };
     view.set_title(format!("p2pmux ({room_name})"));
-    view.set_focus(tab_id, pane_id)
-        .map_err(|error| io::Error::other(format!("invalid node focus: {error:?}")))?;
     screens.retain(|pane_id, _| view.snapshot().panes.contains_key(pane_id));
     for frame in next_screens {
         let screen = screens.entry(frame.pane_id).or_default();
@@ -326,24 +327,47 @@ fn apply_snapshot(
             })
             .collect(),
     );
+    reconcile_snapshot_focus(view, pending_focus, tab_id, pane_id)?;
     Ok(())
+}
+
+fn reconcile_snapshot_focus(
+    view: &mut MultiPaneTui,
+    pending_focus: &mut Option<(u64, u64)>,
+    tab_id: u64,
+    pane_id: u64,
+) -> Result<(), io::Error> {
+    if let Some((pending_tab_id, pending_pane_id)) = *pending_focus {
+        if (tab_id, pane_id) == (pending_tab_id, pending_pane_id) {
+            *pending_focus = None;
+        } else if view.set_focus(pending_tab_id, pending_pane_id).is_ok() {
+            return Ok(());
+        } else {
+            *pending_focus = None;
+        }
+    }
+    view.set_focus(tab_id, pane_id)
+        .map_err(|error| io::Error::other(format!("invalid node focus: {error:?}")))
 }
 
 fn send_intents(
     stream: &mut UnixStream,
     tui: &MultiPaneTui,
     intents: Vec<crate::tui::UiIntent>,
+    pending_focus: &mut Option<(u64, u64)>,
 ) -> io::Result<()> {
     for intent in intents {
         match intent {
             crate::tui::UiIntent::FocusPane { .. } | crate::tui::UiIntent::SwitchTab { .. } => {
+                let focus = (tui.current_tab(), tui.focused_pane());
                 write_message(
                     stream,
                     &ClientMessage::Focus {
-                        tab_id: tui.current_tab(),
-                        pane_id: tui.focused_pane(),
+                        tab_id: focus.0,
+                        pane_id: focus.1,
                     },
                 )?;
+                *pending_focus = Some(focus);
             }
             intent => write_message(stream, &ClientMessage::StructuralIntent { intent })?,
         }
@@ -583,6 +607,7 @@ mod tests {
         pane_ids: &[u64],
         rows: Vec<AgentOverlaySnapshotRow>,
     ) {
+        let mut pending_focus = None;
         apply_snapshot(
             tui,
             crate::config::UiTheme::default(),
@@ -594,6 +619,30 @@ mod tests {
             rows,
             1,
             pane_ids[0],
+            &mut pending_focus,
+        )
+        .unwrap();
+    }
+
+    fn apply_focus_snapshot(
+        tui: &mut Option<MultiPaneTui>,
+        layout: LayoutSnapshot,
+        tab_id: u64,
+        pane_id: u64,
+        pending_focus: &mut Option<(u64, u64)>,
+    ) {
+        apply_snapshot(
+            tui,
+            crate::config::UiTheme::default(),
+            &mut BTreeMap::new(),
+            String::from("room"),
+            layout,
+            vec![],
+            vec![],
+            vec![],
+            tab_id,
+            pane_id,
+            pending_focus,
         )
         .unwrap();
     }
@@ -607,6 +656,47 @@ mod tests {
             client_key_bytes(KeyCode::Char('q'), KeyModifiers::CONTROL),
             Some(vec![17])
         );
+    }
+
+    #[test]
+    fn stale_snapshot_preserves_pending_focus_after_applying_layout() {
+        let mut tui = None;
+        let mut pending_focus = None;
+        apply_focus_snapshot(&mut tui, layout(&[1, 2]), 1, 1, &mut pending_focus);
+        pending_focus = Some((1, 2));
+        let mut updated_layout = layout(&[1, 2]);
+        updated_layout.revision = 2;
+
+        apply_focus_snapshot(&mut tui, updated_layout, 1, 1, &mut pending_focus);
+
+        let tui = tui.unwrap();
+        assert_eq!(tui.snapshot().revision, 2);
+        assert_eq!((tui.current_tab(), tui.focused_pane()), (1, 2));
+        assert_eq!(pending_focus, Some((1, 2)));
+    }
+
+    #[test]
+    fn matching_snapshot_clears_pending_focus() {
+        let mut tui = None;
+        let mut pending_focus = Some((1, 2));
+
+        apply_focus_snapshot(&mut tui, layout(&[1, 2]), 1, 2, &mut pending_focus);
+
+        let tui = tui.unwrap();
+        assert_eq!((tui.current_tab(), tui.focused_pane()), (1, 2));
+        assert_eq!(pending_focus, None);
+    }
+
+    #[test]
+    fn snapshot_focus_replaces_pending_focus_when_layout_removes_it() {
+        let mut tui = None;
+        let mut pending_focus = Some((1, 2));
+
+        apply_focus_snapshot(&mut tui, layout(&[1]), 1, 1, &mut pending_focus);
+
+        let tui = tui.unwrap();
+        assert_eq!((tui.current_tab(), tui.focused_pane()), (1, 1));
+        assert_eq!(pending_focus, None);
     }
 
     #[test]

--- a/src/node.rs
+++ b/src/node.rs
@@ -534,7 +534,7 @@ mod tests {
         ));
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn local_focus_reads_runtime_state_without_drain() {
         let host = SharedLayoutHost::new(HostSession::create().await.unwrap(), 2, 8).unwrap();
         let panes = host.pane_server();
@@ -586,7 +586,7 @@ mod tests {
         node.focus(1, 2).unwrap();
 
         assert_eq!(node.local_focus(), (1, 2));
-        node.shutdown();
+        tokio::task::block_in_place(|| node.shutdown());
     }
 
     #[test]

--- a/src/node.rs
+++ b/src/node.rs
@@ -38,8 +38,6 @@ use crate::tui::SharedLayoutRuntime;
 
 pub struct SharedLayoutNode {
     runtime: SharedLayoutRuntime,
-    last_tab_id: u64,
-    last_pane_id: u64,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -452,20 +450,13 @@ fn write_snapshot(
 
 impl SharedLayoutNode {
     pub fn new(runtime: SharedLayoutRuntime) -> Self {
-        let (last_tab_id, last_pane_id) = runtime.local_focus();
-        Self {
-            runtime,
-            last_tab_id,
-            last_pane_id,
-        }
+        Self { runtime }
     }
 
     /// Advances Iroh, pane servers, PTYs, leases, subscriptions and agent sampling without ever
     /// touching terminal state.
     pub fn drain(&mut self) -> Result<bool, Box<dyn Error>> {
-        let changed = self.runtime.drain_node()?;
-        (self.last_tab_id, self.last_pane_id) = self.runtime.local_focus();
-        Ok(changed)
+        self.runtime.drain_node()
     }
 
     pub fn input(&mut self, bytes: Vec<u8>) -> Result<(), Box<dyn Error>> {
@@ -475,7 +466,7 @@ impl SharedLayoutNode {
         self.runtime.release_all_local_control()
     }
     pub fn local_focus(&self) -> (u64, u64) {
-        (self.last_tab_id, self.last_pane_id)
+        self.runtime.local_focus()
     }
     pub fn snapshot(
         &self,
@@ -504,6 +495,11 @@ impl SharedLayoutNode {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{
+        layout::{Axis, Node, Pane},
+        session::{HostSession, SharedLayoutHost, layout_snapshot_from_state},
+        tui::SharedLocalPane,
+    };
     use std::{
         io::Write,
         os::unix::{
@@ -536,6 +532,61 @@ mod tests {
             read_message(&mut reader).unwrap(),
             Some(ClientMessage::Detach { generation: 7 })
         ));
+    }
+
+    #[tokio::test]
+    async fn local_focus_reads_runtime_state_without_drain() {
+        let host = SharedLayoutHost::new(HostSession::create().await.unwrap(), 2, 8).unwrap();
+        let panes = host.pane_server();
+        let host_peer_id = host.ticket().endpoint_addr().id.as_bytes().to_vec();
+        let initial = SharedLocalPane::spawn(1, 2, 8, host_peer_id.clone()).unwrap();
+        panes
+            .register_local_pane(
+                crate::protocol::PaneDescriptor {
+                    pane_id: 1,
+                    host_peer_id: host_peer_id.clone(),
+                    grid_rows: 2,
+                    grid_cols: 8,
+                    title: None,
+                },
+                initial.channels(),
+            )
+            .unwrap();
+        let state = host.session_snapshot().unwrap().state.unwrap();
+        let mut snapshot = layout_snapshot_from_state(&state).unwrap();
+        let first = snapshot.tabs[0].root.clone();
+        snapshot.tabs[0].root = Node::Split {
+            axis: Axis::LeftRight,
+            first_share_bps: 5_000,
+            first: Box::new(first),
+            second: Box::new(Node::Leaf { pane_id: 2 }),
+        };
+        snapshot.panes.insert(
+            2,
+            Pane {
+                pane_id: 2,
+                host_peer_id,
+                grid_rows: 2,
+                grid_cols: 8,
+                title: None,
+            },
+        );
+        let mut node = SharedLayoutNode::new(
+            SharedLayoutRuntime::host(
+                host,
+                panes,
+                snapshot,
+                initial,
+                String::from("TESTCODE"),
+                tokio::runtime::Handle::current(),
+            )
+            .unwrap(),
+        );
+
+        node.focus(1, 2).unwrap();
+
+        assert_eq!(node.local_focus(), (1, 2));
+        node.shutdown();
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -577,9 +577,6 @@ impl MultiPaneTui {
             .is_some_and(|then| now.duration_since(then) >= AGENT_TOGGLE_WINDOW)
         {
             self.pending_agent_toggle = None;
-            self.modal = ModalState::Agents;
-            self.exit_chord_mode();
-            return true;
         }
         false
     }
@@ -980,26 +977,34 @@ impl MultiPaneTui {
     pub fn handle_key(&mut self, key: KeyEvent, area: Rect) -> KeyHandling {
         if is_quit(key) {
             self.modal = ModalState::None;
+            self.pending_agent_toggle = None;
             self.exit_chord_mode();
             return KeyHandling::Quit;
         }
         if matches!(self.modal, ModalState::Rename(_)) {
             return self.handle_rename_key(key);
         }
+        if key.code == KeyCode::Char('a') && key.modifiers == KeyModifiers::CONTROL {
+            if self.overlay_open() {
+                let forward = self
+                    .pending_agent_toggle
+                    .is_some_and(|then| then.elapsed() <= AGENT_TOGGLE_WINDOW);
+                self.modal = ModalState::None;
+                self.pending_agent_toggle = None;
+                return if forward {
+                    KeyHandling::Forward
+                } else {
+                    KeyHandling::Consumed(vec![])
+                };
+            }
+            self.modal = ModalState::Agents;
+            self.pending_agent_toggle = Some(Instant::now());
+            self.exit_chord_mode();
+            return KeyHandling::Consumed(vec![]);
+        }
         if self.overlay_open() {
             self.set_agent_overlay_viewport(area);
             return self.handle_agent_overlay_key(key);
-        }
-        if key.code == KeyCode::Char('a') && key.modifiers == KeyModifiers::CONTROL {
-            if self
-                .pending_agent_toggle
-                .is_some_and(|then| then.elapsed() <= AGENT_TOGGLE_WINDOW)
-            {
-                self.pending_agent_toggle = None;
-                return KeyHandling::Forward;
-            }
-            self.pending_agent_toggle = Some(Instant::now());
-            return KeyHandling::Consumed(vec![]);
         }
         if key.code == KeyCode::Esc
             && key.modifiers.is_empty()
@@ -1114,6 +1119,7 @@ impl MultiPaneTui {
         match key.code {
             KeyCode::Esc => {
                 self.modal = ModalState::None;
+                self.pending_agent_toggle = None;
                 KeyHandling::Consumed(vec![])
             }
             KeyCode::Up | KeyCode::Char('k') => {
@@ -1234,6 +1240,7 @@ impl MultiPaneTui {
         self.current_tab = tab.tab_id;
         self.focused_pane = pane_id;
         self.modal = ModalState::None;
+        self.pending_agent_toggle = None;
         vec![UiIntent::FocusPane { pane_id }]
     }
 
@@ -5398,7 +5405,7 @@ mod tests {
     }
 
     #[test]
-    fn agents_overlay_toggles_and_double_tap_forwards_ctrl_a() {
+    fn agents_overlay_opens_immediately_and_double_tap_forwards_ctrl_a() {
         let mut tui = MultiPaneTui::new(layout(
             vec![Tab {
                 tab_id: 1,
@@ -5413,6 +5420,7 @@ mod tests {
             tui.handle_key(ctrl_a, Rect::new(0, 0, 80, 24)),
             KeyHandling::Consumed(vec![])
         );
+        assert!(tui.overlay_open());
         assert_eq!(
             tui.handle_key(ctrl_a, Rect::new(0, 0, 80, 24)),
             KeyHandling::Forward
@@ -5422,13 +5430,13 @@ mod tests {
             tui.handle_key(ctrl_a, Rect::new(0, 0, 80, 24)),
             KeyHandling::Consumed(vec![])
         );
-        assert!(tui.expire_agent_toggle(Instant::now() + AGENT_TOGGLE_WINDOW));
         assert!(tui.overlay_open());
+        tui.pending_agent_toggle = Some(Instant::now() - AGENT_TOGGLE_WINDOW);
+        assert!(!tui.expire_agent_toggle(Instant::now()));
+        assert!(tui.overlay_open());
+        assert_eq!(tui.pending_agent_toggle, None);
         assert_eq!(
-            tui.handle_key(
-                KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
-                Rect::new(0, 0, 80, 24)
-            ),
+            tui.handle_key(ctrl_a, Rect::new(0, 0, 80, 24)),
             KeyHandling::Consumed(vec![])
         );
         assert!(!tui.overlay_open());
@@ -5453,8 +5461,8 @@ mod tests {
         );
         let mut tui = MultiPaneTui::new(snapshot).unwrap();
         tui.set_agent_rows(vec![agent_row(2, 2, 1)]);
-        tui.pending_agent_toggle = Some(Instant::now() - AGENT_TOGGLE_WINDOW);
-        tui.expire_agent_toggle(Instant::now());
+        let ctrl_a = KeyEvent::new(KeyCode::Char('a'), KeyModifiers::CONTROL);
+        tui.handle_key(ctrl_a, Rect::new(0, 0, 80, 24));
         assert_eq!(
             tui.handle_key(
                 KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE),
@@ -5471,6 +5479,24 @@ mod tests {
         );
         assert_eq!(tui.current_tab(), 2);
         assert_eq!(tui.focused_pane(), 2);
+        assert_eq!(tui.pending_agent_toggle, None);
+        assert_eq!(
+            tui.handle_key(ctrl_a, Rect::new(0, 0, 80, 24)),
+            KeyHandling::Consumed(vec![])
+        );
+        assert!(tui.overlay_open());
+        assert_eq!(
+            tui.handle_key(
+                KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
+                Rect::new(0, 0, 80, 24)
+            ),
+            KeyHandling::Consumed(vec![])
+        );
+        assert_eq!(tui.pending_agent_toggle, None);
+        assert_eq!(
+            tui.handle_key(ctrl_a, Rect::new(0, 0, 80, 24)),
+            KeyHandling::Consumed(vec![])
+        );
     }
 
     #[test]
@@ -5698,9 +5724,9 @@ mod tests {
         );
         let mut tui = MultiPaneTui::new(snapshot).unwrap();
         tui.set_agent_rows(vec![agent_row(1, 1, 1), agent_row(2, 2, 1)]);
-        tui.pending_agent_toggle = Some(Instant::now() - AGENT_TOGGLE_WINDOW);
-        tui.expire_agent_toggle(Instant::now());
         let area = Rect::new(0, 0, 80, 24);
+        let ctrl_a = KeyEvent::new(KeyCode::Char('a'), KeyModifiers::CONTROL);
+        tui.handle_key(ctrl_a, area);
 
         assert_eq!(tui.handle_agent_overlay_click(0, 0, area), Vec::new());
         assert!(tui.overlay_open());
@@ -5736,6 +5762,8 @@ mod tests {
         assert!(!tui.overlay_open());
         assert_eq!(tui.current_tab(), 2);
         assert_eq!(tui.focused_pane(), 2);
+        assert_eq!(tui.pending_agent_toggle, None);
+        assert_eq!(tui.handle_key(ctrl_a, area), KeyHandling::Consumed(vec![]));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Make node snapshot focus read runtime state directly so tab/pane switches stop lagging one drain behind.
- Keep optimistic attach focus across in-flight stale snapshots until the node echoes the new focus (or the layout invalidates it).
- Open the Agents overlay immediately on Ctrl+A while preserving double-tap Ctrl+A forwarding within 400ms.

## Test plan
- [ ] `cargo test node::tests`
- [ ] `cargo test client::tests`
- [ ] `cargo test --lib tui::`
- [ ] Attach to a multi-tab session; switch tabs/panes quickly and confirm chrome no longer snaps back
- [ ] Ctrl+A once → Agents opens immediately; Ctrl+A twice quickly → closes and forwards; Esc/Enter clear the double-tap window cleanly


Made with [Cursor](https://cursor.com)