### PR TITLE
Join inherits host session name

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,12 @@ its default. Colors accept lowercase named values (`white`, `yellow`, `gray`, `d
 case-insensitive `#RRGGBB` values. The theme is client-local and is never synchronized over P2P;
 detach and reattach after editing the file to reload it.
 
-Every `create` and `join` automatically receives a memorable world-city session name such as
-`tokyo` or `cape-town`; no session name is required. `create --session-name <name>` remains
-available when you want to choose a name explicitly. Automatically chosen names avoid live local
-session names, adding `-2`, `-3`, and so on if every city name is already in use.
+Every `create` automatically receives a memorable world-city session name such as `tokyo` or
+`cape-town`; no session name is required. `create --session-name <name>` remains available when
+you want to choose a name explicitly. A joining peer uses the coordinator's session name for its
+local chrome and finder record when that name is free locally; on the same Mac it adds `-2`, `-3`,
+and so on to avoid a collision. Automatically chosen create names avoid live local session names
+the same way.
 
 `create` and `join` start a session-scoped background node, then attach the local TUI client.
 Ctrl+Q detaches that client without stopping shells, Iroh, rendezvous, or hosted panes. It prints

--- a/src/node.rs
+++ b/src/node.rs
@@ -161,6 +161,16 @@ pub async fn run_background(bootstrap: NodeBootstrap) -> Result<(), Box<dyn Erro
                     );
                 }
             };
+            let live_names = SessionStore::for_current_user()?
+                .list_live()?
+                .into_iter()
+                .map(|session| session.name)
+                .collect();
+            if let Some(name) =
+                crate::session_store::unique_local_name(&member.session_name, &live_names)
+            {
+                descriptor.name = name;
+            }
             let panes = member.pane_server(ticket.session_id().to_vec())?;
             panes.replace_roster_from_layout(&state)?;
             let acceptor = panes.clone();

