### PR TITLE
perf: snappy attach echo and faithful local scrollback

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,11 @@ There is one local client per session: a second attach is refused rather than ta
 finder descriptor is the only durable session data, under `~/Library/Application Support/p2pmux/`;
 the Unix socket is under `/tmp/p2pmux-$UID/`. Screens, PTYs, tickets, layout state, and focus are
 never restored from disk. The node survives terminal closure but is not managed by launchd.
+Local scrollback is available only for locally hosted, non-alternate-screen panes. Starting a
+scroll freezes a host-authored viewport for that browse session, so output can continue at the
+live edge without changing what is being read; resize, alternate-screen changes, and reconnects
+discard that frozen history. Local IPC is intentionally versioned as an implementation detail, so
+restart an existing session after upgrading when attach protocol changes are present.
 Short join codes resolve through a restrictive local cache on the same Mac, so they are for current
 dogfooding only; they work while the corresponding `create` process is alive and are removed when
 it exits. Long `p2pmux-v1:` tickets remain accepted for backwards compatibility.

--- a/src/client.rs
+++ b/src/client.rs
@@ -5,12 +5,15 @@ use std::{
     io::{self, BufRead, BufReader, Write},
     net::Shutdown,
     os::unix::net::UnixStream,
-    sync::mpsc::{self, Receiver, TryRecvError},
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+        mpsc::{self, RecvTimeoutError, TryRecvError},
+    },
     thread,
     time::{Duration, Instant},
 };
 
-use base64::{Engine as _, engine::general_purpose::STANDARD};
 use crossterm::{
     event::{
         self, DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture,
@@ -34,48 +37,36 @@ use crate::{
     },
 };
 
+const IPC_BATCH_PER_WAKE: usize = 32;
+
 #[derive(Default)]
 struct HistoryCache {
-    grid: Option<(u16, u16)>,
+    history_id: Option<u64>,
     total_rows: u64,
-    history_end: u64,
-    rows: Vec<Vec<u8>>,
+    grid: Option<(u16, u16)>,
+    viewports: BTreeMap<usize, GuestScreen>,
 }
 
 impl HistoryCache {
-    fn install_window(
+    fn install_viewport(
         &mut self,
+        history_id: u64,
         total_rows: u64,
-        history_end: u64,
-        grid: (u16, u16),
-        rows: Vec<String>,
-    ) {
+        offset: usize,
+        payload: &[u8],
+    ) -> Result<(), crate::screen::ScreenError> {
+        let mut viewport = GuestScreen::new();
+        viewport.apply_snapshot(1, payload)?;
+        let grid = viewport.screen().expect("decoded viewport").size();
+        self.history_id = Some(history_id);
         self.grid = Some(grid);
         self.total_rows = total_rows;
-        self.history_end = history_end;
-        self.rows = rows
-            .into_iter()
-            .filter_map(|row| STANDARD.decode(row).ok())
-            .collect();
+        self.viewports.insert(offset, viewport);
+        Ok(())
     }
 
     fn available_rows(&self) -> usize {
-        self.rows.len()
-    }
-
-    fn reaches_live(&self) -> bool {
-        self.total_rows <= self.rows.len() as u64
-    }
-
-    fn viewport(&self, live: &vt100::Screen) -> vt100::Screen {
-        let (rows, cols) = live.size();
-        let mut parser = vt100::Parser::new(rows, cols, self.rows.len());
-        for row in &self.rows {
-            parser.process(row);
-            parser.process(b"\r\n");
-        }
-        parser.process(&live.contents_formatted());
-        parser.screen().clone()
+        self.total_rows as usize
     }
 }
 
@@ -85,13 +76,16 @@ fn copy_attach_selection(
     history: &BTreeMap<u64, HistoryCache>,
 ) -> Option<usize> {
     let pane_id = tui.selection_pane()?;
-    let live = screens.get(&pane_id)?.screen()?;
-    let mut viewport = history
-        .get(&pane_id)
-        .filter(|history| !history.rows.is_empty())
-        .map_or_else(|| live.clone(), |history| history.viewport(live));
-    viewport.set_scrollback(tui.pane_scrollback_offset(pane_id));
-    let text = tui.selected_text(&viewport)?;
+    let offset = tui.pane_scrollback_offset(pane_id);
+    let viewport = if offset == 0 {
+        screens.get(&pane_id)?.screen()?
+    } else {
+        history
+            .get(&pane_id)
+            .and_then(|history| history.viewports.get(&offset))
+            .and_then(GuestScreen::screen)?
+    };
+    let text = tui.selected_text(viewport)?;
     copy_selection_to_clipboard(&text).ok()
 }
 
@@ -128,7 +122,9 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
         Some(NodeMessage::AttachRejected { reason }) => return Err(io::Error::other(reason).into()),
         _ => return Err(io::Error::other("node did not accept attachment").into()),
     };
-    let (messages, reader_thread) = spawn_message_reader(reader);
+    let (wake_tx, wakes) = mpsc::channel();
+    let reader_thread = spawn_message_reader(reader, wake_tx.clone());
+    let terminal_stop = Arc::new(AtomicBool::new(false));
     let mut guard = ClientTerminalGuard::enter(&descriptor.name)?;
     let backend = CrosstermBackend::new(io::stdout());
     let mut terminal = Terminal::with_options(
@@ -137,6 +133,7 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
             viewport: Viewport::Fixed(Rect::new(0, 0, initial_cols, initial_rows)),
         },
     )?;
+    let terminal_thread = spawn_terminal_reader(wake_tx, Arc::clone(&terminal_stop));
     let mut tui = None;
     let mut screens = BTreeMap::new();
     let mut history = BTreeMap::new();
@@ -154,11 +151,18 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
     let mut history_refresh = BTreeSet::new();
     let mut local_peer_id = Vec::new();
     let mut join_code = None;
+    let mut pending_wake = None;
+    let mut next_perf_id = 1_u64;
+    let mut draw_perf_id = None;
 
     'attached: loop {
