### PR TITLE
Fix attached input latency

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -38,6 +38,10 @@ use crate::{
 
 use crate::tui::SharedLayoutRuntime;
 
+const FIRST_MESSAGE_TIMEOUT: Duration = Duration::from_millis(5);
+const ATTACHED_IDLE_BACKOFF: Duration = Duration::from_millis(1);
+const DETACHED_IDLE_BACKOFF: Duration = Duration::from_millis(16);
+
 pub struct SharedLayoutNode {
     runtime: SharedLayoutRuntime,
 }
@@ -196,11 +200,12 @@ fn run_socket_loop(
     let mut client: Option<(BufReader<UnixStream>, u64, BTreeMap<u64, u64>)> = None;
     loop {
         let mut shutdown = false;
+        let mut did_work = false;
         loop {
             match listener.accept() {
                 Ok((stream, _)) => {
                     stream.set_nonblocking(false)?;
-                    stream.set_read_timeout(Some(Duration::from_millis(100)))?;
+                    stream.set_read_timeout(Some(FIRST_MESSAGE_TIMEOUT))?;
                     // Prevent stalled clients from wedging the node on large Snapshot writes.
                     stream.set_write_timeout(Some(Duration::from_secs(5)))?;
                     let mut reader = BufReader::new(stream);
@@ -240,6 +245,7 @@ fn run_socket_loop(
                                             .get_mut()
                                             .set_read_timeout(Some(Duration::from_millis(1)))?;
                                         client = Some((reader, generation, screen_sequences));
+                                        did_work = true;
                                     }
                                     Err(error) => {
                                         eprintln!(
@@ -284,6 +290,7 @@ fn run_socket_loop(
         let mut changed = node
             .drain()
             .map_err(|error| io::Error::other(error.to_string()))?;
+        did_work |= changed;
         let mut detached = false;
         if !shutdown && let Some((reader, generation, screen_sequences)) = client.as_mut() {
             match read_message(reader) {
@@ -377,7 +384,18 @@ fn run_socket_loop(
         if shutdown {
             return Ok(());
         }
-        std::thread::sleep(Duration::from_millis(16));
+        match socket_loop_backoff(client.is_some(), did_work) {
+            Some(backoff) => std::thread::sleep(backoff),
+            None => std::thread::yield_now(),
+        }
+    }
+}
+
+fn socket_loop_backoff(client_attached: bool, did_work: bool) -> Option<Duration> {
+    match (client_attached, did_work) {
+        (true, true) => None,
+        (true, false) => Some(ATTACHED_IDLE_BACKOFF),
+        (false, _) => Some(DETACHED_IDLE_BACKOFF),
     }
 }
 
@@ -616,6 +634,20 @@ mod tests {
             read_message(&mut reader).unwrap(),
             Some(ClientMessage::Detach { generation: 7 })
         ));
+    }
+
+    #[test]
+    fn socket_loop_uses_short_attached_backoff() {
+        assert_eq!(socket_loop_backoff(true, true), None);
+        assert_eq!(
+            socket_loop_backoff(true, false),
+            Some(Duration::from_millis(1))
+        );
+        assert_eq!(
+            socket_loop_backoff(false, false),
+            Some(Duration::from_millis(16))
+        );
+        assert!(FIRST_MESSAGE_TIMEOUT <= Duration::from_millis(5));
     }
 
     #[test]

--- a/src/node.rs
+++ b/src/node.rs
@@ -294,9 +294,13 @@ fn run_socket_loop(
         let mut detached = false;
         if !shutdown && let Some((reader, generation, screen_sequences)) = client.as_mut() {
             match read_message(reader) {
-                Ok(Some(ClientMessage::Input { bytes })) => node
-                    .input(bytes)
-                    .map_err(|error| io::Error::other(error.to_string()))?,
+                Ok(Some(ClientMessage::Input { bytes })) => {
+                    node.input(bytes)
+                        .map_err(|error| io::Error::other(error.to_string()))?;
+                    changed |= node
+                        .drain()
+                        .map_err(|error| io::Error::other(error.to_string()))?;
+                }
                 Ok(Some(ClientMessage::StructuralIntent { intent })) => {
                     node.intent(intent)
                         .map_err(|error| io::Error::other(error.to_string()))?;
@@ -364,6 +368,7 @@ fn run_socket_loop(
                 Ok(None) => detached = true,
                 Err(_) => detached = true,
             }
+            did_work |= changed;
             if changed
                 && !detached
                 && let Err(error) =

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -99,6 +99,7 @@ const TAB_BAR_SEPARATOR: &str = " · ";
 const CONTROL_HELP: &str = "Ctrl+ <p> PANE   <t> TAB   <q> QUIT   Option+ <shift> + <↑↓←→> FOCUS";
 const ESC_PREFIX_WINDOW: Duration = Duration::from_millis(50);
 const CHORD_IDLE_TIMEOUT: Duration = Duration::from_secs(2);
+const PANE_SCROLL_WHEEL_STEP: usize = 3;
 
 fn unix_ms_now() -> u64 {
     SystemTime::now()
@@ -879,9 +880,11 @@ impl MultiPaneTui {
             return false;
         };
         let scrollback = if up {
-            view.scrollback.saturating_add(1).min(scrollback_len)
+            view.scrollback
+                .saturating_add(PANE_SCROLL_WHEEL_STEP)
+                .min(scrollback_len)
         } else {
-            view.scrollback.saturating_sub(1)
+            view.scrollback.saturating_sub(PANE_SCROLL_WHEEL_STEP)
         };
         if view.scrollback == scrollback {
             return false;
@@ -7572,13 +7575,15 @@ mod tests {
         let pane_id = tui.pane_at_or_focused(60, 17, area);
         assert_eq!(pane_id, 3);
 
-        assert!(tui.scroll_pane(pane_id, 2, true));
-        assert!(tui.scroll_pane(pane_id, 2, true));
-        assert!(!tui.scroll_pane(pane_id, 2, true));
-        assert_eq!(tui.pane_view(pane_id).expect("pane view").scrollback, 2);
-        assert!(tui.scroll_pane(pane_id, 2, false));
-        assert!(tui.scroll_pane(pane_id, 2, false));
-        assert!(!tui.scroll_pane(pane_id, 2, false));
+        assert!(tui.scroll_pane(pane_id, 10, true));
+        assert_eq!(tui.pane_view(pane_id).expect("pane view").scrollback, 3);
+        assert!(tui.scroll_pane(pane_id, 4, true));
+        assert_eq!(tui.pane_view(pane_id).expect("pane view").scrollback, 4);
+        assert!(!tui.scroll_pane(pane_id, 4, true));
+        assert!(tui.scroll_pane(pane_id, 4, false));
+        assert_eq!(tui.pane_view(pane_id).expect("pane view").scrollback, 1);
+        assert!(tui.scroll_pane(pane_id, 4, false));
+        assert!(!tui.scroll_pane(pane_id, 4, false));
         assert_eq!(tui.pane_view(pane_id).expect("pane view").scrollback, 0);
     }
 
@@ -7597,7 +7602,7 @@ mod tests {
         assert!(tui.scroll_pane(1, 10, true));
         assert!(tui.scroll_pane(1, 10, true));
         assert!(tui.pin_scrollback_after_output(1, 3, 10));
-        assert_eq!(tui.pane_view(1).expect("pane view").scrollback, 5);
+        assert_eq!(tui.pane_view(1).expect("pane view").scrollback, 9);
         tui.reset_scrollback(1);
         assert!(!tui.pin_scrollback_after_output(1, 3, 10));
     }

--- a/tests/detach_resume_node.rs
+++ b/tests/detach_resume_node.rs
@@ -176,7 +176,7 @@ fn run_detach_resume_round_trip(
             bytes: b"printf p2pmux-detach-roundtrip\\r".to_vec(),
         },
     );
-    let updated = receive_until_snapshot(&mut reader, "snapshot after input");
+    let updated = receive_until_screen_update(&mut reader, 1, "snapshot after input");
     let NodeMessage::Snapshot { screens, .. } = updated else {
         unreachable!()
     };
@@ -255,6 +255,34 @@ fn receive_until_snapshot(reader: &mut BufReader<UnixStream>, phase: &str) -> No
             return message;
         }
         assert!(Instant::now() < deadline, "timed out waiting for snapshot");
+    }
+}
+
+fn receive_until_screen_update(
+    reader: &mut BufReader<UnixStream>,
+    pane_id: u64,
+    phase: &str,
+) -> NodeMessage {
+    let deadline = Instant::now() + RECEIVE_TIMEOUT;
+    loop {
+        let message = receive_until_deadline(reader, deadline, phase);
+        if matches!(
+            &message,
+            NodeMessage::Snapshot { screens, .. }
+                if screens.iter().any(|frame|
+                    frame.pane_id == pane_id
+                        && matches!(
+                            frame.state,
+                            ScreenUpdate::Snapshot { .. } | ScreenUpdate::Delta { .. }
+                        )
+                )
+        ) {
+            return message;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for screen update"
+        );
     }
 }
 


### PR DESCRIPTION
## Problem

The attached node loop imposed an unconditional 16 ms sleep and did not drain PTY output until a later tick after input, making interactive typing feel laggy.

## Fixes

- Yield after useful attached work and use a 1 ms attached-idle backoff; cap first client-frame reads at 5 ms.
- Drain once immediately after attached input, then snapshot only when a drain reports a change.
- Scroll attached panes three lines per mouse-wheel tick, with clamping.

## Deferred

- Key-repeat acknowledgement gating.
- Scrollbar UI/chrome.

## Test plan

- [x] Deterministic node scheduler-backoff unit test.
- [x] Detach/resume input-to-Snapshot-or-Delta integration test.
- [x] Wheel-step and clamping unit tests.
- [x] `cargo test --quiet`.