--- a/src/node.rs
+++ b/src/node.rs
@@ -100,7 +100,7 @@ pub async fn run_background(bootstrap: NodeBootstrap) -> Result<(), Box<dyn Erro
         } => {
             let (shell_rows, shell_cols) = crate::tui::initial_root_pane_grid(cols, rows);
             let host = SharedLayoutHost::with_display_name(
-                HostSession::create().await?,
+                HostSession::create_with_session_name(descriptor.name.clone()).await?,
                 display_name,
                 shell_rows,
                 shell_cols,

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -17,6 +17,7 @@ pub const MAX_AGENT_ROSTER_ENTRIES: usize = 32;
 pub const MAX_AGENT_KIND_BYTES: usize = 32;
 pub const MAX_AGENT_CWD_BYTES: usize = 512;
 pub const MAX_LAYOUT_TITLE_BYTES: usize = 128;
+pub const MAX_SESSION_NAME_BYTES: usize = 48;
 
 #[derive(Debug)]
 pub enum ProtocolError {
@@ -177,6 +178,8 @@ pub struct Welcome {
     pub admitted_peer_id: Vec<u8>,
     #[prost(bytes = "vec", tag = "3")]
     pub coordinator_peer_id: Vec<u8>,
+    #[prost(string, tag = "4")]
+    pub session_name: String,
 }
 
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -694,6 +697,11 @@ fn validate_envelope(envelope: &Envelope) -> Result<(), ProtocolError> {
                 "welcome.coordinator_peer_id",
                 &welcome.coordinator_peer_id,
                 MAX_PEER_ID_BYTES,
+            )?;
+            validate_field_size(
+                "welcome.session_name",
+                welcome.session_name.len(),
+                MAX_SESSION_NAME_BYTES,
             )?;
         }
         envelope::Body::Input(input) => {

--- a/src/session.rs
+++ b/src/session.rs
@@ -1483,6 +1483,7 @@ pub struct HostSession {
     transport: Transport,
     ticket: JoinTicket,
     address_ready: bool,
+    session_name: String,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -1492,6 +1493,7 @@ pub struct JoinReceipt {
     pub coordinator_peer_id: Vec<u8>,
     pub endpoint_addr: EndpointAddr,
     pub display_name: String,
+    pub session_name: String,
 }
 
 #[derive(Debug)]
@@ -1563,6 +1565,10 @@ impl From<CoordinatorError> for SessionError {
 
 impl HostSession {
     pub async fn create() -> Result<Self, SessionError> {
+        Self::create_with_session_name(String::new()).await
+    }
+
+    pub async fn create_with_session_name(session_name: String) -> Result<Self, SessionError> {
         let transport = Transport::bind().await?;
         let address_ready = transport.wait_until_online().await;
         let ticket = JoinTicket::mint(transport.endpoint_addr()).map_err(SessionError::Ticket)?;
@@ -1570,15 +1576,24 @@ impl HostSession {
             transport,
             ticket,
             address_ready,
+            session_name,
         })
     }
 
     pub fn from_transport(transport: Transport) -> Result<Self, SessionError> {
+        Self::from_transport_with_session_name(transport, String::new())
+    }
+
+    pub fn from_transport_with_session_name(
+        transport: Transport,
+        session_name: String,
+    ) -> Result<Self, SessionError> {
         let ticket = JoinTicket::mint(transport.endpoint_addr()).map_err(SessionError::Ticket)?;
         Ok(Self {
             transport,
             ticket,
             address_ready: true,
+            session_name,
         })
     }
 
@@ -1732,6 +1747,7 @@ impl HostSession {
             coordinator_peer_id: coordinator.as_bytes().to_vec(),
             endpoint_addr,
             display_name: join.display_name,
+            session_name: self.session_name.clone(),
         };
         self.transport
             .write_frame(
@@ -1743,6 +1759,7 @@ impl HostSession {
                         session_id: receipt.session_id.clone(),
                         admitted_peer_id: receipt.admitted_peer_id.clone(),
                         coordinator_peer_id: receipt.coordinator_peer_id.clone(),
+                        session_name: receipt.session_name.clone(),
                     })),
                 },
             )
@@ -3349,6 +3366,7 @@ async fn join_handshake_with_display_name(
         coordinator_peer_id: welcome.coordinator_peer_id,
         endpoint_addr: ticket.endpoint_addr().clone(),
         display_name: String::new(),
+        session_name: welcome.session_name,
     })
 }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -1962,6 +1962,7 @@ impl ControlFrameSink for crate::transport::FrameWriter {
 pub struct SharedLayoutMember {
     pub peer_id: Vec<u8>,
     pub coordinator_peer_id: Vec<u8>,
+    pub session_name: String,
     pub events: mpsc::Receiver<LayoutControlEvent>,
     outbound: mpsc::Sender<LayoutClientMessage>,
     transport: Transport,
@@ -2619,6 +2620,7 @@ pub async fn join_layout_with_display_name(
         let (outbound, outbound_rx) = mpsc::channel(64);
         let peer_id = transport.endpoint_id().as_bytes().to_vec();
         let coordinator_peer_id = receipt.coordinator_peer_id;
+        let session_name = receipt.session_name;
         let tasks = vec![
             tokio::spawn(layout_member_reader_task(
                 reader,
@@ -2634,6 +2636,7 @@ pub async fn join_layout_with_display_name(
         Ok(SharedLayoutMember {
             peer_id,
             coordinator_peer_id,
+            session_name,
             events,
             outbound,
             transport: transport.clone(),

--- a/src/session_store.rs
+++ b/src/session_store.rs
@@ -343,6 +343,28 @@ fn available_city_name(live_names: &HashSet<String>, start: usize) -> String {
     unreachable!("an unbounded suffix range always yields a name")
 }
 
+/// Returns a locally available version of `preferred`, or `None` when the caller should use a
+/// generated fallback name instead.
+pub fn unique_local_name(preferred: &str, live_names: &HashSet<String>) -> Option<String> {
+    if !valid_name(preferred) {
+        return None;
+    }
+    if !live_names.contains(preferred) {
+        return Some(preferred.to_owned());
+    }
+
+    for suffix in 2.. {
+        let candidate = format!("{preferred}-{suffix}");
+        if !valid_name(&candidate) {
+            return None;
+        }
+        if !live_names.contains(&candidate) {
+            return Some(candidate);
+        }
+    }
+    unreachable!("a valid suffix is found before the name length limit")
+}
+
 pub fn valid_name(name: &str) -> bool {
     !name.is_empty()
         && name.len() <= 48
@@ -529,6 +551,34 @@ mod tests {
         assert_eq!(
             available_city_name(&live_names, 0),
             format!("{}-3", CITY_NAMES[0])
+        );
+    }
+
+    #[test]
+    fn unique_local_name_uses_preferred_or_available_suffix() {
+        let mut live_names = HashSet::from(["lisbon".to_owned(), "lisbon-2".to_owned()]);
+
+        assert_eq!(
+            unique_local_name("lisbon", &live_names),
+            Some("lisbon-3".to_owned())
+        );
+        assert_eq!(
+            unique_local_name("tokyo", &live_names),
+            Some("tokyo".to_owned())
+        );
+        live_names.insert("lisbon-3".to_owned());
+        assert_eq!(
+            unique_local_name("lisbon", &live_names),
+            Some("lisbon-4".to_owned())
+        );
+    }
+
+    #[test]
+    fn unique_local_name_requires_a_valid_preferred_and_suffix() {
+        assert_eq!(unique_local_name("", &HashSet::new()), None);
+        assert_eq!(
+            unique_local_name(&"a".repeat(48), &HashSet::from(["a".repeat(48)])),
+            None
         );
     }
 }

--- a/tests/protocol.rs
+++ b/tests/protocol.rs
@@ -149,6 +149,7 @@ fn envelope_exposes_each_v1_body() {
             session_id: b"session-a".to_vec(),
             admitted_peer_id: b"peer-a".to_vec(),
             coordinator_peer_id: b"peer-host".to_vec(),
+            session_name: String::new(),
         })),
         envelope(envelope::Body::Input(Input {
             pane_id: b"pane-a".to_vec(),
@@ -276,6 +277,7 @@ fn sample_envelopes() -> Vec<Envelope> {
             session_id: b"session-a".to_vec(),
             admitted_peer_id: b"peer-a".to_vec(),
             coordinator_peer_id: b"peer-host".to_vec(),
+            session_name: String::new(),
         })),
         envelope(envelope::Body::Input(Input {
             pane_id: b"pane-a".to_vec(),

--- a/tests/protocol.rs
+++ b/tests/protocol.rs
@@ -32,6 +32,29 @@ fn protocol_version_is_v7() {
 }
 
 #[test]
+fn welcome_session_name_round_trips_and_defaults_empty() {
+    let named = envelope(envelope::Body::Welcome(Welcome {
+        session_id: b"session-a".to_vec(),
+        admitted_peer_id: b"peer-a".to_vec(),
+        coordinator_peer_id: b"peer-host".to_vec(),
+        session_name: "lisbon".to_owned(),
+    }));
+    assert_eq!(decode_frame(&encode_frame(&named).unwrap()).unwrap(), named);
+
+    let legacy = envelope(envelope::Body::Welcome(Welcome {
+        session_id: b"session-a".to_vec(),
+        admitted_peer_id: b"peer-a".to_vec(),
+        coordinator_peer_id: b"peer-host".to_vec(),
+        session_name: String::new(),
+    }));
+    let decoded = decode_frame(&encode_frame(&legacy).unwrap()).unwrap();
+    let Some(envelope::Body::Welcome(welcome)) = decoded.body else {
+        panic!("expected Welcome");
+    };
+    assert!(welcome.session_name.is_empty());
+}
+
+#[test]
 fn ratio_and_grid_actions_validate_strictly() {
     let request = LayoutRequest {
         request_id: 1,

--- a/tests/session_layout_control.rs
+++ b/tests/session_layout_control.rs
@@ -64,6 +64,30 @@ async fn control_snapshot_converts_to_a_renderable_local_layout() {
     coordinator.close().await;
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn member_carries_host_session_name_from_welcome() {
+    let host = HostSession::from_transport_with_session_name(
+        loopback_transport().await,
+        "lisbon".to_owned(),
+    )
+    .expect("host");
+    let coordinator = SharedLayoutHost::new(host, 24, 80).expect("shared host");
+    let accept = {
+        let coordinator = coordinator.clone();
+        tokio::spawn(async move { coordinator.accept_one_member().await })
+    };
+    let member = join_layout(loopback_transport().await, coordinator.ticket().clone())
+        .await
+        .expect("member joins");
+    let receipt = accept.await.expect("accept task").expect("accept member");
+
+    assert_eq!(receipt.session_name, "lisbon");
+    assert_eq!(member.session_name, "lisbon");
+
+    member.shutdown().await;
+    coordinator.close().await;
+}
+
 async fn next_event(member: &mut p2pmux::session::SharedLayoutMember) -> LayoutControlEvent {
     timeout(TEST_TIMEOUT, member.events.recv())
         .await


### PR DESCRIPTION
## Summary
- Advertise the coordinator’s create-time city/session name on `Welcome` (no ticket or protocol-version change).
- Joiners adopt that name for the local finder/chrome when free; same-Mac collisions use `-2`, `-3`, …; legacy empty Welcome keeps the generated bootstrap name.
- Add protocol/helper/layout tests and update the README.

## Test plan
- [x] `cargo test` (full suite) on this branch
- [ ] `cargo run -- create` and note the city name top-left
- [ ] From another machine (or after freeing the name), `cargo run -- join <code>` and confirm the same city name top-left / `attach`
- [ ] Same-Mac dogfood: create + join on one Mac and confirm joiner gets `name-2` (or similar) instead of failing
- [ ] Join against an older host without `Welcome.session_name` still works with a generated local name


Made with [Cursor](https://cursor.com)