-        loop {
-            match messages.try_recv() {
-                Ok(ReaderEvent::Message(message)) => match *message {
+        for _ in 0..IPC_BATCH_PER_WAKE {
+            let wake = pending_wake
+                .take()
+                .map(Ok)
+                .unwrap_or_else(|| wakes.try_recv());
+            match wake {
+                Ok(WakeEvent::Ipc(ReaderEvent::Message(message))) => match *message {
                     NodeMessage::Snapshot {
                         room_name,
                         layout,
@@ -207,6 +211,7 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
                                 &mut stream,
                                 pane_id,
                                 view.pane_scrollback_offset(pane_id),
+                                &history,
                                 &mut pending_scroll,
                                 &mut next_scrollback_request_id,
                             )?;
@@ -231,6 +236,7 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
                     }
                     NodeMessage::Screens {
                         screens: next_screens,
+                        perf_id,
                     } => {
                         let view = tui.as_mut().ok_or_else(|| {
                             io::Error::other("screens received before attachment snapshot")
@@ -251,45 +257,51 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
                                 &mut stream,
                                 pane_id,
                                 view.pane_scrollback_offset(pane_id),
+                                &history,
                                 &mut pending_scroll,
                                 &mut next_scrollback_request_id,
                             )?;
                         }
                         dirty = true;
+                        if let Some(perf_id) = perf_id {
+                            crate::perf::log(&format!("P2PMUX_PERF id={perf_id} client_apply"));
+                            draw_perf_id = Some(perf_id);
+                        }
                     }
                     NodeMessage::ScrollbackWindow {
                         pane_id,
                         request_id,
-                        sequence,
-                        grid_rows,
-                        grid_cols,
+                        history_id,
                         total_rows,
                         offset,
-                        rows,
+                        snapshot,
+                        unavailable,
                     } => {
                         let Some(pending) = pending_scroll.remove(&pane_id) else {
                             continue;
                         };
-                        let Some(guest) = screens.get(&pane_id) else {
-                            continue;
-                        };
-                        let Some(screen) = guest.screen() else {
-                            continue;
-                        };
-                        if pending.request_id != request_id
-                            || offset != 0
-                            || screen.size() != (grid_rows, grid_cols)
-                            || guest.sequence().is_some_and(|current| sequence < current)
-                        {
+                        if pending.request_id != request_id {
                             continue;
                         }
+                        let Some(snapshot) = snapshot else {
+                            footer_notice = unavailable;
+                            dirty = true;
+                            continue;
+                        };
                         let cache = history.entry(pane_id).or_default();
-                        let history_end = cache.history_end.max(total_rows);
-                        cache.install_window(total_rows, history_end, screen.size(), rows);
+                        if cache.history_id.is_some_and(|id| id != history_id) {
+                            *cache = HistoryCache::default();
+                        }
+                        cache.install_viewport(
+                            history_id,
+                            total_rows,
+                            offset as usize,
+                            &snapshot,
+                        )?;
                         if let Some(view) = tui.as_mut() {
                             view.set_pane_scrollback_offset(
                                 pane_id,
-                                pending.target.min(cache.available_rows()),
+                                pending.target.min(total_rows as usize),
                             );
                         }
                         dirty = true;
@@ -314,18 +326,22 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
                     }
                     _ => {}
                 },
-                Ok(ReaderEvent::Ended) | Err(TryRecvError::Disconnected) => {
+                Ok(WakeEvent::Ipc(ReaderEvent::Ended)) | Err(TryRecvError::Disconnected) => {
                     node_ended = true;
                     break 'attached;
                 }
-                Ok(ReaderEvent::DecodeError(error)) => {
+                Ok(WakeEvent::Ipc(ReaderEvent::DecodeError(error))) => {
                     attach_error = Some(error);
                     break 'attached;
                 }
-                Ok(ReaderEvent::ReadError(error)) => {
+                Ok(WakeEvent::Ipc(ReaderEvent::ReadError(error))) => {
                     attach_error = Some(error);
                     node_ended = true;
                     break 'attached;
+                }
+                Ok(WakeEvent::Terminal(event)) => {
+                    pending_wake = Some(WakeEvent::Terminal(event));
+                    break;
                 }
                 Err(TryRecvError::Empty) => break,
             }
@@ -340,17 +356,15 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
                     let viewport_screens = screens
                         .iter()
                         .filter(|(pane_id, _)| tui.pane_scrollback_offset(**pane_id) != 0)
-                        .filter_map(|(pane_id, screen)| {
-                            screen.screen().map(|screen| {
-                                let viewport = history
-                                    .get(pane_id)
-                                    .filter(|history| !history.rows.is_empty())
-                                    .map_or_else(
-                                        || screen.clone(),
-                                        |history| history.viewport(screen),
-                                    );
-                                (*pane_id, viewport)
-                            })
+                        .filter_map(|(pane_id, _)| {
+                            history
+                                .get(pane_id)
+                                .and_then(|history| {
+                                    history.viewports.get(&tui.pane_scrollback_offset(*pane_id))
+                                })
+                                .and_then(GuestScreen::screen)
+                                .cloned()
+                                .map(|viewport| (*pane_id, viewport))
                         })
                         .collect::<BTreeMap<_, _>>();
                     let visible = screens
@@ -380,16 +394,32 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
                         screens.len(),
                     ));
                 }
+                if let Some(perf_id) = draw_perf_id.take() {
+                    crate::perf::log(&format!("P2PMUX_PERF id={perf_id} client_draw"));
+                }
             }
             dirty = false;
         }
-        if !event::poll(Duration::from_millis(16))? {
-            continue;
-        }
+        let event = match pending_wake.take() {
+            Some(WakeEvent::Terminal(event)) => event,
+            Some(wake) => {
+                pending_wake = Some(wake);
+                continue;
+            }
+            None => match wakes.recv_timeout(Duration::from_millis(16)) {
+                Ok(WakeEvent::Terminal(event)) => event,
+                Ok(wake) => {
+                    pending_wake = Some(wake);
+                    continue;
+                }
+                Err(RecvTimeoutError::Timeout) => continue,
+                Err(RecvTimeoutError::Disconnected) => break,
+            },
+        };
         let Some(tui) = tui.as_mut() else {
             continue;
         };
-        match event::read()? {
+        match event {
             Event::Key(key) if matches!(key.kind, KeyEventKind::Press | KeyEventKind::Repeat) => {
                 match tui.handle_key(key, terminal.size()?.into()) {
                     KeyHandling::Quit => {
@@ -409,7 +439,11 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
                             && let Some(bytes) =
                                 client_key_bytes(key.code, key.modifiers, kitty_keyboard_active)
                         {
-                            write_message(&mut stream, &ClientMessage::Input { bytes })?;
+                            let perf_id = next_perf_id_if_enabled(&mut next_perf_id);
+                            if let Some(perf_id) = perf_id {
+                                crate::perf::log(&format!("P2PMUX_PERF id={perf_id} client_input"));
+                            }
+                            write_message(&mut stream, &ClientMessage::Input { bytes, perf_id })?;
                             history.remove(&tui.focused_pane());
                             pending_scroll.remove(&tui.focused_pane());
                             tui.set_pane_scrollback_offset(tui.focused_pane(), 0);
@@ -419,10 +453,15 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
             }
             Event::Paste(text) => {
                 if should_forward_paste(tui, &local_peer_id) {
+                    let perf_id = next_perf_id_if_enabled(&mut next_perf_id);
+                    if let Some(perf_id) = perf_id {
+                        crate::perf::log(&format!("P2PMUX_PERF id={perf_id} client_input"));
+                    }
                     write_message(
                         &mut stream,
                         &ClientMessage::Input {
                             bytes: text.into_bytes(),
+                            perf_id,
                         },
                     )?;
                     history.remove(&tui.focused_pane());
@@ -466,15 +505,22 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
                     let scrollback_len = history
                         .get(&pane_id)
                         .map(HistoryCache::available_rows)
-                        .unwrap_or_default();
-                    if up && scrollback_len == 0 {
-                        let target = pending_scroll
-                            .get(&pane_id)
-                            .map_or(3, |pending| pending.target.saturating_add(3));
+                        .unwrap_or(1_000);
+                    let current = tui.pane_scrollback_offset(pane_id);
+                    let target = if up {
+                        current.saturating_add(3)
+                    } else {
+                        current.saturating_sub(3)
+                    };
+                    let cached = history
+                        .get(&pane_id)
+                        .is_some_and(|history| history.viewports.contains_key(&target));
+                    if target > 0 && !cached {
                         request_scrollback(
                             &mut stream,
                             pane_id,
                             target,
+                            &history,
                             &mut pending_scroll,
                             &mut next_scrollback_request_id,
                         )?;
@@ -529,7 +575,8 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
         let _ = write_message(&mut stream, &ClientMessage::Detach { generation });
     }
     let _ = stream.shutdown(Shutdown::Both);
-    drop(messages);
+    terminal_stop.store(true, Ordering::Release);
+    let _ = terminal_thread.join();
     let _ = reader_thread.join();
     guard.leave()?;
     if let Some(error) = attach_error {
@@ -566,6 +613,15 @@ fn input_allowed(tui: &MultiPaneTui, local_peer_id: &[u8]) -> bool {
         .panes
         .get(&tui.focused_pane())
         .is_none_or(|pane| !pane.exited && (!pane.locked || pane.host_peer_id == local_peer_id))
+}
+
+fn next_perf_id_if_enabled(next: &mut u64) -> Option<u64> {
+    if !crate::perf::enabled() {
+        return None;
+    }
+    let id = *next;
+    *next = next.wrapping_add(1).max(1);
+    Some(id)
 }
 
 fn should_forward_paste(tui: &MultiPaneTui, local_peer_id: &[u8]) -> bool {
@@ -636,13 +692,12 @@ fn apply_screens(
     history: &mut BTreeMap<u64, HistoryCache>,
     next_screens: Vec<crate::local_ipc::PaneScreenSnapshot>,
     pending_resync: &mut BTreeSet<u64>,
-    history_refresh: &mut BTreeSet<u64>,
+    _history_refresh: &mut BTreeSet<u64>,
 ) -> Result<Vec<u64>, Box<dyn std::error::Error>> {
     let mut resync = Vec::new();
     for frame in next_screens {
         let pane_id = frame.pane_id;
         let history_len = frame.history_len;
-        let history_end = frame.history_end;
         let screen = screens.entry(frame.pane_id).or_default();
         match frame.state {
             ScreenUpdate::Snapshot {
@@ -670,24 +725,9 @@ fn apply_screens(
         }
         if let Some(screen) = screen.screen() {
             let cache = history.entry(pane_id).or_default();
-            let previous_end = cache.history_end;
-            let cache_reached_live = cache.reaches_live();
-            if cache.grid.is_some_and(|grid| grid != screen.size())
-                || history_end < cache.history_end
-                || history_len < cache.total_rows
-            {
+            if cache.grid.is_some_and(|grid| grid != screen.size()) || history_len == 0 {
                 *cache = HistoryCache::default();
                 view.set_pane_scrollback_offset(pane_id, 0);
-            }
-            let appended = history_end.saturating_sub(previous_end) as usize;
-            cache.grid = Some(screen.size());
-            cache.total_rows = history_len;
-            cache.history_end = history_end;
-            if appended > 0 && view.pane_scrollback_offset(pane_id) > 0 {
-                view.pin_scrollback_after_output(pane_id, appended, history_len as usize);
-                if cache_reached_live {
-                    history_refresh.insert(pane_id);
-                }
             }
         }
     }
@@ -785,26 +825,23 @@ fn request_scrollback(
     stream: &mut UnixStream,
     pane_id: u64,
     target: usize,
+    history: &BTreeMap<u64, HistoryCache>,
     pending: &mut BTreeMap<u64, PendingScroll>,
     next_request_id: &mut u64,
 ) -> io::Result<()> {
     let request_id = *next_request_id;
-    let entry = pending.entry(pane_id).or_insert_with(|| {
-        *next_request_id = (*next_request_id).wrapping_add(1);
-        PendingScroll { request_id, target }
-    });
-    entry.target = entry.target.max(target);
-    if entry.request_id == request_id {
-        write_message(
-            stream,
-            &ClientMessage::ScrollbackQuery {
-                pane_id,
-                offset: 0,
-                max_rows: 1_000,
-                request_id,
-            },
-        )?;
-    }
+    *next_request_id = (*next_request_id).wrapping_add(1).max(1);
+    let history_id = history.get(&pane_id).and_then(|history| history.history_id);
+    pending.insert(pane_id, PendingScroll { request_id, target });
+    write_message(
+        stream,
+        &ClientMessage::ScrollbackQuery {
+            pane_id,
+            history_id,
+            offset: target as u64,
+            request_id,
+        },
+    )?;
     Ok(())
 }
 
@@ -857,41 +894,67 @@ enum ReaderEvent {
     Ended,
 }
 
+enum WakeEvent {
+    Ipc(ReaderEvent),
+    Terminal(Event),
+}
+
 fn spawn_message_reader(
     mut reader: BufReader<UnixStream>,
-) -> (Receiver<ReaderEvent>, thread::JoinHandle<()>) {
-    let (sender, receiver) = mpsc::sync_channel(16);
-    let thread = thread::spawn(move || {
+    sender: mpsc::Sender<WakeEvent>,
+) -> thread::JoinHandle<()> {
+    thread::spawn(move || {
         loop {
             match read_message(&mut reader) {
                 Ok(Some(message)) => {
                     if sender
-                        .send(ReaderEvent::Message(Box::new(message)))
+                        .send(WakeEvent::Ipc(ReaderEvent::Message(Box::new(message))))
                         .is_err()
                     {
                         return;
                     }
                 }
                 Ok(None) => {
-                    let _ = sender.send(ReaderEvent::Ended);
+                    let _ = sender.send(WakeEvent::Ipc(ReaderEvent::Ended));
                     return;
                 }
                 Err(error) if error.kind() == io::ErrorKind::InvalidData => {
                     if sender
-                        .send(ReaderEvent::DecodeError(error.to_string()))
+                        .send(WakeEvent::Ipc(ReaderEvent::DecodeError(error.to_string())))
                         .is_err()
                     {
                         return;
                     }
                 }
                 Err(error) => {
-                    let _ = sender.send(ReaderEvent::ReadError(error.to_string()));
+                    let _ = sender.send(WakeEvent::Ipc(ReaderEvent::ReadError(error.to_string())));
                     return;
                 }
             }
         }
-    });
-    (receiver, thread)
+    })
+}
+
+fn spawn_terminal_reader(
+    sender: mpsc::Sender<WakeEvent>,
+    stop: Arc<AtomicBool>,
+) -> thread::JoinHandle<()> {
+    thread::spawn(move || {
+        while !stop.load(Ordering::Acquire) {
+            match event::poll(Duration::from_millis(50)) {
+                Ok(true) => match event::read() {
+                    Ok(event) => {
+                        if sender.send(WakeEvent::Terminal(event)).is_err() {
+                            return;
+                        }
+                    }
+                    Err(_) => return,
+                },
+                Ok(false) => {}
+                Err(_) => return,
+            }
+        }
+    })
 }
 
 fn client_key_bytes(
@@ -1149,21 +1212,21 @@ mod tests {
     }
 
     #[test]
-    fn history_cache_rebuilds_a_scrollback_viewport() {
+    fn history_cache_keeps_a_render_ready_scrollback_viewport() {
         let mut host = HostScreen::new(1, 3).unwrap();
         host.process_pty(b"one\r\ntwo").unwrap();
-        let (total_rows, rows) = host.visual_scrollback(1_000, 256 * 1024);
+        let mut host_view = host.screen().clone();
+        host_view.set_scrollback(1);
         let mut history = HistoryCache::default();
-        history.install_window(
-            total_rows as u64,
-            total_rows as u64,
-            host.screen().size(),
-            rows.into_iter().map(|row| STANDARD.encode(row)).collect(),
+        let payload = crate::screen::snapshot_payload(&host_view).unwrap();
+        history.install_viewport(7, 1, 1, payload.as_ref()).unwrap();
+        assert!(
+            history.viewports[&1]
+                .screen()
+                .unwrap()
+                .contents()
+                .contains("one")
         );
-
-        let mut viewport = history.viewport(host.screen());
-        viewport.set_scrollback(history.available_rows());
-        assert!(viewport.contents().contains("one"));
     }
 
     #[test]

--- a/src/local_ipc.rs
+++ b/src/local_ipc.rs
@@ -27,6 +27,8 @@ pub enum ClientMessage {
     },
     Input {
         bytes: Vec<u8>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        perf_id: Option<u64>,
     },
     StructuralIntent {
         intent: UiIntent,
@@ -40,8 +42,9 @@ pub enum ClientMessage {
     },
     ScrollbackQuery {
         pane_id: u64,
+        /// Omitted when starting a new frozen local-history browsing session.
+        history_id: Option<u64>,
         offset: u64,
-        max_rows: u32,
         request_id: u64,
     },
     Focus {
@@ -85,17 +88,21 @@ pub enum NodeMessage {
     },
     Screens {
         screens: Vec<PaneScreenSnapshot>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        perf_id: Option<u64>,
     },
-    /// Bounded host visual rows, encoded so terminal control bytes remain JSON-safe.
+    /// A frozen, render-ready host viewport.  This deliberately uses the normal screen codec:
+    /// history is never replayed through a second client-side VT parser.
     ScrollbackWindow {
         pane_id: u64,
         request_id: u64,
-        sequence: u64,
-        grid_rows: u16,
-        grid_cols: u16,
+        history_id: u64,
         total_rows: u64,
         offset: u64,
-        rows: Vec<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        snapshot: Option<Vec<u8>>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        unavailable: Option<String>,
     },
     Layout {
         layout: Box<LayoutSnapshot>,

--- a/src/node.rs
+++ b/src/node.rs
@@ -5,7 +5,7 @@
 //! only component allowed to render a terminal.
 
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, VecDeque},
     error::Error,
     fs,
     io::{self, BufRead, BufReader, Write},
@@ -14,10 +14,11 @@ use std::{
         fs::OpenOptionsExt,
         net::{UnixListener, UnixStream},
     },
+    sync::{Arc, Condvar, Mutex},
+    thread,
     time::{Duration, Instant},
 };
 
-use base64::{Engine as _, engine::general_purpose::STANDARD};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -42,8 +43,10 @@ const FIRST_MESSAGE_TIMEOUT: Duration = Duration::from_millis(5);
 const ATTACHED_IDLE_BACKOFF: Duration = Duration::from_millis(1);
 const DETACHED_IDLE_BACKOFF: Duration = Duration::from_millis(16);
 const SCREEN_PUBLISH_INTERVAL: Duration = Duration::from_millis(16);
-const MAX_SCROLLBACK_ROWS: usize = 1_000;
-const MAX_SCROLLBACK_BYTES: usize = 256 * 1024;
+const TARGET_SCREEN_PUBLISH_INTERVAL: Duration = Duration::from_millis(8);
+const TARGET_SCREEN_URGENCY_TTL: Duration = Duration::from_millis(64);
+const MAX_FROZEN_SCROLLBACK_SESSIONS: usize = 8;
+const OUTBOUND_QUEUE: usize = 64;
 
 pub struct SharedLayoutNode {
     runtime: SharedLayoutRuntime,
@@ -211,7 +214,9 @@ fn run_socket_loop(
     descriptor: &SessionDescriptor,
 ) -> io::Result<()> {
     let gate = AttachmentGate::default();
-    let mut client: Option<(BufReader<UnixStream>, u64, AttachmentPublishState)> = None;
+    let mut client: Option<AttachedClient> = None;
+    let mut frozen_scrollback = BTreeMap::<u64, FrozenScrollback>::new();
+    let mut next_history_id = 1_u64;
     loop {
         let mut shutdown = false;
         let mut did_work = false;
@@ -259,7 +264,16 @@ fn run_socket_loop(
                                         reader
                                             .get_mut()
                                             .set_read_timeout(Some(Duration::from_millis(1)))?;
-                                        client = Some((reader, generation, publish));
+                                        let writer =
+                                            AttachmentWriter::start(reader.get_mut().try_clone()?)?;
+                                        client = Some(AttachedClient {
+                                            reader,
+                                            generation,
+                                            publish,
+                                            writer,
+                                            close_after_ack: false,
+                                            shutdown_after_ack: false,
+                                        });
                                         did_work = true;
                                     }
                                     Err(error) => {
@@ -310,11 +324,19 @@ fn run_socket_loop(
         did_work |= changed;
         let mut detached = false;
         let mut full_snapshot = false;
-        if !shutdown && let Some((reader, generation, publish)) = client.as_mut() {
-            match read_message(reader) {
-                Ok(Some(ClientMessage::Input { bytes })) => {
+        if !shutdown && let Some(client) = client.as_mut() {
+            match read_message(&mut client.reader) {
+                Ok(Some(ClientMessage::Input { bytes, perf_id })) => {
+                    let focused_pane = node.local_focus().1;
                     node.input(bytes)
                         .map_err(|error| io::Error::other(error.to_string()))?;
+                    client
+                        .publish
+                        .arm_target_urgency(focused_pane, Instant::now());
+                    client.publish.perf_id = perf_id;
+                    if let Some(perf_id) = perf_id {
+                        crate::perf::log(&format!("P2PMUX_PERF id={perf_id} node_input"));
+                    }
                     let drain_started = Instant::now();
                     changed |= node
                         .drain()
@@ -329,45 +351,67 @@ fn run_socket_loop(
                 Ok(Some(ClientMessage::Resize { cols, rows })) => {
                     node.resize(cols, rows)
                         .map_err(|error| io::Error::other(error.to_string()))?;
+                    frozen_scrollback.clear();
                     changed = true;
                 }
                 Ok(Some(ClientMessage::ResyncScreen { pane_id })) => {
-                    publish.screen_sequences.remove(&pane_id);
-                    publish.force_screens = true;
+                    client.publish.screen_sequences.remove(&pane_id);
+                    client.publish.force_screens = true;
                     changed = true;
                     full_snapshot = true;
                 }
                 Ok(Some(ClientMessage::ScrollbackQuery {
                     pane_id,
+                    history_id,
                     offset,
-                    max_rows,
                     request_id,
                 })) => {
-                    let window = node
-                        .node_local_scrollback(
-                            pane_id,
-                            offset,
-                            (max_rows as usize).min(MAX_SCROLLBACK_ROWS),
-                            MAX_SCROLLBACK_BYTES,
-                        )
-                        .unwrap_or_default();
-                    write_message(
-                        reader.get_mut(),
-                        &NodeMessage::ScrollbackWindow {
-                            pane_id,
-                            request_id,
-                            sequence: window.sequence,
-                            grid_rows: window.grid_rows,
-                            grid_cols: window.grid_cols,
-                            total_rows: window.total_rows,
-                            offset: offset.min(window.total_rows),
-                            rows: window
-                                .rows
-                                .into_iter()
-                                .map(|row| STANDARD.encode(row))
-                                .collect(),
-                        },
-                    )?;
+                    let (history_id, result) = if let Some(history_id) = history_id {
+                        let result = frozen_scrollback
+                            .get(&history_id)
+                            .filter(|frozen| frozen.pane_id == pane_id)
+                            .map(|frozen| frozen.viewport(offset));
+                        (history_id, result)
+                    } else {
+                        if frozen_scrollback.len() >= MAX_FROZEN_SCROLLBACK_SESSIONS {
+                            // History browsing is local UI state; evicting old sessions is safe
+                            // because a stale id receives an explicit unavailable response.
+                            frozen_scrollback.clear();
+                        }
+                        frozen_scrollback.retain(|_, frozen| frozen.pane_id != pane_id);
+                        let history_id = next_history_id;
+                        next_history_id = next_history_id.wrapping_add(1).max(1);
+                        let result = node.node_local_scrollback(pane_id).map(|window| {
+                            let frozen = FrozenScrollback {
+                                pane_id,
+                                total_rows: window.total_rows,
+                                screen: window.screen,
+                            };
+                            let viewport = frozen.viewport(offset);
+                            frozen_scrollback.insert(history_id, frozen);
+                            viewport
+                        });
+                        (history_id, result)
+                    };
+                    let (total_rows, snapshot, unavailable) = match result {
+                        Some((total_rows, snapshot)) => (total_rows, Some(snapshot), None),
+                        None => (
+                            0,
+                            None,
+                            Some(String::from(
+                                "local scrollback is unavailable for this pane (remote, alternate screen, or stale history)",
+                            )),
+                        ),
+                    };
+                    let _ = client.writer.enqueue(NodeMessage::ScrollbackWindow {
+                        pane_id,
+                        request_id,
+                        history_id,
+                        total_rows,
+                        offset: offset.min(total_rows),
+                        snapshot,
+                        unavailable,
+                    });
                     did_work = true;
                 }
                 Ok(Some(ClientMessage::Focus { tab_id, pane_id })) => {
@@ -377,43 +421,31 @@ fn run_socket_loop(
                 }
                 Ok(Some(ClientMessage::Detach {
                     generation: requested,
-                })) if requested == *generation => {
+                })) if requested == client.generation => {
                     node.release_all_local_control()
                         .map_err(|error| io::Error::other(error.to_string()))?;
-                    let _ = write_message(
-                        reader.get_mut(),
-                        &NodeMessage::DetachAck {
-                            generation: *generation,
-                        },
-                    );
-                    detached = true;
+                    let _ = client.writer.enqueue_control(NodeMessage::DetachAck {
+                        generation: client.generation,
+                    });
+                    client.close_after_ack = true;
                 }
                 Ok(Some(ClientMessage::Shutdown {
                     generation: requested,
-                })) if requested == *generation => {
-                    write_message(
-                        reader.get_mut(),
-                        &NodeMessage::ShutdownAck {
-                            generation: *generation,
-                        },
-                    )?;
-                    shutdown = true;
+                })) if requested == client.generation => {
+                    let _ = client.writer.enqueue_control(NodeMessage::ShutdownAck {
+                        generation: client.generation,
+                    });
+                    client.shutdown_after_ack = true;
                 }
                 Ok(Some(ClientMessage::Rename { name })) => {
                     if crate::session_store::valid_name(&name) {
-                        write_message(
-                            reader.get_mut(),
-                            &NodeMessage::Update {
-                                state: serde_json::json!({"name": name}),
-                            },
-                        )?;
+                        let _ = client.writer.enqueue_control(NodeMessage::Update {
+                            state: serde_json::json!({"name": name}),
+                        });
                     } else {
-                        write_message(
-                            reader.get_mut(),
-                            &NodeMessage::Error {
-                                message: "invalid session name".into(),
-                            },
-                        )?;
+                        let _ = client.writer.enqueue_control(NodeMessage::Error {
+                            message: "invalid session name".into(),
+                        });
                     }
                 }
                 Ok(Some(_)) => {}
@@ -424,17 +456,23 @@ fn run_socket_loop(
                 Err(_) => detached = true,
             }
             did_work |= changed;
-            if !detached {
+            if !detached && !client.close_after_ack && !client.shutdown_after_ack {
                 let result = if full_snapshot {
-                    write_snapshot(reader.get_mut(), descriptor, node, publish, drain_elapsed)
-                        .map(|()| true)
-                } else {
-                    write_updates(
-                        reader.get_mut(),
+                    queue_snapshot(
+                        descriptor,
                         node,
-                        publish,
+                        &mut client.publish,
+                        drain_elapsed,
+                        &client.writer,
+                    )
+                    .map(|()| true)
+                } else {
+                    queue_updates(
+                        node,
+                        &mut client.publish,
                         drain_elapsed,
                         Instant::now(),
+                        &client.writer,
                     )
                 };
                 match result {
@@ -445,15 +483,22 @@ fn run_socket_loop(
                     }
                 }
             }
+            if client.close_after_ack && client.writer.is_idle() {
+                detached = true;
+            }
+            if client.shutdown_after_ack && client.writer.is_idle() {
+                shutdown = true;
+            }
         }
         if !changed {
             log_slow_drain(drain_elapsed);
         }
         if (detached || shutdown)
-            && let Some((mut reader, generation, _)) = client.take()
+            && let Some(client) = client.take()
         {
-            let _ = reader.get_mut().shutdown(Shutdown::Both);
-            let _ = gate.detach(generation);
+            let _ = client.reader.get_ref().shutdown(Shutdown::Both);
+            client.writer.close();
+            let _ = gate.detach(client.generation);
             node.release_all_local_control()
                 .map_err(|error| io::Error::other(error.to_string()))?;
         }
@@ -464,6 +509,24 @@ fn run_socket_loop(
             Some(backoff) => std::thread::sleep(backoff),
             None => std::thread::yield_now(),
         }
+    }
+}
+
+struct FrozenScrollback {
+    pane_id: u64,
+    total_rows: u64,
+    screen: vt100::Screen,
+}
+
+impl FrozenScrollback {
+    fn viewport(&self, offset: u64) -> (u64, Vec<u8>) {
+        let mut screen = self.screen.clone();
+        screen.set_scrollback(offset.min(self.total_rows) as usize);
+        let snapshot = crate::screen::snapshot_payload(&screen)
+            .expect("host scrollback viewport must fit the screen codec")
+            .as_ref()
+            .to_vec();
+        (self.total_rows, snapshot)
     }
 }
 
@@ -491,6 +554,142 @@ fn write_message(stream: &mut UnixStream, message: &NodeMessage) -> io::Result<(
     stream.write_all(&frame)?;
     stream.flush()
 }
+
+struct AttachedClient {
+    reader: BufReader<UnixStream>,
+    generation: u64,
+    publish: AttachmentPublishState,
+    writer: AttachmentWriter,
+    close_after_ack: bool,
+    shutdown_after_ack: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum QueueResult {
+    Queued,
+    Dropped,
+    CoalesceScreens,
+    Disconnected,
+}
+
+struct OutboundState {
+    messages: VecDeque<NodeMessage>,
+    writing: bool,
+    closed: bool,
+}
+
+struct AttachmentWriter {
+    state: Arc<(Mutex<OutboundState>, Condvar)>,
+    shutdown: UnixStream,
+    worker: thread::JoinHandle<()>,
+}
+
+impl AttachmentWriter {
+    fn start(mut stream: UnixStream) -> io::Result<Self> {
+        stream.set_write_timeout(Some(Duration::from_secs(5)))?;
+        let shutdown = stream.try_clone()?;
+        let state = Arc::new((
+            Mutex::new(OutboundState {
+                messages: VecDeque::with_capacity(OUTBOUND_QUEUE),
+                writing: false,
+                closed: false,
+            }),
+            Condvar::new(),
+        ));
+        let worker_state = Arc::clone(&state);
+        let worker = thread::spawn(move || {
+            loop {
+                let message = {
+                    let (lock, ready) = &*worker_state;
+                    let mut state = lock.lock().expect("outbound queue poisoned");
+                    while state.messages.is_empty() && !state.closed {
+                        state = ready.wait(state).expect("outbound queue poisoned");
+                    }
+                    let message = state.messages.pop_front();
+                    state.writing = message.is_some();
+                    ready.notify_all();
+                    match message {
+                        Some(message) => message,
+                        None => return,
+                    }
+                };
+                if write_message(&mut stream, &message).is_err() {
+                    let (lock, ready) = &*worker_state;
+                    lock.lock().expect("outbound queue poisoned").closed = true;
+                    ready.notify_all();
+                    return;
+                }
+                let (lock, ready) = &*worker_state;
+                lock.lock().expect("outbound queue poisoned").writing = false;
+                ready.notify_all();
+            }
+        });
+        Ok(Self {
+            state,
+            shutdown,
+            worker,
+        })
+    }
+
+    fn enqueue(&self, message: NodeMessage) -> QueueResult {
+        self.push(message, false)
+    }
+
+    fn enqueue_control(&self, message: NodeMessage) -> QueueResult {
+        self.push(message, true)
+    }
+
+    fn push(&self, message: NodeMessage, control: bool) -> QueueResult {
+        let (lock, ready) = &*self.state;
+        let mut state = lock.lock().expect("outbound queue poisoned");
+        let result = push_outbound(&mut state, message, control);
+        if result == QueueResult::Queued {
+            ready.notify_one();
+        }
+        result
+    }
+
+    fn is_idle(&self) -> bool {
+        let (lock, _) = &*self.state;
+        let state = lock.lock().expect("outbound queue poisoned");
+        (state.messages.is_empty() && !state.writing) || state.closed
+    }
+
+    fn close(self) {
+        let (lock, ready) = &*self.state;
+        lock.lock().expect("outbound queue poisoned").closed = true;
+        ready.notify_all();
+        let _ = self.shutdown.shutdown(Shutdown::Both);
+        let _ = self.worker.join();
+    }
+}
+
+fn push_outbound(state: &mut OutboundState, message: NodeMessage, control: bool) -> QueueResult {
+    if state.closed {
+        return QueueResult::Disconnected;
+    }
+    if state.messages.len() == OUTBOUND_QUEUE {
+        if matches!(message, NodeMessage::Screens { .. }) {
+            return QueueResult::CoalesceScreens;
+        }
+        if matches!(message, NodeMessage::ScrollbackWindow { .. }) {
+            return QueueResult::Dropped;
+        }
+        state
+            .messages
+            .retain(|queued| !matches!(queued, NodeMessage::ScrollbackWindow { .. }));
+        if control && state.messages.len() == OUTBOUND_QUEUE {
+            state
+                .messages
+                .retain(|queued| !matches!(queued, NodeMessage::Screens { .. }));
+        }
+        if state.messages.len() == OUTBOUND_QUEUE {
+            return QueueResult::Dropped;
+        }
+    }
+    state.messages.push_back(message);
+    QueueResult::Queued
+}
 fn write_snapshot(
     stream: &mut UnixStream,
     descriptor: &SessionDescriptor,
@@ -498,16 +697,63 @@ fn write_snapshot(
     publish: &mut AttachmentPublishState,
     drain_elapsed: Duration,
 ) -> io::Result<()> {
+    let (message, layout, leases, rosters, screens, stats) =
+        snapshot_message(descriptor, node, publish)?;
+    let json_started = Instant::now();
+    let mut frame = serde_json::to_vec(&message).map_err(io::Error::other)?;
+    frame.push(b'\n');
+    let json_serialize = json_started.elapsed();
+    let write_started = Instant::now();
+    stream.write_all(&frame)?;
+    stream.flush()?;
+    let json_write = write_started.elapsed();
+    publish.layout = Some(layout);
+    publish.leases = Some(leases);
+    publish.rosters = Some(rosters);
+    publish.focus = Some(node.local_focus());
+    update_screen_sequences(&mut publish.screen_sequences, &screens);
+    publish.last_screen_publish = Some(Instant::now());
+    publish.force_screens = false;
+    if crate::perf::enabled()
+        && [drain_elapsed, json_serialize, json_write]
+            .into_iter()
+            .any(|elapsed| elapsed >= Duration::from_millis(5))
+    {
+        crate::perf::log(&format!(
+            "P2PMUX_PERF node drain_ms={} snapshot_json_ms={} snapshot_write_ms={} write_bytes={} updates_snapshot={}({}B) updates_delta={}({}B) updates_unchanged={}",
+            drain_elapsed.as_millis(),
+            json_serialize.as_millis(),
+            json_write.as_millis(),
+            frame.len(),
+            stats.snapshots,
+            stats.snapshot_bytes,
+            stats.deltas,
+            stats.delta_bytes,
+            stats.unchanged,
+        ));
+    }
+    Ok(())
+}
+
+type SnapshotMessage = (
+    NodeMessage,
+    crate::layout::LayoutSnapshot,
+    Vec<PaneLeaseSnapshot>,
+    Vec<AgentOverlaySnapshotRow>,
+    Vec<PaneScreenSnapshot>,
+    ScreenUpdateStats,
+);
+
+fn snapshot_message(
+    descriptor: &SessionDescriptor,
+    node: &SharedLayoutNode,
+    publish: &AttachmentPublishState,
+) -> io::Result<SnapshotMessage> {
     let snapshot_started = Instant::now();
     let (tab_id, pane_id) = node.local_focus();
     let local_peer_id = node.local_peer_id();
     let (layout, screens, leases, rosters) = node.snapshot();
-    let snapshot_build = snapshot_started.elapsed();
-    let local_panes = screens
-        .values()
-        .filter(|screen| matches!(screen, crate::tui::NodeScreenSnapshot::Local { .. }))
-        .count();
-    let remote_panes = screens.len().saturating_sub(local_panes);
+    let _snapshot_build = snapshot_started.elapsed();
     let hosts = layout
         .panes
         .values()
@@ -556,41 +802,37 @@ fn write_snapshot(
         pane_id,
         join_code: node.runtime.join_code().map(str::to_owned),
     };
-    let json_started = Instant::now();
-    let mut frame = serde_json::to_vec(&message).map_err(io::Error::other)?;
-    frame.push(b'\n');
-    let json_serialize = json_started.elapsed();
-    let write_started = Instant::now();
-    stream.write_all(&frame)?;
-    stream.flush()?;
-    let json_write = write_started.elapsed();
-    publish.layout = Some(layout.clone());
-    publish.leases = Some(leases);
-    publish.rosters = Some(rosters);
-    publish.focus = Some((tab_id, pane_id));
-    update_screen_sequences(&mut publish.screen_sequences, &screens);
-    publish.last_screen_publish = Some(Instant::now());
-    publish.force_screens = false;
-    if crate::perf::enabled()
-        && [drain_elapsed, snapshot_build, json_serialize, json_write]
-            .into_iter()
-            .any(|elapsed| elapsed >= Duration::from_millis(5))
-    {
-        crate::perf::log(&format!(
-            "P2PMUX_PERF node drain_ms={} snapshot_build_ms={} json_serialize_ms={} json_write_ms={} write_bytes={} panes_local={} panes_remote={} updates_snapshot={}({}B) updates_delta={}({}B) updates_unchanged={}",
-            drain_elapsed.as_millis(),
-            snapshot_build.as_millis(),
-            json_serialize.as_millis(),
-            json_write.as_millis(),
-            frame.len(),
-            local_panes,
-            remote_panes,
-            updates.snapshots,
-            updates.snapshot_bytes,
-            updates.deltas,
-            updates.delta_bytes,
-            updates.unchanged,
-        ));
+    Ok((message, layout, leases, rosters, screens, updates))
+}
+
+fn queue_snapshot(
+    descriptor: &SessionDescriptor,
+    node: &SharedLayoutNode,
+    publish: &mut AttachmentPublishState,
+    _drain_elapsed: Duration,
+    writer: &AttachmentWriter,
+) -> io::Result<()> {
+    let (message, layout, leases, rosters, screens, _) =
+        snapshot_message(descriptor, node, publish)?;
+    match writer.enqueue(message) {
+        QueueResult::Queued => {
+            publish.layout = Some(layout);
+            publish.leases = Some(leases);
+            publish.rosters = Some(rosters);
+            publish.focus = Some(node.local_focus());
+            update_screen_sequences(&mut publish.screen_sequences, &screens);
+            publish.last_screen_publish = Some(Instant::now());
+            publish.force_screens = false;
+        }
+        QueueResult::Dropped | QueueResult::CoalesceScreens => {
+            publish.reset_for_snapshot();
+        }
+        QueueResult::Disconnected => {
+            return Err(io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "local attachment disconnected",
+            ));
+        }
     }
     Ok(())
 }
@@ -605,14 +847,32 @@ struct AttachmentPublishState {
     last_screen_publish: Option<Instant>,
     pending_screens: bool,
     force_screens: bool,
+    target_urgency: Option<(u64, Instant)>,
+    perf_id: Option<u64>,
 }
 
-fn write_updates(
-    stream: &mut UnixStream,
+impl AttachmentPublishState {
+    fn arm_target_urgency(&mut self, pane_id: u64, now: Instant) {
+        self.target_urgency = Some((pane_id, now + TARGET_SCREEN_URGENCY_TTL));
+    }
+
+    fn reset_for_snapshot(&mut self) {
+        self.layout = None;
+        self.leases = None;
+        self.rosters = None;
+        self.focus = None;
+        self.screen_sequences.clear();
+        self.pending_screens = true;
+        self.force_screens = true;
+    }
+}
+
+fn queue_updates(
     node: &SharedLayoutNode,
     publish: &mut AttachmentPublishState,
     _drain_elapsed: Duration,
     now: Instant,
+    writer: &AttachmentWriter,
 ) -> io::Result<bool> {
     let (layout, screens, leases, rosters) = node.snapshot();
     let leases = leases
@@ -630,12 +890,15 @@ fn write_updates(
     let layout_changed = publish.layout.as_ref() != Some(&layout);
     let mut published = false;
     if layout_changed {
-        write_message(
-            stream,
-            &NodeMessage::Layout {
+        if !queue_update(
+            writer,
+            publish,
+            NodeMessage::Layout {
                 layout: Box::new(layout.clone()),
             },
-        )?;
+        )? {
+            return Ok(published);
+        }
         publish.layout = Some(layout.clone());
         publish
             .screen_sequences
@@ -643,33 +906,42 @@ fn write_updates(
         published = true;
     }
     if publish.leases.as_ref() != Some(&leases) {
-        write_message(
-            stream,
-            &NodeMessage::Leases {
+        if !queue_update(
+            writer,
+            publish,
+            NodeMessage::Leases {
                 leases: leases.clone(),
             },
-        )?;
+        )? {
+            return Ok(published);
+        }
         publish.leases = Some(leases);
         published = true;
     }
     if publish.rosters.as_ref() != Some(&rosters) {
-        write_message(
-            stream,
-            &NodeMessage::Rosters {
+        if !queue_update(
+            writer,
+            publish,
+            NodeMessage::Rosters {
                 rosters: rosters.clone(),
             },
-        )?;
+        )? {
+            return Ok(published);
+        }
         publish.rosters = Some(rosters);
         published = true;
     }
     if publish.focus != Some(focus) {
-        write_message(
-            stream,
-            &NodeMessage::Focus {
+        if !queue_update(
+            writer,
+            publish,
+            NodeMessage::Focus {
                 tab_id: focus.0,
                 pane_id: focus.1,
             },
-        )?;
+        )? {
+            return Ok(published);
+        }
         publish.focus = Some(focus);
         published = true;
     }
@@ -681,16 +953,25 @@ fn write_updates(
         publish.force_screens = false;
         return Ok(published);
     }
-    if !screens_due(publish, published, now) {
+    if !screens_due(publish, published, now, &frames) {
         publish.pending_screens = true;
         return Ok(published);
     }
-    write_message(
-        stream,
-        &NodeMessage::Screens {
+    let perf_id = publish.perf_id;
+    if !queue_update(
+        writer,
+        publish,
+        NodeMessage::Screens {
             screens: frames.clone(),
+            perf_id,
         },
-    )?;
+    )? {
+        return Ok(published);
+    }
+    if let Some(perf_id) = perf_id {
+        crate::perf::log(&format!("P2PMUX_PERF id={perf_id} node_publish"));
+        publish.perf_id = None;
+    }
     update_screen_sequences(&mut publish.screen_sequences, &frames);
     publish.last_screen_publish = Some(now);
     publish.pending_screens = false;
@@ -698,9 +979,40 @@ fn write_updates(
     Ok(true)
 }
 
-fn screens_due(publish: &AttachmentPublishState, structural: bool, now: Instant) -> bool {
+fn queue_update(
+    writer: &AttachmentWriter,
+    publish: &mut AttachmentPublishState,
+    message: NodeMessage,
+) -> io::Result<bool> {
+    match writer.enqueue(message) {
+        QueueResult::Queued => Ok(true),
+        QueueResult::Dropped | QueueResult::CoalesceScreens => {
+            publish.reset_for_snapshot();
+            Ok(false)
+        }
+        QueueResult::Disconnected => Err(io::Error::new(
+            io::ErrorKind::BrokenPipe,
+            "local attachment disconnected",
+        )),
+    }
+}
+
+fn screens_due(
+    publish: &AttachmentPublishState,
+    structural: bool,
+    now: Instant,
+    frames: &[PaneScreenSnapshot],
+) -> bool {
+    let target_due = publish.target_urgency.is_some_and(|(pane_id, expires)| {
+        now <= expires
+            && frames.iter().any(|frame| frame.pane_id == pane_id)
+            && publish
+                .last_screen_publish
+                .is_none_or(|last| now.duration_since(last) >= TARGET_SCREEN_PUBLISH_INTERVAL)
+    });
     structural
         || publish.force_screens
+        || target_due
         || publish
             .last_screen_publish
             .is_none_or(|last| now.duration_since(last) >= SCREEN_PUBLISH_INTERVAL)
@@ -858,12 +1170,8 @@ impl SharedLayoutNode {
     pub(crate) fn node_local_scrollback(
         &self,
         pane_id: u64,
-        offset: u64,
-        max_rows: usize,
-        max_bytes: usize,
     ) -> Option<crate::tui::LocalScrollbackWindow> {
-        self.runtime
-            .node_local_scrollback(pane_id, offset, max_rows, max_bytes)
+        self.runtime.node_local_scrollback(pane_id)
     }
     pub(crate) fn node_remote_snapshot(&self, pane_id: u64) -> Option<Vec<u8>> {
         self.runtime.node_remote_snapshot(pane_id)
@@ -906,6 +1214,7 @@ mod tests {
         let (mut writer, stream) = UnixStream::pair().unwrap();
         let mut frames = serde_json::to_vec(&ClientMessage::Input {
             bytes: b"first".to_vec(),
+            perf_id: None,
         })
         .unwrap();
         frames.push(b'\n');
@@ -918,7 +1227,7 @@ mod tests {
         let mut reader = BufReader::new(stream);
         assert!(matches!(
             read_message(&mut reader).unwrap(),
-            Some(ClientMessage::Input { bytes }) if bytes == b"first"
+            Some(ClientMessage::Input { bytes, .. }) if bytes == b"first"
         ));
         assert!(matches!(
             read_message(&mut reader).unwrap(),
@@ -950,12 +1259,99 @@ mod tests {
         assert!(!screens_due(
             &publish,
             false,
-            now + SCREEN_PUBLISH_INTERVAL - Duration::from_millis(1)
+            now + SCREEN_PUBLISH_INTERVAL - Duration::from_millis(1),
+            &[],
         ));
-        assert!(screens_due(&publish, false, now + SCREEN_PUBLISH_INTERVAL));
-        assert!(screens_due(&publish, true, now + Duration::from_millis(1)));
+        assert!(screens_due(
+            &publish,
+            false,
+            now + SCREEN_PUBLISH_INTERVAL,
+            &[],
+        ));
+        assert!(screens_due(
+            &publish,
+            true,
+            now + Duration::from_millis(1),
+            &[]
+        ));
         publish.force_screens = true;
-        assert!(screens_due(&publish, false, now + Duration::from_millis(1)));
+        assert!(screens_due(
+            &publish,
+            false,
+            now + Duration::from_millis(1),
+            &[]
+        ));
+    }
+
+    #[test]
+    fn focused_input_urgency_beats_background_screen_throttle_only_for_target() {
+        let now = Instant::now();
+        let mut publish = AttachmentPublishState {
+            last_screen_publish: Some(now),
+            ..Default::default()
+        };
+        let target = vec![PaneScreenSnapshot {
+            pane_id: 7,
+            state: ScreenUpdate::Unchanged {
+                sequence: 1,
+                kitty_keyboard_active: false,
+            },
+            history_len: 0,
+            history_end: 0,
+        }];
+        publish.arm_target_urgency(7, now);
+        assert!(screens_due(
+            &publish,
+            false,
+            now + TARGET_SCREEN_PUBLISH_INTERVAL,
+            &target,
+        ));
+        assert!(!screens_due(
+            &publish,
+            false,
+            now + TARGET_SCREEN_PUBLISH_INTERVAL,
+            &[],
+        ));
+    }
+
+    #[test]
+    fn full_outbound_queue_coalesces_screens_and_drops_scrollback() {
+        let mut state = OutboundState {
+            messages: VecDeque::with_capacity(OUTBOUND_QUEUE),
+            writing: false,
+            closed: false,
+        };
+        state
+            .messages
+            .extend(std::iter::repeat_n(NodeMessage::ProbeAck, OUTBOUND_QUEUE));
+        assert_eq!(
+            push_outbound(
+                &mut state,
+                NodeMessage::Screens {
+                    screens: vec![],
+                    perf_id: None,
+                },
+                false,
+            ),
+            QueueResult::CoalesceScreens,
+        );
+        assert_eq!(
+            push_outbound(
+                &mut state,
+                NodeMessage::ScrollbackWindow {
+                    pane_id: 1,
+                    request_id: 1,
+                    history_id: 1,
+                    total_rows: 0,
+                    offset: 0,
+                    snapshot: None,
+                    unavailable: None,
+                },
+                false,
+            ),
+            QueueResult::Dropped,
+        );
+        assert_eq!(state.messages.len(), OUTBOUND_QUEUE);
     }
 
     #[test]
@@ -1014,6 +1410,27 @@ mod tests {
         )]);
         let updates = pane_screen_updates(unchanged, &sequences, |_| None);
         assert!(updates.is_empty());
+    }
+
+    #[test]
+    fn frozen_scrollback_viewport_uses_the_host_screen_codec() {
+        let mut host = HostScreen::new(2, 6).unwrap();
+        host.process_pty(b"one\r\ntwo\r\nthree\r\nfour").unwrap();
+        let (total_rows, _) = host.history_metadata();
+        let frozen = FrozenScrollback {
+            pane_id: 1,
+            total_rows,
+            screen: host.screen().clone(),
+        };
+        let (_, payload) = frozen.viewport(1);
+        let mut guest = crate::screen::GuestScreen::new();
+        guest.apply_snapshot(1, &payload).unwrap();
+        let mut expected = host.screen().clone();
+        expected.set_scrollback(1);
+        assert_eq!(
+            guest.screen().unwrap().state_formatted(),
+            expected.state_formatted()
+        );
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -89,13 +89,10 @@ pub(crate) enum NodeScreenSnapshot {
 pub(crate) type NodeScreenSnapshots = BTreeMap<PaneId, NodeScreenSnapshot>;
 pub(crate) type NodeLeaseSnapshots = BTreeMap<PaneId, (bool, Option<Vec<u8>>, bool)>;
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub(crate) struct LocalScrollbackWindow {
     pub total_rows: u64,
-    pub sequence: u64,
-    pub grid_rows: u16,
-    pub grid_cols: u16,
-    pub rows: Vec<Vec<u8>>,
+    pub screen: vt100::Screen,
 }
 
 /// Kept as the module's public marker from the scaffold.
@@ -4429,24 +4426,15 @@ impl SharedLayoutRuntime {
         )
     }
 
-    pub(crate) fn node_local_scrollback(
-        &self,
-        pane_id: PaneId,
-        offset: u64,
-        max_rows: usize,
-        max_bytes: usize,
-    ) -> Option<LocalScrollbackWindow> {
+    pub(crate) fn node_local_scrollback(&self, pane_id: PaneId) -> Option<LocalScrollbackWindow> {
         let pane = self.local.get(&pane_id)?;
-        let (total_rows, rows) = pane
-            .screen
-            .visual_scrollback_window(offset, max_rows, max_bytes);
-        let (grid_rows, grid_cols) = pane.screen.screen().size();
+        let (total_rows, _) = pane.screen.history_metadata();
+        if total_rows == 0 || pane.screen.screen().alternate_screen() {
+            return None;
+        }
         Some(LocalScrollbackWindow {
             total_rows,
-            sequence: pane.screen.current_frame().sequence,
-            grid_rows,
-            grid_cols,
-            rows,
+            screen: pane.screen.screen().clone(),
         })
     }
 

--- a/tests/detach_resume_node.rs
+++ b/tests/detach_resume_node.rs
@@ -174,10 +174,11 @@ fn run_detach_resume_round_trip(
         &mut stream,
         &ClientMessage::Input {
             bytes: b"printf p2pmux-detach-roundtrip\\r".to_vec(),
+            perf_id: None,
         },
     );
     let updated = receive_until_screen_update(&mut reader, 1, "snapshot after input");
-    let NodeMessage::Screens { screens } = updated else {
+    let NodeMessage::Screens { screens, .. } = updated else {
         unreachable!()
     };
     assert!(
@@ -268,7 +269,7 @@ fn receive_until_screen_update(
         let message = receive_until_deadline(reader, deadline, phase);
         if matches!(
             &message,
-            NodeMessage::Screens { screens }
+            NodeMessage::Screens { screens, .. }
                 if screens.iter().any(|frame|
                     frame.pane_id == pane_id
                         && matches!(

--- a/tests/local_ipc.rs
+++ b/tests/local_ipc.rs
@@ -1,4 +1,3 @@
-use base64::Engine as _;
 use p2pmux::{
     layout::LayoutSnapshot,
     local_ipc::{
@@ -73,6 +72,7 @@ fn incremental_node_messages_round_trip_without_unchanged_screens() {
                     history_end: 0,
                 },
             ],
+            perf_id: None,
         },
         NodeMessage::Layout {
             layout: Box::new(layout),
@@ -98,19 +98,18 @@ fn incremental_node_messages_round_trip_without_unchanged_screens() {
         NodeMessage::ScrollbackWindow {
             pane_id: 1,
             request_id: 9,
-            sequence: 3,
-            grid_rows: 24,
-            grid_cols: 80,
+            history_id: 3,
             total_rows: 12,
             offset: 0,
-            rows: vec![base64::engine::general_purpose::STANDARD.encode(b"row")],
+            snapshot: Some(vec![1, 2, 3]),
+            unavailable: None,
         },
     ];
     for message in messages {
         let encoded = serde_json::to_vec(&message).unwrap();
         let decoded: NodeMessage = serde_json::from_slice(&encoded).unwrap();
         assert_eq!(decoded, message);
-        if let NodeMessage::Screens { screens } = decoded {
+        if let NodeMessage::Screens { screens, .. } = decoded {
             assert!(
                 screens
                     .iter()
@@ -124,8 +123,8 @@ fn incremental_node_messages_round_trip_without_unchanged_screens() {
 fn scrollback_query_round_trips_and_screen_updates_carry_no_rows() {
     let query = ClientMessage::ScrollbackQuery {
         pane_id: 7,
+        history_id: None,
         offset: 3,
-        max_rows: 64,
         request_id: 11,
     };
     let encoded = serde_json::to_value(&query).unwrap();


### PR DESCRIPTION
## Summary
- Wake the attach TUI immediately on IPC (no 16ms input-only poll), with bounded IPC batching and fair key handling.
- Isolate slow local clients behind a bounded node writer queue so PTY/Iroh drain never blocks; coalesced screens recover via snapshot.
- Urgently publish the focused pane after input (rate-limited), while background panes keep 16ms coalescing.
- Replace lossy client VT-replay scrollback with frozen host `vt100::Screen` snapshot views (`history_id`), so scrolled history matches the host buffer for local shells.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features`
- [x] `cargo check --all-targets --all-features`
- [ ] Dogfood: attach to a local shell, type rapidly, confirm near-native echo
- [ ] Dogfood: generate tall shell output, scroll up, confirm history is intact (not cut/mangled)
- [ ] Dogfood: alternate-screen / remote pane shows honest unavailable scrollback
- [ ] Restart running sessions after upgrade (local IPC scrollback payload changed)


Made with [Cursor](https://cursor.com)