### PR TITLE
feat: host pane lock (read-only guests)

### DIFF
--- a/docs/MVP_DESIGN.md
+++ b/docs/MVP_DESIGN.md
@@ -8,7 +8,7 @@ This document is the **source of truth** for the MVP. Older Notion section pages
 
 ## 0. Trust warning (product + README + invite UI)
 
-This is a **fully trusted shared-shell** session. Anyone with the join ticket can see every pane and may obtain interactive control of available terminals (run commands, see output, touch files reachable to that macOS user). Share the ticket only with people you trust with that access. For risky/unknown collaborators, use a separate low-privilege Mac account and avoid production credentials in shared panes.
+This is a **fully trusted shared-shell** session. Anyone with the join ticket can see every pane and may obtain interactive control of unlocked terminals (run commands, see output, touch files reachable to that macOS user). A pane host can temporarily make its own pane host-only, but locking is not an ACL. Share the ticket only with people you trust with that access. For risky/unknown collaborators, use a separate low-privilege Mac account and avoid production credentials in shared panes.
 
 **Clarification:** Processes and credential *files* stay on the pane host’s Mac (not uploaded to peers). That does **not** stop a controller from using or displaying them via the shared shell.
 
@@ -32,6 +32,9 @@ Brew-installable macOS terminal mux: each pane’s process runs on its host’s 
 - **Input:** a pane has a controller only while that peer is actively typing. After about eight
   seconds idle, the host clears the controller and the pane is free; the next ordinary key claims
   it and is delivered as the first input. Active typing is protected; there is no forced takeover.
+- **Pane lock:** a pane host may toggle its own pane to host-only. All members still see its
+  screen, but only its host may input or claim control. Locking clears a guest controller and does
+  not claim control for the host.
 - **Later-spike disconnect behavior:** 5-minute unavailable placeholders and coordinator failover
   are MVP goals, not implemented by Spike 3.
 - **Layout:** nested binary 50/50; **depth ≤ 4**; **≤ 8 panes/tab**; max **9 tabs**.
@@ -111,7 +114,8 @@ The last pane in a tab must be removed by deleting the tab; the final tab is ret
 
 ### Spike 3 controls
 
-`Ctrl+P` then `N` splits; `Ctrl+P` then `X` requests focused-pane deletion; `Ctrl+P` then `e`
+`Ctrl+P` then `N` splits; `Ctrl+P` then `X` requests focused-pane deletion; `Ctrl+P` then `k`
+toggles host-only lock for a host-owned focused pane; `Ctrl+P` then `e`
 renames the focused pane for all admitted members. `Ctrl+P` plus arrows moves focus. `Ctrl+T` then
 `N` creates a tab; `Ctrl+T` then `X` requests tab deletion; `Ctrl+T` then `e` renames the current
 tab for all admitted members; `Ctrl+T` plus left/right switches tabs. Rename uses Enter to save and
@@ -125,7 +129,8 @@ the local view while the session node remains live; F9 and F10 reach the focused
 ## 5. UI / presence
 
 Tabs + nested splits as above. Tab labels are clickable for local tab switching. Each pane title is
-`Pane #N  host: <name>  control: free|<name>|…`; a focused free pane has a white border, an
+`Pane #N  host: <name>  control: free|<name>|…|host-only`; a locked pane also reserves a
+right-aligned `(locked by <host>)` badge. A focused free pane has a white border, an
 actively controlled pane a red-orange border, and an unbootstrapped lease a yellow focused border.
 The dark contextual footer uses red key accents: normal mode shows
 `Ctrl+ <p> PANE   <t> TAB   <q> QUIT    type to claim when free`; pane and tab modes show their
@@ -156,7 +161,7 @@ See [SPIKE_PLAN.md](./SPIKE_PLAN.md).
 ## 10. MVP success criteria
 
 Two (then more) Macs join via reusable ticket; shared layout; both host panes; anyone can split
-available panes; pane hosts delete their own panes; all-host tabs can be deleted; free-pane first-
+available panes; pane hosts delete and lock their own panes; all-host tabs can be deleted; free-pane first-
 key claims and protected active typing; presence; locality of processes; encrypted P2P/relay; ≈ SSH feel;
 disconnect grace works; coordinator leave does not kill whole session.
 

--- a/docs/superpowers/specs/2026-07-26-pane-lock-design.md
+++ b/docs/superpowers/specs/2026-07-26-pane-lock-design.md
@@ -1,0 +1,38 @@
+# Host pane lock
+
+## Goal
+
+Let a pane host temporarily make that pane host-only. Every member continues to receive its screen,
+but only the host may provide PTY input or take its control lease.
+
+## Rules
+
+- `Pane.locked: bool` is authoritative shared layout state. The locker is always `host_peer_id`;
+  there is no separate locker field.
+- Only the pane host may request `SetPaneLock`. A guest request receives the existing `NotHost`
+  layout rejection.
+- The pane host enforces the lock before `LeaseManager`: guest `Input` and `TakeControl` events are
+  discarded. Lease behavior itself is otherwise unchanged.
+- Locking clears a guest controller and publishes the resulting free lease. It preserves an
+  existing host controller and never auto-claims for the host. Unlocking restores normal lease
+  claim behavior.
+- Client, node IPC, and remote forwarding suppress guest key/paste sends as UX. Host enforcement
+  remains the authority.
+
+## UI
+
+`Ctrl+P`, then lowercase `k`, toggles the focused host-owned pane. Pane mode remains sticky and the
+footer shows `<k> LOCK`. Locked chrome shows `control: host-only` in the left title and a
+right-aligned `(locked by <host display name>)` badge. The badge receives width budget first; the
+left title uses the remainder.
+
+## Wire
+
+This is protocol version 7. `PaneDescriptor.locked` is bool tag 6. `LayoutRequest.set_pane_lock`
+is message tag 11 with `SetPaneLock { pane_id = 1, locked = 2 }`. Requests must contain exactly
+one layout action; mixed v6/v7 peers fail the existing version handshake.
+
+## Non-goals
+
+This is not a visibility feature, ACL, forced takeover, or change to idle timeouts. It does not
+lock tabs or preserve a lock across a new PTY.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -172,8 +172,8 @@ async fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
                     host_peer_id,
                     grid_rows: u32::from(shell_rows),
                     grid_cols: u32::from(shell_cols),
-
                     title: None,
+                    locked: false,
                 },
                 initial.channels(),
             )?;

