### PR TITLE
Load attach scrollback on demand

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,13 @@ claiming control or sending input. Mouse wheel scrolls pane history locally. The
 `PANE MODE  <←↓↑→> FOCUS   <e> RENAME   <n> NEW   <r/l/d/u> SPLIT   <x> CLOSE   <k> LOCK   <Esc> BACK`; tab mode is
 `TAB MODE  <←→> SWITCH   <e> RENAME   <n> NEW   <x> CLOSE   <Esc> BACK`.
 
+For locally hosted panes, mouse-wheel scrollback is loaded from the host on demand when you first
+scroll up, then cached while you browse it. Alternate-screen applications have no attach
+scrollback, and a resize establishes the existing history floor (so pre-attach history can be
+empty after the attach-triggered resize). Remote-hosted panes return an empty scrollback window in
+this v1 implementation. This release changes the local IPC screen payload: restart any running
+p2pmux sessions after upgrading before attaching a new client.
+
 Slow viewers may receive coalesced screen deltas and then a fresh snapshot to recover. Resizing an
 outer terminal reflows locally hosted panes: the host resizes its PTY and VT screen and commits any
 changed host-owned grids. Guests only receive the resulting commit and screen snapshot.

--- a/src/client.rs
+++ b/src/client.rs
@@ -1170,7 +1170,7 @@ mod tests {
             &mut pending_focus,
         )
         .unwrap();
-        assert!(history.is_empty());
+        assert_eq!(history[&1].available_rows(), 0);
 
         apply_snapshot(
             &mut tui,
@@ -1195,7 +1195,7 @@ mod tests {
             &mut pending_focus,
         )
         .unwrap();
-        assert!(history.is_empty());
+        assert_eq!(history[&1].available_rows(), 0);
     }
 
     #[test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -149,6 +149,7 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
     let mut last_agent_overlay_animation = Instant::now();
     let mut pending_focus = None;
     let mut pending_resync = BTreeSet::new();
+    let mut history_refresh = BTreeSet::new();
     let mut local_peer_id = Vec::new();
     let mut join_code = None;
 
@@ -183,6 +184,7 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
                             &mut history,
                             next_screens,
                             &mut pending_resync,
+                            &mut history_refresh,
                         )?;
                         apply_leases(view, leases);
                         apply_rosters(view, rosters);
@@ -197,6 +199,15 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
                         }
                         for pane_id in new_resync_requests(&mut pending_resync, resync) {
                             write_message(&mut stream, &ClientMessage::ResyncScreen { pane_id })?;
+                        }
+                        for pane_id in std::mem::take(&mut history_refresh) {
+                            request_scrollback(
+                                &mut stream,
+                                pane_id,
+                                view.pane_scrollback_offset(pane_id),
+                                &mut pending_scroll,
+                                &mut next_scrollback_request_id,
+                            )?;
                         }
                         local_peer_id = next_local_peer_id;
                         join_code = next_join_code;
@@ -228,9 +239,19 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
                             &mut history,
                             next_screens,
                             &mut pending_resync,
+                            &mut history_refresh,
                         )?;
                         for pane_id in new_resync_requests(&mut pending_resync, resync) {
                             write_message(&mut stream, &ClientMessage::ResyncScreen { pane_id })?;
+                        }
+                        for pane_id in std::mem::take(&mut history_refresh) {
+                            request_scrollback(
+                                &mut stream,
+                                pane_id,
+                                view.pane_scrollback_offset(pane_id),
+                                &mut pending_scroll,
+                                &mut next_scrollback_request_id,
+                            )?;
                         }
                         dirty = true;
                     }
@@ -434,26 +455,16 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
                         .map(HistoryCache::available_rows)
                         .unwrap_or_default();
                     if up && scrollback_len == 0 {
-                        let pending = pending_scroll.entry(pane_id).or_insert_with(|| {
-                            let request_id = next_scrollback_request_id;
-                            next_scrollback_request_id = next_scrollback_request_id.wrapping_add(1);
-                            PendingScroll {
-                                request_id,
-                                target: 0,
-                            }
-                        });
-                        pending.target = pending.target.saturating_add(3);
-                        if pending.target == 3 {
-                            write_message(
-                                &mut stream,
-                                &ClientMessage::ScrollbackQuery {
-                                    pane_id,
-                                    offset: 0,
-                                    max_rows: 1_000,
-                                    request_id: pending.request_id,
-                                },
-                            )?;
-                        }
+                        let target = pending_scroll
+                            .get(&pane_id)
+                            .map_or(3, |pending| pending.target.saturating_add(3));
+                        request_scrollback(
+                            &mut stream,
+                            pane_id,
+                            target,
+                            &mut pending_scroll,
+                            &mut next_scrollback_request_id,
+                        )?;
                     } else {
                         tui.scroll_mouse_pane(mouse.column, mouse.row, area, scrollback_len, up);
                         if !up && tui.pane_scrollback_offset(pane_id) == 0 {
@@ -555,6 +566,7 @@ fn apply_snapshot(
         history,
         next_screens,
         &mut BTreeSet::new(),
+        &mut BTreeSet::new(),
     )?;
     apply_leases(view, leases);
     apply_rosters(view, rosters);
@@ -590,11 +602,12 @@ fn apply_layout<'a>(
 }
 
 fn apply_screens(
-    _view: &mut MultiPaneTui,
+    view: &mut MultiPaneTui,
     screens: &mut BTreeMap<u64, GuestScreen>,
     history: &mut BTreeMap<u64, HistoryCache>,
     next_screens: Vec<crate::local_ipc::PaneScreenSnapshot>,
     pending_resync: &mut BTreeSet<u64>,
+    history_refresh: &mut BTreeSet<u64>,
 ) -> Result<Vec<u64>, Box<dyn std::error::Error>> {
     let mut resync = Vec::new();
     for frame in next_screens {
@@ -628,15 +641,25 @@ fn apply_screens(
         }
         if let Some(screen) = screen.screen() {
             let cache = history.entry(pane_id).or_default();
+            let previous_end = cache.history_end;
+            let cache_reached_live = cache.reaches_live();
             if cache.grid.is_some_and(|grid| grid != screen.size())
                 || history_end < cache.history_end
                 || history_len < cache.total_rows
             {
                 *cache = HistoryCache::default();
+                view.set_pane_scrollback_offset(pane_id, 0);
             }
+            let appended = history_end.saturating_sub(previous_end) as usize;
             cache.grid = Some(screen.size());
             cache.total_rows = history_len;
             cache.history_end = history_end;
+            if appended > 0 && view.pane_scrollback_offset(pane_id) > 0 {
+                view.pin_scrollback_after_output(pane_id, appended, history_len as usize);
+                if cache_reached_live {
+                    history_refresh.insert(pane_id);
+                }
+            }
         }
     }
     Ok(resync)
@@ -725,6 +748,36 @@ fn send_intents(
             }
             intent => write_message(stream, &ClientMessage::StructuralIntent { intent })?,
         }
+    }
+    Ok(())
+}
+
+fn request_scrollback(
+    stream: &mut UnixStream,
+    pane_id: u64,
+    target: usize,
+    pending: &mut BTreeMap<u64, PendingScroll>,
+    next_request_id: &mut u64,
+) -> io::Result<()> {
+    let request_id = *next_request_id;
+    let entry = pending.entry(pane_id).or_insert_with(|| {
+        *next_request_id = (*next_request_id).wrapping_add(1);
+        PendingScroll {
+            request_id,
+            target,
+        }
+    });
+    entry.target = entry.target.max(target);
+    if entry.request_id == request_id {
+        write_message(
+            stream,
+            &ClientMessage::ScrollbackQuery {
+                pane_id,
+                offset: 0,
+                max_rows: 1_000,
+                request_id,
+            },
+        )?;
     }
     Ok(())
 }
