### PR TITLE
fix(client): Shift+Enter newline in create/attach

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -13,7 +13,8 @@ use std::{
 use crossterm::{
     event::{
         self, DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture,
-        Event, KeyCode, KeyEventKind, KeyModifiers, MouseEventKind,
+        Event, KeyCode, KeyEventKind, KeyModifiers, KeyboardEnhancementFlags, MouseEventKind,
+        PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
     },
     execute,
     terminal::{self, EnterAlternateScreen, LeaveAlternateScreen, SetTitle},
@@ -500,40 +501,56 @@ fn available_scrollback(screen: &vt100::Screen) -> usize {
 }
 
 struct ClientTerminalGuard {
+    stdout: io::Stdout,
     raw: bool,
+    keyboard_enhancement: bool,
     alternate: bool,
     paste: bool,
     mouse: bool,
 }
 impl ClientTerminalGuard {
     fn enter(name: &str) -> io::Result<Self> {
+        let mut guard = Self {
+            stdout: io::stdout(),
+            raw: false,
+            keyboard_enhancement: false,
+            alternate: false,
+            paste: false,
+            mouse: false,
+        };
         terminal::enable_raw_mode()?;
+        guard.raw = true;
         execute!(
-            io::stdout(),
-            SetTitle(format!("p2pmux ({name})")),
-            EnterAlternateScreen,
-            EnableBracketedPaste,
-            EnableMouseCapture,
+            guard.stdout,
+            PushKeyboardEnhancementFlags(KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES),
         )?;
-        Ok(Self {
-            raw: true,
-            alternate: true,
-            paste: true,
-            mouse: true,
-        })
+        guard.keyboard_enhancement = true;
+        execute!(guard.stdout, SetTitle(format!("p2pmux ({name})")))?;
+        execute!(guard.stdout, EnterAlternateScreen)?;
+        guard.alternate = true;
+        execute!(guard.stdout, EnableBracketedPaste)?;
+        guard.paste = true;
+        execute!(guard.stdout, EnableMouseCapture)?;
+        guard.mouse = true;
+        Ok(guard)
     }
     fn leave(&mut self) -> io::Result<()> {
         if self.mouse {
-            execute!(io::stdout(), DisableMouseCapture)?;
+            execute!(self.stdout, DisableMouseCapture)?;
             self.mouse = false;
         }
         if self.paste {
-            execute!(io::stdout(), DisableBracketedPaste)?;
+            execute!(self.stdout, DisableBracketedPaste)?;
             self.paste = false;
         }
         if self.alternate {
-            execute!(io::stdout(), LeaveAlternateScreen)?;
+            execute!(self.stdout, LeaveAlternateScreen)?;
             self.alternate = false;
+        }
+        if self.keyboard_enhancement {
+            execute!(self.stdout, PopKeyboardEnhancementFlags)?;
+            self.stdout.flush()?;
+            self.keyboard_enhancement = false;
         }
         if self.raw {
             terminal::disable_raw_mode()?;

--- a/src/client.rs
+++ b/src/client.rs
@@ -170,11 +170,8 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
                             .get(&tui.focused_pane())
                             .is_some_and(GuestScreen::kitty_keyboard_active);
                         if input_allowed(tui, &local_peer_id)
-                            && let Some(bytes) = client_key_bytes(
-                                key.code,
-                                key.modifiers,
-                                kitty_keyboard_active,
-                            )
+                            && let Some(bytes) =
+                                client_key_bytes(key.code, key.modifiers, kitty_keyboard_active)
                         {
                             write_message(&mut stream, &ClientMessage::Input { bytes })?;
                         }
@@ -703,6 +700,34 @@ mod tests {
         assert_eq!(
             client_key_bytes(KeyCode::Char('q'), KeyModifiers::CONTROL, false),
             Some(vec![17])
+        );
+    }
+
+    #[test]
+    fn encodes_shift_enter_for_the_focused_pane_keyboard_mode() {
+        assert_eq!(
+            client_key_bytes(KeyCode::Enter, KeyModifiers::NONE, false),
+            Some(b"\r".to_vec())
+        );
+        assert_eq!(
+            client_key_bytes(KeyCode::Enter, KeyModifiers::SHIFT, false),
+            Some(b"\n".to_vec())
+        );
+        assert_eq!(
+            client_key_bytes(KeyCode::Enter, KeyModifiers::SHIFT, true),
+            Some(b"\x1b[13;2u".to_vec())
+        );
+        assert_eq!(
+            client_key_bytes(KeyCode::Char('j'), KeyModifiers::CONTROL, false),
+            Some(b"\n".to_vec())
+        );
+        assert_eq!(
+            client_key_bytes(KeyCode::Enter, KeyModifiers::ALT, true),
+            Some(b"\r".to_vec())
+        );
+        assert_eq!(
+            client_key_bytes(KeyCode::Enter, KeyModifiers::CONTROL, true),
+            Some(b"\r".to_vec())
         );
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -166,8 +166,15 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
                         dirty = true;
                     }
                     KeyHandling::Forward => {
+                        let kitty_keyboard_active = screens
+                            .get(&tui.focused_pane())
+                            .is_some_and(GuestScreen::kitty_keyboard_active);
                         if input_allowed(tui, &local_peer_id)
-                            && let Some(bytes) = client_key_bytes(key.code, key.modifiers)
+                            && let Some(bytes) = client_key_bytes(
+                                key.code,
+                                key.modifiers,
+                                kitty_keyboard_active,
+                            )
                         {
                             write_message(&mut stream, &ClientMessage::Input { bytes })?;
                         }
@@ -474,7 +481,11 @@ fn spawn_message_reader(
     (receiver, thread)
 }
 
-fn client_key_bytes(code: KeyCode, modifiers: KeyModifiers) -> Option<Vec<u8>> {
+fn client_key_bytes(
+    code: KeyCode,
+    modifiers: KeyModifiers,
+    kitty_keyboard_active: bool,
+) -> Option<Vec<u8>> {
     match code {
         KeyCode::Char(character)
             if modifiers.contains(KeyModifiers::CONTROL) && character.is_ascii_alphabetic() =>
@@ -482,6 +493,13 @@ fn client_key_bytes(code: KeyCode, modifiers: KeyModifiers) -> Option<Vec<u8>> {
             Some(vec![character.to_ascii_lowercase() as u8 - b'a' + 1])
         }
         KeyCode::Char(character) => Some(character.to_string().into_bytes()),
+        KeyCode::Enter if modifiers == KeyModifiers::SHIFT => {
+            if kitty_keyboard_active {
+                Some(b"\x1b[13;2u".to_vec())
+            } else {
+                Some(b"\n".to_vec())
+            }
+        }
         KeyCode::Enter => Some(b"\r".to_vec()),
         KeyCode::Backspace => Some(b"\x7f".to_vec()),
         KeyCode::Tab => Some(b"\t".to_vec()),
@@ -679,11 +697,11 @@ mod tests {
     #[test]
     fn ctrl_q_is_reserved_for_detach() {
         assert_eq!(
-            client_key_bytes(KeyCode::Char('c'), KeyModifiers::CONTROL),
+            client_key_bytes(KeyCode::Char('c'), KeyModifiers::CONTROL, false),
             Some(vec![3])
         );
         assert_eq!(
-            client_key_bytes(KeyCode::Char('q'), KeyModifiers::CONTROL),
+            client_key_bytes(KeyCode::Char('q'), KeyModifiers::CONTROL, false),
             Some(vec![17])
         );
     }


### PR DESCRIPTION
## Summary
- Enable kitty keyboard disambiguation on the attach client so Ghostty can report Shift+Enter distinctly from Enter.
- Map Enter+Shift to `\n` (or kitty CSI-u when the focused pane has kitty mode active), matching Ctrl+J / the existing TUI encode path.
- Leave plain Enter as `\r` submit; Alt/Ctrl Enter unchanged.

## Test plan
- [ ] `cargo test --all-features`
- [ ] In Ghostty: `p2pmux create`, open an agent (e.g. Claude Code), confirm Shift+Enter inserts a newline and Enter submits
- [ ] Confirm Ctrl+J still inserts a newline
- [ ] `p2pmux attach <name>` and repeat Shift+Enter / Enter / Ctrl+J


Made with [Cursor](https://cursor.com)