### PR TITLE
Make local attach updates incremental and lighter

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,12 @@ Slow viewers may receive coalesced screen deltas and then a fresh snapshot to re
 outer terminal reflows locally hosted panes: the host resizes its PTY and VT screen and commits any
 changed host-owned grids. Guests only receive the resulting commit and screen snapshot.
 
+### Performance logging
+
+Set `P2PMUX_PERF=1` to write optional local performance timing logs. By default they append to
+`std::env::temp_dir()/p2pmux-perf.log`; set `P2PMUX_PERF_LOG` to override that path. Logging is
+best-effort and remains silent if the destination cannot be opened.
+
 Full product/architecture docs live in [`docs/`](./docs/).
 
 | Doc | Description |

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,7 +1,7 @@
 //! Terminal-facing half of a local session attachment.
 
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, BTreeSet},
     io::{self, BufRead, BufReader, Write},
     net::Shutdown,
     os::unix::net::UnixStream,
@@ -138,13 +138,14 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
     let mut detach_sent = false;
     let mut last_agent_overlay_animation = Instant::now();
     let mut pending_focus = None;
+    let mut pending_resync = BTreeSet::new();
     let mut local_peer_id = Vec::new();
 
     'attached: loop {
         loop {
             match messages.try_recv() {
-                Ok(ReaderEvent::Message(message)) => {
-                    if let NodeMessage::Snapshot {
+                Ok(ReaderEvent::Message(message)) => match *message {
+                    NodeMessage::Snapshot {
                         room_name,
                         layout,
                         screens: next_screens,
@@ -154,23 +155,26 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
                         tab_id,
                         pane_id,
                         ..
-                    } = *message
-                    {
+                    } => {
                         let apply_started = Instant::now();
-                        let resync = apply_snapshot(
+                        let view = apply_layout(
                             &mut tui,
                             theme,
                             &mut screens,
                             &mut local_history,
                             room_name,
                             *layout,
-                            next_screens,
-                            leases,
-                            rosters,
-                            tab_id,
-                            pane_id,
-                            &mut pending_focus,
                         )?;
+                        let resync = apply_screens(
+                            view,
+                            &mut screens,
+                            &mut local_history,
+                            next_screens,
+                            &mut pending_resync,
+                        )?;
+                        apply_leases(view, leases);
+                        apply_rosters(view, rosters);
+                        apply_focus(view, &mut pending_focus, tab_id, pane_id)?;
                         let apply_elapsed = apply_started.elapsed();
                         if crate::perf::enabled() && apply_elapsed >= Duration::from_millis(5) {
                             crate::perf::log(&format!(
@@ -179,7 +183,7 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
                                 screens.len(),
                             ));
                         }
-                        for pane_id in resync {
+                        for pane_id in new_resync_requests(&mut pending_resync, resync) {
                             write_message(&mut stream, &ClientMessage::ResyncScreen { pane_id })?;
                         }
                         local_peer_id = next_local_peer_id;
@@ -188,7 +192,55 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
                         }
                         dirty = true;
                     }
-                }
+                    NodeMessage::Layout { layout } => {
+                        apply_layout(
+                            &mut tui,
+                            theme,
+                            &mut screens,
+                            &mut local_history,
+                            String::new(),
+                            *layout,
+                        )?;
+                        dirty = true;
+                    }
+                    NodeMessage::Screens {
+                        screens: next_screens,
+                    } => {
+                        let view = tui.as_mut().ok_or_else(|| {
+                            io::Error::other("screens received before attachment snapshot")
+                        })?;
+                        let resync = apply_screens(
+                            view,
+                            &mut screens,
+                            &mut local_history,
+                            next_screens,
+                            &mut pending_resync,
+                        )?;
+                        for pane_id in new_resync_requests(&mut pending_resync, resync) {
+                            write_message(&mut stream, &ClientMessage::ResyncScreen { pane_id })?;
+                        }
+                        dirty = true;
+                    }
+                    NodeMessage::Leases { leases } => {
+                        if let Some(view) = tui.as_mut() {
+                            apply_leases(view, leases);
+                            dirty = true;
+                        }
+                    }
+                    NodeMessage::Rosters { rosters } => {
+                        if let Some(view) = tui.as_mut() {
+                            apply_rosters(view, rosters);
+                            dirty = true;
+                        }
+                    }
+                    NodeMessage::Focus { tab_id, pane_id } => {
+                        if let Some(view) = tui.as_mut() {
+                            apply_focus(view, &mut pending_focus, tab_id, pane_id)?;
+                            dirty = true;
+                        }
+                    }
+                    _ => {}
+                },
                 Ok(ReaderEvent::Ended) | Err(TryRecvError::Disconnected) => {
                     node_ended = true;
                     break 'attached;
@@ -214,26 +266,28 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
                 terminal.draw(|frame| {
                     let viewport_screens = screens
                         .iter()
+                        .filter(|(pane_id, _)| tui.pane_scrollback_offset(**pane_id) != 0)
                         .filter_map(|(pane_id, screen)| {
                             screen.screen().map(|screen| {
-                                let screen = if tui.pane_scrollback_offset(*pane_id) == 0 {
-                                    screen.clone()
-                                } else {
-                                    local_history
-                                        .get(pane_id)
-                                        .filter(|history| !history.rows.is_empty())
-                                        .map_or_else(
-                                            || screen.clone(),
-                                            |history| history.viewport(screen),
-                                        )
-                                };
-                                (*pane_id, screen)
+                                let viewport = local_history
+                                    .get(pane_id)
+                                    .filter(|history| !history.rows.is_empty())
+                                    .map_or_else(
+                                        || screen.clone(),
+                                        |history| history.viewport(screen),
+                                    );
+                                (*pane_id, viewport)
                             })
                         })
                         .collect::<BTreeMap<_, _>>();
-                    let visible = viewport_screens
+                    let visible = screens
                         .iter()
-                        .map(|(pane_id, screen)| (*pane_id, screen))
+                        .filter_map(|(pane_id, guest)| {
+                            viewport_screens
+                                .get(pane_id)
+                                .or_else(|| guest.screen())
+                                .map(|screen| (*pane_id, screen))
+                        })
                         .collect();
                     render_multi_pane_with_copy_feedback(frame, tui, &visible, copied_lines);
                 })?;
@@ -356,6 +410,7 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
         let _ = write_message(&mut stream, &ClientMessage::Detach { generation });
     }
     let _ = stream.shutdown(Shutdown::Both);
+    drop(messages);
     let _ = reader_thread.join();
     guard.leave()?;
     if let Some(error) = attach_error {
@@ -398,6 +453,7 @@ fn should_forward_paste(tui: &MultiPaneTui, local_peer_id: &[u8]) -> bool {
     !tui.overlay_open() && !tui.modal_open() && input_allowed(tui, local_peer_id)
 }
 
+#[cfg(test)]
 #[allow(clippy::too_many_arguments)]
 fn apply_snapshot(
     tui: &mut Option<MultiPaneTui>,
@@ -413,6 +469,28 @@ fn apply_snapshot(
     pane_id: u64,
     pending_focus: &mut Option<(u64, u64)>,
 ) -> Result<Vec<u64>, Box<dyn std::error::Error>> {
+    let view = apply_layout(tui, theme, screens, local_history, room_name, layout)?;
+    let resync = apply_screens(
+        view,
+        screens,
+        local_history,
+        next_screens,
+        &mut BTreeSet::new(),
+    )?;
+    apply_leases(view, leases);
+    apply_rosters(view, rosters);
+    apply_focus(view, pending_focus, tab_id, pane_id)?;
+    Ok(resync)
+}
+
+fn apply_layout<'a>(
+    tui: &'a mut Option<MultiPaneTui>,
+    theme: crate::config::UiTheme,
+    screens: &mut BTreeMap<u64, GuestScreen>,
+    local_history: &mut BTreeMap<u64, LocalHistory>,
+    room_name: String,
+    layout: crate::layout::LayoutSnapshot,
+) -> Result<&'a mut MultiPaneTui, Box<dyn std::error::Error>> {
     let view = match tui {
         Some(view) => {
             view.apply_snapshot(layout)
@@ -424,9 +502,21 @@ fn apply_snapshot(
                 io::Error::other(format!("invalid layout snapshot: {error:?}"))
             })?),
     };
-    view.set_title(format!("p2pmux ({room_name})"));
+    if !room_name.is_empty() {
+        view.set_title(format!("p2pmux ({room_name})"));
+    }
     screens.retain(|pane_id, _| view.snapshot().panes.contains_key(pane_id));
     local_history.retain(|pane_id, _| view.snapshot().panes.contains_key(pane_id));
+    Ok(view)
+}
+
+fn apply_screens(
+    view: &mut MultiPaneTui,
+    screens: &mut BTreeMap<u64, GuestScreen>,
+    local_history: &mut BTreeMap<u64, LocalHistory>,
+    next_screens: Vec<crate::local_ipc::PaneScreenSnapshot>,
+    pending_resync: &mut BTreeSet<u64>,
+) -> Result<Vec<u64>, Box<dyn std::error::Error>> {
     let mut resync = Vec::new();
     for frame in next_screens {
         let pane_id = frame.pane_id;
@@ -439,6 +529,7 @@ fn apply_snapshot(
             } => {
                 screen.apply_snapshot(sequence, &snapshot)?;
                 screen.set_kitty_keyboard_active(kitty_keyboard_active);
+                pending_resync.remove(&pane_id);
             }
             ScreenUpdate::Delta {
                 base_sequence,
@@ -464,6 +555,10 @@ fn apply_snapshot(
             }
         }
     }
+    Ok(resync)
+}
+
+fn apply_leases(view: &mut MultiPaneTui, leases: Vec<crate::local_ipc::PaneLeaseSnapshot>) {
     for lease in leases {
         view.set_pane_view(
             lease.pane_id,
@@ -474,6 +569,9 @@ fn apply_snapshot(
             ),
         );
     }
+}
+
+fn apply_rosters(view: &mut MultiPaneTui, rosters: Vec<crate::local_ipc::AgentOverlaySnapshotRow>) {
     view.set_agent_rows(
         rosters
             .into_iter()
@@ -494,11 +592,9 @@ fn apply_snapshot(
             })
             .collect(),
     );
-    reconcile_snapshot_focus(view, pending_focus, tab_id, pane_id)?;
-    Ok(resync)
 }
 
-fn reconcile_snapshot_focus(
+fn apply_focus(
     view: &mut MultiPaneTui,
     pending_focus: &mut Option<(u64, u64)>,
     tab_id: u64,
@@ -515,6 +611,13 @@ fn reconcile_snapshot_focus(
     }
     view.set_focus(tab_id, pane_id)
         .map_err(|error| io::Error::other(format!("invalid node focus: {error:?}")))
+}
+
+fn new_resync_requests(pending: &mut BTreeSet<u64>, resync: Vec<u64>) -> Vec<u64> {
+    resync
+        .into_iter()
+        .filter(|pane_id| pending.insert(*pane_id))
+        .collect()
 }
 
 fn send_intents(
@@ -594,7 +697,7 @@ enum ReaderEvent {
 fn spawn_message_reader(
     mut reader: BufReader<UnixStream>,
 ) -> (Receiver<ReaderEvent>, thread::JoinHandle<()>) {
-    let (sender, receiver) = mpsc::channel();
+    let (sender, receiver) = mpsc::sync_channel(16);
     let thread = thread::spawn(move || {
         loop {
             match read_message(&mut reader) {
@@ -966,6 +1069,47 @@ mod tests {
         )
         .unwrap();
         assert_eq!(local_history[&1].available_rows(), 1);
+    }
+
+    #[test]
+    fn screens_apply_without_replacing_layout() {
+        let host = HostScreen::new(2, 8).unwrap();
+        let mut tui = Some(MultiPaneTui::new(layout(&[1])).unwrap());
+        let mut screens = BTreeMap::new();
+        let mut history = BTreeMap::new();
+        let mut pending_resync = BTreeSet::new();
+
+        apply_screens(
+            tui.as_mut().unwrap(),
+            &mut screens,
+            &mut history,
+            vec![PaneScreenSnapshot {
+                pane_id: 1,
+                state: ScreenUpdate::Snapshot {
+                    sequence: 1,
+                    snapshot: host.current_frame().snapshot.as_ref().to_vec(),
+                    kitty_keyboard_active: false,
+                },
+                local_history: None,
+            }],
+            &mut pending_resync,
+        )
+        .unwrap();
+
+        assert_eq!(tui.unwrap().snapshot().revision, 1);
+        assert_eq!(
+            screens[&1].screen().unwrap().contents(),
+            host.screen().contents()
+        );
+    }
+
+    #[test]
+    fn resync_requests_are_deduplicated_until_a_snapshot_arrives() {
+        let mut pending = BTreeSet::new();
+        assert_eq!(new_resync_requests(&mut pending, vec![1, 1]), vec![1]);
+        assert!(new_resync_requests(&mut pending, vec![1]).is_empty());
+        pending.remove(&1);
+        assert_eq!(new_resync_requests(&mut pending, vec![1]), vec![1]);
     }
 
     #[test]

--- a/src/local_ipc.rs
+++ b/src/local_ipc.rs
@@ -54,6 +54,22 @@ pub enum NodeMessage {
         tab_id: u64,
         pane_id: u64,
     },
+    Screens {
+        screens: Vec<PaneScreenSnapshot>,
+    },
+    Layout {
+        layout: Box<LayoutSnapshot>,
+    },
+    Leases {
+        leases: Vec<PaneLeaseSnapshot>,
+    },
+    Rosters {
+        rosters: Vec<AgentOverlaySnapshotRow>,
+    },
+    Focus {
+        tab_id: u64,
+        pane_id: u64,
+    },
     Update {
         state: serde_json::Value,
     },

--- a/src/node.rs
+++ b/src/node.rs
@@ -41,6 +41,7 @@ use crate::tui::SharedLayoutRuntime;
 const FIRST_MESSAGE_TIMEOUT: Duration = Duration::from_millis(5);
 const ATTACHED_IDLE_BACKOFF: Duration = Duration::from_millis(1);
 const DETACHED_IDLE_BACKOFF: Duration = Duration::from_millis(16);
+const SCREEN_PUBLISH_INTERVAL: Duration = Duration::from_millis(16);
 
 pub struct SharedLayoutNode {
     runtime: SharedLayoutRuntime,
@@ -295,6 +296,7 @@ fn run_socket_loop(
         let mut drain_elapsed = drain_started.elapsed();
         did_work |= changed;
         let mut detached = false;
+        let mut full_snapshot = false;
         if !shutdown && let Some((reader, generation, publish)) = client.as_mut() {
             match read_message(reader) {
                 Ok(Some(ClientMessage::Input { bytes })) => {
@@ -318,7 +320,9 @@ fn run_socket_loop(
                 }
                 Ok(Some(ClientMessage::ResyncScreen { pane_id })) => {
                     publish.screen_sequences.remove(&pane_id);
+                    publish.force_screens = true;
                     changed = true;
+                    full_snapshot = true;
                 }
                 Ok(Some(ClientMessage::Focus { tab_id, pane_id })) => {
                     node.focus(tab_id, pane_id)
@@ -375,7 +379,19 @@ fn run_socket_loop(
             }
             did_work |= changed;
             if !detached {
-                match write_updates(reader.get_mut(), node, publish, drain_elapsed) {
+                let result = if full_snapshot {
+                    write_snapshot(reader.get_mut(), descriptor, node, publish, drain_elapsed)
+                        .map(|()| true)
+                } else {
+                    write_updates(
+                        reader.get_mut(),
+                        node,
+                        publish,
+                        drain_elapsed,
+                        Instant::now(),
+                    )
+                };
+                match result {
                     Ok(published) => did_work |= published,
                     Err(error) => {
                         eprintln!("p2pmux node: failed to write local update: {error}");
@@ -520,6 +536,8 @@ fn write_snapshot(
     publish.rosters = Some(rosters);
     publish.focus = Some((tab_id, pane_id));
     update_screen_sequences(&mut publish.screen_sequences, &screens);
+    publish.last_screen_publish = Some(Instant::now());
+    publish.force_screens = false;
     if crate::perf::enabled()
         && [
             drain_elapsed,
@@ -559,6 +577,9 @@ struct AttachmentPublishState {
     rosters: Option<Vec<AgentOverlaySnapshotRow>>,
     focus: Option<(u64, u64)>,
     screen_sequences: BTreeMap<u64, u64>,
+    last_screen_publish: Option<Instant>,
+    pending_screens: bool,
+    force_screens: bool,
 }
 
 fn write_updates(
@@ -566,6 +587,7 @@ fn write_updates(
     node: &SharedLayoutNode,
     publish: &mut AttachmentPublishState,
     _drain_elapsed: Duration,
+    now: Instant,
 ) -> io::Result<bool> {
     let (layout, screens, leases, rosters) = node.snapshot();
     let leases = leases
@@ -583,9 +605,12 @@ fn write_updates(
     let layout_changed = publish.layout.as_ref() != Some(&layout);
     let mut published = false;
     if layout_changed {
-        write_message(stream, &NodeMessage::Layout {
-            layout: Box::new(layout.clone()),
-        })?;
+        write_message(
+            stream,
+            &NodeMessage::Layout {
+                layout: Box::new(layout.clone()),
+            },
+        )?;
         publish.layout = Some(layout.clone());
         publish
             .screen_sequences
@@ -593,16 +618,22 @@ fn write_updates(
         published = true;
     }
     if publish.leases.as_ref() != Some(&leases) {
-        write_message(stream, &NodeMessage::Leases {
-            leases: leases.clone(),
-        })?;
+        write_message(
+            stream,
+            &NodeMessage::Leases {
+                leases: leases.clone(),
+            },
+        )?;
         publish.leases = Some(leases);
         published = true;
     }
     if publish.rosters.as_ref() != Some(&rosters) {
-        write_message(stream, &NodeMessage::Rosters {
-            rosters: rosters.clone(),
-        })?;
+        write_message(
+            stream,
+            &NodeMessage::Rosters {
+                rosters: rosters.clone(),
+            },
+        )?;
         publish.rosters = Some(rosters);
         published = true;
     }
@@ -630,13 +661,33 @@ fn write_updates(
         |pane_id| node.node_remote_snapshot(pane_id),
     );
     if frames.is_empty() {
+        publish.pending_screens = false;
+        publish.force_screens = false;
         return Ok(published);
     }
-    write_message(stream, &NodeMessage::Screens {
-        screens: frames.clone(),
-    })?;
+    if !screens_due(publish, published, now) {
+        publish.pending_screens = true;
+        return Ok(published);
+    }
+    write_message(
+        stream,
+        &NodeMessage::Screens {
+            screens: frames.clone(),
+        },
+    )?;
     update_screen_sequences(&mut publish.screen_sequences, &frames);
+    publish.last_screen_publish = Some(now);
+    publish.pending_screens = false;
+    publish.force_screens = false;
     Ok(true)
+}
+
+fn screens_due(publish: &AttachmentPublishState, structural: bool, now: Instant) -> bool {
+    structural
+        || publish.force_screens
+        || publish
+            .last_screen_publish
+            .is_none_or(|last| now.duration_since(last) >= SCREEN_PUBLISH_INTERVAL)
 }
 
 fn pane_screen_updates<LocalHistory, RemoteSnapshot>(
@@ -862,6 +913,24 @@ mod tests {
             Some(Duration::from_millis(16))
         );
         assert!(FIRST_MESSAGE_TIMEOUT <= Duration::from_millis(5));
+    }
+
+    #[test]
+    fn screen_publishes_are_throttled_but_structural_and_resync_are_immediate() {
+        let now = Instant::now();
+        let mut publish = AttachmentPublishState {
+            last_screen_publish: Some(now),
+            ..Default::default()
+        };
+        assert!(!screens_due(
+            &publish,
+            false,
+            now + SCREEN_PUBLISH_INTERVAL - Duration::from_millis(1)
+        ));
+        assert!(screens_due(&publish, false, now + SCREEN_PUBLISH_INTERVAL));
+        assert!(screens_due(&publish, true, now + Duration::from_millis(1)));
+        publish.force_screens = true;
+        assert!(screens_due(&publish, false, now + Duration::from_millis(1)));
     }
 
     #[test]

--- a/src/node.rs
+++ b/src/node.rs
@@ -943,7 +943,7 @@ mod tests {
                 frame: screen.current_frame().clone(),
             },
         )]);
-        let updates = pane_screen_updates(initial, &mut sequences, |_| None, |_| None);
+        let updates = pane_screen_updates(initial, &sequences, |_| None, |_| None);
         assert!(matches!(updates[0].state, ScreenUpdate::Snapshot { .. }));
         update_screen_sequences(&mut sequences, &updates);
 
@@ -954,7 +954,7 @@ mod tests {
                 frame: screen.current_frame().clone(),
             },
         )]);
-        let updates = pane_screen_updates(changed, &mut sequences, |_| None, |_| None);
+        let updates = pane_screen_updates(changed, &sequences, |_| None, |_| None);
         assert!(matches!(updates[0].state, ScreenUpdate::Delta { .. }));
         update_screen_sequences(&mut sequences, &updates);
 
@@ -964,7 +964,7 @@ mod tests {
                 frame: screen.current_frame().clone(),
             },
         )]);
-        let updates = pane_screen_updates(unchanged, &mut sequences, |_| None, |_| None);
+        let updates = pane_screen_updates(unchanged, &sequences, |_| None, |_| None);
         assert!(updates.is_empty());
 
         screen.resize(2, 3).unwrap();
@@ -974,7 +974,7 @@ mod tests {
                 frame: screen.current_frame().clone(),
             },
         )]);
-        let updates = pane_screen_updates(resized, &mut sequences, |_| None, |_| None);
+        let updates = pane_screen_updates(resized, &sequences, |_| None, |_| None);
         assert!(matches!(updates[0].state, ScreenUpdate::Snapshot { .. }));
     }
 
@@ -990,7 +990,7 @@ mod tests {
         )]);
         let updates = pane_screen_updates(
             initial,
-            &mut sequences,
+            &sequences,
             |_| {
                 Some(LocalHistorySnapshot {
                     total_rows: 1,
@@ -1010,7 +1010,7 @@ mod tests {
         )]);
         let updates = pane_screen_updates(
             unchanged,
-            &mut sequences,
+            &sequences,
             |_| panic!("unchanged local panes must not fetch history"),
             |_| None,
         );
@@ -1028,7 +1028,7 @@ mod tests {
         let initial = BTreeMap::from([(1, remote())]);
         let updates = pane_screen_updates(
             initial,
-            &mut sequences,
+            &sequences,
             |_| None,
             |_| {
                 calls.set(calls.get() + 1);
@@ -1042,7 +1042,7 @@ mod tests {
         let unchanged = BTreeMap::from([(1, remote())]);
         let updates = pane_screen_updates(
             unchanged,
-            &mut sequences,
+            &sequences,
             |_| None,
             |_| panic!("unchanged remote panes must not encode a snapshot"),
         );

--- a/src/node.rs
+++ b/src/node.rs
@@ -197,7 +197,7 @@ fn run_socket_loop(
     descriptor: &SessionDescriptor,
 ) -> io::Result<()> {
     let gate = AttachmentGate::default();
-    let mut client: Option<(BufReader<UnixStream>, u64, BTreeMap<u64, u64>)> = None;
+    let mut client: Option<(BufReader<UnixStream>, u64, AttachmentPublishState)> = None;
     loop {
         let mut shutdown = false;
         let mut did_work = false;
@@ -227,7 +227,7 @@ fn run_socket_loop(
                             if let Ok(generation) = gate.attach() {
                                 node.resize(cols, rows)
                                     .map_err(|error| io::Error::other(error.to_string()))?;
-                                let mut screen_sequences = BTreeMap::new();
+                                let mut publish = AttachmentPublishState::default();
                                 match write_message(
                                     reader.get_mut(),
                                     &NodeMessage::AttachAccepted { generation },
@@ -237,7 +237,7 @@ fn run_socket_loop(
                                         reader.get_mut(),
                                         descriptor,
                                         node,
-                                        &mut screen_sequences,
+                                        &mut publish,
                                         Duration::ZERO,
                                     )
                                 }) {
@@ -245,7 +245,7 @@ fn run_socket_loop(
                                         reader
                                             .get_mut()
                                             .set_read_timeout(Some(Duration::from_millis(1)))?;
-                                        client = Some((reader, generation, screen_sequences));
+                                        client = Some((reader, generation, publish));
                                         did_work = true;
                                     }
                                     Err(error) => {
@@ -295,7 +295,7 @@ fn run_socket_loop(
         let mut drain_elapsed = drain_started.elapsed();
         did_work |= changed;
         let mut detached = false;
-        if !shutdown && let Some((reader, generation, screen_sequences)) = client.as_mut() {
+        if !shutdown && let Some((reader, generation, publish)) = client.as_mut() {
             match read_message(reader) {
                 Ok(Some(ClientMessage::Input { bytes })) => {
                     node.input(bytes)
@@ -317,7 +317,7 @@ fn run_socket_loop(
                     changed = true;
                 }
                 Ok(Some(ClientMessage::ResyncScreen { pane_id })) => {
-                    screen_sequences.remove(&pane_id);
+                    publish.screen_sequences.remove(&pane_id);
                     changed = true;
                 }
                 Ok(Some(ClientMessage::Focus { tab_id, pane_id })) => {
@@ -374,18 +374,14 @@ fn run_socket_loop(
                 Err(_) => detached = true,
             }
             did_work |= changed;
-            if changed
-                && !detached
-                && let Err(error) = write_snapshot(
-                    reader.get_mut(),
-                    descriptor,
-                    node,
-                    screen_sequences,
-                    drain_elapsed,
-                )
-            {
-                eprintln!("p2pmux node: failed to write local snapshot: {error}");
-                detached = true;
+            if !detached {
+                match write_updates(reader.get_mut(), node, publish, drain_elapsed) {
+                    Ok(published) => did_work |= published,
+                    Err(error) => {
+                        eprintln!("p2pmux node: failed to write local update: {error}");
+                        detached = true;
+                    }
+                }
             }
         }
         if !changed {
@@ -437,7 +433,7 @@ fn write_snapshot(
     stream: &mut UnixStream,
     descriptor: &SessionDescriptor,
     node: &SharedLayoutNode,
-    screen_sequences: &mut BTreeMap<u64, u64>,
+    publish: &mut AttachmentPublishState,
     drain_elapsed: Duration,
 ) -> io::Result<()> {
     let snapshot_started = Instant::now();
@@ -464,7 +460,7 @@ fn write_snapshot(
     let mut history_extract = Duration::ZERO;
     let screens = pane_screen_updates(
         screens,
-        screen_sequences,
+        &publish.screen_sequences,
         |pane_id| {
             let started = Instant::now();
             let history =
@@ -479,6 +475,17 @@ fn write_snapshot(
         |pane_id| node.node_remote_snapshot(pane_id),
     );
     let updates = ScreenUpdateStats::from_screens(&screens);
+    let leases = leases
+        .into_iter()
+        .map(
+            |(pane_id, (ready, controller_peer_id, controller_active))| PaneLeaseSnapshot {
+                pane_id,
+                ready,
+                controller_peer_id,
+                controller_active,
+            },
+        )
+        .collect::<Vec<_>>();
     let message = NodeMessage::Snapshot {
         room_name: descriptor.name.clone(),
         role: match descriptor.role {
@@ -492,20 +499,10 @@ fn write_snapshot(
             hosts,
             coordinator_name,
         },
-        layout: Box::new(layout),
-        screens,
-        leases: leases
-            .into_iter()
-            .map(
-                |(pane_id, (ready, controller_peer_id, controller_active))| PaneLeaseSnapshot {
-                    pane_id,
-                    ready,
-                    controller_peer_id,
-                    controller_active,
-                },
-            )
-            .collect(),
-        rosters,
+        layout: Box::new(layout.clone()),
+        screens: screens.clone(),
+        leases: leases.clone(),
+        rosters: rosters.clone(),
         local_peer_id,
         tab_id,
         pane_id,
@@ -518,6 +515,11 @@ fn write_snapshot(
     stream.write_all(&frame)?;
     stream.flush()?;
     let json_write = write_started.elapsed();
+    publish.layout = Some(layout.clone());
+    publish.leases = Some(leases);
+    publish.rosters = Some(rosters);
+    publish.focus = Some((tab_id, pane_id));
+    update_screen_sequences(&mut publish.screen_sequences, &screens);
     if crate::perf::enabled()
         && [
             drain_elapsed,
@@ -550,9 +552,96 @@ fn write_snapshot(
     Ok(())
 }
 
+#[derive(Default)]
+struct AttachmentPublishState {
+    layout: Option<crate::layout::LayoutSnapshot>,
+    leases: Option<Vec<PaneLeaseSnapshot>>,
+    rosters: Option<Vec<AgentOverlaySnapshotRow>>,
+    focus: Option<(u64, u64)>,
+    screen_sequences: BTreeMap<u64, u64>,
+}
+
+fn write_updates(
+    stream: &mut UnixStream,
+    node: &SharedLayoutNode,
+    publish: &mut AttachmentPublishState,
+    _drain_elapsed: Duration,
+) -> io::Result<bool> {
+    let (layout, screens, leases, rosters) = node.snapshot();
+    let leases = leases
+        .into_iter()
+        .map(
+            |(pane_id, (ready, controller_peer_id, controller_active))| PaneLeaseSnapshot {
+                pane_id,
+                ready,
+                controller_peer_id,
+                controller_active,
+            },
+        )
+        .collect::<Vec<_>>();
+    let focus = node.local_focus();
+    let layout_changed = publish.layout.as_ref() != Some(&layout);
+    let mut published = false;
+    if layout_changed {
+        write_message(stream, &NodeMessage::Layout {
+            layout: Box::new(layout.clone()),
+        })?;
+        publish.layout = Some(layout.clone());
+        publish
+            .screen_sequences
+            .retain(|pane_id, _| layout.panes.contains_key(pane_id));
+        published = true;
+    }
+    if publish.leases.as_ref() != Some(&leases) {
+        write_message(stream, &NodeMessage::Leases {
+            leases: leases.clone(),
+        })?;
+        publish.leases = Some(leases);
+        published = true;
+    }
+    if publish.rosters.as_ref() != Some(&rosters) {
+        write_message(stream, &NodeMessage::Rosters {
+            rosters: rosters.clone(),
+        })?;
+        publish.rosters = Some(rosters);
+        published = true;
+    }
+    if publish.focus != Some(focus) {
+        write_message(
+            stream,
+            &NodeMessage::Focus {
+                tab_id: focus.0,
+                pane_id: focus.1,
+            },
+        )?;
+        publish.focus = Some(focus);
+        published = true;
+    }
+    let frames = pane_screen_updates(
+        screens,
+        &publish.screen_sequences,
+        |pane_id| {
+            node.node_local_history(pane_id)
+                .map(|(total_rows, rows)| LocalHistorySnapshot {
+                    total_rows,
+                    rows: rows.into_iter().map(|row| STANDARD.encode(row)).collect(),
+                })
+        },
+        |pane_id| node.node_remote_snapshot(pane_id),
+    );
+    if frames.is_empty() {
+        return Ok(published);
+    }
+    write_message(stream, &NodeMessage::Screens {
+        screens: frames.clone(),
+    })?;
+    update_screen_sequences(&mut publish.screen_sequences, &frames);
+    Ok(true)
+}
+
 fn pane_screen_updates<LocalHistory, RemoteSnapshot>(
     screens: crate::tui::NodeScreenSnapshots,
-    sequences: &mut BTreeMap<u64, u64>,
+    sequences: &BTreeMap<u64, u64>,
     mut local_history: LocalHistory,
     mut remote_snapshot: RemoteSnapshot,
 ) -> Vec<PaneScreenSnapshot>
@@ -560,56 +649,50 @@ where
     LocalHistory: FnMut(u64) -> Option<LocalHistorySnapshot>,
     RemoteSnapshot: FnMut(u64) -> Option<Vec<u8>>,
 {
-    sequences.retain(|pane_id, _| screens.contains_key(pane_id));
     screens
         .into_iter()
         .filter_map(|(pane_id, screen)| {
-            let (sequence, state, local_history) = match screen {
+            let update = match screen {
                 crate::tui::NodeScreenSnapshot::Local { frame } => {
-                    let state = if sequences.get(&pane_id) == Some(&frame.sequence) {
-                        ScreenUpdate::Unchanged {
-                            sequence: frame.sequence,
-                            kitty_keyboard_active: frame.kitty_keyboard_active,
-                        }
+                    if sequences.get(&pane_id) == Some(&frame.sequence) {
+                        None
                     } else if sequences.get(&pane_id) == Some(&frame.base_sequence) {
-                        ScreenUpdate::Delta {
+                        let state = ScreenUpdate::Delta {
                             base_sequence: frame.base_sequence,
                             sequence: frame.sequence,
                             delta: frame.delta.as_ref().to_vec(),
                             kitty_keyboard_active: frame.kitty_keyboard_active,
-                        }
+                        };
+                        Some((frame.sequence, state, local_history(pane_id)))
                     } else {
-                        ScreenUpdate::Snapshot {
+                        let state = ScreenUpdate::Snapshot {
                             sequence: frame.sequence,
                             snapshot: frame.snapshot.as_ref().to_vec(),
                             kitty_keyboard_active: frame.kitty_keyboard_active,
-                        }
-                    };
-                    let history = (!matches!(&state, ScreenUpdate::Unchanged { .. }))
-                        .then(|| local_history(pane_id))
-                        .flatten();
-                    (frame.sequence, state, history)
+                        };
+                        Some((frame.sequence, state, local_history(pane_id)))
+                    }
                 }
                 crate::tui::NodeScreenSnapshot::Remote {
                     sequence,
                     kitty_keyboard_active,
                 } => {
-                    let state = if sequences.get(&pane_id) == Some(&sequence) {
-                        ScreenUpdate::Unchanged {
-                            sequence,
-                            kitty_keyboard_active,
-                        }
+                    if sequences.get(&pane_id) == Some(&sequence) {
+                        None
                     } else {
-                        ScreenUpdate::Snapshot {
+                        Some((
                             sequence,
-                            snapshot: remote_snapshot(pane_id)?,
-                            kitty_keyboard_active,
-                        }
-                    };
-                    (sequence, state, None)
+                            ScreenUpdate::Snapshot {
+                                sequence,
+                                snapshot: remote_snapshot(pane_id)?,
+                                kitty_keyboard_active,
+                            },
+                            None,
+                        ))
+                    }
                 }
             };
-            sequences.insert(pane_id, sequence);
+            let (_, state, local_history) = update?;
             Some(PaneScreenSnapshot {
                 pane_id,
                 state,
@@ -617,6 +700,17 @@ where
             })
         })
         .collect()
+}
+
+fn update_screen_sequences(sequences: &mut BTreeMap<u64, u64>, screens: &[PaneScreenSnapshot]) {
+    for screen in screens {
+        let sequence = match screen.state {
+            ScreenUpdate::Snapshot { sequence, .. }
+            | ScreenUpdate::Delta { sequence, .. }
+            | ScreenUpdate::Unchanged { sequence, .. } => sequence,
+        };
+        sequences.insert(screen.pane_id, sequence);
+    }
 }
 
 #[derive(Default)]
@@ -782,6 +876,7 @@ mod tests {
         )]);
         let updates = pane_screen_updates(initial, &mut sequences, |_| None, |_| None);
         assert!(matches!(updates[0].state, ScreenUpdate::Snapshot { .. }));
+        update_screen_sequences(&mut sequences, &updates);
 
         screen.process_pty(b"a").unwrap();
         let changed = BTreeMap::from([(
@@ -792,6 +887,7 @@ mod tests {
         )]);
         let updates = pane_screen_updates(changed, &mut sequences, |_| None, |_| None);
         assert!(matches!(updates[0].state, ScreenUpdate::Delta { .. }));
+        update_screen_sequences(&mut sequences, &updates);
 
         let unchanged = BTreeMap::from([(
             1,
@@ -800,7 +896,7 @@ mod tests {
             },
         )]);
         let updates = pane_screen_updates(unchanged, &mut sequences, |_| None, |_| None);
-        assert!(matches!(updates[0].state, ScreenUpdate::Unchanged { .. }));
+        assert!(updates.is_empty());
 
         screen.resize(2, 3).unwrap();
         let resized = BTreeMap::from([(
@@ -835,6 +931,7 @@ mod tests {
             |_| None,
         );
         assert!(updates[0].local_history.is_some());
+        update_screen_sequences(&mut sequences, &updates);
 
         let unchanged = BTreeMap::from([(
             1,
@@ -848,8 +945,7 @@ mod tests {
             |_| panic!("unchanged local panes must not fetch history"),
             |_| None,
         );
-        assert!(matches!(updates[0].state, ScreenUpdate::Unchanged { .. }));
-        assert!(updates[0].local_history.is_none());
+        assert!(updates.is_empty());
     }
 
     #[test]
@@ -872,6 +968,7 @@ mod tests {
         );
         assert!(matches!(updates[0].state, ScreenUpdate::Snapshot { .. }));
         assert_eq!(calls.get(), 1);
+        update_screen_sequences(&mut sequences, &updates);
 
         let unchanged = BTreeMap::from([(1, remote())]);
         let updates = pane_screen_updates(
@@ -880,7 +977,7 @@ mod tests {
             |_| None,
             |_| panic!("unchanged remote panes must not encode a snapshot"),
         );
-        assert!(matches!(updates[0].state, ScreenUpdate::Unchanged { .. }));
+        assert!(updates.is_empty());
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src/perf.rs
+++ b/src/perf.rs
@@ -1,6 +1,12 @@
 //! Optional performance logging shared by the client and background node.
 
-use std::{ffi::OsString, fs::OpenOptions, io::Write, path::PathBuf};
+use std::{
+    ffi::OsString,
+    fs::{File, OpenOptions},
+    io::{IsTerminal, Write},
+    path::{Path, PathBuf},
+    sync::{Mutex, OnceLock},
+};
 
 const LOG_NAME: &str = "p2pmux-perf.log";
 
@@ -9,14 +15,41 @@ pub(crate) fn enabled() -> bool {
 }
 
 pub(crate) fn log(message: &str) {
-    let Ok(mut file) = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(log_path())
-    else {
+    let Ok(mut logger) = logger().lock() else {
         return;
     };
-    let _ = file.write_all(format!("{message}\n").as_bytes());
+    logger.log(&log_path(), message);
+}
+
+#[derive(Default)]
+struct PerfLogger {
+    path: Option<PathBuf>,
+    file: Option<File>,
+}
+
+impl PerfLogger {
+    fn log(&mut self, path: &Path, message: &str) {
+        if self.path.as_deref() != Some(path) {
+            self.path = None;
+            self.file = None;
+            let Ok(file) = OpenOptions::new().create(true).append(true).open(path) else {
+                return;
+            };
+            if file.is_terminal() {
+                return;
+            }
+            self.path = Some(path.to_path_buf());
+            self.file = Some(file);
+        }
+        if let Some(file) = self.file.as_mut() {
+            let _ = writeln!(file, "{message}");
+        }
+    }
+}
+
+fn logger() -> &'static Mutex<PerfLogger> {
+    static LOGGER: OnceLock<Mutex<PerfLogger>> = OnceLock::new();
+    LOGGER.get_or_init(|| Mutex::new(PerfLogger::default()))
 }
 
 fn log_path() -> PathBuf {
@@ -39,5 +72,26 @@ mod tests {
             PathBuf::from("/tmp/custom-perf.log"),
         );
         assert_eq!(log_path_from(None), std::env::temp_dir().join(LOG_NAME),);
+    }
+
+    #[test]
+    fn logger_reuses_the_open_file() {
+        let directory = std::env::temp_dir().join(format!("p2pmux-perf-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&directory);
+        std::fs::create_dir(&directory).unwrap();
+        let path = directory.join("perf.log");
+        let renamed = directory.join("renamed.log");
+        let mut logger = PerfLogger::default();
+
+        logger.log(&path, "first");
+        std::fs::rename(&path, &renamed).unwrap();
+        logger.log(&path, "second");
+
+        assert_eq!(
+            std::fs::read_to_string(&renamed).unwrap(),
+            "first\nsecond\n"
+        );
+        assert!(!path.exists());
+        std::fs::remove_dir_all(directory).unwrap();
     }
 }

--- a/tests/detach_resume_node.rs
+++ b/tests/detach_resume_node.rs
@@ -177,7 +177,7 @@ fn run_detach_resume_round_trip(
         },
     );
     let updated = receive_until_screen_update(&mut reader, 1, "snapshot after input");
-    let NodeMessage::Snapshot { screens, .. } = updated else {
+    let NodeMessage::Screens { screens } = updated else {
         unreachable!()
     };
     assert!(
@@ -268,7 +268,7 @@ fn receive_until_screen_update(
         let message = receive_until_deadline(reader, deadline, phase);
         if matches!(
             &message,
-            NodeMessage::Snapshot { screens, .. }
+            NodeMessage::Screens { screens }
                 if screens.iter().any(|frame|
                     frame.pane_id == pane_id
                         && matches!(

--- a/tests/local_ipc.rs
+++ b/tests/local_ipc.rs
@@ -97,9 +97,11 @@ fn incremental_node_messages_round_trip_without_unchanged_screens() {
         let decoded: NodeMessage = serde_json::from_slice(&encoded).unwrap();
         assert_eq!(decoded, message);
         if let NodeMessage::Screens { screens } = decoded {
-            assert!(screens
-                .iter()
-                .all(|frame| !matches!(frame.state, ScreenUpdate::Unchanged { .. })));
+            assert!(
+                screens
+                    .iter()
+                    .all(|frame| !matches!(frame.state, ScreenUpdate::Unchanged { .. }))
+            );
         }
     }
 }

--- a/tests/local_ipc.rs
+++ b/tests/local_ipc.rs
@@ -1,6 +1,9 @@
 use p2pmux::{
     layout::LayoutSnapshot,
-    local_ipc::{AttachmentGate, ClientMessage, NodeMessage, SessionSummary},
+    local_ipc::{
+        AgentOverlaySnapshotRow, AttachmentGate, ClientMessage, NodeMessage, PaneLeaseSnapshot,
+        PaneScreenSnapshot, ScreenUpdate, SessionSummary,
+    },
 };
 
 #[test]
@@ -33,4 +36,70 @@ fn protocol_messages_are_tagged_and_attachment_is_generation_safe() {
     let current = gate.attach().unwrap();
     assert!(!gate.detach(old));
     assert!(gate.detach(current));
+}
+
+#[test]
+fn incremental_node_messages_round_trip_without_unchanged_screens() {
+    let layout = LayoutSnapshot {
+        revision: 0,
+        members: vec![],
+        tabs: vec![],
+        panes: Default::default(),
+    };
+    let messages = vec![
+        NodeMessage::Screens {
+            screens: vec![
+                PaneScreenSnapshot {
+                    pane_id: 1,
+                    state: ScreenUpdate::Snapshot {
+                        sequence: 1,
+                        snapshot: vec![1],
+                        kitty_keyboard_active: false,
+                    },
+                    local_history: None,
+                },
+                PaneScreenSnapshot {
+                    pane_id: 2,
+                    state: ScreenUpdate::Delta {
+                        base_sequence: 1,
+                        sequence: 2,
+                        delta: vec![2],
+                        kitty_keyboard_active: true,
+                    },
+                    local_history: None,
+                },
+            ],
+        },
+        NodeMessage::Layout {
+            layout: Box::new(layout),
+        },
+        NodeMessage::Leases {
+            leases: vec![PaneLeaseSnapshot::default()],
+        },
+        NodeMessage::Rosters {
+            rosters: vec![AgentOverlaySnapshotRow {
+                pane_id: 1,
+                kind: "agent".into(),
+                cwd: "/tmp".into(),
+                state: 1,
+                working_since_unix_ms: 2,
+                host: "host".into(),
+                controller: "controller".into(),
+            }],
+        },
+        NodeMessage::Focus {
+            tab_id: 2,
+            pane_id: 3,
+        },
+    ];
+    for message in messages {
+        let encoded = serde_json::to_vec(&message).unwrap();
+        let decoded: NodeMessage = serde_json::from_slice(&encoded).unwrap();
+        assert_eq!(decoded, message);
+        if let NodeMessage::Screens { screens } = decoded {
+            assert!(screens
+                .iter()
+                .all(|frame| !matches!(frame.state, ScreenUpdate::Unchanged { .. })));
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Replace steady-state full attachment snapshots with incremental local IPC messages (`Screens`, `Layout`, `Leases`, `Rosters`, `Focus`), keeping full `Snapshot` for attach/resync.
- Coalesce screen-only publishes to ~60fps, reuse the perf log file handle, and avoid cloning live screens on zero-scrollback draws.
- Keep attach/resume correctness: initial Hello and explicit `ResyncScreen` still use full snapshots; skipped sequences fall back to pane snapshots.

## Test plan
- [ ] `cargo test`
- [ ] Create → type/output → detach → resume; initial/reattach still render correctly
- [ ] Rapid pane output feels smoother; resize recovers without stale panes
- [ ] Rename/split/focus updates chrome without full-session churn
- [ ] Scroll a pane, return to live output; no render artifacts
- [ ] `P2PMUX_PERF=1` logs to temp dir / `P2PMUX_PERF_LOG` without TUI bleed


Made with [Cursor](https://cursor.com)