@@ -1168,6 +1221,7 @@ mod tests {
                 history_end: 0,
             }],
             &mut pending_resync,
+            &mut BTreeSet::new(),
         )
         .unwrap();
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -23,7 +23,7 @@ use crossterm::{
 use ratatui::{Terminal, TerminalOptions, Viewport, backend::CrosstermBackend, layout::Rect};
 
 use crate::{
-    local_ipc::{ClientMessage, LocalHistorySnapshot, NodeMessage, ScreenUpdate},
+    local_ipc::{ClientMessage, NodeMessage, ScreenUpdate},
     protocol::AgentRosterState,
     screen::{ApplyDelta, GuestScreen},
     session_store::SessionDescriptor,
@@ -34,34 +34,36 @@ use crate::{
 };
 
 #[derive(Default)]
-struct LocalHistory {
+struct HistoryCache {
     grid: Option<(u16, u16)>,
-    total_rows: usize,
+    total_rows: u64,
+    history_end: u64,
     rows: Vec<Vec<u8>>,
 }
 
-impl LocalHistory {
-    fn replace(&mut self, snapshot: LocalHistorySnapshot, grid: (u16, u16)) -> usize {
-        let grid_changed = self
-            .grid
-            .replace(grid)
-            .is_some_and(|previous| previous != grid);
-        let previous_total = if grid_changed { 0 } else { self.total_rows };
-        self.rows = snapshot
-            .rows
+impl HistoryCache {
+    fn install_window(
+        &mut self,
+        total_rows: u64,
+        history_end: u64,
+        grid: (u16, u16),
+        rows: Vec<String>,
+    ) {
+        self.grid = Some(grid);
+        self.total_rows = total_rows;
+        self.history_end = history_end;
+        self.rows = rows
             .into_iter()
             .filter_map(|row| STANDARD.decode(row).ok())
             .collect();
-        self.total_rows = snapshot.total_rows;
-        if grid_changed || snapshot.total_rows < previous_total {
-            0
-        } else {
-            snapshot.total_rows.saturating_sub(previous_total)
-        }
     }
 
     fn available_rows(&self) -> usize {
         self.rows.len()
+    }
+
+    fn reaches_live(&self) -> bool {
+        self.total_rows <= self.rows.len() as u64
     }
 
     fn viewport(&self, live: &vt100::Screen) -> vt100::Screen {
@@ -79,17 +81,23 @@ impl LocalHistory {
 fn copy_attach_selection(
     tui: &MultiPaneTui,
     screens: &BTreeMap<u64, GuestScreen>,
-    local_history: &BTreeMap<u64, LocalHistory>,
+    history: &BTreeMap<u64, HistoryCache>,
 ) -> Option<usize> {
     let pane_id = tui.selection_pane()?;
     let live = screens.get(&pane_id)?.screen()?;
-    let mut viewport = local_history
+    let mut viewport = history
         .get(&pane_id)
         .filter(|history| !history.rows.is_empty())
         .map_or_else(|| live.clone(), |history| history.viewport(live));
     viewport.set_scrollback(tui.pane_scrollback_offset(pane_id));
     let text = tui.selected_text(&viewport)?;
     copy_selection_to_clipboard(&text).ok()
+}
+
+#[derive(Clone, Copy)]
+struct PendingScroll {
+    request_id: u64,
+    target: usize,
 }
 
 pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Error>> {
@@ -130,7 +138,9 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
     )?;
     let mut tui = None;
     let mut screens = BTreeMap::new();
-    let mut local_history = BTreeMap::new();
+    let mut history = BTreeMap::new();
+    let mut pending_scroll: BTreeMap<u64, PendingScroll> = BTreeMap::new();
+    let mut next_scrollback_request_id = 1_u64;
     let mut copied_lines = None;
     let mut dirty = false;
     let mut node_ended = false;
@@ -163,14 +173,14 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
                             &mut tui,
                             theme,
                             &mut screens,
-                            &mut local_history,
+                            &mut history,
                             room_name,
                             *layout,
                         )?;
                         let resync = apply_screens(
                             view,
                             &mut screens,
-                            &mut local_history,
+                            &mut history,
                             next_screens,
                             &mut pending_resync,
                         )?;
@@ -200,7 +210,7 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
                             &mut tui,
                             theme,
                             &mut screens,
-                            &mut local_history,
+                            &mut history,
                             String::new(),
                             *layout,
                         )?;
@@ -215,12 +225,49 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
                         let resync = apply_screens(
                             view,
                             &mut screens,
-                            &mut local_history,
+                            &mut history,
                             next_screens,
                             &mut pending_resync,
                         )?;
                         for pane_id in new_resync_requests(&mut pending_resync, resync) {
                             write_message(&mut stream, &ClientMessage::ResyncScreen { pane_id })?;
+                        }
+                        dirty = true;
+                    }
+                    NodeMessage::ScrollbackWindow {
+                        pane_id,
+                        request_id,
+                        sequence,
+                        grid_rows,
+                        grid_cols,
+                        total_rows,
+                        offset,
+                        rows,
+                    } => {
+                        let Some(pending) = pending_scroll.remove(&pane_id) else {
+                            continue;
+                        };
+                        let Some(guest) = screens.get(&pane_id) else {
+                            continue;
+                        };
+                        let Some(screen) = guest.screen() else {
+                            continue;
+                        };
+                        if pending.request_id != request_id
+                            || offset != 0
+                            || screen.size() != (grid_rows, grid_cols)
+                            || guest.sequence().is_some_and(|current| sequence < current)
+                        {
+                            continue;
+                        }
+                        let cache = history.entry(pane_id).or_default();
+                        let history_end = cache.history_end.max(total_rows);
+                        cache.install_window(total_rows, history_end, screen.size(), rows);
+                        if let Some(view) = tui.as_mut() {
+                            view.set_pane_scrollback_offset(
+                                pane_id,
+                                pending.target.min(cache.available_rows()),
+                            );
                         }
                         dirty = true;
                     }
@@ -272,7 +319,7 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
                         .filter(|(pane_id, _)| tui.pane_scrollback_offset(**pane_id) != 0)
                         .filter_map(|(pane_id, screen)| {
                             screen.screen().map(|screen| {
-                                let viewport = local_history
+                                let viewport = history
                                     .get(pane_id)
                                     .filter(|history| !history.rows.is_empty())
                                     .map_or_else(
@@ -338,6 +385,9 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
                                 client_key_bytes(key.code, key.modifiers, kitty_keyboard_active)
                         {
                             write_message(&mut stream, &ClientMessage::Input { bytes })?;
+                            history.remove(&tui.focused_pane());
+                            pending_scroll.remove(&tui.focused_pane());
+                            tui.set_pane_scrollback_offset(tui.focused_pane(), 0);
                         }
                     }
                 }
@@ -350,6 +400,9 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
                             bytes: text.into_bytes(),
                         },
                     )?;
+                    history.remove(&tui.focused_pane());
+                    pending_scroll.remove(&tui.focused_pane());
+                    tui.set_pane_scrollback_offset(tui.focused_pane(), 0);
                 }
                 dirty = true;
             }
@@ -375,23 +428,38 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
                     MouseEventKind::ScrollUp | MouseEventKind::ScrollDown
                 ) {
                     let pane_id = tui.pane_at_or_focused_for_mouse(mouse.column, mouse.row, area);
-                    let scrollback_len = local_history.get(&pane_id).map_or_else(
-                        || {
-                            screens
-                                .get(&pane_id)
-                                .and_then(GuestScreen::screen)
-                                .map(available_scrollback)
-                                .unwrap_or_default()
-                        },
-                        LocalHistory::available_rows,
-                    );
-                    tui.scroll_mouse_pane(
-                        mouse.column,
-                        mouse.row,
-                        area,
-                        scrollback_len,
-                        matches!(mouse.kind, MouseEventKind::ScrollUp),
-                    );
+                    let up = matches!(mouse.kind, MouseEventKind::ScrollUp);
+                    let scrollback_len = history
+                        .get(&pane_id)
+                        .map(HistoryCache::available_rows)
+                        .unwrap_or_default();
+                    if up && scrollback_len == 0 {
+                        let pending = pending_scroll.entry(pane_id).or_insert_with(|| {
+                            let request_id = next_scrollback_request_id;
+                            next_scrollback_request_id = next_scrollback_request_id.wrapping_add(1);
+                            PendingScroll {
+                                request_id,
+                                target: 0,
+                            }
+                        });
+                        pending.target = pending.target.saturating_add(3);
+                        if pending.target == 3 {
+                            write_message(
+                                &mut stream,
+                                &ClientMessage::ScrollbackQuery {
+                                    pane_id,
+                                    offset: 0,
+                                    max_rows: 1_000,
+                                    request_id: pending.request_id,
+                                },
+                            )?;
+                        }
+                    } else {
+                        tui.scroll_mouse_pane(mouse.column, mouse.row, area, scrollback_len, up);
+                        if !up && tui.pane_scrollback_offset(pane_id) == 0 {
+                            history.remove(&pane_id);
+                        }
+                    }
                 } else {
                     if matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left)) {
                         copied_lines = None;
@@ -399,7 +467,7 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
                     let handling = tui.handle_mouse(mouse, area);
                     send_intents(&mut stream, tui, handling.intents, &mut pending_focus)?;
                     if handling.copy_selection_requested {
-                        copied_lines = copy_attach_selection(tui, &screens, &local_history);
+                        copied_lines = copy_attach_selection(tui, &screens, &history);
                     }
                 }
                 dirty = true;
@@ -408,6 +476,8 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
                 terminal.resize(Rect::new(0, 0, cols, rows))?;
                 if !tui.modal_open() {
                     tui.set_agent_overlay_viewport(Rect::new(0, 0, cols, rows));
+                    history.clear();
+                    pending_scroll.clear();
                     write_message(&mut stream, &ClientMessage::Resize { cols, rows })?;
                 }
                 dirty = true;
@@ -468,7 +538,7 @@ fn apply_snapshot(
     tui: &mut Option<MultiPaneTui>,
     theme: crate::config::UiTheme,
     screens: &mut BTreeMap<u64, GuestScreen>,
-    local_history: &mut BTreeMap<u64, LocalHistory>,
+    history: &mut BTreeMap<u64, HistoryCache>,
     room_name: String,
     layout: crate::layout::LayoutSnapshot,
     next_screens: Vec<crate::local_ipc::PaneScreenSnapshot>,
@@ -478,11 +548,11 @@ fn apply_snapshot(
     pane_id: u64,
     pending_focus: &mut Option<(u64, u64)>,
 ) -> Result<Vec<u64>, Box<dyn std::error::Error>> {
-    let view = apply_layout(tui, theme, screens, local_history, room_name, layout)?;
+    let view = apply_layout(tui, theme, screens, history, room_name, layout)?;
     let resync = apply_screens(
         view,
         screens,
-        local_history,
+        history,
         next_screens,
         &mut BTreeSet::new(),
     )?;
@@ -496,7 +566,7 @@ fn apply_layout<'a>(
     tui: &'a mut Option<MultiPaneTui>,
     theme: crate::config::UiTheme,
     screens: &mut BTreeMap<u64, GuestScreen>,
-    local_history: &mut BTreeMap<u64, LocalHistory>,
+    history: &mut BTreeMap<u64, HistoryCache>,
     room_name: String,
     layout: crate::layout::LayoutSnapshot,
 ) -> Result<&'a mut MultiPaneTui, Box<dyn std::error::Error>> {
@@ -515,20 +585,22 @@ fn apply_layout<'a>(
         view.set_title(format!("p2pmux ({room_name})"));
     }
     screens.retain(|pane_id, _| view.snapshot().panes.contains_key(pane_id));
-    local_history.retain(|pane_id, _| view.snapshot().panes.contains_key(pane_id));
+    history.retain(|pane_id, _| view.snapshot().panes.contains_key(pane_id));
     Ok(view)
 }
 
 fn apply_screens(
-    view: &mut MultiPaneTui,
+    _view: &mut MultiPaneTui,
     screens: &mut BTreeMap<u64, GuestScreen>,
-    local_history: &mut BTreeMap<u64, LocalHistory>,
+    history: &mut BTreeMap<u64, HistoryCache>,
     next_screens: Vec<crate::local_ipc::PaneScreenSnapshot>,
     pending_resync: &mut BTreeSet<u64>,
 ) -> Result<Vec<u64>, Box<dyn std::error::Error>> {
     let mut resync = Vec::new();
     for frame in next_screens {
         let pane_id = frame.pane_id;
+        let history_len = frame.history_len;
+        let history_end = frame.history_end;
         let screen = screens.entry(frame.pane_id).or_default();
         match frame.state {
             ScreenUpdate::Snapshot {
@@ -554,14 +626,17 @@ fn apply_screens(
                 kitty_keyboard_active,
             } => screen.set_kitty_keyboard_active(kitty_keyboard_active),
         }
-        if let Some(snapshot) = frame.local_history
-            && let Some(screen) = screen.screen()
-        {
-            let local = local_history.entry(pane_id).or_default();
-            let appended = local.replace(snapshot, screen.size());
-            if appended > 0 {
-                view.pin_scrollback_after_output(pane_id, appended, local.available_rows());
+        if let Some(screen) = screen.screen() {
+            let cache = history.entry(pane_id).or_default();
+            if cache.grid.is_some_and(|grid| grid != screen.size())
+                || history_end < cache.history_end
+                || history_len < cache.total_rows
+            {
+                *cache = HistoryCache::default();
             }
+            cache.grid = Some(screen.size());
+            cache.total_rows = history_len;
+            cache.history_end = history_end;
         }
     }
     Ok(resync)
@@ -771,12 +846,6 @@ fn client_key_bytes(
     }
 }
 
-fn available_scrollback(screen: &vt100::Screen) -> usize {
-    let mut screen = screen.clone();
-    screen.set_scrollback(crate::screen::SCROLLBACK_LINES);
-    screen.scrollback()
-}
-
 struct ClientTerminalGuard {
     stdout: io::Stdout,
     raw: bool,
@@ -851,7 +920,7 @@ mod tests {
 
     use crate::{
         layout::{LayoutSnapshot, Member, Node, Pane, Tab},
-        local_ipc::{AgentOverlaySnapshotRow, LocalHistorySnapshot, PaneScreenSnapshot},
+        local_ipc::{AgentOverlaySnapshotRow, PaneScreenSnapshot},
         screen::HostScreen,
         tui::{AGENT_TOGGLE_WINDOW, UiIntent},
     };
@@ -1000,19 +1069,16 @@ mod tests {
     }
 
     #[test]
-    fn local_history_rebuilds_a_scrollback_viewport() {
+    fn history_cache_rebuilds_a_scrollback_viewport() {
         let mut host = HostScreen::new(1, 3).unwrap();
         host.process_pty(b"one\r\ntwo").unwrap();
         let (total_rows, rows) = host.visual_scrollback(1_000, 256 * 1024);
-        let mut history = LocalHistory::default();
-        assert!(
-            history.replace(
-                LocalHistorySnapshot {
-                    total_rows,
-                    rows: rows.into_iter().map(|row| STANDARD.encode(row)).collect(),
-                },
-                host.screen().size(),
-            ) > 0
+        let mut history = HistoryCache::default();
+        history.install_window(
+            total_rows as u64,
+            total_rows as u64,
+            host.screen().size(),
+            rows.into_iter().map(|row| STANDARD.encode(row)).collect(),
         );
 
         let mut viewport = history.viewport(host.screen());
@@ -1021,17 +1087,17 @@ mod tests {
     }
 
     #[test]
-    fn unchanged_screen_update_preserves_local_history() {
+    fn screen_updates_do_not_fill_the_history_cache() {
         let host = HostScreen::new(2, 8).unwrap();
         let mut tui = None;
         let mut screens = BTreeMap::new();
-        let mut local_history = BTreeMap::new();
+        let mut history = BTreeMap::new();
         let mut pending_focus = None;
         apply_snapshot(
             &mut tui,
             crate::config::UiTheme::default(),
             &mut screens,
-            &mut local_history,
+            &mut history,
             String::from("room"),
             layout(&[1]),
             vec![PaneScreenSnapshot {
@@ -1041,10 +1107,8 @@ mod tests {
                     snapshot: host.current_frame().snapshot.as_ref().to_vec(),
                     kitty_keyboard_active: false,
                 },
-                local_history: Some(LocalHistorySnapshot {
-                    total_rows: 1,
-                    rows: vec![STANDARD.encode(b"history")],
-                }),
+                history_len: 1,
+                history_end: 1,
             }],
             vec![],
             vec![],
@@ -1053,13 +1117,13 @@ mod tests {
             &mut pending_focus,
         )
         .unwrap();
-        assert_eq!(local_history[&1].available_rows(), 1);
+        assert!(history.is_empty());
 
         apply_snapshot(
             &mut tui,
             crate::config::UiTheme::default(),
             &mut screens,
-            &mut local_history,
+            &mut history,
             String::from("room"),
             layout(&[1]),
             vec![PaneScreenSnapshot {
@@ -1068,7 +1132,8 @@ mod tests {
                     sequence: 1,
                     kitty_keyboard_active: false,
                 },
-                local_history: None,
+                history_len: 1,
+                history_end: 1,
             }],
             vec![],
             vec![],
@@ -1077,7 +1142,7 @@ mod tests {
             &mut pending_focus,
         )
         .unwrap();
-        assert_eq!(local_history[&1].available_rows(), 1);
+        assert!(history.is_empty());
     }
 
     #[test]
@@ -1099,7 +1164,8 @@ mod tests {
                     snapshot: host.current_frame().snapshot.as_ref().to_vec(),
                     kitty_keyboard_active: false,
                 },
-                local_history: None,
+                history_len: 0,
+                history_end: 0,
             }],
             &mut pending_resync,
         )

--- a/src/client.rs
+++ b/src/client.rs
@@ -762,10 +762,7 @@ fn request_scrollback(
     let request_id = *next_request_id;
     let entry = pending.entry(pane_id).or_insert_with(|| {
         *next_request_id = (*next_request_id).wrapping_add(1);
-        PendingScroll {
-            request_id,
-            target,
-        }
+        PendingScroll { request_id, target }
     });
     entry.target = entry.target.max(target);
     if entry.request_id == request_id {

--- a/src/local_ipc.rs
+++ b/src/local_ipc.rs
@@ -26,6 +26,12 @@ pub enum ClientMessage {
     StructuralIntent { intent: UiIntent },
     Resize { cols: u16, rows: u16 },
     ResyncScreen { pane_id: u64 },
+    ScrollbackQuery {
+        pane_id: u64,
+        offset: u64,
+        max_rows: u32,
+        request_id: u64,
+    },
     Focus { tab_id: u64, pane_id: u64 },
     Detach { generation: u64 },
     Rename { name: String },
@@ -58,6 +64,17 @@ pub enum NodeMessage {
     },
     Screens {
         screens: Vec<PaneScreenSnapshot>,
+    },
+    /// Bounded host visual rows, encoded so terminal control bytes remain JSON-safe.
+    ScrollbackWindow {
+        pane_id: u64,
+        request_id: u64,
+        sequence: u64,
+        grid_rows: u16,
+        grid_cols: u16,
+        total_rows: u64,
+        offset: u64,
+        rows: Vec<String>,
     },
     Layout {
         layout: Box<LayoutSnapshot>,
@@ -116,14 +133,9 @@ impl From<&crate::tui::AgentOverlayRow> for AgentOverlaySnapshotRow {
 pub struct PaneScreenSnapshot {
     pub pane_id: u64,
     pub state: ScreenUpdate,
-    pub local_history: Option<LocalHistorySnapshot>,
-}
-
-/// Bounded local-host visual rows, encoded so terminal control bytes remain JSON-safe.
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-pub struct LocalHistorySnapshot {
-    pub total_rows: usize,
-    pub rows: Vec<String>,
+    /// Local-host history metadata. Remote panes publish zeroes.
+    pub history_len: u64,
+    pub history_end: u64,
 }
 
 /// The screen state carried inside every local attachment snapshot.

--- a/src/local_ipc.rs
+++ b/src/local_ipc.rs
@@ -21,21 +21,42 @@ pub const OUTBOUND_QUEUE: usize = 64;
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ClientMessage {
     Probe,
-    Hello { cols: u16, rows: u16 },
-    Input { bytes: Vec<u8> },
-    StructuralIntent { intent: UiIntent },
-    Resize { cols: u16, rows: u16 },
-    ResyncScreen { pane_id: u64 },
+    Hello {
+        cols: u16,
+        rows: u16,
+    },
+    Input {
+        bytes: Vec<u8>,
+    },
+    StructuralIntent {
+        intent: UiIntent,
+    },
+    Resize {
+        cols: u16,
+        rows: u16,
+    },
+    ResyncScreen {
+        pane_id: u64,
+    },
     ScrollbackQuery {
         pane_id: u64,
         offset: u64,
         max_rows: u32,
         request_id: u64,
     },
-    Focus { tab_id: u64, pane_id: u64 },
-    Detach { generation: u64 },
-    Rename { name: String },
-    Shutdown { generation: u64 },
+    Focus {
+        tab_id: u64,
+        pane_id: u64,
+    },
+    Detach {
+        generation: u64,
+    },
+    Rename {
+        name: String,
+    },
+    Shutdown {
+        generation: u64,
+    },
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]

--- a/src/node.rs
+++ b/src/node.rs
@@ -22,7 +22,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     local_ipc::{
-        AgentOverlaySnapshotRow, AttachmentGate, ClientMessage, LocalHistorySnapshot, NodeMessage,
+        AgentOverlaySnapshotRow, AttachmentGate, ClientMessage, NodeMessage,
         PaneLeaseSnapshot, PaneScreenSnapshot, ScreenUpdate, SessionSummary,
     },
     rendezvous::LocalRendezvous,
@@ -42,6 +42,8 @@ const FIRST_MESSAGE_TIMEOUT: Duration = Duration::from_millis(5);
 const ATTACHED_IDLE_BACKOFF: Duration = Duration::from_millis(1);
 const DETACHED_IDLE_BACKOFF: Duration = Duration::from_millis(16);
 const SCREEN_PUBLISH_INTERVAL: Duration = Duration::from_millis(16);
+const MAX_SCROLLBACK_ROWS: usize = 1_000;
+const MAX_SCROLLBACK_BYTES: usize = 256 * 1024;
 
 pub struct SharedLayoutNode {
     runtime: SharedLayoutRuntime,
@@ -324,6 +326,35 @@ fn run_socket_loop(
                     changed = true;
                     full_snapshot = true;
                 }
+                Ok(Some(ClientMessage::ScrollbackQuery {
+                    pane_id,
+                    offset,
+                    max_rows,
+                    request_id,
+                })) => {
+                    let (total_rows, sequence, grid_rows, grid_cols, rows) = node
+                        .node_local_scrollback(
+                            pane_id,
+                            offset,
+                            (max_rows as usize).min(MAX_SCROLLBACK_ROWS),
+                            MAX_SCROLLBACK_BYTES,
+                        )
+                        .unwrap_or((0, 0, 0, 0, Vec::new()));
+                    write_message(
+                        reader.get_mut(),
+                        &NodeMessage::ScrollbackWindow {
+                            pane_id,
+                            request_id,
+                            sequence,
+                            grid_rows,
+                            grid_cols,
+                            total_rows,
+                            offset: offset.min(total_rows),
+                            rows: rows.into_iter().map(|row| STANDARD.encode(row)).collect(),
+                        },
+                    )?;
+                    did_work = true;
+                }
                 Ok(Some(ClientMessage::Focus { tab_id, pane_id })) => {
                     node.focus(tab_id, pane_id)
                         .map_err(|error| io::Error::other(error.to_string()))?;
@@ -473,23 +504,9 @@ fn write_snapshot(
         .first()
         .map(|member| member.display_name.clone())
         .unwrap_or_default();
-    let mut history_extract = Duration::ZERO;
-    let screens = pane_screen_updates(
-        screens,
-        &publish.screen_sequences,
-        |pane_id| {
-            let started = Instant::now();
-            let history =
-                node.node_local_history(pane_id)
-                    .map(|(total_rows, rows)| LocalHistorySnapshot {
-                        total_rows,
-                        rows: rows.into_iter().map(|row| STANDARD.encode(row)).collect(),
-                    });
-            history_extract += started.elapsed();
-            history
-        },
-        |pane_id| node.node_remote_snapshot(pane_id),
-    );
+    let screens = pane_screen_updates(screens, &publish.screen_sequences, |pane_id| {
+        node.node_remote_snapshot(pane_id)
+    });
     let updates = ScreenUpdateStats::from_screens(&screens);
     let leases = leases
         .into_iter()
@@ -543,7 +560,6 @@ fn write_snapshot(
         && [
             drain_elapsed,
             snapshot_build,
-            history_extract,
             json_serialize,
             json_write,
         ]
@@ -551,11 +567,9 @@ fn write_snapshot(
         .any(|elapsed| elapsed >= Duration::from_millis(5))
     {
         crate::perf::log(&format!(
-            "P2PMUX_PERF node drain_ms={} snapshot_build_ms={} history_extract_ms={} history_panes={} json_serialize_ms={} json_write_ms={} write_bytes={} panes_local={} panes_remote={} updates_snapshot={}({}B) updates_delta={}({}B) updates_unchanged={}",
+            "P2PMUX_PERF node drain_ms={} snapshot_build_ms={} json_serialize_ms={} json_write_ms={} write_bytes={} panes_local={} panes_remote={} updates_snapshot={}({}B) updates_delta={}({}B) updates_unchanged={}",
             drain_elapsed.as_millis(),
             snapshot_build.as_millis(),
-            history_extract.as_millis(),
-            updates.history_panes,
             json_serialize.as_millis(),
             json_write.as_millis(),
             frame.len(),
@@ -649,18 +663,9 @@ fn write_updates(
         publish.focus = Some(focus);
         published = true;
     }
-    let frames = pane_screen_updates(
-        screens,
-        &publish.screen_sequences,
-        |pane_id| {
-            node.node_local_history(pane_id)
-                .map(|(total_rows, rows)| LocalHistorySnapshot {
-                    total_rows,
-                    rows: rows.into_iter().map(|row| STANDARD.encode(row)).collect(),
-                })
-        },
-        |pane_id| node.node_remote_snapshot(pane_id),
-    );
+    let frames = pane_screen_updates(screens, &publish.screen_sequences, |pane_id| {
+        node.node_remote_snapshot(pane_id)
+    });
     if frames.is_empty() {
         publish.pending_screens = false;
         publish.force_screens = false;
@@ -691,21 +696,23 @@ fn screens_due(publish: &AttachmentPublishState, structural: bool, now: Instant)
             .is_none_or(|last| now.duration_since(last) >= SCREEN_PUBLISH_INTERVAL)
 }
 
-fn pane_screen_updates<LocalHistory, RemoteSnapshot>(
+fn pane_screen_updates<RemoteSnapshot>(
     screens: crate::tui::NodeScreenSnapshots,
     sequences: &BTreeMap<u64, u64>,
-    mut local_history: LocalHistory,
     mut remote_snapshot: RemoteSnapshot,
 ) -> Vec<PaneScreenSnapshot>
 where
-    LocalHistory: FnMut(u64) -> Option<LocalHistorySnapshot>,
     RemoteSnapshot: FnMut(u64) -> Option<Vec<u8>>,
 {
     screens
         .into_iter()
         .filter_map(|(pane_id, screen)| {
             let update = match screen {
-                crate::tui::NodeScreenSnapshot::Local { frame } => {
+                crate::tui::NodeScreenSnapshot::Local {
+                    frame,
+                    history_len,
+                    history_end,
+                } => {
                     if sequences.get(&pane_id) == Some(&frame.sequence) {
                         None
                     } else if sequences.get(&pane_id) == Some(&frame.base_sequence) {
@@ -715,14 +722,14 @@ where
                             delta: frame.delta.as_ref().to_vec(),
                             kitty_keyboard_active: frame.kitty_keyboard_active,
                         };
-                        Some((frame.sequence, state, local_history(pane_id)))
+                        Some((frame.sequence, state, history_len, history_end))
                     } else {
                         let state = ScreenUpdate::Snapshot {
                             sequence: frame.sequence,
                             snapshot: frame.snapshot.as_ref().to_vec(),
                             kitty_keyboard_active: frame.kitty_keyboard_active,
                         };
-                        Some((frame.sequence, state, local_history(pane_id)))
+                        Some((frame.sequence, state, history_len, history_end))
                     }
                 }
                 crate::tui::NodeScreenSnapshot::Remote {
@@ -739,16 +746,18 @@ where
                                 snapshot: remote_snapshot(pane_id)?,
                                 kitty_keyboard_active,
                             },
-                            None,
+                            0,
+                            0,
                         ))
                     }
                 }
             };
-            let (_, state, local_history) = update?;
+            let (_, state, history_len, history_end) = update?;
             Some(PaneScreenSnapshot {
                 pane_id,
                 state,
-                local_history,
+                history_len,
+                history_end,
             })
         })
         .collect()
@@ -772,14 +781,12 @@ struct ScreenUpdateStats {
     deltas: usize,
     delta_bytes: usize,
     unchanged: usize,
-    history_panes: usize,
 }
 
 impl ScreenUpdateStats {
     fn from_screens(screens: &[PaneScreenSnapshot]) -> Self {
         let mut stats = Self::default();
         for screen in screens {
-            stats.history_panes += usize::from(screen.local_history.is_some());
             match &screen.state {
                 ScreenUpdate::Snapshot { snapshot, .. } => {
                     stats.snapshots += 1;
@@ -838,8 +845,15 @@ impl SharedLayoutNode {
     ) {
         self.runtime.node_snapshot()
     }
-    pub(crate) fn node_local_history(&self, pane_id: u64) -> Option<(usize, Vec<Vec<u8>>)> {
-        self.runtime.node_local_history(pane_id)
+    pub(crate) fn node_local_scrollback(
+        &self,
+        pane_id: u64,
+        offset: u64,
+        max_rows: usize,
+        max_bytes: usize,
+    ) -> Option<(u64, u64, u16, u16, Vec<Vec<u8>>)> {
+        self.runtime
+            .node_local_scrollback(pane_id, offset, max_rows, max_bytes)
     }
     pub(crate) fn node_remote_snapshot(&self, pane_id: u64) -> Option<Vec<u8>> {
         self.runtime.node_remote_snapshot(pane_id)
@@ -938,83 +952,57 @@ mod tests {
     fn local_screen_updates_use_snapshot_delta_and_unchanged() {
         let mut screen = HostScreen::new(1, 3).unwrap();
         let mut sequences = BTreeMap::new();
-        let initial = BTreeMap::from([(
-            1,
-            crate::tui::NodeScreenSnapshot::Local {
-                frame: screen.current_frame().clone(),
-            },
-        )]);
-        let updates = pane_screen_updates(initial, &sequences, |_| None, |_| None);
+        let local = |screen: &HostScreen| crate::tui::NodeScreenSnapshot::Local {
+            frame: screen.current_frame().clone(),
+            history_len: screen.history_metadata().0,
+            history_end: screen.history_metadata().1,
+        };
+        let initial = BTreeMap::from([(1, local(&screen))]);
+        let updates = pane_screen_updates(initial, &sequences, |_| None);
         assert!(matches!(updates[0].state, ScreenUpdate::Snapshot { .. }));
         update_screen_sequences(&mut sequences, &updates);
 
         screen.process_pty(b"a").unwrap();
-        let changed = BTreeMap::from([(
-            1,
-            crate::tui::NodeScreenSnapshot::Local {
-                frame: screen.current_frame().clone(),
-            },
-        )]);
-        let updates = pane_screen_updates(changed, &sequences, |_| None, |_| None);
+        let changed = BTreeMap::from([(1, local(&screen))]);
+        let updates = pane_screen_updates(changed, &sequences, |_| None);
         assert!(matches!(updates[0].state, ScreenUpdate::Delta { .. }));
         update_screen_sequences(&mut sequences, &updates);
 
-        let unchanged = BTreeMap::from([(
-            1,
-            crate::tui::NodeScreenSnapshot::Local {
-                frame: screen.current_frame().clone(),
-            },
-        )]);
-        let updates = pane_screen_updates(unchanged, &sequences, |_| None, |_| None);
+        let unchanged = BTreeMap::from([(1, local(&screen))]);
+        let updates = pane_screen_updates(unchanged, &sequences, |_| None);
         assert!(updates.is_empty());
 
         screen.resize(2, 3).unwrap();
-        let resized = BTreeMap::from([(
-            1,
-            crate::tui::NodeScreenSnapshot::Local {
-                frame: screen.current_frame().clone(),
-            },
-        )]);
-        let updates = pane_screen_updates(resized, &sequences, |_| None, |_| None);
+        let resized = BTreeMap::from([(1, local(&screen))]);
+        let updates = pane_screen_updates(resized, &sequences, |_| None);
         assert!(matches!(updates[0].state, ScreenUpdate::Snapshot { .. }));
     }
 
     #[test]
-    fn unchanged_local_screen_updates_omit_history() {
+    fn local_screen_updates_publish_metadata_without_rows() {
         let screen = HostScreen::new(1, 3).unwrap();
         let mut sequences = BTreeMap::new();
         let initial = BTreeMap::from([(
             1,
             crate::tui::NodeScreenSnapshot::Local {
                 frame: screen.current_frame().clone(),
+                history_len: 3,
+                history_end: 7,
             },
         )]);
-        let updates = pane_screen_updates(
-            initial,
-            &sequences,
-            |_| {
-                Some(LocalHistorySnapshot {
-                    total_rows: 1,
-                    rows: vec![STANDARD.encode(b"history")],
-                })
-            },
-            |_| None,
-        );
-        assert!(updates[0].local_history.is_some());
+        let updates = pane_screen_updates(initial, &sequences, |_| None);
+        assert_eq!((updates[0].history_len, updates[0].history_end), (3, 7));
         update_screen_sequences(&mut sequences, &updates);
 
         let unchanged = BTreeMap::from([(
             1,
             crate::tui::NodeScreenSnapshot::Local {
                 frame: screen.current_frame().clone(),
+                history_len: 3,
+                history_end: 7,
             },
         )]);
-        let updates = pane_screen_updates(
-            unchanged,
-            &sequences,
-            |_| panic!("unchanged local panes must not fetch history"),
-            |_| None,
-        );
+        let updates = pane_screen_updates(unchanged, &sequences, |_| None);
         assert!(updates.is_empty());
     }
 
@@ -1027,26 +1015,18 @@ mod tests {
             kitty_keyboard_active: false,
         };
         let initial = BTreeMap::from([(1, remote())]);
-        let updates = pane_screen_updates(
-            initial,
-            &sequences,
-            |_| None,
-            |_| {
+        let updates = pane_screen_updates(initial, &sequences, |_| {
                 calls.set(calls.get() + 1);
                 Some(vec![1])
-            },
-        );
+            });
         assert!(matches!(updates[0].state, ScreenUpdate::Snapshot { .. }));
         assert_eq!(calls.get(), 1);
         update_screen_sequences(&mut sequences, &updates);
 
         let unchanged = BTreeMap::from([(1, remote())]);
-        let updates = pane_screen_updates(
-            unchanged,
-            &sequences,
-            |_| None,
-            |_| panic!("unchanged remote panes must not encode a snapshot"),
-        );
+        let updates = pane_screen_updates(unchanged, &sequences, |_| {
+            panic!("unchanged remote panes must not encode a snapshot")
+        });
         assert!(updates.is_empty());
     }
 
@@ -1158,7 +1138,8 @@ mod tests {
                         snapshot: vec![b'x'; 256 * 1024],
                         kitty_keyboard_active: false,
                     },
-                    local_history: None,
+                    history_len: 0,
+                    history_end: 0,
                 }],
                 leases: vec![],
                 rosters: vec![],

--- a/src/node.rs
+++ b/src/node.rs
@@ -332,25 +332,29 @@ fn run_socket_loop(
                     max_rows,
                     request_id,
                 })) => {
-                    let (total_rows, sequence, grid_rows, grid_cols, rows) = node
+                    let window = node
                         .node_local_scrollback(
                             pane_id,
                             offset,
                             (max_rows as usize).min(MAX_SCROLLBACK_ROWS),
                             MAX_SCROLLBACK_BYTES,
                         )
-                        .unwrap_or((0, 0, 0, 0, Vec::new()));
+                        .unwrap_or_default();
                     write_message(
                         reader.get_mut(),
                         &NodeMessage::ScrollbackWindow {
                             pane_id,
                             request_id,
-                            sequence,
-                            grid_rows,
-                            grid_cols,
-                            total_rows,
-                            offset: offset.min(total_rows),
-                            rows: rows.into_iter().map(|row| STANDARD.encode(row)).collect(),
+                            sequence: window.sequence,
+                            grid_rows: window.grid_rows,
+                            grid_cols: window.grid_cols,
+                            total_rows: window.total_rows,
+                            offset: offset.min(window.total_rows),
+                            rows: window
+                                .rows
+                                .into_iter()
+                                .map(|row| STANDARD.encode(row))
+                                .collect(),
                         },
                     )?;
                     did_work = true;
@@ -846,7 +850,7 @@ impl SharedLayoutNode {
         offset: u64,
         max_rows: usize,
         max_bytes: usize,
-    ) -> Option<(u64, u64, u16, u16, Vec<Vec<u8>>)> {
+    ) -> Option<crate::tui::LocalScrollbackWindow> {
         self.runtime
             .node_local_scrollback(pane_id, offset, max_rows, max_bytes)
     }

--- a/src/node.rs
+++ b/src/node.rs
@@ -22,8 +22,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     local_ipc::{
-        AgentOverlaySnapshotRow, AttachmentGate, ClientMessage, NodeMessage,
-        PaneLeaseSnapshot, PaneScreenSnapshot, ScreenUpdate, SessionSummary,
+        AgentOverlaySnapshotRow, AttachmentGate, ClientMessage, NodeMessage, PaneLeaseSnapshot,
+        PaneScreenSnapshot, ScreenUpdate, SessionSummary,
     },
     rendezvous::LocalRendezvous,
     session::{
@@ -557,14 +557,9 @@ fn write_snapshot(
     publish.last_screen_publish = Some(Instant::now());
     publish.force_screens = false;
     if crate::perf::enabled()
-        && [
-            drain_elapsed,
-            snapshot_build,
-            json_serialize,
-            json_write,
-        ]
-        .into_iter()
-        .any(|elapsed| elapsed >= Duration::from_millis(5))
+        && [drain_elapsed, snapshot_build, json_serialize, json_write]
+            .into_iter()
+            .any(|elapsed| elapsed >= Duration::from_millis(5))
     {
         crate::perf::log(&format!(
             "P2PMUX_PERF node drain_ms={} snapshot_build_ms={} json_serialize_ms={} json_write_ms={} write_bytes={} panes_local={} panes_remote={} updates_snapshot={}({}B) updates_delta={}({}B) updates_unchanged={}",
@@ -1016,9 +1011,9 @@ mod tests {
         };
         let initial = BTreeMap::from([(1, remote())]);
         let updates = pane_screen_updates(initial, &sequences, |_| {
-                calls.set(calls.get() + 1);
-                Some(vec![1])
-            });
+            calls.set(calls.get() + 1);
+            Some(vec![1])
+        });
         assert!(matches!(updates[0].state, ScreenUpdate::Snapshot { .. }));
         assert_eq!(calls.get(), 1);
         update_screen_sequences(&mut sequences, &updates);

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -156,7 +156,10 @@ impl HostScreen {
         let mut screen = self.parser.screen().clone();
         screen.set_scrollback(SCROLLBACK_LINES);
         let retained = screen.scrollback() as u64;
-        let first = self.history_end.saturating_sub(retained).max(self.history_floor);
+        let first = self
+            .history_end
+            .saturating_sub(retained)
+            .max(self.history_floor);
         (self.history_end.saturating_sub(first), self.history_end)
     }
 

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -56,7 +56,8 @@ pub struct HostScreen {
     previous: vt100::Screen,
     current: ScreenFrame,
     kitty_keyboard: KittyKeyboardTracker,
-    history_floor: usize,
+    history_floor: u64,
+    history_end: u64,
 }
 
 impl HostScreen {
@@ -77,12 +78,20 @@ impl HostScreen {
             },
             kitty_keyboard: KittyKeyboardTracker::default(),
             history_floor: 0,
+            history_end: 0,
         })
     }
 
     pub fn process_pty(&mut self, bytes: &[u8]) -> Result<ScreenFrame, ScreenError> {
+        let before_history = screen_scrollback_len(self.parser.screen());
         self.kitty_keyboard.observe(bytes);
         self.parser.process(bytes);
+        let after_history = screen_scrollback_len(self.parser.screen());
+        let appended = after_history.saturating_sub(before_history).max(
+            usize::from(before_history == SCROLLBACK_LINES && after_history == SCROLLBACK_LINES)
+                * bytes.iter().filter(|byte| **byte == b'\n').count(),
+        );
+        self.history_end = self.history_end.saturating_add(appended as u64);
         let sequence = self
             .current
             .sequence
@@ -115,7 +124,7 @@ impl HostScreen {
             .ok_or(ScreenError::SequenceExhausted)?;
         self.parser.screen_mut().set_size(rows, cols);
         self.previous = self.parser.screen().clone();
-        self.history_floor = screen_scrollback_len(self.parser.screen());
+        self.history_floor = self.history_end;
         let frame = ScreenFrame {
             sequence,
             base_sequence: 0,
@@ -139,20 +148,43 @@ impl HostScreen {
         self.kitty_keyboard.active()
     }
 
-    /// Returns the authoritative visual scrollback rows accumulated since the last resize.
-    pub fn visual_scrollback(&self, max_rows: usize, max_bytes: usize) -> (usize, Vec<Vec<u8>>) {
+    /// Returns available rows and the monotonic end position without formatting rows.
+    pub fn history_metadata(&self) -> (u64, u64) {
         if self.parser.screen().alternate_screen() {
-            return (0, Vec::new());
+            return (0, 0);
         }
         let mut screen = self.parser.screen().clone();
         screen.set_scrollback(SCROLLBACK_LINES);
-        let total_rows = screen.scrollback().saturating_sub(self.history_floor);
-        let first_row = total_rows.saturating_sub(max_rows);
+        let retained = screen.scrollback() as u64;
+        let first = self.history_end.saturating_sub(retained).max(self.history_floor);
+        (self.history_end.saturating_sub(first), self.history_end)
+    }
+
+    /// Returns a bounded history window. `offset` skips newest rows; returned rows are oldest to
+    /// newest.
+    pub fn visual_scrollback_window(
+        &self,
+        offset: u64,
+        max_rows: usize,
+        max_bytes: usize,
+    ) -> (u64, Vec<Vec<u8>>) {
+        let (total_rows, history_end) = self.history_metadata();
+        if total_rows == 0 {
+            return (0, Vec::new());
+        }
+        let offset = offset.min(total_rows);
+        let last = total_rows.saturating_sub(offset);
+        let first = last.saturating_sub(max_rows as u64);
         let mut rows = Vec::new();
         let mut bytes = 0_usize;
-        for row in first_row..total_rows {
-            let offset = total_rows.saturating_sub(row);
-            screen.set_scrollback(offset);
+        let retained = screen_scrollback_len(self.parser.screen()) as u64;
+        let retained_start = history_end.saturating_sub(retained);
+        let available_start = history_end.saturating_sub(total_rows);
+        let mut screen = self.parser.screen().clone();
+        for row in first..last {
+            let absolute = available_start.saturating_add(row);
+            let physical = absolute.saturating_sub(retained_start);
+            screen.set_scrollback(retained.saturating_sub(physical) as usize);
             let Some(formatted) = screen.rows_formatted(0, screen.size().1).next() else {
                 continue;
             };
@@ -163,6 +195,12 @@ impl HostScreen {
             rows.push(formatted);
         }
         (total_rows, rows)
+    }
+
+    /// Compatibility helper for callers that need the newest window.
+    pub fn visual_scrollback(&self, max_rows: usize, max_bytes: usize) -> (usize, Vec<Vec<u8>>) {
+        let (total, rows) = self.visual_scrollback_window(0, max_rows, max_bytes);
+        (total as usize, rows)
     }
 
     pub fn take_kitty_keyboard_query_reply(&mut self) -> Option<Vec<u8>> {
@@ -312,5 +350,18 @@ mod tests {
 
         screen.process_pty(b"\x1b[?1049h").unwrap();
         assert_eq!(screen.visual_scrollback(10, 1024), (0, vec![]));
+    }
+
+    #[test]
+    fn visual_scrollback_window_skips_newest_rows() {
+        let mut screen = HostScreen::new(1, 8).unwrap();
+        screen.process_pty(b"one\r\ntwo\r\nthree").unwrap();
+
+        let (total, newest) = screen.visual_scrollback_window(0, 1, 1024);
+        let (_, older) = screen.visual_scrollback_window(1, 1, 1024);
+        assert!(total >= 2);
+        assert_eq!(newest.len(), 1);
+        assert_eq!(older.len(), 1);
+        assert_ne!(newest, older);
     }
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -78,6 +78,8 @@ use crate::{
 pub(crate) enum NodeScreenSnapshot {
     Local {
         frame: ScreenFrame,
+        history_len: u64,
+        history_end: u64,
     },
     Remote {
         sequence: u64,
@@ -862,6 +864,17 @@ impl MultiPaneTui {
 
     pub(crate) fn pane_scrollback_offset(&self, pane_id: PaneId) -> usize {
         self.scrollback_offset(pane_id)
+    }
+
+    pub(crate) fn set_pane_scrollback_offset(&mut self, pane_id: PaneId, offset: usize) -> bool {
+        let Some(view) = self.pane_views.get_mut(&pane_id) else {
+            return false;
+        };
+        if view.scrollback == offset {
+            return false;
+        }
+        view.scrollback = offset;
+        true
     }
 
     fn pane_at_or_focused(&self, column: u16, row: u16, area: Rect) -> PaneId {
@@ -4077,6 +4090,8 @@ impl SharedLayoutRuntime {
                 *pane_id,
                 NodeScreenSnapshot::Local {
                     frame: pane.screen.current_frame().clone(),
+                    history_len: pane.screen.history_metadata().0,
+                    history_end: pane.screen.history_metadata().1,
                 },
             );
             let view = pane.view_state();
@@ -4112,9 +4127,25 @@ impl SharedLayoutRuntime {
         )
     }
 
-    pub(crate) fn node_local_history(&self, pane_id: PaneId) -> Option<(usize, Vec<Vec<u8>>)> {
+    pub(crate) fn node_local_scrollback(
+        &self,
+        pane_id: PaneId,
+        offset: u64,
+        max_rows: usize,
+        max_bytes: usize,
+    ) -> Option<(u64, u64, u16, u16, Vec<Vec<u8>>)> {
         let pane = self.local.get(&pane_id)?;
-        Some(pane.screen.visual_scrollback(1_000, 256 * 1024))
+        let (total_rows, rows) = pane
+            .screen
+            .visual_scrollback_window(offset, max_rows, max_bytes);
+        let (grid_rows, grid_cols) = pane.screen.screen().size();
+        Some((
+            total_rows,
+            pane.screen.current_frame().sequence,
+            grid_rows,
+            grid_cols,
+            rows,
+        ))
     }
 
     pub(crate) fn node_remote_snapshot(&self, pane_id: PaneId) -> Option<Vec<u8>> {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -89,6 +89,15 @@ pub(crate) enum NodeScreenSnapshot {
 pub(crate) type NodeScreenSnapshots = BTreeMap<PaneId, NodeScreenSnapshot>;
 pub(crate) type NodeLeaseSnapshots = BTreeMap<PaneId, (bool, Option<Vec<u8>>, bool)>;
 
+#[derive(Clone, Debug, Default)]
+pub(crate) struct LocalScrollbackWindow {
+    pub total_rows: u64,
+    pub sequence: u64,
+    pub grid_rows: u16,
+    pub grid_cols: u16,
+    pub rows: Vec<Vec<u8>>,
+}
+
 /// Kept as the module's public marker from the scaffold.
 pub struct Tui;
 
@@ -4133,19 +4142,19 @@ impl SharedLayoutRuntime {
         offset: u64,
         max_rows: usize,
         max_bytes: usize,
-    ) -> Option<(u64, u64, u16, u16, Vec<Vec<u8>>)> {
+    ) -> Option<LocalScrollbackWindow> {
         let pane = self.local.get(&pane_id)?;
         let (total_rows, rows) = pane
             .screen
             .visual_scrollback_window(offset, max_rows, max_bytes);
         let (grid_rows, grid_cols) = pane.screen.screen().size();
-        Some((
+        Some(LocalScrollbackWindow {
             total_rows,
-            pane.screen.current_frame().sequence,
+            sequence: pane.screen.current_frame().sequence,
             grid_rows,
             grid_cols,
             rows,
-        ))
+        })
     }
 
     pub(crate) fn node_remote_snapshot(&self, pane_id: PaneId) -> Option<Vec<u8>> {

--- a/tests/local_ipc.rs
+++ b/tests/local_ipc.rs
@@ -130,7 +130,10 @@ fn scrollback_query_round_trips_and_screen_updates_carry_no_rows() {
     };
     let encoded = serde_json::to_value(&query).unwrap();
     assert_eq!(encoded["type"], "scrollback_query");
-    assert_eq!(serde_json::from_value::<ClientMessage>(encoded).unwrap(), query);
+    assert_eq!(
+        serde_json::from_value::<ClientMessage>(encoded).unwrap(),
+        query
+    );
 
     let screen = PaneScreenSnapshot {
         pane_id: 7,

--- a/tests/local_ipc.rs
+++ b/tests/local_ipc.rs
@@ -1,3 +1,4 @@
+use base64::Engine as _;
 use p2pmux::{
     layout::LayoutSnapshot,
     local_ipc::{
@@ -57,7 +58,8 @@ fn incremental_node_messages_round_trip_without_unchanged_screens() {
                         snapshot: vec![1],
                         kitty_keyboard_active: false,
                     },
-                    local_history: None,
+                    history_len: 4,
+                    history_end: 12,
                 },
                 PaneScreenSnapshot {
                     pane_id: 2,
@@ -67,7 +69,8 @@ fn incremental_node_messages_round_trip_without_unchanged_screens() {
                         delta: vec![2],
                         kitty_keyboard_active: true,
                     },
-                    local_history: None,
+                    history_len: 0,
+                    history_end: 0,
                 },
             ],
         },
@@ -92,6 +95,16 @@ fn incremental_node_messages_round_trip_without_unchanged_screens() {
             tab_id: 2,
             pane_id: 3,
         },
+        NodeMessage::ScrollbackWindow {
+            pane_id: 1,
+            request_id: 9,
+            sequence: 3,
+            grid_rows: 24,
+            grid_cols: 80,
+            total_rows: 12,
+            offset: 0,
+            rows: vec![base64::engine::general_purpose::STANDARD.encode(b"row")],
+        },
     ];
     for message in messages {
         let encoded = serde_json::to_vec(&message).unwrap();
@@ -105,4 +118,30 @@ fn incremental_node_messages_round_trip_without_unchanged_screens() {
             );
         }
     }
+}
+
+#[test]
+fn scrollback_query_round_trips_and_screen_updates_carry_no_rows() {
+    let query = ClientMessage::ScrollbackQuery {
+        pane_id: 7,
+        offset: 3,
+        max_rows: 64,
+        request_id: 11,
+    };
+    let encoded = serde_json::to_value(&query).unwrap();
+    assert_eq!(encoded["type"], "scrollback_query");
+    assert_eq!(serde_json::from_value::<ClientMessage>(encoded).unwrap(), query);
+
+    let screen = PaneScreenSnapshot {
+        pane_id: 7,
+        state: ScreenUpdate::Unchanged {
+            sequence: 4,
+            kitty_keyboard_active: false,
+        },
+        history_len: 2,
+        history_end: 9,
+    };
+    let encoded = serde_json::to_value(screen).unwrap();
+    assert!(encoded.get("local_history").is_none());
+    assert!(encoded.get("rows").is_none());
 }


### PR DESCRIPTION
## Summary
- Stop shipping visual history rows on every attach `Screens`/`Snapshot` update; live paints stay VT-only (Zellij-like).
- Add `ScrollbackQuery` / `ScrollbackWindow` local IPC so the client loads a contiguous host history window when the user first scrolls a local pane, then caches it.
- Publish tiny `history_len` / `history_end` metadata for pinning while scrolled; input/paste clears history mode. Document restart of running sessions after upgrade (breaking local IPC).

## Test plan
- [x] `cargo test --lib` scrollback/history/client/node/screen suites
- [x] `cargo test --test local_ipc`
- [x] `cargo test --test detach_resume_node` (after clearing orphaned `__node` processes)
- [ ] Manual: create session → produce output → scroll up (first tick may hitch) → scroll further without IPC chatter feel → type to jump to live
- [ ] Manual: overlay open → wheel scrolls overlay, not pane
- [ ] Manual: after upgrade, restart existing sessions before attach
- [ ] Note: pre-existing flaky cwd inheritance tests (`runtime_create_then_committed_delete…`, `pty_host_default_shell_uses_explicit_working_directory`) also fail on current `main`; unrelated to this PR


Made with [Cursor](https://cursor.com)