### PR TITLE
fix: keep Shift+Enter working after alternate screen

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -535,11 +535,6 @@ impl ClientTerminalGuard {
         };
         terminal::enable_raw_mode()?;
         guard.raw = true;
-        execute!(
-            guard.stdout,
-            PushKeyboardEnhancementFlags(KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES),
-        )?;
-        guard.keyboard_enhancement = true;
         execute!(guard.stdout, SetTitle(format!("p2pmux ({name})")))?;
         execute!(guard.stdout, EnterAlternateScreen)?;
         guard.alternate = true;
@@ -547,6 +542,11 @@ impl ClientTerminalGuard {
         guard.paste = true;
         execute!(guard.stdout, EnableMouseCapture)?;
         guard.mouse = true;
+        execute!(
+            guard.stdout,
+            PushKeyboardEnhancementFlags(KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES),
+        )?;
+        guard.keyboard_enhancement = true;
         Ok(guard)
     }
     fn leave(&mut self) -> io::Result<()> {

--- a/src/client.rs
+++ b/src/client.rs
@@ -582,15 +582,40 @@ impl Drop for ClientTerminalGuard {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
+    use std::{
+        collections::BTreeMap,
+        thread,
+        time::{Duration, Instant},
+    };
+
+    use portable_pty::{CommandBuilder, PtySize};
 
     use crate::{
         layout::{LayoutSnapshot, Member, Node, Pane, Tab},
         local_ipc::AgentOverlaySnapshotRow,
+        pty_host::PtyHost,
         tui::{AGENT_TOGGLE_WINDOW, UiIntent},
     };
 
     use super::*;
+
+    fn read_until(host: &mut PtyHost, expected: &str) -> String {
+        let deadline = Instant::now() + Duration::from_secs(2);
+        let mut output = String::new();
+        while Instant::now() < deadline {
+            while let Some(bytes) = host
+                .try_read_output()
+                .expect("PTY reader should stay healthy")
+            {
+                output.push_str(&String::from_utf8_lossy(&bytes));
+            }
+            if output.contains(expected) {
+                return output;
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+        panic!("did not receive {expected:?}; received {output:?}");
+    }
 
     fn layout(pane_ids: &[u64]) -> LayoutSnapshot {
         let root = pane_ids
@@ -729,6 +754,35 @@ mod tests {
             client_key_bytes(KeyCode::Enter, KeyModifiers::CONTROL, true),
             Some(b"\r".to_vec())
         );
+    }
+
+    #[test]
+    fn shift_enter_encodes_as_lf_and_agent_treats_it_as_newline() {
+        let bytes = client_key_bytes(KeyCode::Enter, KeyModifiers::SHIFT, false)
+            .expect("Shift+Enter should encode");
+        assert_eq!(bytes, b"\n");
+
+        let probe = format!(
+            "{}/tests/fixtures/agent_newline_probe.js",
+            env!("CARGO_MANIFEST_DIR")
+        );
+        let mut command = CommandBuilder::new("node");
+        command.arg(probe);
+        let mut host = PtyHost::spawn(
+            command,
+            PtySize {
+                rows: 24,
+                cols: 80,
+                pixel_width: 0,
+                pixel_height: 0,
+            },
+        )
+        .expect("Node probe PTY should spawn");
+
+        assert!(read_until(&mut host, "READY").contains("READY"));
+        host.write_input(&bytes).expect("PTY should accept LF");
+        assert!(read_until(&mut host, "NEWLINE").contains("NEWLINE"));
+        host.shutdown().expect("PTY should shut down cleanly");
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -3837,7 +3837,6 @@ impl SharedLayoutRuntime {
         let mut guard = TerminalGuard::new();
         enable_raw_mode()?;
         guard.raw_mode = true;
-        guard.keyboard_enhancement = enable_keyboard_enhancement()?;
         execute!(io::stdout(), SetTitle("p2pmux"))?;
         guard.alternate_screen = true;
         execute!(io::stdout(), EnterAlternateScreen)?;
@@ -3845,6 +3844,7 @@ impl SharedLayoutRuntime {
         execute!(io::stdout(), crossterm::event::EnableBracketedPaste)?;
         guard.mouse_capture = true;
         execute!(io::stdout(), EnableMouseCapture)?;
+        guard.keyboard_enhancement = enable_keyboard_enhancement()?;
         let backend = CrosstermBackend::new(io::stdout());
         let mut terminal = Terminal::with_options(
             backend,
@@ -5154,12 +5154,12 @@ pub fn run_local() -> Result<(), Box<dyn Error>> {
     let mut guard = TerminalGuard::new();
     enable_raw_mode()?;
     guard.raw_mode = true;
-    guard.keyboard_enhancement = enable_keyboard_enhancement()?;
     execute!(io::stdout(), SetTitle("p2pmux"))?;
     guard.alternate_screen = true;
     execute!(io::stdout(), EnterAlternateScreen)?;
     guard.bracketed_paste = true;
     execute!(io::stdout(), crossterm::event::EnableBracketedPaste)?;
+    guard.keyboard_enhancement = enable_keyboard_enhancement()?;
 
     let backend = CrosstermBackend::new(io::stdout());
     let fixed_area = Rect::new(0, 0, cols, rows);
@@ -5234,11 +5234,11 @@ pub fn run_host(mut runtime: HostPaneRuntime) -> Result<(), Box<dyn Error>> {
     let mut guard = TerminalGuard::new();
     enable_raw_mode()?;
     guard.raw_mode = true;
-    guard.keyboard_enhancement = enable_keyboard_enhancement()?;
     guard.alternate_screen = true;
     execute!(io::stdout(), EnterAlternateScreen)?;
     guard.bracketed_paste = true;
     execute!(io::stdout(), crossterm::event::EnableBracketedPaste)?;
+    guard.keyboard_enhancement = enable_keyboard_enhancement()?;
     let backend = CrosstermBackend::new(io::stdout());
     let mut terminal = Terminal::with_options(
         backend,
@@ -5388,11 +5388,11 @@ pub fn run_guest(mut pane: GuestPane) -> Result<(), Box<dyn Error>> {
     let mut guard = TerminalGuard::new();
     enable_raw_mode()?;
     guard.raw_mode = true;
-    guard.keyboard_enhancement = enable_keyboard_enhancement()?;
     guard.alternate_screen = true;
     execute!(io::stdout(), EnterAlternateScreen)?;
     guard.bracketed_paste = true;
     execute!(io::stdout(), crossterm::event::EnableBracketedPaste)?;
+    guard.keyboard_enhancement = enable_keyboard_enhancement()?;
 
     let backend = CrosstermBackend::new(io::stdout());
     let mut terminal = Terminal::with_options(

--- a/tests/fixtures/ghostty_keyboard_order.sh
+++ b/tests/fixtures/ghostty_keyboard_order.sh
@@ -1,0 +1,83 @@
+#!/bin/sh
+
+set -eu
+
+ghostty=/Applications/Ghostty.app/Contents/MacOS/ghostty
+
+probe() {
+    mode=$1
+    result=$2
+    python3 - "$mode" "$result" <<'PY'
+import os
+import select
+import sys
+import termios
+import tty
+
+mode, result = sys.argv[1:]
+fd = sys.stdin.fileno()
+try:
+    saved = termios.tcgetattr(fd)
+    tty.setraw(fd)
+except termios.error:
+    saved = None
+try:
+    if mode == "before-alt":
+        sequence = b"\x1b[>1u\x1b[?1049h"
+    elif mode == "after-alt":
+        sequence = b"\x1b[?1049h\x1b[>1u"
+    else:
+        raise SystemExit(f"unknown probe mode: {mode}")
+    os.write(fd, sequence + b"\x1b[?u")
+    ready, _, _ = select.select([fd], [], [], 2)
+    reply = os.read(fd, 64) if ready else b""
+finally:
+    os.write(fd, b"\x1b[<1u\x1b[?1049l")
+    if saved is not None:
+        termios.tcsetattr(fd, termios.TCSADRAIN, saved)
+
+with open(result, "w", encoding="ascii") as output:
+    output.write(reply.hex() + "\n")
+PY
+}
+
+if [ "${1:-}" = --probe ]; then
+    probe "$2" "$3"
+    exit 0
+fi
+
+if [ ! -x "$ghostty" ]; then
+    echo "SKIP: Ghostty is not installed at $ghostty"
+    exit 0
+fi
+
+if [ ! -t 0 ] || [ ! -t 1 ]; then
+    echo "SKIP: run this script from an interactive Ghostty terminal"
+    exit 0
+fi
+
+case ${TERM_PROGRAM:-} in
+    Ghostty|ghostty) ;;
+    *)
+        echo "SKIP: run this script from an interactive Ghostty terminal"
+        exit 0
+        ;;
+esac
+
+tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/p2pmux-ghostty-order.XXXXXX")
+trap 'rm -rf "$tmpdir"' EXIT HUP INT TERM
+
+probe before-alt "$tmpdir/before-alt"
+probe after-alt "$tmpdir/after-alt"
+before=$(cat "$tmpdir/before-alt")
+after=$(cat "$tmpdir/after-alt")
+
+printf 'Ghostty keyboard flags: before-alt=%s after-alt=%s\n' "$before" "$after"
+[ "$before" = 1b5b3f3075 ] || {
+    echo "FAIL: expected before-alt reply ESC[?0u" >&2
+    exit 1
+}
+[ "$after" = 1b5b3f3175 ] || {
+    echo "FAIL: expected after-alt reply ESC[?1u" >&2
+    exit 1
+}


### PR DESCRIPTION
## Summary
- Ghostty clears kitty keyboard enhancement flags when entering the alternate screen. PR #27 pushed enhancement *before* alt-screen, so Shift+Enter still arrived as plain Enter (`\r`) and submitted.
- Push keyboard disambiguation **after** alternate screen (and other setup) in the attach client and TUI paths.
- Add a Ghostty order regression script plus encoding coverage for the LF newline path.

## Repro / verification
Under Ghostty:
- old order `>1u` then alt-screen → query replies `?0u` (broken)
- new order alt-screen then `>1u` → query replies `?1u` (fixed)

## Test plan
- [x] `cargo test --all-features`
- [x] Ghostty manual order check (`?1u` after fixed sequence, `?0u` after old sequence)
- [ ] In Ghostty: `cargo run -- create` (or installed binary from this branch), open an agent, confirm Shift+Enter inserts a newline and Enter submits
- [ ] Confirm Ctrl+J still inserts a newline
- [ ] Optional: `tests/fixtures/ghostty_keyboard_order.sh` from an interactive Ghostty shell


Made with [Cursor](https://cursor.com)