### PR TITLE
feat: cross-machine invites — `p2pmux ticket`, an invite chord, and a 66-char ticket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,6 +170,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -277,6 +286,12 @@ name = "by_address"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -962,7 +977,7 @@ dependencies = [
  "diatomic-waker",
  "futures-core",
  "pin-project-lite",
- "spin",
+ "spin 0.10.1",
 ]
 
 [[package]]
@@ -1157,6 +1172,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1176,6 +1200,20 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash",
+]
+
+[[package]]
+name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version",
+ "serde",
+ "spin 0.9.9",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -2465,6 +2503,7 @@ dependencies = [
  "getrandom 0.3.4",
  "iroh",
  "portable-pty",
+ "postcard",
  "prost",
  "ratatui",
  "serde",
@@ -2700,6 +2739,7 @@ dependencies = [
  "cobs",
  "embedded-io 0.4.0",
  "embedded-io 0.6.1",
+ "heapless",
  "postcard-derive",
  "serde",
 ]
@@ -3410,6 +3450,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ crossterm = "0.29"
 getrandom = "0.3"
 iroh = "1.0.3"
 portable-pty = "0.9"
+postcard = { version = "1", features = ["alloc"] }
 ratatui = { version = "0.30", default-features = false, features = ["crossterm"] }
 prost = "0.14"
 serde = { version = "1", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -124,6 +124,11 @@ p2pmux ticket            # the one session live on this Mac
 p2pmux ticket <code>     # when several are live; the code is in the session footer
 ```
 
+From inside a session, `Ctrl+P`, then `i` copies the same ticket straight to the clipboard and
+flashes `copied full ticket` in the footer. That overlay text is local chrome, so unlike running
+the command in a shared pane it is not visible to the other members. Only a coordinator has a
+ticket to copy; a guest is told so.
+
 The ticket is printed to stdout on its own, so `p2pmux ticket | pbcopy` gives you something
 directly pasteable. Treat it as a password: it grants full shared-shell access to the session, to
 anyone holding it, for as long as the session lives. There is no hosted rendezvous yet, so this is
@@ -179,6 +184,8 @@ prompt does not report mouse, so nothing changes there.
   focused pane. Its local PTY inherits the target pane’s cwd when that pane is hosted locally by
   the requester and its cwd is available; otherwise it starts in the p2pmux process cwd.
 - `Ctrl+P`, then `X` — delete the focused pane. Only that pane’s host may delete it.
+- `Ctrl+P`, then `i` — copy this session’s full join ticket to the clipboard, for inviting
+  someone on another Mac. Coordinator only.
 - `Ctrl+P`, then `e` — rename the focused pane for every admitted member. Enter saves; Esc
   cancels; a blank title restores `Pane #N`.
 - `Ctrl+P`, then arrows — move focus.
@@ -199,7 +206,7 @@ soft-green border; Tab mode dims inactive tab labels. Click tab labels to switch
 claiming control or sending input. Mouse wheel scrolls pane history locally unless the focused
 pane's program reports mouse, in which case the wheel reaches that program. The dark contextual footer uses red key accents: normal mode is
 `Ctrl+ <p> PANE   <t> TAB   <q> QUIT   Option+ <shift> + <↑↓←→> FOCUS    type to claim when free`; pane mode is
-`PANE MODE  <←↓↑→> FOCUS   <e> RENAME   <n> NEW   <r/l/d/u> SPLIT   <x> CLOSE   <k> LOCK   <Esc> BACK`; tab mode is
+`PANE MODE  <←↓↑→> FOCUS   <e> RENAME   <n> NEW   <r/l/d/u> SPLIT   <x> CLOSE   <k> LOCK   <i> INVITE   <Esc> BACK`; tab mode is
 `TAB MODE  <←→> SWITCH   <e> RENAME   <n> NEW   <x> CLOSE   <Esc> BACK`.
 
 For locally hosted panes, mouse-wheel scrollback is loaded from the host on demand when you first

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Short join codes resolve through a restrictive local cache on the same Mac, so t
 dogfooding only; they work while the corresponding `create` process is alive and are removed when
 it exits. A peer on another machine cannot resolve one.
 
-To invite someone on another Mac, use the full `p2pmux-v1:` ticket, which `join` also accepts:
+To invite someone on another Mac, use the full `p2pmux-v2:` ticket, which `join` also accepts:
 
 ```text
 p2pmux ticket            # the one session live on this Mac
@@ -133,6 +133,11 @@ The ticket is printed to stdout on its own, so `p2pmux ticket | pbcopy` gives yo
 directly pasteable. Treat it as a password: it grants full shared-shell access to the session, to
 anyone holding it, for as long as the session lives. There is no hosted rendezvous yet, so this is
 the portable invite until one exists.
+
+Tickets are emitted as `p2pmux-v2:` — roughly 66 characters for a typical session, against about
+370 for the original `p2pmux-v1:` form, which restated the session ID as a JSON array of 32
+decimal numbers even though it is required to equal the endpoint ID. `join` still accepts v1
+tickets, so a peer one release behind can be invited without upgrading first.
 
 Only one peer controls a pane while they are actively typing. After about thirty seconds without
 activity, the host clears the controller and the pane becomes free. The next member's ordinary key

--- a/README.md
+++ b/README.md
@@ -115,7 +115,19 @@ discard that frozen history. Local IPC is intentionally versioned as an implemen
 restart an existing session after upgrading when attach protocol changes are present.
 Short join codes resolve through a restrictive local cache on the same Mac, so they are for current
 dogfooding only; they work while the corresponding `create` process is alive and are removed when
-it exits. Long `p2pmux-v1:` tickets remain accepted for backwards compatibility.
+it exits. A peer on another machine cannot resolve one.
+
+To invite someone on another Mac, use the full `p2pmux-v1:` ticket, which `join` also accepts:
+
+```text
+p2pmux ticket            # the one session live on this Mac
+p2pmux ticket <code>     # when several are live; the code is in the session footer
+```
+
+The ticket is printed to stdout on its own, so `p2pmux ticket | pbcopy` gives you something
+directly pasteable. Treat it as a password: it grants full shared-shell access to the session, to
+anyone holding it, for as long as the session lives. There is no hosted rendezvous yet, so this is
+the portable invite until one exists.
 
 Only one peer controls a pane while they are actively typing. After about thirty seconds without
 activity, the host clears the controller and the pane becomes free. The next member's ordinary key

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -16,7 +16,7 @@ use crate::{
         HostSession, LayoutControlEvent, SharedLayoutHost, join_layout_with_display_name,
         layout_snapshot_from_state,
     },
-    ticket::{JoinTicket, TICKET_PREFIX},
+    ticket::{JoinTicket, looks_like_ticket},
     transport::Transport,
 };
 
@@ -548,7 +548,7 @@ fn resolve_display_name(override_name: Option<String>) -> Result<String, Box<dyn
 }
 
 fn resolve_join_ticket(input: &str) -> Result<JoinTicket, CliError> {
-    if input.starts_with(TICKET_PREFIX) {
+    if looks_like_ticket(input) {
         return JoinTicket::from_str(input).map_err(|_| CliError("invalid ticket format"));
     }
     LocalRendezvous::for_current_user()

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -50,6 +50,11 @@ enum Command {
         #[arg(long)]
         name: Option<String>,
     },
+    /// Print the full reusable join ticket for a live local session.
+    Ticket {
+        /// The join code shown in the session footer. Omit it when one session is live.
+        code: Option<String>,
+    },
     /// Attach a live local session by memorable name.
     Attach { name: String },
     /// Gracefully stop a live local session.
@@ -84,6 +89,9 @@ const TRUST_WARNING: &str = "TRUST WARNING: This is a fully trusted shared-shell
 Share the ticket only with people you trust with that access. For risky/unknown collaborators, use a separate low-privilege Mac account and avoid production credentials in shared panes.
 
 Processes and credential files stay on the pane host's Mac (not uploaded to peers). That does not stop a controller from using or displaying them via the shared shell.";
+
+/// The short form of `TRUST_WARNING`, for a command whose stdout is meant to be piped.
+const TICKET_WARNING: &str = "TRUST WARNING: this ticket grants full shared-shell access to the session for as long as it lives, to anyone who holds it. Share it only with people you trust with that access.";
 
 #[derive(Debug)]
 struct CliError(&'static str);
@@ -323,6 +331,7 @@ async fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
             guest_result.map_err(io::Error::other)?;
             Ok(())
         }
+        Some(Command::Ticket { code }) => print_join_ticket(code),
         Some(Command::Attach { name }) => crate::client::run(&find_live(&name)?),
         Some(Command::Kill { name, yes }) => {
             let descriptor = find_live(&name)?;
@@ -544,10 +553,54 @@ fn resolve_join_ticket(input: &str) -> Result<JoinTicket, CliError> {
     }
     LocalRendezvous::for_current_user()
         .and_then(|store| store.resolve(input))
-        .map_err(|error| match error {
-            RendezvousError::NotFound => CliError("join code was not found on this Mac"),
-            _ => CliError("invalid ticket format"),
-        })
+        .map_err(rendezvous_error)
+}
+
+/// Print the portable join ticket for a session created on this Mac.
+///
+/// The short code only resolves through this Mac's local cache, so it is useless to a peer on
+/// another machine. The ticket is the portable form, and until a hosted rendezvous exists this
+/// command is the only way to obtain one. It goes to stdout alone so `p2pmux ticket | pbcopy`
+/// yields something directly pasteable.
+fn print_join_ticket(code: Option<String>) -> Result<(), Box<dyn Error>> {
+    let store = LocalRendezvous::for_current_user().map_err(rendezvous_error)?;
+    let code = match code {
+        Some(code) => code,
+        None => sole_local_code(&store)?,
+    };
+    let ticket = store.resolve(&code).map_err(rendezvous_error)?;
+    {
+        let mut stderr = io::stderr().lock();
+        writeln!(stderr, "{TICKET_WARNING}\n")?;
+        stderr.flush()?;
+    }
+    println!("{ticket}");
+    Ok(())
+}
+
+/// The one code published here, when leaving it off is unambiguous.
+fn sole_local_code(store: &LocalRendezvous) -> Result<String, CliError> {
+    let mut codes = store.codes().map_err(rendezvous_error)?;
+    match codes.len() {
+        0 => Err(CliError(
+            "no session was created on this Mac; run p2pmux create first",
+        )),
+        1 => Ok(codes.remove(0)),
+        _ => Err(CliError(
+            "several sessions are live on this Mac; pass the join code from the session footer",
+        )),
+    }
+}
+
+/// Describe a rendezvous failure without ever echoing the code that caused it.
+fn rendezvous_error(error: RendezvousError) -> CliError {
+    match error {
+        RendezvousError::NotFound => CliError("join code was not found on this Mac"),
+        RendezvousError::InvalidCode | RendezvousError::InvalidRecord => {
+            CliError("invalid ticket format")
+        }
+        _ => CliError("local rendezvous store is unavailable"),
+    }
 }
 
 fn wait_for_enter() -> io::Result<()> {

--- a/src/client.rs
+++ b/src/client.rs
@@ -89,6 +89,27 @@ fn copy_attach_selection(
     copy_selection_to_clipboard(&text).ok()
 }
 
+/// Put the session's full join ticket on the clipboard, and say what the footer should report.
+///
+/// A client shares a Mac with its node, so it reads the same rendezvous record rather than
+/// having a bearer credential travel over the local socket for the sake of one keypress. Only a
+/// coordinator publishes a record, so a guest is told plainly that it has no invite to give.
+fn copy_join_ticket(join_code: Option<&str>) -> String {
+    let Some(code) = join_code else {
+        return String::from("only the session host has a ticket to copy");
+    };
+    let ticket = match crate::rendezvous::LocalRendezvous::for_current_user()
+        .and_then(|store| store.resolve(code))
+    {
+        Ok(ticket) => ticket,
+        Err(error) => return format!("ticket unavailable: {error}"),
+    };
+    match copy_selection_to_clipboard(&ticket.to_string()) {
+        Ok(_) => String::from("copied full ticket"),
+        Err(error) => format!("clipboard copy failed: {error}"),
+    }
+}
+
 #[derive(Clone, Copy)]
 struct PendingScroll {
     request_id: u64,
@@ -444,6 +465,9 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
                     }
                     KeyHandling::Consumed(intents) => {
                         send_intents(&mut stream, tui, intents, &mut pending_focus)?;
+                        if tui.take_ticket_copy_request() {
+                            footer_notice = Some(copy_join_ticket(join_code.as_deref()));
+                        }
                         dirty = true;
                     }
                     KeyHandling::Forward => {

--- a/src/rendezvous.rs
+++ b/src/rendezvous.rs
@@ -121,6 +121,26 @@ impl LocalRendezvous {
             .map_err(ticket_error_to_rendezvous_error)
     }
 
+    /// The join codes published on this Mac, sorted.
+    ///
+    /// A missing directory means no session has been created here yet, which is an ordinary
+    /// state rather than a failure. Names that are not codes are ignored so an unrelated file
+    /// dropped in the cache cannot make the whole listing unusable.
+    pub fn codes(&self) -> Result<Vec<String>, RendezvousError> {
+        let entries = match fs::read_dir(&self.directory) {
+            Ok(entries) => entries,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(_) => return Err(RendezvousError::Io),
+        };
+        let mut codes: Vec<String> = entries
+            .filter_map(|entry| entry.ok())
+            .filter_map(|entry| entry.file_name().into_string().ok())
+            .filter(|name| validate_code(name).is_ok())
+            .collect();
+        codes.sort();
+        Ok(codes)
+    }
+
     fn ensure_directory(&self) -> Result<(), RendezvousError> {
         fs::create_dir_all(&self.directory).map_err(|_| RendezvousError::Io)?;
         restrict_directory(&self.directory).map_err(|_| RendezvousError::Io)

--- a/src/ticket.rs
+++ b/src/ticket.rs
@@ -6,9 +6,24 @@ use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 use iroh::EndpointAddr;
 use serde::{Deserialize, Serialize};
 
+/// The verbose original encoding: base64 of JSON. Still parsed, never emitted.
 pub const TICKET_PREFIX: &str = "p2pmux-v1:";
+/// The current encoding: base64 of a postcard-encoded [`EndpointAddr`].
+///
+/// v1 spent roughly a third of its length restating `session_id` as a JSON array of 32 decimal
+/// numbers, even though [`JoinTicket::from_parts`] requires it to equal `endpoint_addr.id`. v2
+/// carries the addresses alone and derives the session ID, which takes a 373-character ticket
+/// under 130. Should the two ever stop being the same value — decoupling them is the obvious
+/// hardening step, since today the join credential is the coordinator's public key — this
+/// becomes a genuine field again and needs a v3 prefix rather than a silent format change.
+pub const TICKET_PREFIX_V2: &str = "p2pmux-v2:";
 pub const TICKET_VERSION: u8 = 1;
 pub const MAX_TICKET_PAYLOAD_BYTES: usize = 16 * 1024;
+
+/// Whether `input` is a ticket rather than a short local join code.
+pub fn looks_like_ticket(input: &str) -> bool {
+    input.starts_with(TICKET_PREFIX) || input.starts_with(TICKET_PREFIX_V2)
+}
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct JoinTicket {
@@ -116,13 +131,13 @@ impl JoinTicket {
 
 impl fmt::Display for JoinTicket {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let payload = TicketPayload {
-            version: TICKET_VERSION,
-            session_id: self.session_id.to_vec(),
-            endpoint_addr: self.endpoint_addr.clone(),
-        };
-        let json = serde_json::to_vec(&payload).expect("ticket payload should serialize");
-        write!(formatter, "{TICKET_PREFIX}{}", URL_SAFE_NO_PAD.encode(json))
+        let bytes =
+            postcard::to_allocvec(&self.endpoint_addr).expect("endpoint address should serialize");
+        write!(
+            formatter,
+            "{TICKET_PREFIX_V2}{}",
+            URL_SAFE_NO_PAD.encode(bytes)
+        )
     }
 }
 
@@ -130,23 +145,34 @@ impl FromStr for JoinTicket {
     type Err = TicketError;
 
     fn from_str(input: &str) -> Result<Self, Self::Err> {
+        if let Some(encoded) = input.strip_prefix(TICKET_PREFIX_V2) {
+            let endpoint_addr: EndpointAddr = postcard::from_bytes(&decode_payload(encoded)?)
+                .map_err(|_| TicketError::MalformedPayload)?;
+            // v2 does not carry the session ID; `from_parts` re-derives the invariant v1 stated.
+            return Self::from_parts(endpoint_addr.id.as_bytes().to_vec(), endpoint_addr);
+        }
         let encoded = input
             .strip_prefix(TICKET_PREFIX)
             .ok_or(TicketError::MissingPrefix)?;
-        if encoded.len() > MAX_TICKET_PAYLOAD_BYTES.div_ceil(3) * 4 {
-            return Err(TicketError::PayloadTooLarge);
-        }
-        let bytes = URL_SAFE_NO_PAD
-            .decode(encoded)
-            .map_err(|_| TicketError::MalformedBase64)?;
-        if bytes.len() > MAX_TICKET_PAYLOAD_BYTES {
-            return Err(TicketError::PayloadTooLarge);
-        }
-        let payload: TicketPayload =
-            serde_json::from_slice(&bytes).map_err(|_| TicketError::MalformedPayload)?;
+        let payload: TicketPayload = serde_json::from_slice(&decode_payload(encoded)?)
+            .map_err(|_| TicketError::MalformedPayload)?;
         if payload.version != TICKET_VERSION {
             return Err(TicketError::UnsupportedVersion);
         }
         Self::from_parts(payload.session_id, payload.endpoint_addr)
     }
+}
+
+/// Decode a ticket body, refusing anything too large to be one before allocating it.
+fn decode_payload(encoded: &str) -> Result<Vec<u8>, TicketError> {
+    if encoded.len() > MAX_TICKET_PAYLOAD_BYTES.div_ceil(3) * 4 {
+        return Err(TicketError::PayloadTooLarge);
+    }
+    let bytes = URL_SAFE_NO_PAD
+        .decode(encoded)
+        .map_err(|_| TicketError::MalformedBase64)?;
+    if bytes.len() > MAX_TICKET_PAYLOAD_BYTES {
+        return Err(TicketError::PayloadTooLarge);
+    }
+    Ok(bytes)
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -196,6 +196,8 @@ const PANE_FOOTER: &[FooterSegment] = &[
     FooterSegment::Text("> CLOSE   <"),
     FooterSegment::Key("k"),
     FooterSegment::Text("> LOCK   <"),
+    FooterSegment::Key("i"),
+    FooterSegment::Text("> INVITE   <"),
     FooterSegment::Key("Esc"),
     FooterSegment::Text("> BACK"),
 ];
@@ -474,6 +476,9 @@ pub struct MultiPaneTui {
     pending_join_click: bool,
     /// Set while a press forwarded to a child owns the drag and release that follow.
     mouse_forwarding: bool,
+    /// A pane-mode invite request. The ticket lives in the node's rendezvous record rather
+    /// than in the layout, so the attached client resolves and copies it.
+    pending_ticket_copy: bool,
 }
 
 impl MultiPaneTui {
@@ -517,6 +522,7 @@ impl MultiPaneTui {
             resize_drag: None,
             pending_join_click: false,
             mouse_forwarding: false,
+            pending_ticket_copy: false,
         })
     }
 
@@ -1698,6 +1704,10 @@ impl MultiPaneTui {
             KeyCode::Char('x') if key.modifiers.is_empty() => Some(UiIntent::DeletePane {
                 pane_id: self.focused_pane,
             }),
+            KeyCode::Char('i') if key.modifiers.is_empty() => {
+                self.pending_ticket_copy = true;
+                None
+            }
             KeyCode::Char('k') if key.modifiers.is_empty() => self
                 .snapshot
                 .panes
@@ -1713,6 +1723,11 @@ impl MultiPaneTui {
             }
             _ => None,
         }
+    }
+
+    /// Claim a pending invite request, if the last key asked for one.
+    pub fn take_ticket_copy_request(&mut self) -> bool {
+        std::mem::take(&mut self.pending_ticket_copy)
     }
 
     fn create_pane(&self, axis: Axis, position: NewPanePosition, area: Rect) -> Option<UiIntent> {
@@ -1995,6 +2010,7 @@ fn is_chord_command(mode: ChordMode, key: KeyEvent) -> bool {
                 | KeyCode::Char('u')
                 | KeyCode::Char('x')
                 | KeyCode::Char('k')
+                | KeyCode::Char('i')
                 | KeyCode::Left
                 | KeyCode::Right
                 | KeyCode::Up
@@ -2586,7 +2602,7 @@ fn contextual_footer(chord_mode: ChordMode) -> (&'static str, &'static [FooterSe
     match chord_mode {
         ChordMode::None => (CONTROL_HELP, NORMAL_FOOTER),
         ChordMode::Pane => (
-            "  <←↓↑→> FOCUS   <e> RENAME   <n> NEW   <r/l/d/u> SPLIT   <x> CLOSE   <k> LOCK   <Esc> BACK",
+            "  <←↓↑→> FOCUS   <e> RENAME   <n> NEW   <r/l/d/u> SPLIT   <x> CLOSE   <k> LOCK   <i> INVITE   <Esc> BACK",
             PANE_FOOTER,
         ),
         ChordMode::Tab => (
@@ -10199,6 +10215,41 @@ mod tests {
     }
 
     #[test]
+    fn pane_mode_invite_requests_a_ticket_copy_once_and_leaves_the_mode() {
+        let mut tui = MultiPaneTui::new(split_layout()).expect("valid layout");
+        let area = Rect::new(0, 0, 80, 24);
+
+        let _ = tui.handle_key(
+            KeyEvent::new(KeyCode::Char('p'), KeyModifiers::CONTROL),
+            area,
+        );
+        assert_eq!(
+            tui.handle_key(KeyEvent::new(KeyCode::Char('i'), KeyModifiers::NONE), area),
+            KeyHandling::Consumed(vec![]),
+            "invite is a mux command and never reaches the PTY"
+        );
+        assert_eq!(tui.chord_mode(), ChordMode::None);
+
+        assert!(tui.take_ticket_copy_request());
+        assert!(
+            !tui.take_ticket_copy_request(),
+            "a claimed request must not copy again on the next key"
+        );
+    }
+
+    #[test]
+    fn plain_invite_key_reaches_the_pty_outside_pane_mode() {
+        let mut tui = MultiPaneTui::new(split_layout()).expect("valid layout");
+        let area = Rect::new(0, 0, 80, 24);
+
+        assert_eq!(
+            tui.handle_key(KeyEvent::new(KeyCode::Char('i'), KeyModifiers::NONE), area),
+            KeyHandling::Forward
+        );
+        assert!(!tui.take_ticket_copy_request());
+    }
+
+    #[test]
     fn option_arrows_accept_extra_modifiers_but_not_control() {
         let mut tui = MultiPaneTui::new(split_layout()).expect("valid layout");
         let area = Rect::new(0, 0, 80, 24);
@@ -10454,7 +10505,7 @@ mod tests {
             ),
             (
                 ChordMode::Pane,
-                "PANE MODE  <←↓↑→> FOCUS   <e> RENAME   <n> NEW   <r/l/d/u> SPLIT   <x> CLOSE   <k> LOCK   <Esc> BACK",
+                "PANE MODE  <←↓↑→> FOCUS   <e> RENAME   <n> NEW   <r/l/d/u> SPLIT   <x> CLOSE   <k> LOCK   <i> INVITE   <Esc> BACK",
             ),
             (
                 ChordMode::Tab,

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,8 +1,28 @@
-use std::process::Command;
+use std::{
+    fs,
+    net::SocketAddr,
+    path::{Path, PathBuf},
+    process::Command,
+    str::FromStr,
+    sync::atomic::{AtomicU64, Ordering},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use iroh::{EndpointAddr, SecretKey};
+use p2pmux::{rendezvous::LocalRendezvous, ticket::JoinTicket};
 
 fn run(args: &[&str]) -> std::process::Output {
     Command::new(env!("CARGO_BIN_EXE_p2pmux"))
         .args(args)
+        .output()
+        .expect("p2pmux binary should run")
+}
+
+/// Run against an isolated rendezvous cache so tests never read the user's live sessions.
+fn run_with_cache(cache_home: &Path, args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_p2pmux"))
+        .args(args)
+        .env("XDG_CACHE_HOME", cache_home)
         .output()
         .expect("p2pmux binary should run")
 }
@@ -40,4 +60,101 @@ fn help_lists_the_local_terminal_command() {
     assert!(stdout.contains("local interactive shell"));
     assert!(stdout.contains("reusable shared-session ticket"));
     assert!(stdout.contains("remote fixed-grid shared pane"));
+    assert!(stdout.contains("ticket"));
+    assert!(stdout.contains("full reusable join ticket"));
+}
+
+#[test]
+fn ticket_prints_a_pasteable_ticket_that_join_would_accept() {
+    let cache_home = temporary_cache_home();
+    let store = LocalRendezvous::at(rendezvous_directory(&cache_home));
+    let ticket = minted_ticket();
+    let entry = store.publish(&ticket).expect("ticket should publish");
+
+    for args in [vec!["ticket"], vec!["ticket", entry.code()]] {
+        let output = run_with_cache(&cache_home, &args);
+
+        assert!(output.status.success());
+        let stdout = String::from_utf8(output.stdout).expect("stdout should be UTF-8");
+        let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
+        // stdout carries the ticket alone, so `p2pmux ticket | pbcopy` is directly pasteable.
+        assert_eq!(
+            JoinTicket::from_str(stdout.trim()).expect("printed ticket should parse"),
+            ticket
+        );
+        assert!(stderr.contains("TRUST WARNING"));
+        assert!(!stdout.contains("TRUST WARNING"));
+    }
+
+    drop(entry);
+    fs::remove_dir_all(cache_home).expect("temporary cache should remove");
+}
+
+#[test]
+fn ticket_reports_an_unresolvable_code_without_echoing_it() {
+    let cache_home = temporary_cache_home();
+    let unknown = "ABCDEFGHJK";
+
+    let cases = [
+        (vec!["ticket"], "no session was created on this Mac"),
+        (vec!["ticket", unknown], "join code was not found"),
+        (vec!["ticket", "not-a-code"], "invalid ticket format"),
+    ];
+    for (args, expected) in cases {
+        let output = run_with_cache(&cache_home, &args);
+
+        assert!(!output.status.success());
+        let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
+        assert!(stderr.contains(expected), "expected {expected} in {stderr}");
+        assert!(output.stdout.is_empty());
+        assert!(!stderr.contains(unknown));
+        assert!(!stderr.contains("not-a-code"));
+    }
+}
+
+#[test]
+fn ticket_asks_for_a_code_when_several_sessions_are_live() {
+    let cache_home = temporary_cache_home();
+    let store = LocalRendezvous::at(rendezvous_directory(&cache_home));
+    let ticket = minted_ticket();
+    let first = store.publish(&ticket).expect("first should publish");
+    let second = store.publish(&ticket).expect("second should publish");
+
+    let output = run_with_cache(&cache_home, &["ticket"]);
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
+    assert!(stderr.contains("several sessions are live"));
+    assert!(output.stdout.is_empty());
+
+    drop(first);
+    drop(second);
+    fs::remove_dir_all(cache_home).expect("temporary cache should remove");
+}
+
+fn minted_ticket() -> JoinTicket {
+    JoinTicket::mint(
+        EndpointAddr::new(SecretKey::from_bytes(&[9; 32]).public())
+            .with_ip_addr(SocketAddr::from(([127, 0, 0, 1], 4242))),
+    )
+    .expect("ticket should mint")
+}
+
+/// Mirror the layout `LocalRendezvous::for_current_user` builds under `XDG_CACHE_HOME`.
+fn rendezvous_directory(cache_home: &Path) -> PathBuf {
+    cache_home.join("p2pmux").join("rendezvous")
+}
+
+static TEMPORARY_CACHE_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+fn temporary_cache_home() -> PathBuf {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock should be after epoch")
+        .as_nanos();
+    let sequence = TEMPORARY_CACHE_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    std::env::temp_dir().join(format!(
+        "p2pmux-cli-test-{}-{nonce}-{sequence}",
+        std::process::id()
+    ))
 }

--- a/tests/ticket.rs
+++ b/tests/ticket.rs
@@ -9,7 +9,9 @@ use std::{
 use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 use iroh::{EndpointAddr, SecretKey};
 use p2pmux::rendezvous::{LocalRendezvous, RendezvousError, SHORT_CODE_LEN};
-use p2pmux::ticket::{JoinTicket, MAX_TICKET_PAYLOAD_BYTES, TICKET_PREFIX, TicketError};
+use p2pmux::ticket::{
+    JoinTicket, MAX_TICKET_PAYLOAD_BYTES, TICKET_PREFIX, TICKET_PREFIX_V2, TicketError,
+};
 use serde_json::{Value, json};
 
 fn endpoint_addr() -> EndpointAddr {
@@ -17,18 +19,13 @@ fn endpoint_addr() -> EndpointAddr {
         .with_ip_addr(SocketAddr::from(([127, 0, 0, 1], 4242)))
 }
 
+/// A well-formed v1 body. Built directly rather than from `Display`, which now emits v2.
 fn valid_payload() -> Value {
-    let ticket = JoinTicket::mint(endpoint_addr()).expect("ticket should mint");
-    let text = ticket.to_string();
-    let encoded = text
-        .strip_prefix(TICKET_PREFIX)
-        .expect("ticket should have the version prefix");
-    serde_json::from_slice(
-        &URL_SAFE_NO_PAD
-            .decode(encoded)
-            .expect("ticket should decode"),
-    )
-    .expect("ticket should contain JSON")
+    json!({
+        "version": 1,
+        "session_id": endpoint_addr().id.as_bytes().to_vec(),
+        "endpoint_addr": endpoint_addr(),
+    })
 }
 
 fn encode_payload(payload: Value) -> String {
@@ -48,9 +45,35 @@ fn minted_ticket_round_trips_and_is_reusable() {
 
     assert_eq!(first, ticket);
     assert_eq!(second, ticket);
-    assert!(text.starts_with(TICKET_PREFIX));
+    assert!(text.starts_with(TICKET_PREFIX_V2));
     assert_eq!(ticket.endpoint_addr(), &endpoint_addr);
     assert_eq!(ticket.session_id(), endpoint_addr.id.as_bytes());
+}
+
+#[test]
+fn v1_tickets_still_parse_so_a_peer_can_lag_a_release() {
+    let ticket = JoinTicket::mint(endpoint_addr()).expect("ticket should mint");
+
+    let parsed = JoinTicket::from_str(&encode_payload(valid_payload()))
+        .expect("a v1 ticket should still parse");
+
+    assert_eq!(parsed, ticket, "both encodings name the same session");
+}
+
+#[test]
+fn v2_is_much_shorter_than_the_v1_encoding_of_the_same_session() {
+    let ticket = JoinTicket::mint(endpoint_addr()).expect("ticket should mint");
+
+    let v2 = ticket.to_string();
+    let v1 = encode_payload(valid_payload());
+
+    // v1 restated session_id as 32 decimal numbers in JSON; v2 derives it from the endpoint ID.
+    assert!(
+        v2.len() * 2 < v1.len(),
+        "v2 ({} chars) should be far under half of v1 ({} chars)",
+        v2.len(),
+        v1.len()
+    );
 }
 
 #[test]
@@ -96,6 +119,23 @@ fn parser_rejects_invalid_ticket_classes_without_echoing_input() {
             TicketError::MissingAddresses,
         ),
         (&oversized, TicketError::PayloadTooLarge),
+        ("p2pmux-v2:%%%", TicketError::MalformedBase64),
+        (
+            &format!("{TICKET_PREFIX_V2}{}", URL_SAFE_NO_PAD.encode([0_u8; 4])),
+            TicketError::MalformedPayload,
+        ),
+        (
+            &format!(
+                "{TICKET_PREFIX_V2}{}",
+                URL_SAFE_NO_PAD.encode(
+                    postcard::to_allocvec(&EndpointAddr::new(
+                        SecretKey::from_bytes(&[7; 32]).public()
+                    ))
+                    .expect("addressless endpoint should encode")
+                )
+            ),
+            TicketError::MissingAddresses,
+        ),
     ];
 
     for (input, expected) in cases {

--- a/tests/ticket.rs
+++ b/tests/ticket.rs
@@ -161,6 +161,39 @@ fn local_rendezvous_rejects_unknown_codes_without_echoing_them() {
     fs::remove_dir_all(directory).expect("temporary directory should remove");
 }
 
+#[test]
+fn local_rendezvous_lists_published_codes_and_ignores_other_files() {
+    let directory = temporary_directory();
+    let store = LocalRendezvous::at(directory.clone());
+    let ticket = JoinTicket::mint(endpoint_addr()).expect("ticket should mint");
+
+    let first = store.publish(&ticket).expect("first ticket should publish");
+    let second = store
+        .publish(&ticket)
+        .expect("second ticket should publish");
+    fs::write(directory.join("not-a-code"), b"ignored").expect("stray file should write");
+
+    let mut expected = vec![first.code().to_owned(), second.code().to_owned()];
+    expected.sort();
+    assert_eq!(store.codes().expect("codes should list"), expected);
+
+    drop(first);
+    drop(second);
+    fs::remove_dir_all(directory).expect("temporary directory should remove");
+}
+
+#[test]
+fn local_rendezvous_lists_no_codes_before_any_session_exists() {
+    let store = LocalRendezvous::at(temporary_directory());
+
+    assert!(
+        store
+            .codes()
+            .expect("a missing directory should not be an error")
+            .is_empty()
+    );
+}
+
 static TEMPORARY_DIRECTORY_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
 fn temporary_directory() -> std::path::PathBuf {


### PR DESCRIPTION
## Why

`join` has always accepted a full ticket, and `JoinTicket` has always implemented `Display` — **but nothing ever printed one**. The only invite obtainable was the 10-character short code, which resolves through `~/.cache/p2pmux/rendezvous/<CODE>` and only works on the Mac that created the session.

So two people on different machines could not join a session at all. This is the zero-infrastructure escape hatch that unblocks Spike 4 internet validation, and it should land before any hosted rendezvous service — a `code → ticket` server is undiagnosable if cross-machine connectivity was never proven first.

## What

**1. `p2pmux ticket [<code>]`** — resolves the record `create` already publishes and prints the portable ticket. No protocol, IPC, or node change.

```
p2pmux ticket            # the one session live on this Mac
p2pmux ticket <code>     # when several are live
p2pmux ticket | pbcopy   # ticket alone on stdout, trust warning on stderr
```

Printing at `create` time is not viable: that path launches a detached node and hands the terminal straight to the client, so the output would flash and be lost.

**2. `Ctrl+P` then `i`** — copies the same ticket from inside the session, flashing `copied full ticket` in the footer. Running `p2pmux ticket` in a shared pane would put a bearer credential on a screen every member can see; the footer notice is local chrome, so nobody else sees anything. The client resolves the rendezvous record itself rather than having the credential travel over the local socket. Coordinator only — a guest publishes no record and is told so.

**3. A compact `p2pmux-v2:` encoding — 373 characters down to 66.**

```
p2pmux-v2:_RckOFqgx1tk-3jNYC-h2ZH96_drE8WO1wLqyDXp9hgBAQDAqAEq7JQD
```

v1 spent roughly a third of its length restating `session_id` as a JSON array of 32 decimal numbers, even though `from_parts` *requires* it to equal `endpoint_addr.id` — then base64'd verbose JSON on top. v2 carries the addresses alone, postcard-encoded, and re-derives the session ID.

- `postcard` was already in the dependency tree, so this adds no new compiled code.
- It goes through serde rather than a hand-rolled encoder because `TransportAddr` is `#[non_exhaustive]` — a variant added upstream would silently outgrow anything written by hand.
- **v1 tickets are still parsed**, so a peer one release behind can be invited without upgrading first.

## Testing

`tests/cli.rs` runs the real binary against an isolated `XDG_CACHE_HOME`, so the suite never reads the user's live sessions. The load-bearing assertion is that stdout **parses back to the exact ticket that was published**. Also covered: v1 tickets still parse, v2 is under half of v1, malformed v2 bodies are rejected by class without echoing input, the chord is consumed once and leaves pane mode, and a plain `i` outside pane mode still reaches the PTY.

All four CI gates pass locally and on CI.

## Follow-up (not in this PR)

`session_id` is minted **as the coordinator's iroh endpoint public key** (`ticket.rs`), and admission is a single comparison against it (`session.rs`). Decoupling those is worth doing before a hosted rendezvous exists — at which point `session_id` becomes a real field again and needs a `v3` prefix rather than a silent format change. Tracked in the Notion plan page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BE4TfQQqeufRt9uwV78v4L