### PR TITLE
fix: restore join code in attach footer

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -140,6 +140,7 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
     let mut pending_focus = None;
     let mut pending_resync = BTreeSet::new();
     let mut local_peer_id = Vec::new();
+    let mut join_code = None;
 
     'attached: loop {
         loop {
@@ -154,6 +155,7 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
                         local_peer_id: next_local_peer_id,
                         tab_id,
                         pane_id,
+                        join_code: next_join_code,
                         ..
                     } => {
                         let apply_started = Instant::now();
@@ -187,6 +189,7 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
                             write_message(&mut stream, &ClientMessage::ResyncScreen { pane_id })?;
                         }
                         local_peer_id = next_local_peer_id;
+                        join_code = next_join_code;
                         if let Some(tui) = tui.as_mut() {
                             tui.set_agent_overlay_viewport(terminal.size()?.into());
                         }
@@ -289,7 +292,13 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
                                 .map(|screen| (*pane_id, screen))
                         })
                         .collect();
-                    render_multi_pane_with_copy_feedback(frame, tui, &visible, copied_lines);
+                    render_multi_pane_with_copy_feedback(
+                        frame,
+                        tui,
+                        &visible,
+                        copied_lines,
+                        join_code.as_deref(),
+                    );
                 })?;
                 let draw_elapsed = draw_started.elapsed();
                 if crate::perf::enabled() && draw_elapsed >= Duration::from_millis(5) {

--- a/src/local_ipc.rs
+++ b/src/local_ipc.rs
@@ -285,4 +285,38 @@ mod tests {
         assert!(gate.attach().is_ok());
         let _ = std::fs::remove_file(path);
     }
+
+    #[test]
+    fn snapshot_join_code_serde_is_optional_and_backwards_compatible() {
+        let snapshot = |join_code| NodeMessage::Snapshot {
+            room_name: "test".into(),
+            role: "coordinator".into(),
+            summary: SessionSummary::default(),
+            layout: Box::new(crate::layout::LayoutSnapshot {
+                revision: 0,
+                members: vec![],
+                tabs: vec![],
+                panes: Default::default(),
+            }),
+            screens: vec![],
+            leases: vec![],
+            rosters: vec![],
+            local_peer_id: vec![],
+            tab_id: 1,
+            pane_id: 1,
+            join_code,
+        };
+
+        let with_join_code = serde_json::to_value(snapshot(Some("TESTCODE".into()))).unwrap();
+        assert_eq!(with_join_code["join_code"], "TESTCODE");
+
+        let without_join_code = serde_json::to_value(snapshot(None)).unwrap();
+        assert!(without_join_code.get("join_code").is_none());
+
+        let parsed: NodeMessage = serde_json::from_value(without_join_code).unwrap();
+        let NodeMessage::Snapshot { join_code, .. } = parsed else {
+            panic!("expected snapshot");
+        };
+        assert_eq!(join_code, None);
+    }
 }

--- a/src/local_ipc.rs
+++ b/src/local_ipc.rs
@@ -53,6 +53,8 @@ pub enum NodeMessage {
         local_peer_id: Vec<u8>,
         tab_id: u64,
         pane_id: u64,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        join_code: Option<String>,
     },
     Screens {
         screens: Vec<PaneScreenSnapshot>,

--- a/src/node.rs
+++ b/src/node.rs
@@ -522,6 +522,7 @@ fn write_snapshot(
         local_peer_id,
         tab_id,
         pane_id,
+        join_code: node.runtime.join_code().map(str::to_owned),
     };
     let json_started = Instant::now();
     let mut frame = serde_json::to_vec(&message).map_err(io::Error::other)?;
@@ -1164,6 +1165,7 @@ mod tests {
                 local_peer_id: vec![],
                 tab_id: 1,
                 pane_id: 1,
+                join_code: None,
             },
         )
         .unwrap();

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -2318,8 +2318,9 @@ pub fn render_multi_pane_with_copy_feedback(
     tui: &MultiPaneTui,
     screens: &BTreeMap<PaneId, &vt100::Screen>,
     copied_lines: Option<usize>,
+    join_code: Option<&str>,
 ) {
-    render_shared_multi_pane(frame, tui, screens, "", copied_lines, None, None);
+    render_shared_multi_pane(frame, tui, screens, "", copied_lines, None, join_code);
 }
 
 fn contextual_footer(chord_mode: ChordMode) -> (&'static str, &'static [FooterSegment]) {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -4031,6 +4031,10 @@ impl SharedLayoutRuntime {
         self.control.peer_id()
     }
 
+    pub(crate) fn join_code(&self) -> Option<&str> {
+        self.join_code.as_deref()
+    }
+
     fn input_allowed(&self, pane_id: PaneId) -> bool {
         let peer_id = self.control.peer_id();
         self.tui

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -5976,7 +5976,8 @@ mod tests {
         is_chord_command, is_chord_navigation, lease_allows_held_input, member_label,
         mouse_to_screen_cell, pane_border_color, pane_title, pane_wire_id,
         reconcile_remote_control_attempt, render_guest_screen, render_multi_pane,
-        render_shared_multi_pane, selection_text, text_width, viewed_screen, visible_leaf_panes,
+        render_multi_pane_with_copy_feedback, render_shared_multi_pane, selection_text, text_width,
+        viewed_screen, visible_leaf_panes,
     };
 
     #[test]
@@ -6845,6 +6846,39 @@ mod tests {
             .map(|cell| cell.symbol())
             .collect::<String>();
         assert!(rendered.contains("waiting for current pane reservation"));
+        assert!(rendered.contains("join: p2pmux join TESTCODE"));
+    }
+
+    #[test]
+    fn attach_renderer_draws_join_code_in_the_footer() {
+        let snapshot = layout(
+            vec![Tab {
+                tab_id: 1,
+                root: Node::Leaf { pane_id: 1 },
+                title: None,
+            }],
+            &[(1, 1, 1)],
+        );
+        let tui = MultiPaneTui::new(snapshot).expect("layout");
+        let mut terminal = Terminal::new(TestBackend::new(160, 5)).expect("terminal");
+        terminal
+            .draw(|frame| {
+                render_multi_pane_with_copy_feedback(
+                    frame,
+                    &tui,
+                    &BTreeMap::new(),
+                    None,
+                    Some("TESTCODE"),
+                );
+            })
+            .expect("draw");
+        let rendered = terminal
+            .backend()
+            .buffer()
+            .content
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
         assert!(rendered.contains("join: p2pmux join TESTCODE"));
     }
 

--- a/tests/local_ipc.rs
+++ b/tests/local_ipc.rs
@@ -24,6 +24,7 @@ fn protocol_messages_are_tagged_and_attachment_is_generation_safe() {
         local_peer_id: vec![],
         tab_id: 2,
         pane_id: 3,
+        join_code: None,
     };
     assert_eq!(serde_json::to_value(message).unwrap()["type"], "snapshot");
     assert_eq!(


### PR DESCRIPTION
## Summary
- Carry the host join code on local attach `Snapshot` IPC (omitted for members)
- Publish it from the node runtime and render it in the attach client footer
- Adds serde + attach-path footer coverage so the bottom-right `join: p2pmux join <code>` returns after detach/resume

## Test plan
- [x] `cargo test` locally
- [ ] CI green on PR
- [ ] Manual: `p2pmux create` → footer shows join code; detach/reattach still shows it
- [ ] Manual: member attach still has no join code


Made with [Cursor](https://cursor.com)