### PR TITLE
Inherit local pane cwd when splitting

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,9 +133,11 @@ hosts then resize their own PTY and VT screen and publish their local grids.
 - `Option+` `<shift>` + arrows — move focus to the nearest pane in that direction in the current
   tab. Some terminals need Shift with Option for horizontal arrows.
 - `Ctrl+P`, then `n` — split the focused pane using its current aspect-ratio axis. The new PTY
-  runs on the requester’s Mac.
+  runs on the requester’s Mac and inherits the target pane’s cwd when that pane is hosted locally
+  by the requester and its cwd is available; otherwise it starts in the p2pmux process cwd.
 - `Ctrl+P`, then `r` / `l` / `d` / `u` — create the new pane right / left / down / up of the
-  focused pane.
+  focused pane. Its local PTY inherits the target pane’s cwd when that pane is hosted locally by
+  the requester and its cwd is available; otherwise it starts in the p2pmux process cwd.
 - `Ctrl+P`, then `X` — delete the focused pane. Only that pane’s host may delete it.
 - `Ctrl+P`, then `e` — rename the focused pane for every admitted member. Enter saves; Esc
   cancels; a blank title restores `Pane #N`.

--- a/src/agent_detect.rs
+++ b/src/agent_detect.rs
@@ -1,11 +1,33 @@
 //! Pure helpers for detecting supported coding agents in a hosted PTY tree.
 
-use std::time::{Duration, Instant};
+use std::{
+    path::{Path, PathBuf},
+    time::{Duration, Instant},
+};
 
-use sysinfo::{ProcessRefreshKind, ProcessesToUpdate, System, UpdateKind};
+use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, System, UpdateKind};
 
 const DONE_GRACE: Duration = Duration::from_secs(15);
 const WORKING_WINDOW: Duration = Duration::from_secs(2);
