### PR TITLE
feat: agent finish sound and star badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,11 @@ its default. Colors accept lowercase named values (`white`, `yellow`, `gray`, `d
 case-insensitive `#RRGGBB` values. The theme is client-local and is never synchronized over P2P;
 detach and reattach after editing the file to reload it.
 
+Agent-completion notifications live under `[ui.notifications]`. `sound_enabled = false` keeps
+the local unread stars while silencing sound. By default p2pmux plays
+`/System/Library/Sounds/Tink.aiff`; set the optional `sound_path` to any local sound file. These
+settings are client-local and load when the client attaches.
+
 Every `create` automatically receives a memorable world-city session name such as `tokyo` or
 `cape-town`; no session name is required. `create --session-name <name>` remains available when
 you want to choose a name explicitly. A joining peer uses the coordinator's session name for its

--- a/src/client.rs
+++ b/src/client.rs
@@ -103,15 +103,16 @@ struct PendingScroll {
 
 pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Error>> {
     let config_path = crate::config::config_path()?;
-    let theme = crate::config::load_config_from(&config_path)
-        .map_err(|error| {
-            io::Error::other(format!(
-                "could not load config {}: {error}",
-                config_path.display()
-            ))
-        })?
-        .ui
-        .theme;
+    let config = crate::config::load_config_from(&config_path).map_err(|error| {
+        io::Error::other(format!(
+            "could not load config {}: {error}",
+            config_path.display()
+        ))
+    })?;
+    let theme = config.ui.theme;
+    let sound_enabled = config.ui.notifications.sound_enabled;
+    let notification_sound =
+        crate::notify_sound::NotificationSound::new(config.ui.notifications.sound_path);
     let mut stream = UnixStream::connect(&descriptor.socket_path)?;
     let read_stream = stream.try_clone()?;
     let mut reader = BufReader::new(read_stream);
@@ -189,8 +190,14 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
                             &mut history_refresh,
                         )?;
                         apply_leases(view, leases);
-                        apply_rosters(view, rosters);
                         apply_focus(view, &mut pending_focus, tab_id, pane_id)?;
+                        if sound_enabled {
+                            for _ in apply_rosters(view, rosters) {
+                                notification_sound.play();
+                            }
+                        } else {
+                            let _ = apply_rosters(view, rosters);
+                        }
                         let apply_elapsed = apply_started.elapsed();
                         if crate::perf::enabled() && apply_elapsed >= Duration::from_millis(5) {
                             crate::perf::log(&format!(
@@ -302,7 +309,13 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
                     }
                     NodeMessage::Rosters { rosters } => {
                         if let Some(view) = tui.as_mut() {
-                            apply_rosters(view, rosters);
+                            if sound_enabled {
+                                for _ in apply_rosters(view, rosters) {
+                                    notification_sound.play();
+                                }
+                            } else {
+                                let _ = apply_rosters(view, rosters);
+                            }
                             dirty = true;
                         }
                     }
@@ -598,8 +611,8 @@ fn apply_snapshot(
         &mut BTreeSet::new(),
     )?;
     apply_leases(view, leases);
-    apply_rosters(view, rosters);
     apply_focus(view, pending_focus, tab_id, pane_id)?;
+    let _ = apply_rosters(view, rosters);
     Ok(resync)
 }
 
@@ -707,8 +720,11 @@ fn apply_leases(view: &mut MultiPaneTui, leases: Vec<crate::local_ipc::PaneLease
     }
 }
 
-fn apply_rosters(view: &mut MultiPaneTui, rosters: Vec<crate::local_ipc::AgentOverlaySnapshotRow>) {
-    view.set_agent_rows(
+fn apply_rosters(
+    view: &mut MultiPaneTui,
+    rosters: Vec<crate::local_ipc::AgentOverlaySnapshotRow>,
+) -> Vec<u64> {
+    view.update_attached_agent_rows(
         rosters
             .into_iter()
             .filter_map(|row| {
@@ -727,7 +743,7 @@ fn apply_rosters(view: &mut MultiPaneTui, rosters: Vec<crate::local_ipc::AgentOv
                 })
             })
             .collect(),
-    );
+    )
 }
 
 fn apply_focus(

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,7 +9,7 @@ use serde::Deserialize;
 
 static CONFIG_WRITE_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
-const DEFAULT_CONFIG_TEMPLATE: &str = "# p2pmux local configuration\n#\n# display_name is visible to peers.\n# display_name = \"your-name\"\n\n# UI chrome is local to this client and is never shared with session peers.\n[ui.theme]\n# Named colors: white, yellow, gray, dark_gray\n# Hex colors: #RRGGBB\n#\n# footer_background = \"#1e1e1e\"\n# footer_muted = \"white\"\n# footer_accent = \"#dc322f\"\n# footer_orange = \"#ff7846\"\n# tab_active_background = \"#dc322f\"\n# tab_foreground = \"white\"\n# tab_separator = \"dark_gray\"\n# copy_feedback_accent = \"#ff4500\"\n# agent_overlay_chrome = \"#ff4500\"\n# agent_overlay_selected_background = \"#2a2a2a\"\n# agent_overlay_muted = \"#919db4\"\n# agent_overlay_warm = \"#ffb84d\"\n# agent_overlay_foreground = \"white\"\n# agent_overlay_secondary = \"gray\"\n# pane_border_free_focused = \"white\"\n# pane_border_unknown_focused = \"yellow\"\n# pane_border_chord_focused = \"#ff1a1a\"\n# pane_border_hovered = \"gray\"\n# pane_border_idle = \"dark_gray\"\n# pane_border_remote_control = \"#ff4500\"\n";
+const DEFAULT_CONFIG_TEMPLATE: &str = "# p2pmux local configuration\n#\n# display_name is visible to peers.\n# display_name = \"your-name\"\n\n# UI chrome is local to this client and is never shared with session peers.\n[ui.theme]\n# Named colors: white, yellow, gray, dark_gray\n# Hex colors: #RRGGBB\n#\n# footer_background = \"#1e1e1e\"\n# footer_muted = \"white\"\n# footer_accent = \"#dc322f\"\n# footer_orange = \"#ff7846\"\n# tab_active_background = \"#dc322f\"\n# tab_foreground = \"white\"\n# tab_separator = \"dark_gray\"\n# copy_feedback_accent = \"#ff4500\"\n# agent_overlay_chrome = \"#ff4500\"\n# agent_overlay_selected_background = \"#2a2a2a\"\n# agent_overlay_muted = \"#919db4\"\n# agent_overlay_warm = \"#ffb84d\"\n# agent_overlay_foreground = \"white\"\n# agent_overlay_secondary = \"gray\"\n# pane_border_free_focused = \"white\"\n# pane_border_unknown_focused = \"yellow\"\n# pane_border_chord_focused = \"#ff1a1a\"\n# pane_border_hovered = \"gray\"\n# pane_border_idle = \"dark_gray\"\n# pane_border_remote_control = \"#ff4500\"\n\n[ui.notifications]\n# Set false to keep agent-completion stars without playing a sound.\nsound_enabled = true\n# sound_path = \"/path/to/custom.aiff\"\n";
 
 #[derive(Debug)]
 pub enum ConfigError {
@@ -49,6 +49,22 @@ pub struct Config {
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct UiConfig {
     pub theme: UiTheme,
+    pub notifications: NotificationsConfig,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct NotificationsConfig {
+    pub sound_enabled: bool,
+    pub sound_path: Option<PathBuf>,
+}
+
+impl Default for NotificationsConfig {
+    fn default() -> Self {
+        Self {
+            sound_enabled: true,
+            sound_path: None,
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -113,6 +129,14 @@ struct ConfigFile {
 struct UiConfigFile {
     #[serde(default)]
     theme: UiThemeFile,
+    #[serde(default)]
+    notifications: NotificationsConfigFile,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct NotificationsConfigFile {
+    sound_enabled: Option<bool>,
+    sound_path: Option<PathBuf>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -281,9 +305,16 @@ pub fn load_config_from(path: &Path) -> Result<Config, ConfigError> {
         config.ui.theme.pane_border_remote_control,
         "pane_border_remote_control",
     )?;
+    let notifications = NotificationsConfig {
+        sound_enabled: config.ui.notifications.sound_enabled.unwrap_or(true),
+        sound_path: config.ui.notifications.sound_path,
+    };
     Ok(Config {
         display_name,
-        ui: UiConfig { theme },
+        ui: UiConfig {
+            theme,
+            notifications,
+        },
     })
 }
 
@@ -418,6 +449,31 @@ mod tests {
         assert_eq!(
             config.ui.theme.footer_accent,
             UiTheme::default().footer_accent
+        );
+
+        fs::remove_dir_all(path.parent().unwrap()).unwrap();
+    }
+
+    #[test]
+    fn notification_settings_default_and_parse() {
+        assert_eq!(NotificationsConfig::default().sound_enabled, true);
+        assert_eq!(NotificationsConfig::default().sound_path, None);
+        assert!(DEFAULT_CONFIG_TEMPLATE.contains("[ui.notifications]"));
+        assert!(DEFAULT_CONFIG_TEMPLATE.contains("sound_enabled = true"));
+
+        let path = temp_config_path();
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(
+            &path,
+            "[ui.notifications]\nsound_enabled = false\nsound_path = \"/tmp/complete.aiff\"\n",
+        )
+        .unwrap();
+
+        let notifications = load_config_from(&path).unwrap().ui.notifications;
+        assert!(!notifications.sound_enabled);
+        assert_eq!(
+            notifications.sound_path,
+            Some(PathBuf::from("/tmp/complete.aiff"))
         );
 
         fs::remove_dir_all(path.parent().unwrap()).unwrap();

--- a/src/config.rs
+++ b/src/config.rs
@@ -456,7 +456,7 @@ mod tests {
 
     #[test]
     fn notification_settings_default_and_parse() {
-        assert_eq!(NotificationsConfig::default().sound_enabled, true);
+        assert!(NotificationsConfig::default().sound_enabled);
         assert_eq!(NotificationsConfig::default().sound_path, None);
         assert!(DEFAULT_CONFIG_TEMPLATE.contains("[ui.notifications]"));
         assert!(DEFAULT_CONFIG_TEMPLATE.contains("sound_enabled = true"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub mod layout;
 pub mod lease;
 pub mod local_ipc;
 pub mod node;
+pub mod notify_sound;
 mod perf;
 pub mod protocol;
 pub mod pty_host;

--- a/src/notify_sound.rs
+++ b/src/notify_sound.rs
@@ -70,8 +70,13 @@ fn report_failure(path: &Path, reported_failures: &Mutex<BTreeSet<PathBuf>>, mes
     let Ok(mut failures) = reported_failures.lock() else {
         return;
     };
+    // The TUI owns the terminal (raw mode + alternate screen), so stderr would
+    // scribble over it; route through the opt-in UI debug log instead.
     if failures.insert(path.to_owned()) {
-        eprintln!("p2pmux notification sound {}: {message}", path.display());
+        crate::tui::ui_debug_log(
+            "notify_sound_failure",
+            format_args!("path={} message={message}", path.display()),
+        );
     }
 }
 

--- a/src/notify_sound.rs
+++ b/src/notify_sound.rs
@@ -1,0 +1,99 @@
+use std::{
+    collections::BTreeSet,
+    path::{Path, PathBuf},
+    process::{Command, Stdio},
+    sync::{Arc, Mutex},
+    thread,
+};
+
+pub const DEFAULT_SOUND_PATH: &str = "/System/Library/Sounds/Tink.aiff";
+
+/// Plays local agent-completion sounds without blocking the terminal UI.
+#[derive(Clone, Debug)]
+pub struct NotificationSound {
+    path: PathBuf,
+    reported_failures: Arc<Mutex<BTreeSet<PathBuf>>>,
+}
+
+impl NotificationSound {
+    pub fn new(path: Option<PathBuf>) -> Self {
+        Self {
+            path: path.unwrap_or_else(|| PathBuf::from(DEFAULT_SOUND_PATH)),
+            reported_failures: Arc::new(Mutex::new(BTreeSet::new())),
+        }
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub fn play(&self) {
+        let path = self.path.clone();
+        let reported_failures = Arc::clone(&self.reported_failures);
+        if thread::Builder::new()
+            .name(String::from("p2pmux-notify-sound"))
+            .spawn(move || play_sound(&path, &reported_failures))
+            .is_err()
+        {
+            report_failure(
+                &self.path,
+                &self.reported_failures,
+                "could not start sound worker",
+            );
+        }
+    }
+}
+
+fn play_sound(path: &Path, reported_failures: &Mutex<BTreeSet<PathBuf>>) {
+    let status = Command::new("afplay")
+        .arg(path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+    match status {
+        Ok(status) if status.success() => {}
+        Ok(status) => report_failure(
+            path,
+            reported_failures,
+            &format!("afplay exited with {status}"),
+        ),
+        Err(error) => report_failure(
+            path,
+            reported_failures,
+            &format!("could not run afplay: {error}"),
+        ),
+    }
+}
+
+fn report_failure(path: &Path, reported_failures: &Mutex<BTreeSet<PathBuf>>, message: &str) {
+    let Ok(mut failures) = reported_failures.lock() else {
+        return;
+    };
+    if failures.insert(path.to_owned()) {
+        eprintln!("p2pmux notification sound {}: {message}", path.display());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::{DEFAULT_SOUND_PATH, NotificationSound};
+
+    #[test]
+    fn uses_default_sound_path() {
+        assert_eq!(
+            NotificationSound::new(None).path(),
+            PathBuf::from(DEFAULT_SOUND_PATH)
+        );
+    }
+
+    #[test]
+    fn uses_custom_sound_path() {
+        assert_eq!(
+            NotificationSound::new(Some(PathBuf::from("/tmp/custom.aiff"))).path(),
+            PathBuf::from("/tmp/custom.aiff")
+        );
+    }
+}

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1183,6 +1183,7 @@ impl MultiPaneTui {
                     tab.title.as_deref(),
                     index + 1,
                     tab.tab_id == self.current_tab,
+                    self.tab_has_unread_agent_pane(tab),
                 ));
                 let width = right.saturating_sub(x).min(label_width);
                 let rect = Rect::new(x, tab_bar.y, width, tab_bar.height);
@@ -1190,6 +1191,12 @@ impl MultiPaneTui {
                 (tab.tab_id, rect)
             })
             .collect()
+    }
+
+    fn tab_has_unread_agent_pane(&self, tab: &crate::layout::Tab) -> bool {
+        self.unread_agent_panes
+            .iter()
+            .any(|pane_id| contains_leaf(&tab.root, *pane_id))
     }
 
     pub fn handle_key(&mut self, key: KeyEvent, area: Rect) -> KeyHandling {
@@ -2015,8 +2022,9 @@ fn truncate_trailing(value: &str, width: usize) -> String {
     result
 }
 
-fn tab_label(title: Option<&str>, index: usize, active: bool) -> String {
+fn tab_label(title: Option<&str>, index: usize, active: bool, unread: bool) -> String {
     let label = title.map_or_else(|| format!("Tab #{index}"), str::to_owned);
+    let label = if unread { format!("* {label}") } else { label };
     if active { format!(" {label} ") } else { label }
 }
 
@@ -2974,7 +2982,12 @@ fn render_shared_multi_pane(
                     .bg(theme.footer_background)
             };
             let label = truncate_trailing(
-                &tab_label(tab.title.as_deref(), index + 1, active),
+                &tab_label(
+                    tab.title.as_deref(),
+                    index + 1,
+                    active,
+                    tui.tab_has_unread_agent_pane(tab),
+                ),
                 usize::from(geometry.tab_labels[&tab.tab_id].width),
             );
             let label_rect = geometry.tab_labels[&tab.tab_id];
@@ -3035,7 +3048,14 @@ fn render_shared_multi_pane(
             &tui.snapshot.members,
             title_width.saturating_sub(badge_width).saturating_sub(2),
         );
-        title.spans.insert(0, Span::raw(" "));
+        title.spans.insert(
+            0,
+            Span::raw(if tui.unread_agent_panes.contains(&pane_id) {
+                " * "
+            } else {
+                " "
+            }),
+        );
         title.spans.push(Span::raw(" "));
         let border_color = pane_border_color(
             theme,
@@ -8285,8 +8305,15 @@ mod tests {
 
     #[test]
     fn title_chrome_uses_custom_labels_and_cell_width_ellipsis() {
-        assert_eq!(super::tab_label(Some("build logs"), 1, false), "build logs");
-        assert_eq!(super::tab_label(None, 2, false), "Tab #2");
+        assert_eq!(
+            super::tab_label(Some("build logs"), 1, false, false),
+            "build logs"
+        );
+        assert_eq!(super::tab_label(None, 2, false, false), "Tab #2");
+        assert_eq!(
+            super::tab_label(Some("build logs"), 1, false, true),
+            "* build logs"
+        );
         assert_eq!(super::truncate_trailing("界界", 3), "界…");
         assert_eq!(super::truncate_trailing("界", 1), "…");
         assert_eq!(super::truncate_trailing("title", 0), "");
@@ -8310,6 +8337,44 @@ mod tests {
             .to_string(),
             "build logs …"
         );
+    }
+
+    #[test]
+    fn unread_agent_badges_use_the_same_starred_tab_label_for_hit_testing() {
+        let mut tui = MultiPaneTui::new(layout(
+            vec![Tab {
+                tab_id: 1,
+                root: Node::Split {
+                    axis: Axis::LeftRight,
+                    first_share_bps: crate::layout::DEFAULT_FIRST_SHARE_BPS,
+                    first: Box::new(Node::Leaf { pane_id: 1 }),
+                    second: Box::new(Node::Leaf { pane_id: 2 }),
+                },
+                title: Some(String::from("build")),
+            }],
+            &[(1, 2, 8), (2, 2, 8)],
+        ))
+        .expect("valid layout");
+        tui.unread_agent_panes.insert(2);
+        let area = Rect::new(0, 0, 80, 8);
+        let geometry = tui.geometry(area);
+        assert_eq!(
+            geometry.tab_labels[&1].width,
+            text_width(&super::tab_label(Some("build"), 1, true, true))
+        );
+
+        let mut terminal = Terminal::new(TestBackend::new(80, 8)).expect("test terminal");
+        terminal
+            .draw(|frame| render_multi_pane(frame, &tui, &BTreeMap::new()))
+            .expect("render");
+        let tab_bar = (0..80)
+            .map(|x| terminal.backend().buffer()[(x, 0)].symbol())
+            .collect::<String>();
+        let pane_titles = (0..80)
+            .map(|x| terminal.backend().buffer()[(x, 1)].symbol())
+            .collect::<String>();
+        assert!(tab_bar.contains("* build"));
+        assert!(pane_titles.contains("* Pane #2"));
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -126,7 +126,7 @@ struct UiDebugLog {
     write_lock: Mutex<()>,
 }
 
-fn ui_debug_log(event: &str, fields: fmt::Arguments<'_>) {
+pub(crate) fn ui_debug_log(event: &str, fields: fmt::Arguments<'_>) {
     static UI_DEBUG_LOG: OnceLock<UiDebugLog> = OnceLock::new();
     let debug_log = UI_DEBUG_LOG.get_or_init(|| {
         let path = env::var("P2PMUX_DEBUG_UI").ok().and_then(|value| {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1067,17 +1067,8 @@ impl MultiPaneTui {
             .iter()
             .find(|tab| tab.tab_id == tab_id)
             .ok_or(LayoutError::UnknownTab { tab_id })?;
-        let old_tab = self.current_tab;
-        let old_pane = self.focused_pane;
-        self.current_tab = tab_id;
-        self.focused_pane = first_leaf(&tab.root).expect("validated layout has a leaf");
-        self.log_selection_change(
-            "tab_switch",
-            old_tab,
-            old_pane,
-            self.current_tab,
-            self.focused_pane,
-        );
+        let pane_id = first_leaf(&tab.root).expect("validated layout has a leaf");
+        self.select_pane(tab_id, pane_id, "tab_switch");
         Ok(())
     }
 
@@ -1085,20 +1076,7 @@ impl MultiPaneTui {
         let Some(pane_id) = pane_at(&self.geometry(area).panes, column, row) else {
             return false;
         };
-        if self.focused_pane == pane_id {
-            return false;
-        }
-        let old_tab = self.current_tab;
-        let old_pane = self.focused_pane;
-        self.focused_pane = pane_id;
-        self.log_selection_change(
-            "mouse",
-            old_tab,
-            old_pane,
-            self.current_tab,
-            self.focused_pane,
-        );
-        true
+        self.select_pane(self.current_tab, pane_id, "mouse")
     }
 
     fn hover_pane_at(&mut self, column: u16, row: u16, area: Rect) -> bool {
@@ -1401,17 +1379,7 @@ impl MultiPaneTui {
         if !contains_leaf(&tab.root, pane_id) {
             return Err(LayoutError::UnknownPane { pane_id });
         }
-        let old_tab = self.current_tab;
-        let old_pane = self.focused_pane;
-        self.current_tab = tab_id;
-        self.focused_pane = pane_id;
-        self.log_selection_change(
-            "node_sync",
-            old_tab,
-            old_pane,
-            self.current_tab,
-            self.focused_pane,
-        );
+        self.select_pane(tab_id, pane_id, "node_sync");
         Ok(())
     }
 
@@ -1563,19 +1531,9 @@ impl MultiPaneTui {
         else {
             return Vec::new();
         };
-        let old_tab = self.current_tab;
-        let old_pane = self.focused_pane;
-        self.current_tab = tab.tab_id;
-        self.focused_pane = pane_id;
+        self.select_pane(tab.tab_id, pane_id, "overlay_jump");
         self.modal = ModalState::None;
         self.pending_agent_toggle = None;
-        self.log_selection_change(
-            "overlay_jump",
-            old_tab,
-            old_pane,
-            self.current_tab,
-            self.focused_pane,
-        );
         ui_debug_log(
             "agents_overlay_close",
             format_args!("reason={close_reason} pane_id={pane_id}"),
@@ -1718,16 +1676,7 @@ impl MultiPaneTui {
                 direction_distance(source_center, rect_center(*rect), direction, *pane_id)
             })?
             .0;
-        let old_tab = self.current_tab;
-        let old_pane = self.focused_pane;
-        self.focused_pane = pane_id;
-        self.log_selection_change(
-            "key",
-            old_tab,
-            old_pane,
-            self.current_tab,
-            self.focused_pane,
-        );
+        self.select_pane(self.current_tab, pane_id, "key");
         Some(UiIntent::FocusPane { pane_id })
     }
 
@@ -1757,53 +1706,42 @@ impl MultiPaneTui {
     }
 
     fn repair_selection(&mut self) {
-        let old_tab = self.current_tab;
-        let old_pane = self.focused_pane;
         if let Some(tab_id) = self.pending_created_tab
             && let Some(tab) = self.snapshot.tabs.iter().find(|tab| tab.tab_id == tab_id)
         {
-            self.current_tab = tab_id;
-            self.focused_pane = first_leaf(&tab.root).expect("validated layout has a leaf");
+            let pane_id = first_leaf(&tab.root).expect("validated layout has a leaf");
             self.pending_created_tab = None;
-            self.log_selection_change(
-                "snapshot_repair",
-                old_tab,
-                old_pane,
-                self.current_tab,
-                self.focused_pane,
-            );
+            self.select_pane(tab_id, pane_id, "snapshot_repair");
             return;
         }
-        let current_tab = self.current_tab_layout();
-        let current_tab = if let Some(tab) = current_tab {
+        let current_tab = if let Some(tab) = self.current_tab_layout() {
             tab
         } else {
-            self.current_tab = self.snapshot.tabs[0].tab_id;
             &self.snapshot.tabs[0]
         };
-        let (contains_focused_pane, first_pane, created_pane) = {
+        let (tab_id, pane_id) = {
             let root = &current_tab.root;
-            (
-                contains_leaf(root, self.focused_pane),
-                first_leaf(root).expect("validated layout has a leaf"),
-                self.pending_created_pane
-                    .filter(|pane_id| contains_leaf(root, *pane_id)),
-            )
+            let pane_id = self
+                .pending_created_pane
+                .filter(|pane_id| contains_leaf(root, *pane_id))
+                .or_else(|| contains_leaf(root, self.focused_pane).then_some(self.focused_pane))
+                .unwrap_or_else(|| first_leaf(root).expect("validated layout has a leaf"));
+            (current_tab.tab_id, pane_id)
         };
-        if !contains_focused_pane {
-            self.focused_pane = first_pane;
-        }
-        if let Some(pane_id) = created_pane {
-            self.focused_pane = pane_id;
+        if self.pending_created_pane == Some(pane_id) {
             self.pending_created_pane = None;
         }
-        self.log_selection_change(
-            "snapshot_repair",
-            old_tab,
-            old_pane,
-            self.current_tab,
-            self.focused_pane,
-        );
+        self.select_pane(tab_id, pane_id, "snapshot_repair");
+    }
+
+    fn select_pane(&mut self, tab_id: TabId, pane_id: PaneId, reason: &str) -> bool {
+        let old_tab = self.current_tab;
+        let old_pane = self.focused_pane;
+        self.current_tab = tab_id;
+        self.focused_pane = pane_id;
+        let unread_cleared = self.unread_agent_panes.remove(&pane_id);
+        self.log_selection_change(reason, old_tab, old_pane, tab_id, pane_id);
+        old_tab != tab_id || old_pane != pane_id || unread_cleared
     }
 
     fn log_selection_change(
@@ -6598,6 +6536,41 @@ mod tests {
             crate::protocol::AgentRosterState::Idle
         );
         assert!(tui.unread_agent_panes.contains(&2));
+    }
+
+    #[test]
+    fn focus_routes_clear_unread_agent_markers() {
+        let snapshot = layout(
+            vec![
+                Tab {
+                    tab_id: 1,
+                    root: Node::Leaf { pane_id: 1 },
+                    title: None,
+                },
+                Tab {
+                    tab_id: 2,
+                    root: Node::Leaf { pane_id: 2 },
+                    title: None,
+                },
+            ],
+            &[(1, 2, 8), (2, 2, 8)],
+        );
+        let mut tui = MultiPaneTui::new(snapshot).expect("valid layout");
+
+        tui.unread_agent_panes.insert(2);
+        tui.select_tab(2).expect("known tab");
+        assert!(!tui.unread_agent_panes.contains(&2));
+
+        tui.unread_agent_panes.insert(1);
+        tui.set_focus(1, 1).expect("known pane");
+        assert!(!tui.unread_agent_panes.contains(&1));
+
+        tui.unread_agent_panes.insert(2);
+        assert_eq!(
+            tui.jump_to_agent_pane(2, "test"),
+            vec![UiIntent::FocusPane { pane_id: 2 }]
+        );
+        assert!(!tui.unread_agent_panes.contains(&2));
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -457,6 +457,8 @@ pub struct MultiPaneTui {
     selection: Option<PaneTextSelection>,
     selection_dragging: bool,
     agent_rows: Vec<AgentOverlayRow>,
+    prior_agent_states: BTreeMap<PaneId, AgentRosterState>,
+    unread_agent_panes: BTreeSet<PaneId>,
     modal: ModalState,
     agent_selected_pane: Option<PaneId>,
     /// Terminal-line offset into the cards (two card lines plus one spacer each).
@@ -496,6 +498,8 @@ impl MultiPaneTui {
             selection: None,
             selection_dragging: false,
             agent_rows: Vec::new(),
+            prior_agent_states: BTreeMap::new(),
+            unread_agent_panes: BTreeSet::new(),
             modal: ModalState::None,
             agent_selected_pane: None,
             agent_overlay_scroll_line: 0,
@@ -582,6 +586,26 @@ impl MultiPaneTui {
         self.clamp_agent_overlay_scroll();
         self.ensure_agent_selection_visible();
         true
+    }
+
+    /// Updates attached-client agent rows and reports newly unread completions.
+    ///
+    /// The first observed roster only establishes the local baseline. Roster rows that disappear
+    /// intentionally retain their previous state and unread marker until their pane is deleted.
+    pub fn update_attached_agent_rows(&mut self, rows: Vec<AgentOverlayRow>) -> Vec<PaneId> {
+        self.set_agent_rows(rows);
+        let mut newly_unread = Vec::new();
+        for row in &self.agent_rows {
+            let previous = self.prior_agent_states.insert(row.pane_id, row.state);
+            if previous == Some(AgentRosterState::Working)
+                && row.state == AgentRosterState::Idle
+                && row.pane_id != self.focused_pane
+                && self.unread_agent_panes.insert(row.pane_id)
+            {
+                newly_unread.push(row.pane_id);
+            }
+        }
+        newly_unread
     }
 
     pub(crate) fn set_agent_overlay_viewport(&mut self, area: Rect) {
@@ -1026,6 +1050,10 @@ impl MultiPaneTui {
             })
             .collect();
         self.snapshot = snapshot;
+        self.prior_agent_states
+            .retain(|pane_id, _| self.snapshot.panes.contains_key(pane_id));
+        self.unread_agent_panes
+            .retain(|pane_id| self.snapshot.panes.contains_key(pane_id));
         self.cancel_resize_drag();
         self.clear_selection();
         self.repair_selection();
@@ -6473,6 +6501,83 @@ mod tests {
         );
         tui.modal = super::ModalState::Agents;
         tui
+    }
+
+    #[test]
+    fn attached_agent_rows_mark_only_unfocused_working_to_idle_transitions_unread() {
+        let snapshot = layout(
+            vec![Tab {
+                tab_id: 1,
+                root: Node::Split {
+                    axis: Axis::LeftRight,
+                    first_share_bps: crate::layout::DEFAULT_FIRST_SHARE_BPS,
+                    first: Box::new(Node::Leaf { pane_id: 1 }),
+                    second: Box::new(Node::Leaf { pane_id: 2 }),
+                },
+                title: None,
+            }],
+            &[(1, 2, 8), (2, 2, 8)],
+        );
+        let mut tui = MultiPaneTui::new(snapshot).expect("valid layout");
+        let working = agent_row(2, 1, 2);
+        let mut idle = working.clone();
+        idle.state = crate::protocol::AgentRosterState::Idle;
+
+        assert_eq!(
+            tui.update_attached_agent_rows(vec![working.clone()]),
+            Vec::<u64>::new()
+        );
+        assert_eq!(tui.update_attached_agent_rows(vec![idle.clone()]), vec![2]);
+        assert!(tui.unread_agent_panes.contains(&2));
+        assert_eq!(
+            tui.update_attached_agent_rows(vec![idle]),
+            Vec::<u64>::new()
+        );
+
+        let mut focused_working = working;
+        focused_working.pane_id = 1;
+        focused_working.pane_ordinal = 1;
+        let mut focused_idle = focused_working.clone();
+        focused_idle.state = crate::protocol::AgentRosterState::Idle;
+        assert_eq!(
+            tui.update_attached_agent_rows(vec![focused_working]),
+            Vec::<u64>::new()
+        );
+        assert_eq!(
+            tui.update_attached_agent_rows(vec![focused_idle]),
+            Vec::<u64>::new()
+        );
+        assert!(!tui.unread_agent_panes.contains(&1));
+    }
+
+    #[test]
+    fn attached_agent_rows_preserve_state_and_unread_when_rows_vanish() {
+        let snapshot = layout(
+            vec![Tab {
+                tab_id: 1,
+                root: Node::Split {
+                    axis: Axis::LeftRight,
+                    first_share_bps: crate::layout::DEFAULT_FIRST_SHARE_BPS,
+                    first: Box::new(Node::Leaf { pane_id: 1 }),
+                    second: Box::new(Node::Leaf { pane_id: 2 }),
+                },
+                title: None,
+            }],
+            &[(1, 2, 8), (2, 2, 8)],
+        );
+        let mut tui = MultiPaneTui::new(snapshot).expect("valid layout");
+        let working = agent_row(2, 1, 2);
+        let mut idle = working.clone();
+        idle.state = crate::protocol::AgentRosterState::Idle;
+
+        tui.update_attached_agent_rows(vec![working]);
+        assert_eq!(tui.update_attached_agent_rows(vec![idle]), vec![2]);
+        tui.update_attached_agent_rows(Vec::new());
+        assert_eq!(
+            tui.prior_agent_states[&2],
+            crate::protocol::AgentRosterState::Idle
+        );
+        assert!(tui.unread_agent_panes.contains(&2));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Notify on agent **Working → Idle** with a client-local sound (`afplay`) and `*` badges on the pane and its tab
- Sound only when that pane is not focused; stars clear when the pane is focused
- Per-user config under `[ui.notifications]` (`sound_enabled`, optional `sound_path`; default Tink)

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features`
- [x] `cargo check --all-targets --all-features`
- [ ] CI green on this PR
- [ ] Manual: run an agent in tab 1, switch to tab 2, confirm sound + tab/pane `*` on finish; focus clears stars
- [ ] Manual: `sound_enabled = false` keeps stars, no sound; custom `sound_path` plays


Made with [Cursor](https://cursor.com)