### PR TITLE
ux: vivid red pane mode, exit chords on actions, confirm multi-pane tab delete

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -270,7 +270,9 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
             }
             Event::Mouse(mouse) => {
                 let area = terminal.size()?.into();
-                if tui.overlay_open() {
+                if tui.modal_open() {
+                    // Blocking dialogs consume mouse input without affecting panes.
+                } else if tui.overlay_open() {
                     if matches!(
                         mouse.kind,
                         MouseEventKind::ScrollUp | MouseEventKind::ScrollDown
@@ -319,8 +321,10 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
             }
             Event::Resize(cols, rows) => {
                 terminal.resize(Rect::new(0, 0, cols, rows))?;
-                tui.set_agent_overlay_viewport(Rect::new(0, 0, cols, rows));
-                write_message(&mut stream, &ClientMessage::Resize { cols, rows })?;
+                if !tui.modal_open() {
+                    tui.set_agent_overlay_viewport(Rect::new(0, 0, cols, rows));
+                    write_message(&mut stream, &ClientMessage::Resize { cols, rows })?;
+                }
                 dirty = true;
             }
             _ => {}
@@ -369,7 +373,7 @@ fn input_allowed(tui: &MultiPaneTui, local_peer_id: &[u8]) -> bool {
 }
 
 fn should_forward_paste(tui: &MultiPaneTui, local_peer_id: &[u8]) -> bool {
-    !tui.overlay_open() && input_allowed(tui, local_peer_id)
+    !tui.overlay_open() && !tui.modal_open() && input_allowed(tui, local_peer_id)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1028,6 +1032,25 @@ mod tests {
 
         assert!(!should_forward_paste(tui, b"host"));
         assert!(tui.scroll_agent_overlay(area, false));
+    }
+
+    #[test]
+    fn delete_confirmation_blocks_paste_and_scrolling() {
+        let mut tui = MultiPaneTui::new(layout(&[1, 2])).expect("layout");
+        let area = Rect::new(0, 0, 80, 24);
+
+        let _ = tui.handle_key(
+            crossterm::event::KeyEvent::new(KeyCode::Char('t'), KeyModifiers::CONTROL),
+            area,
+        );
+        let _ = tui.handle_key(
+            crossterm::event::KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE),
+            area,
+        );
+
+        assert!(tui.modal_open());
+        assert!(!should_forward_paste(&tui, b"host"));
+        assert!(!tui.scroll_mouse_pane(10, 2, area, 10, true));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,7 +9,7 @@ use serde::Deserialize;
 
 static CONFIG_WRITE_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
-const DEFAULT_CONFIG_TEMPLATE: &str = "# p2pmux local configuration\n#\n# display_name is visible to peers.\n# display_name = \"your-name\"\n\n# UI chrome is local to this client and is never shared with session peers.\n[ui.theme]\n# Named colors: white, yellow, gray, dark_gray\n# Hex colors: #RRGGBB\n#\n# footer_background = \"#1e1e1e\"\n# footer_muted = \"white\"\n# footer_accent = \"#dc322f\"\n# footer_orange = \"#ff7846\"\n# tab_active_background = \"#dc322f\"\n# tab_foreground = \"white\"\n# tab_separator = \"dark_gray\"\n# copy_feedback_accent = \"#ff4500\"\n# agent_overlay_chrome = \"#ff4500\"\n# agent_overlay_selected_background = \"#2a2a2a\"\n# agent_overlay_muted = \"#919db4\"\n# agent_overlay_warm = \"#ffb84d\"\n# agent_overlay_foreground = \"white\"\n# agent_overlay_secondary = \"gray\"\n# pane_border_free_focused = \"white\"\n# pane_border_unknown_focused = \"yellow\"\n# pane_border_chord_focused = \"#3dd68c\"\n# pane_border_hovered = \"gray\"\n# pane_border_idle = \"dark_gray\"\n# pane_border_remote_control = \"#ff4500\"\n";
+const DEFAULT_CONFIG_TEMPLATE: &str = "# p2pmux local configuration\n#\n# display_name is visible to peers.\n# display_name = \"your-name\"\n\n# UI chrome is local to this client and is never shared with session peers.\n[ui.theme]\n# Named colors: white, yellow, gray, dark_gray\n# Hex colors: #RRGGBB\n#\n# footer_background = \"#1e1e1e\"\n# footer_muted = \"white\"\n# footer_accent = \"#dc322f\"\n# footer_orange = \"#ff7846\"\n# tab_active_background = \"#dc322f\"\n# tab_foreground = \"white\"\n# tab_separator = \"dark_gray\"\n# copy_feedback_accent = \"#ff4500\"\n# agent_overlay_chrome = \"#ff4500\"\n# agent_overlay_selected_background = \"#2a2a2a\"\n# agent_overlay_muted = \"#919db4\"\n# agent_overlay_warm = \"#ffb84d\"\n# agent_overlay_foreground = \"white\"\n# agent_overlay_secondary = \"gray\"\n# pane_border_free_focused = \"white\"\n# pane_border_unknown_focused = \"yellow\"\n# pane_border_chord_focused = \"#ff1a1a\"\n# pane_border_hovered = \"gray\"\n# pane_border_idle = \"dark_gray\"\n# pane_border_remote_control = \"#ff4500\"\n";
 
 #[derive(Debug)]
 pub enum ConfigError {
@@ -94,7 +94,7 @@ impl Default for UiTheme {
             agent_overlay_secondary: Color::Gray,
             pane_border_free_focused: Color::White,
             pane_border_unknown_focused: Color::Yellow,
-            pane_border_chord_focused: Color::Rgb(61, 214, 140),
+            pane_border_chord_focused: Color::Rgb(255, 26, 26),
             pane_border_hovered: Color::Gray,
             pane_border_idle: Color::DarkGray,
             pane_border_remote_control: Color::Rgb(255, 69, 0),
@@ -435,12 +435,12 @@ mod tests {
     }
 
     #[test]
-    fn chord_focused_pane_border_defaults_to_soft_green_and_is_configurable() {
+    fn chord_focused_pane_border_defaults_to_vivid_red_and_is_configurable() {
         assert_eq!(
             UiTheme::default().pane_border_chord_focused,
-            Color::Rgb(61, 214, 140)
+            Color::Rgb(255, 26, 26)
         );
-        assert!(DEFAULT_CONFIG_TEMPLATE.contains("pane_border_chord_focused = \"#3dd68c\""));
+        assert!(DEFAULT_CONFIG_TEMPLATE.contains("pane_border_chord_focused = \"#ff1a1a\""));
 
         let path = temp_config_path();
         fs::create_dir_all(path.parent().unwrap()).unwrap();

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -341,6 +341,10 @@ enum ModalState {
     None,
     Agents,
     Rename(RenamePrompt),
+    ConfirmDeleteTab {
+        tab_id: TabId,
+        pane_count: usize,
+    },
 }
 
 /// Rectangles for one rendered terminal frame.
@@ -507,6 +511,14 @@ impl MultiPaneTui {
 
     pub fn overlay_open(&self) -> bool {
         matches!(self.modal, ModalState::Agents)
+    }
+
+    /// Whether a blocking dialog is open, excluding the interactive agents overlay.
+    pub fn modal_open(&self) -> bool {
+        matches!(
+            self.modal,
+            ModalState::Rename(_) | ModalState::ConfirmDeleteTab { .. }
+        )
     }
 
     pub fn set_agent_rows(&mut self, mut rows: Vec<AgentOverlayRow>) -> bool {
@@ -870,6 +882,9 @@ impl MultiPaneTui {
         scrollback_len: usize,
         up: bool,
     ) -> bool {
+        if self.modal_open() {
+            return false;
+        }
         let pane_id = self.pane_at_or_focused(column, row, area);
         self.scroll_pane(pane_id, scrollback_len, up)
     }
@@ -1124,6 +1139,9 @@ impl MultiPaneTui {
         if matches!(self.modal, ModalState::Rename(_)) {
             return self.handle_rename_key(key);
         }
+        if matches!(self.modal, ModalState::ConfirmDeleteTab { .. }) {
+            return self.handle_confirm_delete_tab_key(key);
+        }
         if key.code == KeyCode::Char('a') && key.modifiers == KeyModifiers::CONTROL {
             if self.overlay_open() {
                 let forward = self
@@ -1211,7 +1229,7 @@ impl MultiPaneTui {
         mouse: crossterm::event::MouseEvent,
         area: Rect,
     ) -> MouseHandling {
-        if matches!(self.modal, ModalState::Rename(_)) {
+        if self.modal_open() {
             return MouseHandling::default();
         }
         match mouse.kind {
@@ -1382,6 +1400,31 @@ impl MultiPaneTui {
         }
     }
 
+    fn confirm_delete_tab(&mut self, tab_id: TabId, pane_count: usize) {
+        self.modal = ModalState::ConfirmDeleteTab { tab_id, pane_count };
+        self.exit_chord_mode();
+        self.clear_selection();
+        self.cancel_resize_drag();
+    }
+
+    fn handle_confirm_delete_tab_key(&mut self, key: KeyEvent) -> KeyHandling {
+        let tab_id = match &self.modal {
+            ModalState::ConfirmDeleteTab { tab_id, .. } => *tab_id,
+            _ => unreachable!("delete confirmation handler requires an active confirmation"),
+        };
+        match key.code {
+            KeyCode::Enter | KeyCode::Char('y') if key.modifiers.is_empty() => {
+                self.modal = ModalState::None;
+                KeyHandling::Consumed(vec![UiIntent::DeleteTab { tab_id }])
+            }
+            KeyCode::Esc | KeyCode::Char('n') if key.modifiers.is_empty() => {
+                self.modal = ModalState::None;
+                KeyHandling::Consumed(vec![])
+            }
+            _ => KeyHandling::Consumed(vec![]),
+        }
+    }
+
     fn handle_agent_overlay_click(&mut self, column: u16, row: u16, area: Rect) -> Vec<UiIntent> {
         let Some(pane_id) = self.agent_overlay_row_at(column, row, area) else {
             return Vec::new();
@@ -1528,9 +1571,20 @@ impl MultiPaneTui {
                     grid_cols,
                 })
             }
-            KeyCode::Char('x') if key.modifiers.is_empty() => Some(UiIntent::DeleteTab {
-                tab_id: self.current_tab,
-            }),
+            KeyCode::Char('x') if key.modifiers.is_empty() => {
+                let tab = self
+                    .snapshot
+                    .tabs
+                    .iter()
+                    .find(|tab| tab.tab_id == self.current_tab)?;
+                let pane_count = visible_leaf_panes(&tab.root).len();
+                if pane_count > 1 {
+                    self.confirm_delete_tab(tab.tab_id, pane_count);
+                    None
+                } else {
+                    Some(UiIntent::DeleteTab { tab_id: tab.tab_id })
+                }
+            }
             KeyCode::Left if key.modifiers.is_empty() => self.switch_tab(false),
             KeyCode::Right if key.modifiers.is_empty() => self.switch_tab(true),
             _ => None,
@@ -2779,6 +2833,9 @@ fn render_shared_multi_pane(
     if let ModalState::Rename(prompt) = &tui.modal {
         render_rename_prompt(frame, prompt, &tui.theme);
     }
+    if let ModalState::ConfirmDeleteTab { pane_count, .. } = &tui.modal {
+        render_delete_tab_confirmation(frame, *pane_count, &tui.theme);
+    }
 }
 
 fn render_agents_overlay(frame: &mut Frame<'_>, tui: &MultiPaneTui, now_unix_ms: u64) {
@@ -2933,6 +2990,38 @@ fn render_rename_prompt(frame: &mut Frame<'_>, prompt: &RenamePrompt, theme: &Ui
         Style::default().fg(theme.footer_muted),
     ));
     frame.render_widget(Paragraph::new(lines), inner);
+}
+
+fn render_delete_tab_confirmation(frame: &mut Frame<'_>, pane_count: usize, theme: &UiTheme) {
+    let area = frame.area();
+    let width = area.width.saturating_sub(8).clamp(28, 64).min(area.width);
+    let height = 7_u16.min(area.height);
+    let panel = Rect::new(
+        area.x.saturating_add(area.width.saturating_sub(width) / 2),
+        area.y
+            .saturating_add(area.height.saturating_sub(height) / 2),
+        width,
+        height,
+    );
+    frame.render_widget(Clear, panel);
+    frame.render_widget(
+        Block::bordered().border_style(Style::default().fg(theme.footer_accent)),
+        panel,
+    );
+    let inner = Block::bordered().inner(panel);
+    let pane_label = if pane_count == 1 { "pane" } else { "panes" };
+    frame.render_widget(
+        Paragraph::new(vec![
+            Line::styled("Delete tab?", Style::default().add_modifier(Modifier::BOLD)),
+            Line::raw(format!("{pane_count} {pane_label}")),
+            Line::raw(""),
+            Line::styled(
+                "Enter/y yes · Esc/n no",
+                Style::default().fg(theme.footer_muted),
+            ),
+        ]),
+        inner,
+    );
 }
 
 fn format_agent_overlay_card(
@@ -4172,14 +4261,14 @@ impl SharedLayoutRuntime {
                     dirty = true;
                 }
                 Event::Paste(text) => {
-                    if !self.tui.overlay_open() {
+                    if !self.tui.overlay_open() && !self.tui.modal_open() {
                         self.tui.exit_chord_mode();
                         self.forward_paste(&text)?;
                     }
                     dirty = true;
                 }
                 Event::Mouse(mouse) if matches!(mouse.kind, MouseEventKind::Moved) => {
-                    if !self.tui.overlay_open() {
+                    if !self.tui.overlay_open() && !self.tui.modal_open() {
                         dirty |= self.tui.hover_pane_at(
                             mouse.column,
                             mouse.row,
@@ -4190,6 +4279,9 @@ impl SharedLayoutRuntime {
                 Event::Mouse(mouse)
                     if matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left)) =>
                 {
+                    if self.tui.modal_open() {
+                        continue;
+                    }
                     if self.tui.overlay_open() {
                         let previously_focused = self.tui.focused_pane();
                         for intent in self.tui.handle_agent_overlay_click(
@@ -4222,6 +4314,9 @@ impl SharedLayoutRuntime {
                 Event::Mouse(mouse)
                     if matches!(mouse.kind, MouseEventKind::Drag(MouseButton::Left)) =>
                 {
+                    if self.tui.modal_open() {
+                        continue;
+                    }
                     if self.tui.extend_resize_drag(mouse.column, mouse.row) {
                         dirty = true;
                     } else {
@@ -4235,6 +4330,9 @@ impl SharedLayoutRuntime {
                 Event::Mouse(mouse)
                     if matches!(mouse.kind, MouseEventKind::Up(MouseButton::Left)) =>
                 {
+                    if self.tui.modal_open() {
+                        continue;
+                    }
                     let handling = self.tui.handle_mouse(mouse, Rect::new(0, 0, cols, rows));
                     for intent in handling.intents {
                         self.handle_intent(intent)?;
@@ -4251,6 +4349,9 @@ impl SharedLayoutRuntime {
                     ) =>
                 {
                     let area = Rect::new(0, 0, cols, rows);
+                    if self.tui.modal_open() {
+                        continue;
+                    }
                     if self.tui.overlay_open() {
                         dirty |= self.tui.scroll_agent_overlay(
                             area,
@@ -4277,6 +4378,9 @@ impl SharedLayoutRuntime {
                     );
                 }
                 Event::Resize(width, height) => {
+                    if self.tui.modal_open() {
+                        continue;
+                    }
                     cols = width;
                     rows = height;
                     self.tui
@@ -7445,6 +7549,104 @@ mod tests {
             KeyHandling::Quit
         );
         assert!(matches!(tui.modal, super::ModalState::None));
+    }
+
+    #[test]
+    fn multi_pane_tab_delete_requires_confirmation_and_blocks_pane_input() {
+        let area = Rect::new(0, 0, 80, 24);
+        let mut tui = MultiPaneTui::new(split_layout()).expect("layout");
+
+        let _ = tui.handle_key(
+            KeyEvent::new(KeyCode::Char('t'), KeyModifiers::CONTROL),
+            area,
+        );
+        assert_eq!(
+            tui.handle_key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE), area),
+            KeyHandling::Consumed(vec![])
+        );
+        assert_eq!(tui.chord_mode(), ChordMode::None);
+        assert!(tui.modal_open());
+        assert!(matches!(
+            &tui.modal,
+            super::ModalState::ConfirmDeleteTab {
+                tab_id: 1,
+                pane_count: 3
+            }
+        ));
+        let mut terminal = Terminal::new(TestBackend::new(80, 24)).expect("terminal");
+        terminal
+            .draw(|frame| render_multi_pane(frame, &tui, &BTreeMap::new()))
+            .expect("render");
+        let mut rendered = String::new();
+        for row in 0..24 {
+            for column in 0..80 {
+                rendered.push_str(terminal.backend().buffer()[(column, row)].symbol());
+            }
+        }
+        assert!(rendered.contains("Delete tab?"));
+        assert!(rendered.contains("3 panes"));
+        assert!(rendered.contains("Enter/y yes · Esc/n no"));
+
+        let mouse = crossterm::event::MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: 60,
+            row: 17,
+            modifiers: KeyModifiers::NONE,
+        };
+        assert_eq!(
+            tui.handle_mouse(mouse, area),
+            super::MouseHandling::default()
+        );
+        assert_eq!(tui.focused_pane(), 1);
+        assert!(!tui.scroll_mouse_pane(60, 17, area, 10, true));
+        assert!(tui.resize_drag.is_none());
+        assert!(tui.selection.is_none());
+        assert_eq!(
+            tui.handle_key(KeyEvent::new(KeyCode::Char('z'), KeyModifiers::NONE), area),
+            KeyHandling::Consumed(vec![])
+        );
+        assert!(tui.modal_open());
+
+        assert_eq!(
+            tui.handle_key(KeyEvent::new(KeyCode::Char('n'), KeyModifiers::NONE), area),
+            KeyHandling::Consumed(vec![])
+        );
+        assert!(!tui.modal_open());
+
+        let _ = tui.handle_key(
+            KeyEvent::new(KeyCode::Char('t'), KeyModifiers::CONTROL),
+            area,
+        );
+        let _ = tui.handle_key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE), area);
+        assert_eq!(
+            tui.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE), area),
+            KeyHandling::Consumed(vec![UiIntent::DeleteTab { tab_id: 1 }])
+        );
+        assert!(!tui.modal_open());
+    }
+
+    #[test]
+    fn single_pane_tab_delete_is_immediate() {
+        let area = Rect::new(0, 0, 80, 24);
+        let mut tui = MultiPaneTui::new(layout(
+            vec![Tab {
+                tab_id: 1,
+                root: Node::Leaf { pane_id: 1 },
+                title: None,
+            }],
+            &[(1, 2, 8)],
+        ))
+        .expect("layout");
+
+        let _ = tui.handle_key(
+            KeyEvent::new(KeyCode::Char('t'), KeyModifiers::CONTROL),
+            area,
+        );
+        assert_eq!(
+            tui.handle_key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE), area),
+            KeyHandling::Consumed(vec![UiIntent::DeleteTab { tab_id: 1 }])
+        );
+        assert!(!tui.modal_open());
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1192,8 +1192,12 @@ impl MultiPaneTui {
             ChordMode::Tab => self.handle_tab_chord(key, area),
             ChordMode::None => None,
         };
-        if intent.is_some() || is_chord_command(chord, key) {
-            self.touch_chord_activity();
+        if is_chord_command(chord, key) {
+            if is_chord_navigation(chord, key) {
+                self.touch_chord_activity();
+            } else {
+                self.exit_chord_mode();
+            }
             KeyHandling::Consumed(intent.into_iter().collect())
         } else {
             self.exit_chord_mode();
@@ -1739,6 +1743,20 @@ fn is_chord_command(mode: ChordMode, key: KeyEvent) -> bool {
                 | KeyCode::Left
                 | KeyCode::Right
         ),
+        ChordMode::None => false,
+    }
+}
+
+fn is_chord_navigation(mode: ChordMode, key: KeyEvent) -> bool {
+    if !key.modifiers.is_empty() {
+        return false;
+    }
+    match mode {
+        ChordMode::Pane => matches!(
+            key.code,
+            KeyCode::Left | KeyCode::Right | KeyCode::Up | KeyCode::Down
+        ),
+        ChordMode::Tab => matches!(key.code, KeyCode::Left | KeyCode::Right),
         ChordMode::None => false,
     }
 }
@@ -5841,10 +5859,10 @@ mod tests {
         ScreenCell, SharedLayoutRuntime, SharedLocalPane, UiIntent, VtScreen,
         allocate_node_with_preview, area_from_terminal_size, chord_footer_badge, contextual_footer,
         copied_line_count, encode_key, encode_paste, grid_for_pane, initial_root_pane_grid,
-        is_chord_command, lease_allows_held_input, member_label, mouse_to_screen_cell,
-        pane_border_color, pane_title, pane_wire_id, reconcile_remote_control_attempt,
-        render_guest_screen, render_multi_pane, render_shared_multi_pane, selection_text,
-        text_width, viewed_screen, visible_leaf_panes,
+        is_chord_command, is_chord_navigation, lease_allows_held_input, member_label,
+        mouse_to_screen_cell, pane_border_color, pane_title, pane_wire_id,
+        reconcile_remote_control_attempt, render_guest_screen, render_multi_pane,
+        render_shared_multi_pane, selection_text, text_width, viewed_screen, visible_leaf_panes,
     };
 
     #[test]
@@ -7957,7 +7975,7 @@ mod tests {
                 grid_cols: 38,
             }])
         );
-        assert_eq!(tui.chord_mode(), ChordMode::Pane);
+        assert_eq!(tui.chord_mode(), ChordMode::None);
 
         let _ = tui.handle_key(
             KeyEvent::new(KeyCode::Char('p'), KeyModifiers::CONTROL),
@@ -8074,14 +8092,18 @@ mod tests {
                 "key: {key}"
             );
             assert_eq!(tui.focused_pane(), 1, "key: {key}");
-            assert_eq!(tui.chord_mode(), ChordMode::Pane, "key: {key}");
+            assert_eq!(tui.chord_mode(), ChordMode::None, "key: {key}");
         }
     }
 
     #[test]
-    fn directional_split_keys_are_sticky_pane_commands_even_without_an_intent() {
+    fn directional_split_keys_are_commands_but_not_chord_navigation() {
         for key in ['r', 'l', 'd', 'u'] {
             assert!(is_chord_command(
+                ChordMode::Pane,
+                KeyEvent::new(KeyCode::Char(key), KeyModifiers::NONE)
+            ));
+            assert!(!is_chord_navigation(
                 ChordMode::Pane,
                 KeyEvent::new(KeyCode::Char(key), KeyModifiers::NONE)
             ));
@@ -8089,7 +8111,7 @@ mod tests {
     }
 
     #[test]
-    fn pane_lock_chord_toggles_lock_and_stays_sticky() {
+    fn pane_lock_chord_toggles_lock_and_exits_mode() {
         let area = Rect::new(0, 0, 80, 24);
         let mut tui = MultiPaneTui::new(split_layout()).expect("valid layout");
 
@@ -8104,11 +8126,32 @@ mod tests {
                 locked: true,
             }])
         );
-        assert_eq!(tui.chord_mode(), ChordMode::Pane);
+        assert_eq!(tui.chord_mode(), ChordMode::None);
         assert!(is_chord_command(
             ChordMode::Pane,
             KeyEvent::new(KeyCode::Char('k'), KeyModifiers::NONE)
         ));
+        assert!(!is_chord_navigation(
+            ChordMode::Pane,
+            KeyEvent::new(KeyCode::Char('k'), KeyModifiers::NONE)
+        ));
+    }
+
+    #[test]
+    fn pane_commands_exit_mode_even_when_no_intent_is_available() {
+        let area = Rect::new(0, 0, 80, 24);
+        let mut tui = MultiPaneTui::new(split_layout()).expect("valid layout");
+        tui.snapshot.panes.clear();
+
+        let _ = tui.handle_key(
+            KeyEvent::new(KeyCode::Char('p'), KeyModifiers::CONTROL),
+            area,
+        );
+        assert_eq!(
+            tui.handle_key(KeyEvent::new(KeyCode::Char('k'), KeyModifiers::NONE), area),
+            KeyHandling::Consumed(vec![])
+        );
+        assert_eq!(tui.chord_mode(), ChordMode::None);
     }
 
     #[test]
@@ -8821,6 +8864,7 @@ mod tests {
                 grid_cols: 10,
             }])
         );
+        assert_eq!(tui.chord_mode(), ChordMode::None);
 
         let _ = tui.handle_key(
             KeyEvent::new(KeyCode::Char('t'), KeyModifiers::CONTROL),
@@ -8830,6 +8874,7 @@ mod tests {
             tui.handle_key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE), area),
             KeyHandling::Consumed(vec![UiIntent::DeleteTab { tab_id: 2 }])
         );
+        assert_eq!(tui.chord_mode(), ChordMode::None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Change Ctrl+P pane-mode focused border from soft green (`#3dd68c`) to vivid red (`#ff1a1a`), still overridable via `[ui.theme] pane_border_chord_focused`.
- Exit pane/tab chord modes after non-navigation commands (create/split/delete/lock/rename); stay sticky only for arrow navigation between panes/tabs.
- Confirm before deleting a tab that has multiple panes (`Enter`/`y` confirm, `Esc`/`n` cancel); single-pane tabs still delete immediately.

## Test plan
- [ ] `Ctrl+P` focuses a pane with vivid red border + `PANE MODE` badge
- [ ] Arrow keys keep pane mode; `n`/`r`/`l`/`d`/`u`/`x`/`k`/`e` exit to normal mode
- [ ] `Ctrl+T` then `n` creates a tab and exits tab mode; Left/Right stay sticky
- [ ] `Ctrl+T` then `x` on a multi-pane tab shows confirm modal; `y` deletes, `Esc` cancels
- [ ] `Ctrl+T` then `x` on a single-pane tab deletes immediately
- [ ] While confirm modal is open, keys/paste/mouse do not reach the PTY


Made with [Cursor](https://cursor.com)