+
+/// Return a process's current working directory when it is an existing absolute directory.
+pub fn cwd_for_pid(pid: u32) -> Option<PathBuf> {
+    let pid = Pid::from_u32(pid);
+    let mut system = System::new();
+    system.refresh_processes_specifics(
+        ProcessesToUpdate::Some(&[pid]),
+        true,
+        ProcessRefreshKind::nothing().with_cwd(UpdateKind::Always),
+    );
+    system
+        .process(pid)
+        .and_then(|process| process.cwd())
+        .and_then(existing_absolute_directory)
+}
+
+fn existing_absolute_directory(path: &Path) -> Option<PathBuf> {
+    (path.is_absolute() && path.is_dir()).then(|| path.to_path_buf())
+}
 
 /// A supported coding agent kind.
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
@@ -353,6 +375,80 @@ impl PaneAgentTracker {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::{
+        fs,
+        process::{Command, Stdio},
+        thread,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    #[test]
+    fn cwd_for_pid_reads_a_live_childs_working_directory() {
+        let directory = std::env::temp_dir().join(format!(
+            "p2pmux-cwd-for-pid-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("system clock is after epoch")
+                .as_nanos()
+        ));
+        fs::create_dir(&directory).expect("create temporary directory");
+        let mut child = Command::new("/bin/sh")
+            .args(["-c", "sleep 5"])
+            .current_dir(&directory)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn child");
+
+        let cwd = (0..20).find_map(|_| {
+            let cwd = cwd_for_pid(child.id());
+            if cwd.is_some() {
+                cwd
+            } else {
+                thread::sleep(Duration::from_millis(25));
+                None
+            }
+        });
+
+        assert_eq!(
+            cwd.as_deref()
+                .map(|cwd| fs::canonicalize(cwd).expect("canonicalize detected cwd")),
+            Some(fs::canonicalize(&directory).expect("canonicalize temporary directory"))
+        );
+
+        let _ = child.kill();
+        let _ = child.wait();
+        fs::remove_dir(&directory).expect("remove temporary directory");
+    }
+
+    #[test]
+    fn cwd_validation_rejects_missing_paths_and_non_directories() {
+        let temporary_root = std::env::temp_dir().join(format!(
+            "p2pmux-cwd-validation-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("system clock is after epoch")
+                .as_nanos()
+        ));
+        fs::create_dir(&temporary_root).expect("create temporary directory");
+        let file = temporary_root.join("file");
+        fs::write(&file, "not a directory").expect("write temporary file");
+
+        assert_eq!(
+            existing_absolute_directory(&temporary_root),
+            Some(temporary_root.clone())
+        );
+        assert_eq!(existing_absolute_directory(&file), None);
+        assert_eq!(
+            existing_absolute_directory(&temporary_root.join("missing")),
+            None
+        );
+        assert_eq!(existing_absolute_directory(Path::new("relative")), None);
+
+        fs::remove_dir_all(&temporary_root).expect("remove temporary directory");
+    }
 
     fn process(
         pid: u32,

--- a/src/pty_host.rs
+++ b/src/pty_host.rs
@@ -4,6 +4,7 @@ use std::{
     error::Error,
     ffi::OsString,
     io::{Read, Write},
+    path::Path,
     sync::mpsc::{self, Receiver, TryRecvError},
     thread::{self, JoinHandle},
 };
@@ -59,10 +60,21 @@ impl PtyHost {
 
     /// Spawn the user's login shell, or `/bin/zsh` when `SHELL` is unset.
     pub fn spawn_default_shell(size: PtySize) -> Result<Self, Box<dyn Error>> {
+        Self::spawn_default_shell_with_cwd(size, None)
+    }
+
+    /// Spawn the user's login shell with an optional working directory.
+    pub fn spawn_default_shell_with_cwd(
+        size: PtySize,
+        cwd: Option<&Path>,
+    ) -> Result<Self, Box<dyn Error>> {
         let shell = std::env::var_os("SHELL").unwrap_or_else(|| OsString::from("/bin/zsh"));
         let mut command = CommandBuilder::new(shell);
         command.arg("-l");
         command.env("TERM", "xterm-256color");
+        if let Some(cwd) = cwd {
+            command.cwd(cwd);
+        }
         Self::spawn(command, size)
     }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -8,7 +8,7 @@ use std::{
     fs::OpenOptions,
     io,
     io::Write,
-    path::PathBuf,
+    path::{Path, PathBuf},
     process::{Command, Stdio},
     sync::{
         Arc, Mutex, OnceLock,
@@ -49,7 +49,7 @@ use ratatui::{
 
 use crate::{
     agent_detect::{
-        PaneAgentTracker, ProcessSnapshot, SysinfoSampler, classify_pane_tree,
+        PaneAgentTracker, ProcessSnapshot, SysinfoSampler, classify_pane_tree, cwd_for_pid,
         sample_global_snapshot,
     },
     config::UiTheme,
@@ -3243,11 +3243,27 @@ impl SharedLocalPane {
         grid_cols: u16,
         host_peer_id: Vec<u8>,
     ) -> Result<Self, Box<dyn Error>> {
+        Self::spawn_with_cwd(pane_id, grid_rows, grid_cols, host_peer_id, None)
+    }
+
+    pub(crate) fn spawn_with_cwd(
+        pane_id: PaneId,
+        grid_rows: u16,
+        grid_cols: u16,
+        host_peer_id: Vec<u8>,
+        cwd: Option<&Path>,
+    ) -> Result<Self, Box<dyn Error>> {
         let size = PtySize {
             rows: grid_rows,
             cols: grid_cols,
             pixel_width: 0,
             pixel_height: 0,
+        };
+        let cwd = cwd.filter(|path| path.is_dir());
+        let host = match PtyHost::spawn_default_shell_with_cwd(size, cwd) {
+            Ok(host) => host,
+            Err(_) if cwd.is_some_and(|path| !path.is_dir()) => PtyHost::spawn_default_shell(size)?,
+            Err(error) => return Err(error),
         };
         let screen = HostScreen::new(grid_rows, grid_cols)?;
         let (screen_tx, _) = watch::channel(screen.current_frame().clone());
@@ -3256,7 +3272,7 @@ impl SharedLocalPane {
         let (control_tx, control_rx) = mpsc::channel(256);
         Ok(Self {
             pane_id,
-            host: PtyHost::spawn_default_shell(size)?,
+            host,
             screen,
             lease,
             host_peer_id,
@@ -3774,12 +3790,12 @@ fn layout_queue_message(error: LayoutControlQueueError) -> String {
     }
 }
 
-#[derive(Clone, Copy)]
 struct PendingCreate {
     request_id: u64,
     base_revision: u64,
     grid_rows: u16,
     grid_cols: u16,
+    cwd: Option<PathBuf>,
 }
 
 /// Pure retry state for direct remote-pane subscriptions. Ticks are supplied by the UI drain
@@ -4794,13 +4810,23 @@ impl SharedLayoutRuntime {
                 grid_rows,
                 grid_cols,
             } => {
-                self.begin_create(Some((target_pane_id, axis, position)), grid_rows, grid_cols)?;
+                let cwd = self
+                    .local
+                    .get(&target_pane_id)
+                    .and_then(|pane| pane.host.process_id())
+                    .and_then(cwd_for_pid);
+                self.begin_create(
+                    Some((target_pane_id, axis, position)),
+                    grid_rows,
+                    grid_cols,
+                    cwd,
+                )?;
             }
             UiIntent::CreateTab {
                 grid_rows,
                 grid_cols,
             } => {
-                self.begin_create(None, grid_rows, grid_cols)?;
+                self.begin_create(None, grid_rows, grid_cols, None)?;
             }
             UiIntent::DeletePane { pane_id } => {
                 let request_id = self.next_id();
@@ -4909,6 +4935,7 @@ impl SharedLayoutRuntime {
         pane: Option<(PaneId, Axis, NewPanePosition)>,
         grid_rows: u16,
         grid_cols: u16,
+        cwd: Option<PathBuf>,
     ) -> Result<(), Box<dyn Error>> {
         if self.pending_create.is_some() {
             self.status = String::from("waiting for current pane reservation");
@@ -4921,6 +4948,7 @@ impl SharedLayoutRuntime {
             base_revision,
             grid_rows,
             grid_cols,
+            cwd,
         });
         self.send_request(LayoutRequest {
             request_id,
@@ -5019,11 +5047,12 @@ impl SharedLayoutRuntime {
             return Ok(());
         };
         let host_peer_id = self.control.peer_id();
-        let pane = match SharedLocalPane::spawn(
+        let pane = match SharedLocalPane::spawn_with_cwd(
             reservation.pane_id,
             pending.grid_rows,
             pending.grid_cols,
             host_peer_id.clone(),
+            pending.cwd.as_deref(),
         ) {
             Ok(pane) => pane,
             Err(error) => {
@@ -5079,6 +5108,7 @@ impl SharedLayoutRuntime {
         self.tui.cancel_resize_drag();
         self.pending_create = self
             .pending_create
+            .take()
             .filter(|pending| pending.request_id != request_id);
         if let Some(pane_id) = self.provisional.remove(&request_id) {
             let _ = self.panes.remove_local_pane(pane_id);

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -5967,10 +5967,10 @@ fn member_label(peer_id: &[u8], members: &[crate::layout::Member]) -> String {
 mod tests {
     use std::{
         collections::BTreeMap,
-        io,
+        fs, io,
         net::Ipv4Addr,
         thread,
-        time::{Duration, Instant},
+        time::{Duration, Instant, SystemTime, UNIX_EPOCH},
     };
     use tokio::sync::{mpsc, watch};
 
@@ -5985,10 +5985,10 @@ mod tests {
         style::{Color, Modifier},
     };
 
-    use crate::config::UiTheme;
     use crate::layout::{Axis, LayoutError, LayoutSnapshot, NewPanePosition, Node, Pane, Tab};
     use crate::lease::{IDLE_AFTER, LeaseManager, LeaseState};
     use crate::screen::{GuestScreen, HostScreen};
+    use crate::{agent_detect::cwd_for_pid, config::UiTheme};
     use crate::{
         protocol::PaneDescriptor,
         session::{HostSession, SharedLayoutHost, layout_snapshot_from_state},
@@ -6553,6 +6553,16 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn runtime_create_then_committed_delete_updates_its_local_pane_lifecycle() {
+        let directory = std::env::temp_dir().join(format!(
+            "p2pmux-runtime-create-cwd-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("system clock is after epoch")
+                .as_nanos()
+        ));
+        fs::create_dir(&directory).expect("create temporary directory");
+        let expected_cwd = fs::canonicalize(&directory).expect("canonicalize temporary directory");
         let host = SharedLayoutHost::new(
             HostSession::from_transport(loopback_transport().await).expect("host session"),
             2,
@@ -6592,6 +6602,35 @@ mod tests {
         .expect("runtime");
         runtime.set_session_id(b"session".to_vec());
 
+        thread::sleep(Duration::from_secs(2));
+        let source_pid = runtime
+            .local
+            .get(&1)
+            .and_then(|pane| pane.host.process_id())
+            .expect("source PTY child PID");
+        runtime
+            .local
+            .get_mut(&1)
+            .expect("source local pane")
+            .host
+            .write_input(format!("cd -- {}\n", directory.display()).as_bytes())
+            .expect("change source PTY directory");
+        let source_cwd = (0..20).find_map(|_| {
+            let cwd = cwd_for_pid(source_pid);
+            if cwd
+                .as_ref()
+                .and_then(|cwd| fs::canonicalize(cwd).ok())
+                .as_ref()
+                == Some(&expected_cwd)
+            {
+                cwd
+            } else {
+                thread::sleep(Duration::from_millis(25));
+                None
+            }
+        });
+        assert!(source_cwd.is_some(), "source PTY changed directory");
+
         runtime.tui.selection = Some(PaneTextSelection {
             pane_id: 1,
             anchor: ScreenCell { row: 0, col: 0 },
@@ -6612,6 +6651,17 @@ mod tests {
             })
             .expect("create intent commits after registering a local pane");
         assert!(runtime.local.contains_key(&2));
+        let created_pid = runtime
+            .local
+            .get(&2)
+            .and_then(|pane| pane.host.process_id())
+            .expect("created PTY child PID");
+        assert_eq!(
+            cwd_for_pid(created_pid)
+                .as_ref()
+                .and_then(|cwd| fs::canonicalize(cwd).ok()),
+            Some(expected_cwd.clone())
+        );
         assert!(runtime.panes.has_registered_pane(2).expect("pane registry"));
         assert!(
             runtime.provisional.is_empty(),
@@ -6646,6 +6696,8 @@ mod tests {
             "committed removal revokes the direct-pane service before the PTY is shut down"
         );
         assert_eq!(runtime.tui.snapshot().panes.len(), 1);
+        drop(runtime);
+        fs::remove_dir(&directory).expect("remove temporary directory");
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/tests/pty_host.rs
+++ b/tests/pty_host.rs
@@ -1,6 +1,6 @@
 use std::{
-    thread,
-    time::{Duration, Instant},
+    fs, thread,
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
 use p2pmux::pty_host::PtyHost;
@@ -79,4 +79,39 @@ fn pty_host_resizes_without_disrupting_io() {
         .expect("writer stays alive");
     assert!(read_until(&mut host, ":reply:still alive").contains("still alive"));
     host.shutdown().expect("clean shutdown");
+}
+
+#[test]
+fn pty_host_default_shell_uses_explicit_working_directory() {
+    let directory = std::env::temp_dir().join(format!(
+        "p2pmux-pty-host-cwd-{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock is after epoch")
+            .as_nanos()
+    ));
+    fs::create_dir(&directory).expect("create temporary directory");
+    let expected = fs::canonicalize(&directory).expect("canonicalize temporary directory");
+    let mut host = PtyHost::spawn_default_shell_with_cwd(
+        PtySize {
+            rows: 24,
+            cols: 80,
+            pixel_width: 0,
+            pixel_height: 0,
+        },
+        Some(&directory),
+    )
+    .expect("PTY should spawn");
+
+    thread::sleep(Duration::from_millis(100));
+    host.write_input(b"pwd -P\n")
+        .expect("PTY should accept input");
+    assert!(
+        read_until(&mut host, &expected.display().to_string())
+            .contains(expected.to_str().expect("utf-8 path"))
+    );
+
+    host.shutdown().expect("PTY should shut down cleanly");
+    fs::remove_dir(&directory).expect("remove temporary directory");
 }


### PR DESCRIPTION
## Summary
- New panes from `Ctrl+P` then `n` / `r` / `l` / `d` / `u` start in the target pane’s working directory when that pane is hosted locally and its cwd can be read
- Remote or unreadable source panes keep the previous default (p2pmux process cwd); `Ctrl+T` new tab is unchanged
- Adds focused `cwd_for_pid` lookup, cwd-aware PTY spawn, create-pane plumbing with vanish/fallback handling, tests, and README notes

## Test plan
- [ ] From a local pane, `cd` into a directory, then `Ctrl+P` `n` — new shell starts there
- [ ] Repeat with `r` / `l` / `d` / `u`
- [ ] Split a remote-hosted pane — new local PTY still creates (default cwd)
- [ ] `Ctrl+T` `n` — new tab still uses default cwd
- [ ] `cargo test agent_detect::tests --lib`
- [ ] `cargo test --test pty_host`
- [ ] Run the runtime create-pane inheritance test in `src/tui.rs`


Made with [Cursor](https://cursor.com)