--- a/src/client.rs
+++ b/src/client.rs
@@ -580,6 +580,7 @@ mod tests {
                         Pane {
                             pane_id: *pane_id,
                             host_peer_id: b"host".to_vec(),
+                            locked: false,
                             grid_rows: 2,
                             grid_cols: 8,
                             title: None,

--- a/src/client.rs
+++ b/src/client.rs
@@ -75,6 +75,7 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
     let mut detach_sent = false;
     let mut last_agent_overlay_animation = Instant::now();
     let mut pending_focus = None;
+    let mut local_peer_id = Vec::new();
 
     'attached: loop {
         loop {
@@ -86,6 +87,7 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
                         screens: next_screens,
                         leases,
                         rosters,
+                        local_peer_id: next_local_peer_id,
                         tab_id,
                         pane_id,
                         ..
@@ -104,6 +106,7 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
                             pane_id,
                             &mut pending_focus,
                         )?;
+                        local_peer_id = next_local_peer_id;
                         if let Some(tui) = tui.as_mut() {
                             tui.set_agent_overlay_viewport(terminal.size()?.into());
                         }
@@ -162,14 +165,16 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
                         dirty = true;
                     }
                     KeyHandling::Forward => {
-                        if let Some(bytes) = client_key_bytes(key.code, key.modifiers) {
+                        if input_allowed(tui, &local_peer_id)
+                            && let Some(bytes) = client_key_bytes(key.code, key.modifiers)
+                        {
                             write_message(&mut stream, &ClientMessage::Input { bytes })?;
                         }
                     }
                 }
             }
             Event::Paste(text) => {
-                if should_forward_paste(tui) {
+                if should_forward_paste(tui, &local_peer_id) {
                     write_message(
                         &mut stream,
                         &ClientMessage::Input {
@@ -261,8 +266,15 @@ fn refresh_tui_timers(
     dirty
 }
 
-fn should_forward_paste(tui: &MultiPaneTui) -> bool {
-    !tui.overlay_open()
+fn input_allowed(tui: &MultiPaneTui, local_peer_id: &[u8]) -> bool {
+    tui.snapshot()
+        .panes
+        .get(&tui.focused_pane())
+        .is_none_or(|pane| !pane.locked || pane.host_peer_id == local_peer_id)
+}
+
+fn should_forward_paste(tui: &MultiPaneTui, local_peer_id: &[u8]) -> bool {
+    !tui.overlay_open() && input_allowed(tui, local_peer_id)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -795,7 +807,19 @@ mod tests {
         let mut animation = Instant::now();
         refresh_tui_timers(tui, Instant::now() + AGENT_TOGGLE_WINDOW, &mut animation);
 
-        assert!(!should_forward_paste(tui));
+        assert!(!should_forward_paste(tui, b"host"));
         assert!(tui.scroll_agent_overlay(area, false));
+    }
+
+    #[test]
+    fn locked_guest_pane_suppresses_key_and_paste_forwarding() {
+        let mut layout = layout(&[1]);
+        layout.panes.get_mut(&1).expect("pane").locked = true;
+        let tui = MultiPaneTui::new(layout).expect("layout");
+
+        assert!(!input_allowed(&tui, b"guest"));
+        assert!(!should_forward_paste(&tui, b"guest"));
+        assert!(input_allowed(&tui, b"host"));
+        assert!(should_forward_paste(&tui, b"host"));
     }
 }

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -83,6 +83,7 @@ pub struct Member {
 pub struct Pane {
     pub pane_id: PaneId,
     pub host_peer_id: Vec<u8>,
+    pub locked: bool,
     pub grid_rows: u16,
     pub grid_cols: u16,
     pub title: Option<String>,
@@ -222,6 +223,7 @@ impl SessionState {
         let initial_pane = Pane {
             pane_id: 1,
             host_peer_id: initial_host.clone(),
+            locked: false,
             grid_rows,
             grid_cols,
             title: None,
@@ -582,6 +584,7 @@ impl SessionState {
                     Pane {
                         pane_id,
                         host_peer_id: creator.to_vec(),
+                        locked: false,
                         grid_rows,
                         grid_cols,
                         title: None,
@@ -610,6 +613,7 @@ impl SessionState {
                     Pane {
                         pane_id,
                         host_peer_id: creator.to_vec(),
+                        locked: false,
                         grid_rows,
                         grid_cols,
                         title: None,
@@ -843,6 +847,28 @@ impl SessionState {
             pane.grid_rows = rows;
             pane.grid_cols = cols;
         }
+        self.advance_revision();
+        Ok(())
+    }
+
+    pub fn set_pane_lock(
+        &mut self,
+        requester: &[u8],
+        base_revision: u64,
+        pane_id: PaneId,
+        locked: bool,
+    ) -> Result<(), LayoutError> {
+        self.check_mutation(base_revision)?;
+        self.require_member(requester)?;
+        self.ensure_no_reservation()?;
+        let pane = self
+            .panes
+            .get_mut(&pane_id)
+            .ok_or(LayoutError::UnknownPane { pane_id })?;
+        if pane.host_peer_id != requester {
+            return Err(LayoutError::NotPaneHost { pane_id });
+        }
+        pane.locked = locked;
         self.advance_revision();
         Ok(())
     }

--- a/src/local_ipc.rs
+++ b/src/local_ipc.rs
@@ -49,6 +49,7 @@ pub enum NodeMessage {
         screens: Vec<PaneScreenSnapshot>,
         leases: Vec<PaneLeaseSnapshot>,
         rosters: Vec<AgentOverlaySnapshotRow>,
+        local_peer_id: Vec<u8>,
         tab_id: u64,
         pane_id: u64,
     },

--- a/src/node.rs
+++ b/src/node.rs
@@ -105,8 +105,8 @@ pub async fn run_background(bootstrap: NodeBootstrap) -> Result<(), Box<dyn Erro
                     host_peer_id,
                     grid_rows: u32::from(shell_rows),
                     grid_cols: u32::from(shell_cols),
-
                     title: None,
+                    locked: false,
                 },
                 initial.channels(),
             )?;
@@ -548,6 +548,7 @@ mod tests {
                     grid_rows: 2,
                     grid_cols: 8,
                     title: None,
+                    locked: false,
                 },
                 initial.channels(),
             )

--- a/src/node.rs
+++ b/src/node.rs
@@ -391,6 +391,7 @@ fn write_snapshot(
     _generation: u64,
 ) -> io::Result<()> {
     let (tab_id, pane_id) = node.local_focus();
+    let local_peer_id = node.local_peer_id();
     let (layout, screens, leases, rosters) = node.snapshot();
     let hosts = layout
         .panes
@@ -442,6 +443,7 @@ fn write_snapshot(
                 )
                 .collect(),
             rosters,
+            local_peer_id,
             tab_id,
             pane_id,
         },
@@ -461,6 +463,9 @@ impl SharedLayoutNode {
 
     pub fn input(&mut self, bytes: Vec<u8>) -> Result<(), Box<dyn Error>> {
         self.runtime.node_input(bytes)
+    }
+    pub fn local_peer_id(&self) -> Vec<u8> {
+        self.runtime.local_peer_id()
     }
     pub fn release_all_local_control(&mut self) -> Result<(), Box<dyn Error>> {
         self.runtime.release_all_local_control()
@@ -643,6 +648,7 @@ mod tests {
                 }],
                 leases: vec![],
                 rosters: vec![],
+                local_peer_id: vec![],
                 tab_id: 1,
                 pane_id: 1,
             },

--- a/src/node.rs
+++ b/src/node.rs
@@ -566,6 +566,7 @@ mod tests {
             Pane {
                 pane_id: 2,
                 host_peer_id,
+                locked: false,
                 grid_rows: 2,
                 grid_cols: 8,
                 title: None,

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -3,7 +3,7 @@
 use prost::Message;
 use std::{collections::HashSet, fmt};
 
-pub const PROTOCOL_VERSION: u32 = 6;
+pub const PROTOCOL_VERSION: u32 = 7;
 pub const MAX_FRAME_BYTES: usize = 1_048_576;
 pub const MAX_ENVELOPE_BYTES: usize = 1_048_560;
 pub const MAX_PEER_ID_BYTES: usize = 64;
@@ -285,6 +285,8 @@ pub struct PaneDescriptor {
     pub grid_cols: u32,
     #[prost(string, optional, tag = "5")]
     pub title: Option<String>,
+    #[prost(bool, tag = "6")]
+    pub locked: bool,
 }
 
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -353,6 +355,16 @@ pub struct LayoutRequest {
     pub rename_pane: Option<RenamePane>,
     #[prost(message, optional, tag = "10")]
     pub rename_tab: Option<RenameTab>,
+    #[prost(message, optional, tag = "11")]
+    pub set_pane_lock: Option<SetPaneLock>,
+}
+
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SetPaneLock {
+    #[prost(uint64, tag = "1")]
+    pub pane_id: u64,
+    #[prost(bool, tag = "2")]
+    pub locked: bool,
 }
 
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -902,7 +914,8 @@ fn validate_layout_request(request: &LayoutRequest) -> Result<(), ProtocolError>
         + usize::from(request.set_split_ratio.is_some())
         + usize::from(request.update_pane_grids.is_some())
         + usize::from(request.rename_pane.is_some())
-        + usize::from(request.rename_tab.is_some());
+        + usize::from(request.rename_tab.is_some())
+        + usize::from(request.set_pane_lock.is_some());
     if actions != 1 {
         return Err(ProtocolError::InvalidLayout("layout_request.action"));
     }
@@ -978,6 +991,9 @@ fn validate_layout_request(request: &LayoutRequest) -> Result<(), ProtocolError>
             rename.title.len(),
             MAX_LAYOUT_TITLE_BYTES,
         )?;
+    }
+    if let Some(lock) = &request.set_pane_lock {
+        validate_nonzero("layout_request.set_pane_lock.pane_id", lock.pane_id)?;
     }
     Ok(())
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -845,6 +845,7 @@ pub fn layout_snapshot_from_state(state: &LayoutState) -> Result<LayoutSnapshot,
                 Pane {
                     pane_id: pane.pane_id,
                     host_peer_id: pane.host_peer_id.clone(),
+                    locked: false,
                     grid_rows,
                     grid_cols,
                     title: pane.title.clone(),

--- a/src/session.rs
+++ b/src/session.rs
@@ -33,8 +33,8 @@ use crate::{
         Input, Join, LayoutCommit, LayoutNode, LayoutReject, LayoutRejectReason, LayoutRequest,
         LayoutSplit, LayoutState, MemberDescriptor, NewPanePosition as ProtocolNewPanePosition,
         PROTOCOL_VERSION, PaneDescriptor, PaneFailed, PaneReady, PaneReservation, PaneSubscribe,
-        ReleaseControl, RenamePane, RenameTab, SessionSnapshot, SetSplitRatio, Snapshot, SplitAxis,
-        TabDescriptor, TakeControl, UpdatePaneGrids, Welcome, envelope,
+        ReleaseControl, RenamePane, RenameTab, SessionSnapshot, SetPaneLock, SetSplitRatio,
+        Snapshot, SplitAxis, TabDescriptor, TakeControl, UpdatePaneGrids, Welcome, envelope,
     },
     screen::ScreenFrame,
     ticket::{JoinTicket, TicketError},
@@ -310,7 +310,8 @@ impl LayoutCoordinator {
             + usize::from(request.update_pane_grids.is_some());
         let action_count = action_count
             + usize::from(request.rename_pane.is_some())
-            + usize::from(request.rename_tab.is_some());
+            + usize::from(request.rename_tab.is_some())
+            + usize::from(request.set_pane_lock.is_some());
         if request_id == 0 || request.base_revision == 0 || action_count != 1 {
             return reject(request_id, LayoutRejectReason::Malformed);
         }
@@ -343,6 +344,8 @@ impl LayoutCoordinator {
             self.rename_pane(authenticated_peer_id, request.base_revision, rename)
         } else if let Some(rename) = request.rename_tab {
             self.rename_tab(authenticated_peer_id, request.base_revision, rename)
+        } else if let Some(lock) = request.set_pane_lock {
+            self.set_pane_lock(authenticated_peer_id, request.base_revision, lock)
         } else {
             Err(LayoutError::InvalidSnapshot)
         };
@@ -657,6 +660,22 @@ impl LayoutCoordinator {
         ))
     }
 
+    fn set_pane_lock(
+        &mut self,
+        peer: &[u8],
+        revision: u64,
+        lock: SetPaneLock,
+    ) -> Result<CoordinatorResponse, LayoutError> {
+        if lock.pane_id == 0 {
+            return Err(LayoutError::InvalidSnapshot);
+        }
+        self.state
+            .set_pane_lock(peer, revision, lock.pane_id, lock.locked)?;
+        Ok(CoordinatorResponse::Commit(
+            self.layout_commit().map_err(layout_error)?,
+        ))
+    }
+
     fn layout_commit(&self) -> Result<LayoutCommit, CoordinatorError> {
         let state = self.protocol_layout_state()?;
         Ok(LayoutCommit {
@@ -807,6 +826,7 @@ fn protocol_layout_state(snapshot: LayoutSnapshot) -> LayoutState {
                 grid_rows: u32::from(pane.grid_rows),
                 grid_cols: u32::from(pane.grid_cols),
                 title: pane.title,
+                locked: pane.locked,
             })
             .collect(),
         tabs: snapshot
@@ -845,7 +865,7 @@ pub fn layout_snapshot_from_state(state: &LayoutState) -> Result<LayoutSnapshot,
                 Pane {
                     pane_id: pane.pane_id,
                     host_peer_id: pane.host_peer_id.clone(),
-                    locked: false,
+                    locked: pane.locked,
                     grid_rows,
                     grid_cols,
                     title: pane.title.clone(),

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -5498,6 +5498,7 @@ mod tests {
                         Pane {
                             pane_id: *pane_id,
                             host_peer_id: b"host".to_vec(),
+                            locked: false,
                             grid_rows: *rows,
                             grid_cols: *cols,
                             title: None,

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -4321,6 +4321,7 @@ impl SharedLayoutRuntime {
 
                 rename_pane: None,
                 rename_tab: None,
+                set_pane_lock: None,
             })?;
         }
         Ok(())
@@ -4376,6 +4377,7 @@ impl SharedLayoutRuntime {
 
                     rename_pane: None,
                     rename_tab: None,
+                    set_pane_lock: None,
                 })?
             }
             UiIntent::DeleteTab { tab_id } => {
@@ -4392,6 +4394,7 @@ impl SharedLayoutRuntime {
 
                     rename_pane: None,
                     rename_tab: None,
+                    set_pane_lock: None,
                 })?
             }
             UiIntent::SetSplitRatio {
@@ -4419,6 +4422,7 @@ impl SharedLayoutRuntime {
                     update_pane_grids: None,
                     rename_pane: None,
                     rename_tab: None,
+                    set_pane_lock: None,
                 })?;
             }
             UiIntent::RenamePane { pane_id, title } => {
@@ -4434,6 +4438,7 @@ impl SharedLayoutRuntime {
                     update_pane_grids: None,
                     rename_pane: Some(RenamePane { pane_id, title }),
                     rename_tab: None,
+                    set_pane_lock: None,
                 })?;
             }
             UiIntent::RenameTab { tab_id, title } => {
@@ -4449,6 +4454,7 @@ impl SharedLayoutRuntime {
                     update_pane_grids: None,
                     rename_pane: None,
                     rename_tab: Some(RenameTab { tab_id, title }),
+                    set_pane_lock: None,
                 })?;
             }
             UiIntent::FocusPane { .. } | UiIntent::SwitchTab { .. } => {}
@@ -4500,6 +4506,7 @@ impl SharedLayoutRuntime {
             update_pane_grids: None,
             rename_pane: None,
             rename_tab: None,
+            set_pane_lock: None,
         })
     }
 
@@ -4549,8 +4556,8 @@ impl SharedLayoutRuntime {
             host_peer_id,
             grid_rows: u32::from(pending.grid_rows),
             grid_cols: u32::from(pending.grid_cols),
-
             title: None,
+            locked: false,
         };
         if let Err(error) = self.panes.register_local_pane(descriptor, pane.channels()) {
             let _ = self.control.try_failed(PaneFailed {
@@ -6032,8 +6039,8 @@ mod tests {
                     host_peer_id: host_id,
                     grid_rows: 2,
                     grid_cols: 8,
-
                     title: None,
+                    locked: false,
                 },
                 initial.channels(),
             )
@@ -6134,8 +6141,8 @@ mod tests {
             host_peer_id: host_id.clone(),
             grid_rows: 1,
             grid_cols: 1,
-
             title: None,
+            locked: false,
         };
         host_panes
             .register_local_pane(

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -62,7 +62,7 @@ use crate::{
     protocol::{
         AgentRoster, AgentRosterEntry, AgentRosterState, CreatePane, CreateTab, DeletePane,
         DeleteTab, LayoutRequest, NewPanePosition as ProtocolNewPanePosition, PaneDescriptor,
-        PaneFailed, PaneReady, RenamePane, RenameTab, SplitAxis,
+        PaneFailed, PaneReady, RenamePane, RenameTab, SetPaneLock, SplitAxis,
     },
     pty_host::PtyHost,
     screen::{GuestScreen, HostScreen, SCROLLBACK_LINES, ScreenFrame},
@@ -272,6 +272,10 @@ pub enum UiIntent {
     RenameTab {
         tab_id: TabId,
         title: String,
+    },
+    SetPaneLock {
+        pane_id: PaneId,
+        locked: bool,
     },
 }
 
@@ -2865,6 +2869,7 @@ pub struct SharedLocalPane {
     screen: HostScreen,
     lease: LeaseManager,
     host_peer_id: Vec<u8>,
+    locked: bool,
     screen_tx: watch::Sender<ScreenFrame>,
     lease_tx: watch::Sender<LeaseState>,
     control_tx: mpsc::Sender<HostControlEvent>,
@@ -2896,6 +2901,7 @@ impl SharedLocalPane {
             screen,
             lease,
             host_peer_id,
+            locked: false,
             screen_tx,
             lease_tx,
             control_tx,
@@ -2932,6 +2938,9 @@ impl SharedLocalPane {
         while let Ok(event) = self.control_rx.try_recv() {
             match event {
                 HostControlEvent::Input { peer_id, input } => {
+                    if self.locked && peer_id != self.host_peer_id {
+                        continue;
+                    }
                     if let LeaseDecision::AcceptInput(bytes) =
                         self.lease
                             .input(&peer_id, input.lease_epoch, input.data, Instant::now())
@@ -2942,6 +2951,9 @@ impl SharedLocalPane {
                     }
                 }
                 HostControlEvent::TakeControl { peer_id, request } => {
+                    if self.locked && peer_id != self.host_peer_id {
+                        continue;
+                    }
                     let decision = self.lease.take_control(
                         peer_id,
                         request.known_lease_epoch,
@@ -3050,6 +3062,20 @@ impl SharedLocalPane {
             return Ok(false);
         };
         self.lease_tx.send_replace(state);
+        Ok(true)
+    }
+
+    fn set_locked(&mut self, locked: bool) -> Result<bool, Box<dyn Error>> {
+        if self.locked == locked {
+            return Ok(false);
+        }
+        self.locked = locked;
+        if locked
+            && self.lease.state().controller_peer_id != self.host_peer_id
+            && let Some(state) = self.lease.clear_controller(Instant::now())?
+        {
+            self.lease_tx.send_replace(state);
+        }
         Ok(true)
     }
 
@@ -3479,6 +3505,7 @@ pub struct SharedLayoutRuntime {
     subscription_rx: tokio::sync::mpsc::UnboundedReceiver<(PaneId, Result<GuestPane, String>)>,
     pending_create: Option<PendingCreate>,
     provisional: BTreeMap<u64, PaneId>,
+    pending_locks: BTreeMap<u64, (PaneId, bool)>,
     next_request_id: u64,
     status: String,
     copied_lines: Option<usize>,
@@ -3585,6 +3612,7 @@ impl SharedLayoutRuntime {
             subscription_rx,
             pending_create: None,
             provisional: BTreeMap::new(),
+            pending_locks: BTreeMap::new(),
             next_request_id: 1,
             status: String::new(),
             copied_lines: None,
@@ -4235,6 +4263,17 @@ impl SharedLayoutRuntime {
                 }
             }
         }
+        for (pane_id, pane) in &snapshot.panes {
+            if let Some(local) = self.local.get_mut(pane_id) {
+                local.set_locked(pane.locked)?;
+            }
+        }
+        self.pending_locks.retain(|_, (pane_id, locked)| {
+            snapshot
+                .panes
+                .get(pane_id)
+                .is_some_and(|pane| pane.locked != *locked)
+        });
         let remote_ids = self.remote.keys().copied().collect::<Vec<_>>();
         for pane_id in remote_ids {
             if !current_ids.contains(&pane_id)
@@ -4457,6 +4496,9 @@ impl SharedLayoutRuntime {
                     set_pane_lock: None,
                 })?;
             }
+            UiIntent::SetPaneLock { pane_id, locked } => {
+                self.set_pane_lock(pane_id, locked)?;
+            }
             UiIntent::FocusPane { .. } | UiIntent::SwitchTab { .. } => {}
         }
         Ok(())
@@ -4508,6 +4550,49 @@ impl SharedLayoutRuntime {
             rename_tab: None,
             set_pane_lock: None,
         })
+    }
+
+    fn set_pane_lock(&mut self, pane_id: PaneId, locked: bool) -> Result<(), Box<dyn Error>> {
+        let peer_id = self.control.peer_id();
+        if self
+            .tui
+            .snapshot()
+            .panes
+            .get(&pane_id)
+            .is_none_or(|pane| pane.host_peer_id != peer_id)
+        {
+            self.footer_notice = Some(String::from("only the pane host can lock it"));
+            return Ok(());
+        }
+        let Some(pane) = self.local.get_mut(&pane_id) else {
+            self.footer_notice = Some(String::from("pane host is unavailable"));
+            return Ok(());
+        };
+        let previous = pane.locked;
+        pane.set_locked(locked)?;
+        let request_id = self.next_id();
+        self.pending_locks.insert(request_id, (pane_id, previous));
+        let request = LayoutRequest {
+            request_id,
+            base_revision: self.tui.snapshot().revision,
+            create_pane: None,
+            delete_pane: None,
+            create_tab: None,
+            delete_tab: None,
+            set_split_ratio: None,
+            update_pane_grids: None,
+            rename_pane: None,
+            rename_tab: None,
+            set_pane_lock: Some(SetPaneLock { pane_id, locked }),
+        };
+        if let Err(error) = self.send_request(request) {
+            self.pending_locks.remove(&request_id);
+            if let Some(pane) = self.local.get_mut(&pane_id) {
+                pane.set_locked(previous)?;
+            }
+            return Err(error);
+        }
+        Ok(())
     }
 
     fn send_request(&mut self, request: LayoutRequest) -> Result<(), Box<dyn Error>> {
@@ -4600,6 +4685,11 @@ impl SharedLayoutRuntime {
             if let Some(mut pane) = self.local.remove(&pane_id) {
                 let _ = pane.shutdown();
             }
+        }
+        if let Some((pane_id, previous)) = self.pending_locks.remove(&request_id)
+            && let Some(pane) = self.local.get_mut(&pane_id)
+        {
+            let _ = pane.set_locked(previous);
         }
         self.footer_notice = Some(format!("layout request {request_id} rejected"));
     }
@@ -6441,6 +6531,73 @@ mod tests {
         let lease = lease_rx.borrow_and_update().clone();
         assert!(lease.controller_peer_id.is_empty());
         assert_eq!(lease.epoch, 2);
+    }
+
+    #[test]
+    fn locked_local_pane_rejects_guest_control_and_accepts_host_control() {
+        let host_id = b"host".to_vec();
+        let guest_id = b"guest".to_vec();
+        let mut pane = SharedLocalPane::spawn(99, 1, 1, host_id.clone()).expect("local pane");
+        pane.set_locked(true).expect("lock pane");
+
+        pane.control_tx
+            .try_send(HostControlEvent::TakeControl {
+                peer_id: guest_id.clone(),
+                request: crate::protocol::TakeControl {
+                    pane_id: pane_wire_id(99),
+                    requester_peer_id: guest_id.clone(),
+                    known_lease_epoch: 1,
+                },
+            })
+            .expect("guest takeover event");
+        pane.drain().expect("drain guest takeover");
+        assert!(pane.lease.state().controller_peer_id.is_empty());
+
+        pane.control_tx
+            .try_send(HostControlEvent::Input {
+                peer_id: guest_id.clone(),
+                input: crate::protocol::Input {
+                    pane_id: pane_wire_id(99),
+                    lease_epoch: 1,
+                    data: b"blocked".to_vec(),
+                },
+            })
+            .expect("guest input event");
+        pane.drain().expect("drain guest input");
+        assert!(pane.lease.state().controller_peer_id.is_empty());
+
+        pane.control_tx
+            .try_send(HostControlEvent::TakeControl {
+                peer_id: host_id.clone(),
+                request: crate::protocol::TakeControl {
+                    pane_id: pane_wire_id(99),
+                    requester_peer_id: host_id.clone(),
+                    known_lease_epoch: 1,
+                },
+            })
+            .expect("host takeover event");
+        pane.drain().expect("drain host takeover");
+        assert_eq!(pane.lease.state().controller_peer_id, host_id);
+        pane.shutdown().expect("shutdown local pane");
+    }
+
+    #[test]
+    fn locking_local_pane_clears_guest_lease_but_keeps_host_lease() {
+        let host_id = b"host".to_vec();
+        let guest_id = b"guest".to_vec();
+        let mut pane = SharedLocalPane::spawn(99, 1, 1, host_id.clone()).expect("local pane");
+        let mut lease_rx = pane.lease_tx.subscribe();
+        pane.lease = LeaseManager::new(guest_id, Instant::now());
+
+        pane.set_locked(true).expect("lock pane");
+        assert!(lease_rx.has_changed().expect("lease watch"));
+        assert!(lease_rx.borrow_and_update().controller_peer_id.is_empty());
+
+        pane.lease = LeaseManager::new(host_id.clone(), Instant::now());
+        pane.set_locked(false).expect("unlock pane");
+        pane.set_locked(true).expect("relock pane");
+        assert_eq!(pane.lease.state().controller_peer_id, host_id);
+        pane.shutdown().expect("shutdown local pane");
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -41,7 +41,7 @@ use ratatui::{
     Frame, Terminal, TerminalOptions, Viewport,
     backend::CrosstermBackend,
     buffer::Buffer,
-    layout::Rect,
+    layout::{Alignment, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Clear, Paragraph, Widget},
@@ -176,6 +176,8 @@ const PANE_FOOTER: &[FooterSegment] = &[
     FooterSegment::Text("> SPLIT   <"),
     FooterSegment::Key("x"),
     FooterSegment::Text("> CLOSE   <"),
+    FooterSegment::Key("k"),
+    FooterSegment::Text("> LOCK   <"),
     FooterSegment::Key("Esc"),
     FooterSegment::Text("> BACK"),
 ];
@@ -1398,6 +1400,14 @@ impl MultiPaneTui {
             KeyCode::Char('x') if key.modifiers.is_empty() => Some(UiIntent::DeletePane {
                 pane_id: self.focused_pane,
             }),
+            KeyCode::Char('k') if key.modifiers.is_empty() => self
+                .snapshot
+                .panes
+                .get(&self.focused_pane)
+                .map(|pane| UiIntent::SetPaneLock {
+                    pane_id: self.focused_pane,
+                    locked: !pane.locked,
+                }),
             KeyCode::Left | KeyCode::Right | KeyCode::Up | KeyCode::Down
                 if key.modifiers.is_empty() =>
             {
@@ -1633,6 +1643,7 @@ fn is_chord_command(mode: ChordMode, key: KeyEvent) -> bool {
                 | KeyCode::Char('d')
                 | KeyCode::Char('u')
                 | KeyCode::Char('x')
+                | KeyCode::Char('k')
                 | KeyCode::Left
                 | KeyCode::Right
                 | KeyCode::Up
@@ -1761,6 +1772,7 @@ fn pane_title(
     index: usize,
     host_peer_id: &[u8],
     controller_peer_id: Option<&[u8]>,
+    locked: bool,
     members: &[crate::layout::Member],
     available_width: usize,
 ) -> Line<'static> {
@@ -1773,10 +1785,8 @@ fn pane_title(
         &custom_title.map_or_else(|| format!("Pane #{index}"), str::to_owned),
         available_width,
     );
-    let metadata = format!(
-        " host: {} control: {control}",
-        member_label(host_peer_id, members)
-    );
+    let control = if locked { "host-only" } else { &control };
+    let metadata = format!(" host: {} control: {control}", member_label(host_peer_id, members));
     let metadata_width = available_width.saturating_sub(UnicodeWidthStr::width(label.as_str()));
     Line::from(vec![
         Span::styled(label, Style::default().add_modifier(Modifier::BOLD)),
@@ -2139,7 +2149,7 @@ fn contextual_footer(chord_mode: ChordMode) -> (&'static str, &'static [FooterSe
     match chord_mode {
         ChordMode::None => (CONTROL_HELP, NORMAL_FOOTER),
         ChordMode::Pane => (
-            "Pane  <←↓↑→> FOCUS   <e> RENAME   <n> NEW   <r/l/d/u> SPLIT   <x> CLOSE   <Esc> BACK",
+            "Pane  <←↓↑→> FOCUS   <e> RENAME   <n> NEW   <r/l/d/u> SPLIT   <x> CLOSE   <k> LOCK   <Esc> BACK",
             PANE_FOOTER,
         ),
         ChordMode::Tab => (
@@ -2452,13 +2462,21 @@ fn render_shared_multi_pane(
         let pane = &tui.snapshot.panes[&pane_id];
         let view = tui.pane_views.get(&pane_id).cloned().unwrap_or_default();
         let focused = pane_id == tui.focused_pane;
+        let title_width = usize::from(rect.width.saturating_sub(2));
+        let lock_badge = pane
+            .locked
+            .then(|| format!("(locked by {})", member_label(&pane.host_peer_id, &tui.snapshot.members)));
+        let badge_width = lock_badge
+            .as_deref()
+            .map_or(0, |badge| UnicodeWidthStr::width(badge).min(title_width));
         let mut title = pane_title(
             pane.title.as_deref(),
             index + 1,
             &pane.host_peer_id,
             view.controller_peer_id.as_deref(),
+            pane.locked,
             &tui.snapshot.members,
-            usize::from(rect.width.saturating_sub(2).saturating_sub(2)),
+            title_width.saturating_sub(badge_width).saturating_sub(2),
         );
         title.spans.insert(0, Span::raw(" "));
         title.spans.push(Span::raw(" "));
@@ -2469,9 +2487,14 @@ fn render_shared_multi_pane(
             focused,
             tui.hovered_pane == Some(pane_id),
         );
-        let block = Block::bordered()
+        let mut block = Block::bordered()
             .title(title)
             .border_style(Style::default().fg(border_color));
+        if let Some(badge) = lock_badge {
+            block = block.title(
+                Line::from(truncate_trailing(&badge, badge_width)).alignment(Alignment::Right),
+            );
+        }
         let content = pane_content_rect(rect);
         frame.render_widget(block, rect);
         // The fixed VT grid may be smaller than this pane after layout reflow. Clear the full
@@ -6931,16 +6954,20 @@ mod tests {
 
         assert_eq!(visible_leaf_panes(&snapshot.tabs[0].root), vec![8, 3]);
         assert_eq!(
-            pane_title(None, 1, b"host", Some(b""), &members, 80).to_string(),
+            pane_title(None, 1, b"host", Some(b""), false, &members, 80).to_string(),
             "Pane #1 host: Host control: free"
         );
         assert_eq!(
-            pane_title(None, 2, b"host", Some(b"guest"), &members, 80).to_string(),
+            pane_title(None, 2, b"host", Some(b"guest"), false, &members, 80).to_string(),
             "Pane #2 host: Host control: Guest"
         );
         assert_eq!(
-            pane_title(None, 2, b"host", None, &members, 80).to_string(),
+            pane_title(None, 2, b"host", None, false, &members, 80).to_string(),
             "Pane #2 host: Host control: …"
+        );
+        assert_eq!(
+            pane_title(None, 2, b"host", Some(b"guest"), true, &members, 80).to_string(),
+            "Pane #2 host: Host control: host-only"
         );
     }
 
@@ -6958,9 +6985,34 @@ mod tests {
             display_name: String::from("Host"),
         }];
         assert_eq!(
-            pane_title(Some("build logs"), 1, b"host", Some(b""), &members, 12).to_string(),
+            pane_title(Some("build logs"), 1, b"host", Some(b""), false, &members, 12).to_string(),
             "build logs …"
         );
+    }
+
+    #[test]
+    fn locked_badge_keeps_right_title_space_on_narrow_chrome() {
+        let mut snapshot = layout(
+            vec![Tab {
+                tab_id: 1,
+                root: Node::Leaf { pane_id: 1 },
+                title: None,
+            }],
+            &[(1, 2, 2)],
+        );
+        snapshot.panes.get_mut(&1).expect("pane").locked = true;
+        snapshot.members[0].display_name = String::from("Host");
+        let tui = MultiPaneTui::new(snapshot).expect("layout");
+        let mut terminal = Terminal::new(TestBackend::new(18, 4)).expect("terminal");
+
+        terminal
+            .draw(|frame| render_multi_pane(frame, &tui, &BTreeMap::new()))
+            .expect("draw");
+        let chrome = (0..18)
+            .map(|x| terminal.backend().buffer()[(x, 1)].symbol())
+            .collect::<String>();
+        assert!(chrome.contains("locked by Host"), "{chrome}");
+        assert!(!chrome.contains("Pane #1"));
     }
 
     #[test]
@@ -7678,6 +7730,29 @@ mod tests {
                 KeyEvent::new(KeyCode::Char(key), KeyModifiers::NONE)
             ));
         }
+    }
+
+    #[test]
+    fn pane_lock_chord_toggles_lock_and_stays_sticky() {
+        let area = Rect::new(0, 0, 80, 24);
+        let mut tui = MultiPaneTui::new(split_layout()).expect("valid layout");
+
+        let _ = tui.handle_key(
+            KeyEvent::new(KeyCode::Char('p'), KeyModifiers::CONTROL),
+            area,
+        );
+        assert_eq!(
+            tui.handle_key(KeyEvent::new(KeyCode::Char('k'), KeyModifiers::NONE), area),
+            KeyHandling::Consumed(vec![UiIntent::SetPaneLock {
+                pane_id: 1,
+                locked: true,
+            }])
+        );
+        assert_eq!(tui.chord_mode(), ChordMode::Pane);
+        assert!(is_chord_command(
+            ChordMode::Pane,
+            KeyEvent::new(KeyCode::Char('k'), KeyModifiers::NONE)
+        ));
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1786,7 +1786,10 @@ fn pane_title(
         available_width,
     );
     let control = if locked { "host-only" } else { &control };
-    let metadata = format!(" host: {} control: {control}", member_label(host_peer_id, members));
+    let metadata = format!(
+        " host: {} control: {control}",
+        member_label(host_peer_id, members)
+    );
     let metadata_width = available_width.saturating_sub(UnicodeWidthStr::width(label.as_str()));
     Line::from(vec![
         Span::styled(label, Style::default().add_modifier(Modifier::BOLD)),
@@ -2463,9 +2466,12 @@ fn render_shared_multi_pane(
         let view = tui.pane_views.get(&pane_id).cloned().unwrap_or_default();
         let focused = pane_id == tui.focused_pane;
         let title_width = usize::from(rect.width.saturating_sub(2));
-        let lock_badge = pane
-            .locked
-            .then(|| format!("(locked by {})", member_label(&pane.host_peer_id, &tui.snapshot.members)));
+        let lock_badge = pane.locked.then(|| {
+            format!(
+                "(locked by {})",
+                member_label(&pane.host_peer_id, &tui.snapshot.members)
+            )
+        });
         let badge_width = lock_badge
             .as_deref()
             .map_or(0, |badge| UnicodeWidthStr::width(badge).min(title_width));
@@ -6985,7 +6991,16 @@ mod tests {
             display_name: String::from("Host"),
         }];
         assert_eq!(
-            pane_title(Some("build logs"), 1, b"host", Some(b""), false, &members, 12).to_string(),
+            pane_title(
+                Some("build logs"),
+                1,
+                b"host",
+                Some(b""),
+                false,
+                &members,
+                12
+            )
+            .to_string(),
             "build logs …"
         );
     }
@@ -7872,7 +7887,7 @@ mod tests {
             ),
             (
                 ChordMode::Pane,
-                "Pane  <←↓↑→> FOCUS   <e> RENAME   <n> NEW   <r/l/d/u> SPLIT   <x> CLOSE   <Esc> BACK",
+                "Pane  <←↓↑→> FOCUS   <e> RENAME   <n> NEW   <r/l/d/u> SPLIT   <x> CLOSE   <k> LOCK   <Esc> BACK",
             ),
             (
                 ChordMode::Tab,

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -3641,6 +3641,9 @@ impl SharedLayoutRuntime {
 
     pub fn node_input(&mut self, bytes: Vec<u8>) -> Result<(), Box<dyn Error>> {
         let pane_id = self.tui.focused_pane();
+        if !self.input_allowed(pane_id) {
+            return Ok(());
+        }
         if let Some(pane) = self.local.get_mut(&pane_id) {
             pane.input(bytes.clone())?;
         }
@@ -3664,6 +3667,19 @@ impl SharedLayoutRuntime {
 
     pub fn local_focus(&self) -> (u64, u64) {
         (self.tui.current_tab(), self.tui.focused_pane())
+    }
+
+    pub fn local_peer_id(&self) -> Vec<u8> {
+        self.control.peer_id()
+    }
+
+    fn input_allowed(&self, pane_id: PaneId) -> bool {
+        let peer_id = self.control.peer_id();
+        self.tui
+            .snapshot()
+            .panes
+            .get(&pane_id)
+            .is_none_or(|pane| !pane.locked || pane.host_peer_id == peer_id)
     }
 
     /// A complete node-owned view for a newly attached local renderer. Frames are deliberately
@@ -4702,6 +4718,9 @@ impl SharedLayoutRuntime {
 
     fn forward_key(&mut self, key: KeyEvent) -> Result<(), Box<dyn Error>> {
         let pane_id = self.tui.focused_pane();
+        if !self.input_allowed(pane_id) {
+            return Ok(());
+        }
         let mut sent = false;
         if let Some(pane) = self.local.get_mut(&pane_id)
             && let Some(bytes) = encode_key(
@@ -4728,6 +4747,9 @@ impl SharedLayoutRuntime {
 
     fn forward_paste(&mut self, text: &str) -> Result<(), Box<dyn Error>> {
         let pane_id = self.tui.focused_pane();
+        if !self.input_allowed(pane_id) {
+            return Ok(());
+        }
         if let Some(pane) = self.local.get_mut(&pane_id) {
             pane.input(encode_paste(text, pane.screen.screen().bracketed_paste()))?;
         }

--- a/tests/layout.rs
+++ b/tests/layout.rs
@@ -57,7 +57,45 @@ fn initial_state_has_one_tab_and_one_hosted_pane() {
     assert_eq!(snapshot.panes.len(), 1);
     assert_eq!(snapshot.tabs[0].root, Node::Leaf { pane_id: 1 });
     assert_eq!(snapshot.panes[&1].host_peer_id, HOST_A);
+    assert!(!snapshot.panes[&1].locked);
     assert_eq!(snapshot.members[0].endpoint_addr, ADDR_A);
+}
+
+#[test]
+fn pane_host_can_lock_and_unlock_while_guests_cannot() {
+    let mut state = state();
+    state
+        .add_member(state.revision(), HOST_B.to_vec(), ADDR_B.to_vec())
+        .expect("member B joins");
+
+    state
+        .set_pane_lock(HOST_A, state.revision(), 1, true)
+        .expect("host locks pane");
+    assert!(state.pane(1).expect("pane").locked);
+    assert_eq!(
+        state.set_pane_lock(HOST_B, state.revision(), 1, false),
+        Err(LayoutError::NotPaneHost { pane_id: 1 })
+    );
+
+    state
+        .set_pane_lock(HOST_A, state.revision(), 1, false)
+        .expect("host unlocks pane");
+    assert!(!state.pane(1).expect("pane").locked);
+}
+
+#[test]
+fn pane_lock_survives_snapshot_round_trip() {
+    let mut state = state();
+    state
+        .set_pane_lock(HOST_A, state.revision(), 1, true)
+        .expect("host locks pane");
+
+    let snapshot = state.snapshot();
+    let round_trip: LayoutSnapshot =
+        serde_json::from_slice(&serde_json::to_vec(&snapshot).expect("serialize snapshot"))
+            .expect("deserialize snapshot");
+    assert_eq!(round_trip, snapshot);
+    assert!(round_trip.panes[&1].locked);
 }
 
 #[test]

--- a/tests/local_ipc.rs
+++ b/tests/local_ipc.rs
@@ -18,6 +18,7 @@ fn protocol_messages_are_tagged_and_attachment_is_generation_safe() {
         screens: Default::default(),
         leases: Default::default(),
         rosters: vec![],
+        local_peer_id: vec![],
         tab_id: 2,
         pane_id: 3,
     };

--- a/tests/module_surface.rs
+++ b/tests/module_surface.rs
@@ -17,5 +17,5 @@ fn exposes_the_scaffold_module_boundaries() {
     let _: Option<JoinTicket> = None;
     let _: Option<HostSession> = None;
     let _: Option<Envelope> = None;
-    assert_eq!(PROTOCOL_VERSION, 6);
+    assert_eq!(PROTOCOL_VERSION, 7);
 }

--- a/tests/protocol.rs
+++ b/tests/protocol.rs
@@ -6,7 +6,7 @@ use p2pmux::protocol::{
     MAX_ENVELOPE_BYTES, MAX_FRAME_BYTES, MAX_INPUT_BYTES, MAX_PANE_ID_BYTES, MAX_PEER_ID_BYTES,
     MAX_SESSION_ID_BYTES, MAX_SNAPSHOT_BYTES, MemberDescriptor, NewPanePosition, PROTOCOL_VERSION,
     PaneDescriptor, PaneFailed, PaneGrid, PaneReady, PaneReservation, PaneSubscribe, ProtocolError,
-    SessionSnapshot, SetSplitRatio, Snapshot, SplitAxis, TabDescriptor, TakeControl,
+    SessionSnapshot, SetPaneLock, SetSplitRatio, Snapshot, SplitAxis, TabDescriptor, TakeControl,
     UpdatePaneGrids, Welcome, decode_frame, encode_frame, envelope,
 };
 use prost::Message;
@@ -27,8 +27,8 @@ fn envelope(body: envelope::Body) -> Envelope {
 }
 
 #[test]
-fn protocol_version_is_v5() {
-    assert_eq!(PROTOCOL_VERSION, 6);
+fn protocol_version_is_v7() {
+    assert_eq!(PROTOCOL_VERSION, 7);
 }
 
 #[test]
@@ -49,6 +49,7 @@ fn ratio_and_grid_actions_validate_strictly() {
 
         rename_pane: None,
         rename_tab: None,
+        set_pane_lock: None,
     };
     let encoded = encode_frame(&envelope(envelope::Body::LayoutRequest(request.clone())))
         .expect("valid request");
@@ -75,6 +76,7 @@ fn ratio_and_grid_actions_validate_strictly() {
                 update_pane_grids: None,
                 rename_pane: None,
                 rename_tab: None,
+                set_pane_lock: None,
             }
         };
         assert!(encode_frame(&envelope(envelope::Body::LayoutRequest(invalid))).is_err());
@@ -98,12 +100,39 @@ fn ratio_and_grid_actions_validate_strictly() {
 
         rename_pane: None,
         rename_tab: None,
+        set_pane_lock: None,
     };
     assert!(
         decode_frame(
             &encode_frame(&envelope(envelope::Body::LayoutRequest(grids))).expect("encode")
         )
         .is_ok()
+    );
+}
+
+#[test]
+fn pane_lock_action_round_trips_and_is_the_only_action() {
+    let request = LayoutRequest {
+        request_id: 1,
+        base_revision: 1,
+        create_pane: None,
+        delete_pane: None,
+        create_tab: None,
+        delete_tab: None,
+        set_split_ratio: None,
+        update_pane_grids: None,
+        rename_pane: None,
+        rename_tab: None,
+        set_pane_lock: Some(SetPaneLock {
+            pane_id: 1,
+            locked: true,
+        }),
+    };
+    let encoded = encode_frame(&envelope(envelope::Body::LayoutRequest(request.clone())))
+        .expect("valid lock request");
+    assert_eq!(
+        decode_frame(&encoded).expect("round trip"),
+        envelope(envelope::Body::LayoutRequest(request))
     );
 }
 
@@ -427,8 +456,8 @@ fn layout_state(root: LayoutNode) -> LayoutState {
             host_peer_id: b"peer-a".to_vec(),
             grid_rows: 24,
             grid_cols: 80,
-
             title: None,
+            locked: true,
         }],
         tabs: vec![TabDescriptor {
             tab_id: 1,
@@ -463,6 +492,7 @@ fn v2_envelopes() -> Vec<Envelope> {
 
             rename_pane: None,
             rename_tab: None,
+            set_pane_lock: None,
         })),
         envelope(envelope::Body::PaneReservation(PaneReservation {
             reservation_id: 1,
@@ -550,6 +580,7 @@ fn layout_messages_reject_invalid_shapes_and_bounds() {
 
         rename_pane: None,
         rename_tab: None,
+        set_pane_lock: None,
     };
     let multiple_actions = LayoutRequest {
         create_pane: Some(CreatePane {
@@ -609,6 +640,7 @@ fn layout_messages_reject_invalid_shapes_and_bounds() {
                 grid_rows: 24,
                 grid_cols: 80,
                 title: None,
+                locked: false,
             })
             .collect(),
         ..state.clone()
@@ -629,8 +661,8 @@ fn layout_messages_reject_invalid_shapes_and_bounds() {
             host_peer_id: b"peer-a".to_vec(),
             grid_rows: 0,
             grid_cols: 80,
-
             title: None,
+            locked: true,
         }],
         ..state.clone()
     };
@@ -771,6 +803,7 @@ fn create_pane_axis_and_position_are_validated() {
 
             rename_pane: None,
             rename_tab: None,
+            set_pane_lock: None,
         }))
     }
 
@@ -782,16 +815,16 @@ fn create_pane_axis_and_position_are_validated() {
                     host_peer_id: b"peer-a".to_vec(),
                     grid_rows: 24,
                     grid_cols: 80,
-
                     title: None,
+                    locked: false,
                 },
                 PaneDescriptor {
                     pane_id: 2,
                     host_peer_id: b"peer-a".to_vec(),
                     grid_rows: 24,
                     grid_cols: 80,
-
                     title: None,
+                    locked: false,
                 },
             ],
             tabs: vec![TabDescriptor {
@@ -879,6 +912,7 @@ fn layout_grids_must_fit_the_reducer_u16_grid() {
 
         rename_pane: None,
         rename_tab: None,
+        set_pane_lock: None,
     };
 
     for valid in [
@@ -1117,6 +1151,7 @@ fn layout_state_rejects_empty_duplicate_and_dangling_references() {
                 grid_rows: 24,
                 grid_cols: 80,
                 title: None,
+                locked: false,
             },
         ],
         ..state
@@ -1166,8 +1201,8 @@ fn layout_state_wire_shape_includes_all_nested_fields() {
             host_peer_id: b"peer-a".to_vec(),
             grid_rows: 24,
             grid_cols: 80,
-
             title: None,
+            locked: true,
         }],
         tabs: vec![TabDescriptor {
             tab_id: 13,
@@ -1195,7 +1230,7 @@ fn layout_state_wire_shape_includes_all_nested_fields() {
     );
     assert_eq!(
         field_shape(&parse_fields(&state_fields[2].value)),
-        vec![(1, 0), (2, 2), (3, 0), (4, 0)]
+        vec![(1, 0), (2, 2), (3, 0), (4, 0), (6, 0)]
     );
     let tab_fields = parse_fields(&state_fields[3].value);
     assert_eq!(field_shape(&tab_fields), vec![(1, 0), (2, 2)]);

--- a/tests/session_layout.rs
+++ b/tests/session_layout.rs
@@ -3,7 +3,7 @@ use p2pmux::{
     protocol::{
         AgentRoster, AgentRosterEntry, AgentRosterState, CreatePane, CreateTab, DeletePane,
         DeleteTab, LayoutCommit, LayoutRejectReason, LayoutRequest, NewPanePosition, PaneFailed,
-        PaneGrid, PaneReady, SetSplitRatio, SplitAxis, UpdatePaneGrids,
+        PaneGrid, PaneReady, SetPaneLock, SetSplitRatio, SplitAxis, UpdatePaneGrids,
     },
     session::{CoordinatorError, CoordinatorResponse, LayoutCoordinator},
 };
@@ -46,6 +46,7 @@ fn request(request_id: u64, base_revision: u64) -> LayoutRequest {
         update_pane_grids: None,
         rename_pane: None,
         rename_tab: None,
+        set_pane_lock: None,
     }
 }
 
@@ -117,6 +118,38 @@ fn admitted_members_set_ratios_and_hosts_reconcile_their_grids() {
             .grid_rows,
         30
     );
+}
+
+#[test]
+fn pane_host_can_set_lock_and_guest_is_rejected() {
+    let mut coordinator = coordinator();
+    coordinator
+        .admit(host_b(), addr_b())
+        .expect("member admitted");
+
+    let commit = commit(coordinator.handle_request(
+        &host_a(),
+        LayoutRequest {
+            set_pane_lock: Some(SetPaneLock {
+                pane_id: 1,
+                locked: true,
+            }),
+            ..request(1, 2)
+        },
+    ));
+    assert!(commit.state.expect("state").panes[0].locked);
+
+    let rejection = reject(coordinator.handle_request(
+        &host_b(),
+        LayoutRequest {
+            set_pane_lock: Some(SetPaneLock {
+                pane_id: 1,
+                locked: false,
+            }),
+            ..request(2, 3)
+        },
+    ));
+    assert_eq!(rejection.reason, LayoutRejectReason::NotHost as i32);
 }
 
 fn commit(response: CoordinatorResponse) -> LayoutCommit {

--- a/tests/session_layout_control.rs
+++ b/tests/session_layout_control.rs
@@ -89,6 +89,7 @@ fn create_request(request_id: u64, base_revision: u64) -> LayoutRequest {
         update_pane_grids: None,
         rename_pane: None,
         rename_tab: None,
+        set_pane_lock: None,
     }
 }
 
@@ -245,8 +246,8 @@ async fn late_joiner_subscribes_after_snapshot_without_preloaded_host_roster() {
         host_peer_id: host_id.clone(),
         grid_rows: 1,
         grid_cols: 1,
-
         title: None,
+        locked: false,
     };
     let screen = HostScreen::new(1, 1).expect("screen");
     let (_screen_tx, screen_rx) = tokio::sync::watch::channel(screen.current_frame().clone());
@@ -322,8 +323,8 @@ async fn departed_member_loses_direct_pane_access_while_healthy_member_receives_
         host_peer_id: host_id.clone(),
         grid_rows: 1,
         grid_cols: 1,
-
         title: None,
+        locked: false,
     };
     let screen = HostScreen::new(1, 1).expect("screen");
     let (_screen_tx, screen_rx) = tokio::sync::watch::channel(screen.current_frame().clone());
@@ -485,6 +486,7 @@ async fn forged_post_welcome_sender_is_rejected_without_a_layout_mutation() {
 
                 rename_pane: None,
                 rename_tab: None,
+                set_pane_lock: None,
             })),
         })
         .await
@@ -555,6 +557,7 @@ async fn deleting_a_member_owned_tab_broadcasts_the_full_commit() {
 
             rename_pane: None,
             rename_tab: None,
+            set_pane_lock: None,
         })
         .expect("queue tab request");
     let reservation = match next_event(&mut second).await {
@@ -591,6 +594,7 @@ async fn deleting_a_member_owned_tab_broadcasts_the_full_commit() {
 
             rename_pane: None,
             rename_tab: None,
+            set_pane_lock: None,
         })
         .expect("queue tab delete");
     for member in [&mut first, &mut second] {
@@ -673,6 +677,7 @@ async fn reservation_is_targeted_and_ready_broadcasts_the_commit() {
 
             rename_pane: None,
             rename_tab: None,
+            set_pane_lock: None,
         })
         .expect("queue deletion");
     assert!(
@@ -695,6 +700,7 @@ async fn reservation_is_targeted_and_ready_broadcasts_the_commit() {
 
             rename_pane: None,
             rename_tab: None,
+            set_pane_lock: None,
         })
         .expect("queue foreign deletion");
     assert!(matches!(

--- a/tests/session_stream.rs
+++ b/tests/session_stream.rs
@@ -106,6 +106,7 @@ async fn direct_subscription_streams_a_registered_non_default_pane_without_synth
         grid_rows: 1,
         grid_cols: 3,
         title: None,
+        locked: false,
     };
     let mut screen = HostScreen::new(1, 3).expect("screen");
     let (screen_tx, screen_rx) = tokio::sync::watch::channel(screen.current_frame().clone());
@@ -218,16 +219,16 @@ async fn one_viewer_subscribes_to_panes_owned_by_two_different_hosts() {
         host_peer_id: first_id.clone(),
         grid_rows: 1,
         grid_cols: 1,
-
         title: None,
+        locked: false,
     };
     let second_descriptor = PaneDescriptor {
         pane_id: 12,
         host_peer_id: second_id.clone(),
         grid_rows: 1,
         grid_cols: 1,
-
         title: None,
+        locked: false,
     };
     let first_screen = HostScreen::new(1, 1).expect("first screen");
     let second_screen = HostScreen::new(1, 1).expect("second screen");
@@ -351,8 +352,8 @@ async fn direct_subscriptions_reject_unknown_nonmember_and_mismatched_hosts() {
         host_peer_id: host_id.clone(),
         grid_rows: 1,
         grid_cols: 1,
-
         title: None,
+        locked: false,
     };
     let unknown_task = {
         let server = server.clone();
@@ -389,8 +390,8 @@ async fn direct_subscriptions_reject_unknown_nonmember_and_mismatched_hosts() {
         host_peer_id: host_id.clone(),
         grid_rows: 1,
         grid_cols: 1,
-
         title: None,
+        locked: false,
     };
     server
         .register_pane(
@@ -472,8 +473,8 @@ async fn rejected_direct_subscriber_cannot_inject_control_into_a_registered_pane
                 host_peer_id: host_id.clone(),
                 grid_rows: 1,
                 grid_cols: 1,
-
                 title: None,
+                locked: false,
             },
             HostPaneChannels {
                 pane_id: pane_wire_id(101),
@@ -575,8 +576,8 @@ async fn pane_server_accept_loop_serves_two_viewers_without_waiting_for_the_firs
         host_peer_id: host_id.clone(),
         grid_rows: 1,
         grid_cols: 1,
-
         title: None,
+        locked: false,
     };
     server
         .register_pane(
@@ -662,8 +663,8 @@ async fn pane_server_retries_an_idle_accept_timeout_before_serving_a_later_conne
         host_peer_id: host_id.clone(),
         grid_rows: 1,
         grid_cols: 1,
-
         title: None,
+        locked: false,
     };
     server
         .register_pane(
@@ -738,8 +739,8 @@ async fn removing_a_pane_disconnects_subscribers_and_blocks_later_control_delive
         host_peer_id: host_id.clone(),
         grid_rows: 1,
         grid_cols: 1,
-
         title: None,
+        locked: false,
     };
     server
         .register_pane(


### PR DESCRIPTION
## Summary
- Hosts can lock their panes (`Ctrl+P` then `k`); guests stay spectators and cannot type or paste
- Protocol v7 carries `Pane.locked`; host-side PTY gate is authoritative; optimistic local gate with rollback on reject
- Locked panes show top-right `(locked by X)` and `control: host-only` on the left title

## Test plan
- [ ] Host: `Ctrl+P` `k` on own pane → lock badge appears; unlock with same chord
- [ ] Guest focused on locked pane: keystrokes and paste do not enter the PTY; screen still updates
- [ ] Guest holding control when host locks → guest loses control immediately
- [ ] Host can still type in a locked pane they own
- [ ] Narrow pane width: left title and `(locked by …)` do not collide unreadably
- [ ] v6 client cannot join a v7 session (version handshake)
- [ ] `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test`


Made with [Cursor](https://cursor.com)