### PR TITLE
feat(agents): report agent status from hooks, not just output timing

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,13 +155,47 @@ shells: Claude Code (`claude`), Codex (`codex`), Cursor Agent (including its `ag
 Pi (including Node-based launches), and OpenCode (`opencode`). Each agent is a two-line card: the
 first line shows its kind and best-effort working directory; the second shows its state, chrome
 location (`Tab #N · Pane #M`), host, and control holder. Working cards have an animated spinner
-and live duration, while idle and done cards use distinct `○` and `✓` visuals. Press `Esc` to
+and live duration; `○ idle`, `✓ done`, `◆ needs you`, and `✗ error` use distinct visuals. The
+panel title counts the agents blocked on a human (`Agents · 2 need you`). Press `Esc` to
 close, use arrows or `j`/`k` to select, and press Enter or left-click a card to jump to that pane
 (including on another tab). Scroll the overlay with the mouse wheel while it is open. To retain
 readline's beginning-of-line shortcut, press `Ctrl+A` twice within 200ms to forward one Ctrl+A to
 the focused PTY instead. Working directories are shared with every member as part of the existing
 trusted shared-shell model, so do not use a session with people who should not see repository
 paths.
+
+`idle`, `working`, and `done` are inferred from PTY output timing, so they need no setup and work
+for every agent above. `needs you` and `error` cannot be inferred at all — silence looks identical
+whether an agent is thinking or waiting on a permission prompt — so they only appear for an agent
+that reports its own state through a hook.
+
+To wire that up for Claude Code, add this to `~/.claude/settings.json`. Each hook pipes its
+payload to `p2pmux notify`, which writes one line to the pane's session and exits. Outside a
+p2pmux pane it is a silent no-op, so it is safe to leave registered everywhere.
+
+```json
+{
+  "hooks": {
+    "UserPromptSubmit": [{ "hooks": [{ "type": "command", "command": "p2pmux notify claude --status running", "timeout": 5 }] }],
+    "PreToolUse":       [{ "matcher": "*", "hooks": [{ "type": "command", "command": "p2pmux notify claude --status running", "timeout": 5 }] }],
+    "PostToolUse":      [{ "matcher": "*", "hooks": [{ "type": "command", "command": "p2pmux notify claude --status running", "timeout": 5 }] }],
+    "Notification":     [{ "hooks": [{ "type": "command", "command": "p2pmux notify claude --status pending", "timeout": 5 }] }],
+    "Stop":             [{ "hooks": [{ "type": "command", "command": "p2pmux notify claude --status done", "timeout": 5 }] }],
+    "SessionEnd":       [{ "hooks": [{ "type": "command", "command": "p2pmux notify claude --status idle", "timeout": 5 }] }]
+  }
+}
+```
+
+A turn that ends by asking a question reports `needs you` rather than `done`, since a green card
+on a turn that is actually waiting reads as safe to ignore. A hook only ever reports for the pane
+it runs in, on the machine it runs on; the node refuses a pane it does not host itself. The
+agent's messages and your prompts are read to decide the status but never leave the machine — only
+the state, the agent kind, and the working directory are shared with the session. A pushed state
+is dropped 20 seconds after its pane returns to a shell prompt, so an agent killed mid-turn stops
+asking for attention.
+
+Hooks also make the mux cheaper: the process scan that infers state drops from every second to
+every five when no pane needs inference.
 
 Clicking a pane focuses it locally without taking control or sending input. When p2pmux runs
 inside Zellij, Zellij may swallow mouse events; try Zellij with mouse mode disabled or a locked

--- a/src/agent_detect.rs
+++ b/src/agent_detect.rs
@@ -1,6 +1,7 @@
 //! Pure helpers for detecting supported coding agents in a hosted PTY tree.
 
 use std::{
+    collections::HashMap,
     path::{Path, PathBuf},
     sync::OnceLock,
     time::{Duration, Instant},
@@ -246,67 +247,94 @@ struct Candidate<'a> {
     kind: AgentKind,
 }
 
-/// Classify a PTY session child process tree from one global process snapshot.
+/// One snapshot, prepared for classification.
 ///
-/// The deepest matching descendant wins, then the newest available start time,
-/// then the highest PID. The PTY session child itself is included in the tree.
+/// The expensive parts of classifying a pane — running every agent matcher over
+/// every process, and finding a process by pid — do not depend on which pane is
+/// being classified, so they happen once per snapshot here rather than once per
+/// pane. With one global scan feeding a session's worth of panes, that is the
+/// difference between O(panes × processes) matcher calls per second and O(panes
+/// × agents).
+pub struct AgentScan<'a> {
+    by_pid: HashMap<u32, &'a ProcessSnapshot>,
+    /// Every process in the snapshot that looks like a supported agent. Tiny
+    /// next to the snapshot itself: a machine has a handful of these, not
+    /// hundreds.
+    agents: Vec<(&'a ProcessSnapshot, AgentKind)>,
+}
+
+impl<'a> AgentScan<'a> {
+    pub fn new(processes: &'a [ProcessSnapshot]) -> Self {
+        let by_pid = processes
+            .iter()
+            .map(|process| (process.pid, process))
+            .collect();
+        let agents = processes
+            .iter()
+            .filter_map(|process| {
+                AgentKind::from_process(&process.exe_basename, &process.name, &process.cmdline)
+                    .map(|kind| (process, kind))
+            })
+            .collect();
+        Self { by_pid, agents }
+    }
+
+    /// Classify one PTY session child's process tree.
+    ///
+    /// The deepest matching descendant wins, then the newest available start
+    /// time, then the highest PID. The PTY session child itself is included in
+    /// the tree.
+    pub fn classify(&self, session_child_pid: u32) -> Option<DetectedAgent> {
+        self.agents
+            .iter()
+            .filter_map(|&(process, kind)| {
+                self.descendant_depth(session_child_pid, process.pid)
+                    .map(|depth| Candidate {
+                        process,
+                        depth,
+                        kind,
+                    })
+            })
+            .max_by(|left, right| {
+                left.depth
+                    .cmp(&right.depth)
+                    .then_with(
+                        || match (left.process.start_time, right.process.start_time) {
+                            (Some(left), Some(right)) => left.cmp(&right),
+                            _ => std::cmp::Ordering::Equal,
+                        },
+                    )
+                    .then_with(|| left.process.pid.cmp(&right.process.pid))
+            })
+            .map(|candidate| DetectedAgent {
+                kind: candidate.kind,
+                cwd: candidate.process.cwd.clone().unwrap_or_default(),
+            })
+    }
+
+    fn descendant_depth(&self, root_pid: u32, pid: u32) -> Option<usize> {
+        let mut current_pid = pid;
+        let mut depth = 0;
+
+        while current_pid != root_pid {
+            current_pid = self.by_pid.get(&current_pid)?.parent_pid?;
+            depth += 1;
+            if depth > self.by_pid.len() {
+                return None;
+            }
+        }
+
+        Some(depth)
+    }
+}
+
+/// Classify one pane against a whole snapshot. Convenience for a single lookup;
+/// classifying several panes should build one [`AgentScan`] and reuse it.
 pub fn classify_pane_tree(
     session_child_pid: u32,
     processes: &[ProcessSnapshot],
 ) -> Option<DetectedAgent> {
-    let mut candidates = Vec::new();
-
-    for process in processes {
-        let Some(kind) =
-            AgentKind::from_process(&process.exe_basename, &process.name, &process.cmdline)
-        else {
-            continue;
-        };
-        let Some(depth) = descendant_depth(session_child_pid, process.pid, processes) else {
-            continue;
-        };
-        candidates.push(Candidate {
-            process,
-            depth,
-            kind,
-        });
-    }
-
-    candidates
-        .into_iter()
-        .max_by(|left, right| {
-            left.depth
-                .cmp(&right.depth)
-                .then_with(
-                    || match (left.process.start_time, right.process.start_time) {
-                        (Some(left), Some(right)) => left.cmp(&right),
-                        _ => std::cmp::Ordering::Equal,
-                    },
-                )
-                .then_with(|| left.process.pid.cmp(&right.process.pid))
-        })
-        .map(|candidate| DetectedAgent {
-            kind: candidate.kind,
-            cwd: candidate.process.cwd.clone().unwrap_or_default(),
-        })
-}
-
-fn descendant_depth(root_pid: u32, pid: u32, processes: &[ProcessSnapshot]) -> Option<usize> {
-    let mut current_pid = pid;
-    let mut depth = 0;
-
-    while current_pid != root_pid {
-        let process = processes
-            .iter()
-            .find(|process| process.pid == current_pid)?;
-        current_pid = process.parent_pid?;
-        depth += 1;
-        if depth > processes.len() {
-            return None;
-        }
-    }
-
-    Some(depth)
+    AgentScan::new(processes).classify(session_child_pid)
 }
 
 /// Coarse activity state shown in the agents overlay.
@@ -454,6 +482,11 @@ impl PaneAgentTracker {
         self.pushed
             .as_ref()
             .filter(|pushed| pushed.state != AgentState::Idle)
+    }
+
+    /// Whether a producer currently owns this pane's state.
+    pub fn has_owning_push(&self) -> bool {
+        self.owning_push().is_some()
     }
 
     /// Working-interval start for whichever source currently owns the state.
@@ -789,6 +822,83 @@ mod tests {
                 cwd: "/repo".into(),
             })
         );
+    }
+
+    #[test]
+    fn one_scan_classifies_every_pane_identically_to_a_per_pane_scan() {
+        // Two panes, two agents, plus filler that no matcher should ever touch
+        // twice. `AgentScan` exists to move the matcher pass off the per-pane
+        // path; it must not change a single verdict doing so.
+        let mut processes = vec![
+            process(10, None, "zsh", None),
+            process(11, Some(10), "claude", Some(1)),
+            process(20, None, "zsh", None),
+            process(21, Some(20), "codex", Some(1)),
+        ];
+        processes[1].cwd = Some("/one".into());
+        processes[3].cwd = Some("/two".into());
+        processes.extend((100..160).map(|pid| process(pid, Some(1), "node", None)));
+
+        let scan = AgentScan::new(&processes);
+        for root in [10, 20, 999] {
+            assert_eq!(
+                scan.classify(root),
+                classify_pane_tree(root, &processes),
+                "shared scan must agree with a standalone one for root {root}"
+            );
+        }
+        assert_eq!(
+            scan.classify(10).map(|agent| agent.kind),
+            Some(AgentKind::Claude)
+        );
+        assert_eq!(
+            scan.classify(20).map(|agent| agent.cwd),
+            Some("/two".into())
+        );
+        assert_eq!(scan.classify(999), None);
+    }
+
+    #[test]
+    fn has_owning_push_tracks_who_owns_the_state() {
+        let now = Instant::now();
+        let mut tracker = PaneAgentTracker::default();
+        assert!(!tracker.has_owning_push());
+
+        tracker.update(
+            Some(DetectedAgent {
+                kind: AgentKind::Claude,
+                cwd: "/repo".into(),
+            }),
+            now,
+            1_000,
+        );
+        assert!(
+            !tracker.has_owning_push(),
+            "a detected agent alone is inference, and inference needs fast sampling"
+        );
+
+        tracker.record_pushed_status(
+            AgentKind::Claude,
+            "/repo".into(),
+            AgentState::Working,
+            now,
+            1_000,
+        );
+        assert!(
+            tracker.has_owning_push(),
+            "a hooked agent reports its own state; sampling only has to watch it exit"
+        );
+
+        // An idle push hands the pane back to inference, so the fast cadence
+        // has to come back with it.
+        tracker.record_pushed_status(
+            AgentKind::Claude,
+            "/repo".into(),
+            AgentState::Idle,
+            now,
+            1_000,
+        );
+        assert!(!tracker.has_owning_push());
     }
 
     #[test]

--- a/src/agent_detect.rs
+++ b/src/agent_detect.rs
@@ -128,6 +128,20 @@ impl AgentKind {
         }
     }
 
+    /// Parse a wire value produced by [`Self::wire_value`]. `None` for anything
+    /// else — a producer naming an agent this build does not know is refused
+    /// rather than coerced, so a typo never files status under the wrong kind.
+    pub fn from_wire(value: &str) -> Option<Self> {
+        match value {
+            "claude" => Some(Self::Claude),
+            "codex" => Some(Self::Codex),
+            "cursor" => Some(Self::Cursor),
+            "pi" => Some(Self::Pi),
+            "opencode" => Some(Self::OpenCode),
+            _ => None,
+        }
+    }
+
     /// Human-readable label for the overlay.
     pub const fn display_label(self) -> &'static str {
         match self {
@@ -296,11 +310,47 @@ fn descendant_depth(root_pid: u32, pid: u32, processes: &[ProcessSnapshot]) -> O
 }
 
 /// Coarse activity state shown in the agents overlay.
+///
+/// `Idle`, `Working`, and `Done` are inferable from PTY output timing.
+/// `Pending` and `Error` are not, and never will be: silence looks identical
+/// whether an agent is thinking or waiting on a permission prompt. They only
+/// ever arrive from a producer inside the pane — see
+/// [`PaneAgentTracker::record_pushed_status`].
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum AgentState {
     Idle,
     Working,
     Done,
+    Pending,
+    Error,
+}
+
+impl AgentState {
+    /// Stable wire value for a pushed status.
+    pub const fn wire_value(self) -> &'static str {
+        match self {
+            Self::Idle => "idle",
+            Self::Working => "working",
+            Self::Done => "done",
+            Self::Pending => "pending",
+            Self::Error => "error",
+        }
+    }
+
+    /// Parse a pushed status. Strict: an unrecognized token is `None`, never a
+    /// lenient fallback to `Idle`. Leniency here would let a producer's typo
+    /// silently erase the row it meant to update, which is the worst possible
+    /// failure for a status a human is waiting on.
+    pub fn from_wire(value: &str) -> Option<Self> {
+        match value {
+            "idle" => Some(Self::Idle),
+            "working" | "running" => Some(Self::Working),
+            "done" => Some(Self::Done),
+            "pending" => Some(Self::Pending),
+            "error" => Some(Self::Error),
+            _ => None,
+        }
+    }
 }
 
 /// A just-finished agent retained for the done grace period.
@@ -311,6 +361,20 @@ pub struct DoneAgent {
     pub entered_done_at: Instant,
 }
 
+/// A status reported by a producer running inside the pane — an agent hook,
+/// not an inference. Authoritative while present: the agent said so.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PushedAgent {
+    pub kind: AgentKind,
+    pub cwd: String,
+    pub state: AgentState,
+    /// When this status arrived. The expiry policy reads it.
+    pub at: Instant,
+    /// Start of the current working interval, carried across pushes that stay
+    /// `Working` so a per-tool-call stream of updates does not reset the clock.
+    pub working_since_unix_ms: u64,
+}
+
 /// Per-pane agent state maintained between global sampler snapshots.
 #[derive(Clone, Debug)]
 pub struct PaneAgentTracker {
@@ -319,6 +383,8 @@ pub struct PaneAgentTracker {
     pub done_agent: Option<DoneAgent>,
     pub working_since: Option<Instant>,
     pub working_since_unix_ms: u64,
+    /// Latest producer-pushed status, when one is running in this pane.
+    pub pushed: Option<PushedAgent>,
     tuning: NotificationTuning,
     settle_until: Option<Instant>,
 }
@@ -337,8 +403,64 @@ impl PaneAgentTracker {
             done_agent: None,
             working_since: None,
             working_since_unix_ms: 0,
+            pushed: None,
             tuning,
             settle_until: None,
+        }
+    }
+
+    /// Apply a status pushed by a producer inside the pane.
+    ///
+    /// A push outranks every inference this module makes, because the producer
+    /// is the agent: it knows it is blocked on a permission prompt, and no
+    /// amount of output timing can tell that apart from waiting on a model.
+    ///
+    /// A `Working` push carries its interval start forward from the previous
+    /// `Working` push, so the per-tool-call stream a hooked agent emits shows
+    /// one continuous interval rather than restarting the clock every few
+    /// seconds.
+    pub fn record_pushed_status(
+        &mut self,
+        kind: AgentKind,
+        cwd: String,
+        state: AgentState,
+        now: Instant,
+        unix_ms_now: u64,
+    ) {
+        let continuing = self
+            .pushed
+            .as_ref()
+            .filter(|pushed| pushed.state == AgentState::Working && pushed.kind == kind)
+            .map(|pushed| pushed.working_since_unix_ms);
+        let working_since_unix_ms = match state {
+            AgentState::Working => continuing.unwrap_or(unix_ms_now),
+            _ => 0,
+        };
+        self.pushed = Some(PushedAgent {
+            kind,
+            cwd,
+            state,
+            at: now,
+            working_since_unix_ms,
+        });
+    }
+
+    /// The authoritative pushed status, if a producer currently owns this pane.
+    ///
+    /// An `Idle` push is deliberately not authoritative: it means "no activity"
+    /// (Claude's `/clear`, a session ending), which should hand the pane back to
+    /// process detection rather than blank a row whose agent is still running.
+    fn owning_push(&self) -> Option<&PushedAgent> {
+        self.pushed
+            .as_ref()
+            .filter(|pushed| pushed.state != AgentState::Idle)
+    }
+
+    /// Working-interval start for whichever source currently owns the state.
+    pub fn reported_working_since_unix_ms(&self) -> u64 {
+        match self.owning_push() {
+            Some(pushed) => pushed.working_since_unix_ms,
+            None => self.working_since_unix_ms,
         }
     }
 
@@ -407,6 +529,18 @@ impl PaneAgentTracker {
         unix_ms_now: u64,
     ) -> Option<(DetectedAgent, AgentState)> {
         self.reconcile_working_state(now, unix_ms_now);
+        // A producer inside the pane outranks detection, and stands alone: a
+        // hooked agent this build's process matchers do not recognize still
+        // gets a row, which is the whole point of accepting pushes.
+        if let Some(pushed) = self.owning_push() {
+            return Some((
+                DetectedAgent {
+                    kind: pushed.kind,
+                    cwd: pushed.cwd.clone(),
+                },
+                pushed.state,
+            ));
+        }
         if let Some(agent) = &self.active_agent {
             let state = if self.working_since.is_some() {
                 AgentState::Working
@@ -823,6 +957,143 @@ mod tests {
             tracker.listed_agent(now + Duration::from_secs(3_601), 1_000),
             Some((agent, AgentState::Idle))
         );
+    }
+
+    #[test]
+    fn a_pushed_status_outranks_detection_and_stands_alone() {
+        let now = Instant::now();
+        let mut tracker = PaneAgentTracker::default();
+
+        // No agent process matched: a hooked agent this build's matchers do not
+        // recognize still gets a row.
+        tracker.record_pushed_status(
+            AgentKind::Claude,
+            "/repo".into(),
+            AgentState::Pending,
+            now,
+            1_000,
+        );
+        assert_eq!(
+            tracker.listed_agent(now, 1_000),
+            Some((
+                DetectedAgent {
+                    kind: AgentKind::Claude,
+                    cwd: "/repo".into(),
+                },
+                AgentState::Pending,
+            ))
+        );
+
+        // Detection says "working" (the pane is chattering); the producer says
+        // the agent is blocked. The producer wins — that is the whole point.
+        tracker.update(
+            Some(DetectedAgent {
+                kind: AgentKind::Claude,
+                cwd: "/detected".into(),
+            }),
+            now,
+            1_000,
+        );
+        tracker.record_output(now, 1_000);
+        assert_eq!(
+            tracker.listed_agent(now, 1_000).map(|(_, state)| state),
+            Some(AgentState::Pending)
+        );
+
+        // An idle push means "no activity", not "blank the row": the pane goes
+        // back to what detection can see rather than losing a live agent.
+        tracker.record_pushed_status(
+            AgentKind::Claude,
+            "/repo".into(),
+            AgentState::Idle,
+            now,
+            1_000,
+        );
+        assert_eq!(
+            tracker.listed_agent(now, 1_000),
+            Some((
+                DetectedAgent {
+                    kind: AgentKind::Claude,
+                    cwd: "/detected".into(),
+                },
+                AgentState::Working,
+            ))
+        );
+    }
+
+    #[test]
+    fn consecutive_working_pushes_keep_one_interval() {
+        let now = Instant::now();
+        let mut tracker = PaneAgentTracker::default();
+
+        // A hooked agent pushes on every tool call. Those must read as one
+        // continuous interval, or the overlay's elapsed clock resets every few
+        // seconds and never shows how long the turn has really run.
+        tracker.record_pushed_status(
+            AgentKind::Codex,
+            "/repo".into(),
+            AgentState::Working,
+            now,
+            5_000,
+        );
+        assert_eq!(tracker.reported_working_since_unix_ms(), 5_000);
+        tracker.record_pushed_status(
+            AgentKind::Codex,
+            "/repo".into(),
+            AgentState::Working,
+            now + Duration::from_secs(3),
+            8_000,
+        );
+        assert_eq!(tracker.reported_working_since_unix_ms(), 5_000);
+
+        // Finishing drops the interval; the next turn starts a fresh one.
+        tracker.record_pushed_status(
+            AgentKind::Codex,
+            "/repo".into(),
+            AgentState::Done,
+            now + Duration::from_secs(4),
+            9_000,
+        );
+        assert_eq!(tracker.reported_working_since_unix_ms(), 0);
+        tracker.record_pushed_status(
+            AgentKind::Codex,
+            "/repo".into(),
+            AgentState::Working,
+            now + Duration::from_secs(5),
+            10_000,
+        );
+        assert_eq!(tracker.reported_working_since_unix_ms(), 10_000);
+    }
+
+    #[test]
+    fn wire_vocabularies_round_trip_and_refuse_typos() {
+        for kind in [
+            AgentKind::Claude,
+            AgentKind::Codex,
+            AgentKind::Cursor,
+            AgentKind::Pi,
+            AgentKind::OpenCode,
+        ] {
+            assert_eq!(AgentKind::from_wire(kind.wire_value()), Some(kind));
+        }
+        assert_eq!(AgentKind::from_wire("Claude"), None);
+        assert_eq!(AgentKind::from_wire("gemini"), None);
+
+        for state in [
+            AgentState::Idle,
+            AgentState::Working,
+            AgentState::Done,
+            AgentState::Pending,
+            AgentState::Error,
+        ] {
+            assert_eq!(AgentState::from_wire(state.wire_value()), Some(state));
+        }
+        // Producers modelled on Claude's hook vocabulary say "running".
+        assert_eq!(AgentState::from_wire("running"), Some(AgentState::Working));
+        // A typo must never lenient-parse: folding it to idle would silently
+        // erase the row the producer meant to update.
+        assert_eq!(AgentState::from_wire("pendign"), None);
+        assert_eq!(AgentState::from_wire(""), None);
     }
 
     #[test]

--- a/src/agent_detect.rs
+++ b/src/agent_detect.rs
@@ -1,7 +1,7 @@
 //! Pure helpers for detecting supported coding agents in a hosted PTY tree.
 
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     path::{Path, PathBuf},
     sync::OnceLock,
     time::{Duration, Instant},
@@ -22,6 +22,14 @@ pub const DEFAULT_QUIET_BEFORE_DONE: Duration = Duration::from_secs(20);
 /// new working interval. Agents ring the bell and then repaint their prompt, and that trailing
 /// redraw would otherwise open a fresh interval that has to time out all over again.
 const COMPLETION_SETTLE: Duration = Duration::from_secs(3);
+/// How long a pane may sit at its shell prompt with a pushed status still
+/// standing before that status is dropped.
+///
+/// No hook fires when an agent is killed, so a `working` or `needs you` push
+/// would otherwise stand forever on a pane whose agent is long gone. Long
+/// enough that a turn briefly between child processes never trips it; short
+/// enough that a killed agent stops asking for attention it will never use.
+pub const PUSHED_STATUS_GRACE: Duration = Duration::from_secs(20);
 
 /// Return a process's current working directory when it is an existing absolute directory.
 pub fn cwd_for_pid(pid: u32) -> Option<PathBuf> {
@@ -257,6 +265,8 @@ struct Candidate<'a> {
 /// × agents).
 pub struct AgentScan<'a> {
     by_pid: HashMap<u32, &'a ProcessSnapshot>,
+    /// Every pid in the snapshot that is some process's parent.
+    parents: HashSet<u32>,
     /// Every process in the snapshot that looks like a supported agent. Tiny
     /// next to the snapshot itself: a machine has a handful of these, not
     /// hundreds.
@@ -269,6 +279,10 @@ impl<'a> AgentScan<'a> {
             .iter()
             .map(|process| (process.pid, process))
             .collect();
+        let parents = processes
+            .iter()
+            .filter_map(|process| process.parent_pid)
+            .collect();
         let agents = processes
             .iter()
             .filter_map(|process| {
@@ -276,7 +290,22 @@ impl<'a> AgentScan<'a> {
                     .map(|kind| (process, kind))
             })
             .collect();
-        Self { by_pid, agents }
+        Self {
+            by_pid,
+            parents,
+            agents,
+        }
+    }
+
+    /// Whether a pane's session child still has any child process — whether the
+    /// pane is running something rather than sitting at its shell prompt.
+    ///
+    /// Deliberately not an agent-aware check. This is the evidence that a
+    /// producer has gone, and it must hold even for an agent launched through a
+    /// wrapper no matcher in this module recognizes: whatever the pane was
+    /// running, it is not running it any more.
+    pub fn has_children(&self, session_child_pid: u32) -> bool {
+        self.parents.contains(&session_child_pid)
     }
 
     /// Classify one PTY session child's process tree.
@@ -413,6 +442,9 @@ pub struct PaneAgentTracker {
     pub working_since_unix_ms: u64,
     /// Latest producer-pushed status, when one is running in this pane.
     pub pushed: Option<PushedAgent>,
+    /// When this pane was first seen sitting at its shell prompt while a pushed
+    /// status was still standing. `None` cancels the grace clock.
+    push_suspect_since: Option<Instant>,
     tuning: NotificationTuning,
     settle_until: Option<Instant>,
 }
@@ -432,8 +464,34 @@ impl PaneAgentTracker {
             working_since: None,
             working_since_unix_ms: 0,
             pushed: None,
+            push_suspect_since: None,
             tuning,
             settle_until: None,
+        }
+    }
+
+    /// Feed the pane's liveness into the pushed-status grace clock.
+    ///
+    /// `has_children` is whether the pane is running anything at all. Nothing
+    /// fires a hook when an agent is killed — no `Stop`, no `SessionEnd` — so a
+    /// `working` or `needs you` push has no other way to end. A pane that has
+    /// fallen back to its shell prompt is the evidence that the producer is
+    /// gone.
+    ///
+    /// A first sighting only starts the clock. A turn is legitimately between
+    /// child processes for moments at a time, and a `pending` agent can sit
+    /// waiting for an answer indefinitely, so nothing is dropped until the pane
+    /// has *stayed* at its prompt for [`PUSHED_STATUS_GRACE`] — and repeat
+    /// sightings do not reset it, because staying there is exactly the point.
+    pub fn observe_pane_liveness(&mut self, has_children: bool, now: Instant) {
+        if self.pushed.is_none() || has_children {
+            self.push_suspect_since = None;
+            return;
+        }
+        let since = *self.push_suspect_since.get_or_insert(now);
+        if now.duration_since(since) >= PUSHED_STATUS_GRACE {
+            self.pushed = None;
+            self.push_suspect_since = None;
         }
     }
 
@@ -471,6 +529,9 @@ impl PaneAgentTracker {
             at: now,
             working_since_unix_ms,
         });
+        // A payload is proof the producer is alive — cancel any grace clock
+        // before it can misfire.
+        self.push_suspect_since = None;
     }
 
     /// The authoritative pushed status, if a producer currently owns this pane.
@@ -856,6 +917,88 @@ mod tests {
             Some("/two".into())
         );
         assert_eq!(scan.classify(999), None);
+    }
+
+    #[test]
+    fn a_pushed_status_expires_once_the_pane_is_back_at_its_prompt() {
+        let now = Instant::now();
+        let mut tracker = PaneAgentTracker::default();
+        tracker.record_pushed_status(
+            AgentKind::Claude,
+            "/repo".into(),
+            AgentState::Pending,
+            now,
+            1_000,
+        );
+
+        // Killing an agent mid-question fires no hook at all, so nothing else
+        // would ever retire this row.
+        tracker.observe_pane_liveness(false, now);
+        assert_eq!(
+            tracker.listed_agent(now, 1_000).map(|(_, state)| state),
+            Some(AgentState::Pending),
+            "one sighting only starts the clock"
+        );
+
+        // Repeat sightings must not push expiry out — the pane *staying* at its
+        // prompt is the evidence.
+        tracker.observe_pane_liveness(false, now + PUSHED_STATUS_GRACE - Duration::from_secs(1));
+        assert!(tracker.pushed.is_some());
+
+        tracker.observe_pane_liveness(false, now + PUSHED_STATUS_GRACE);
+        assert!(tracker.pushed.is_none(), "a dead producer stops asking");
+        assert_eq!(tracker.listed_agent(now + PUSHED_STATUS_GRACE, 1_000), None);
+    }
+
+    #[test]
+    fn a_live_pane_or_a_fresh_push_cancels_the_grace_clock() {
+        let now = Instant::now();
+        let mut tracker = PaneAgentTracker::default();
+        tracker.record_pushed_status(
+            AgentKind::Claude,
+            "/repo".into(),
+            AgentState::Working,
+            now,
+            1_000,
+        );
+
+        // A turn is legitimately between child processes for moments at a time.
+        tracker.observe_pane_liveness(false, now);
+        tracker.observe_pane_liveness(true, now + Duration::from_secs(1));
+        tracker.observe_pane_liveness(false, now + Duration::from_secs(2));
+        tracker.observe_pane_liveness(false, now + PUSHED_STATUS_GRACE);
+        assert!(
+            tracker.pushed.is_some(),
+            "the clock restarted when the pane came back to life"
+        );
+
+        // A payload is proof the producer is alive, even mid-suspicion.
+        tracker.observe_pane_liveness(false, now + PUSHED_STATUS_GRACE + Duration::from_secs(1));
+        tracker.record_pushed_status(
+            AgentKind::Claude,
+            "/repo".into(),
+            AgentState::Working,
+            now + PUSHED_STATUS_GRACE + Duration::from_secs(2),
+            1_000,
+        );
+        tracker.observe_pane_liveness(
+            false,
+            now + PUSHED_STATUS_GRACE + PUSHED_STATUS_GRACE + Duration::from_secs(1),
+        );
+        assert!(tracker.pushed.is_some());
+    }
+
+    #[test]
+    fn scan_reports_whether_a_pane_is_running_anything() {
+        let processes = vec![
+            process(10, None, "zsh", None),
+            process(11, Some(10), "claude", None),
+            process(20, None, "zsh", None),
+        ];
+        let scan = AgentScan::new(&processes);
+        assert!(scan.has_children(10), "pane 10 is running an agent");
+        assert!(!scan.has_children(20), "pane 20 is back at its prompt");
+        assert!(!scan.has_children(999));
     }
 
     #[test]

--- a/src/agent_notify.rs
+++ b/src/agent_notify.rs
@@ -1,0 +1,332 @@
+//! The agent-hook producer: a hook payload on stdin, one pushed status out.
+//!
+//! This runs as its own short-lived process (`p2pmux notify claude`), spawned
+//! by the agent's hook runner rather than by the mux. It reads the hook JSON,
+//! decides a status, writes one line to the pane's node socket, and exits.
+//!
+//! Two properties matter more than anything else here, because this code runs
+//! on the agent's critical path — `UserPromptSubmit` blocks the user's prompt,
+//! and the tool hooks fire on every single tool call:
+//!
+//! - **It never errors into the agent.** Every failure — no session, no
+//!   socket, unparseable payload, a node that vanished — is a silent success.
+//!   A hook that fails is a hook the user disables.
+//! - **It never blocks.** One connect and one small write, both with timeouts.
+//!
+//! Note what is *not* sent: the assistant's message, the user's prompt, the
+//! tool being run. Those reach this process and are used only to decide the
+//! status; they never go on the wire. A p2pmux session is shared with every
+//! member, and the agent's conversation is not the mux's to publish.
+
+use std::{
+    error::Error,
+    io::{Read, Write},
+    os::unix::net::UnixStream,
+    path::PathBuf,
+    time::Duration,
+};
+
+use serde_json::Value;
+
+use crate::{
+    agent_detect::{AgentKind, AgentState},
+    local_ipc::ClientMessage,
+    pty_host::{PANE_ID_ENV, SOCKET_ENV},
+};
+
+/// Cap on the hook payload read from stdin. A degenerate multi-gigabyte stream
+/// must bound memory rather than buffer whole; a truncated read simply fails to
+/// parse and no-ops, which is the safe degradation.
+const MAX_STDIN_BYTES: u64 = 8 * 1024 * 1024;
+
+/// Bound on the socket write. The node accepts on its next loop iteration and
+/// the message is one short line, so this never trips in practice — it exists
+/// so a wedged node can never hold an agent's prompt open.
+const WRITE_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Claude's placeholder notification text. These carry no information about
+/// what is actually being asked, and firing "needs you" for them trains the
+/// user to ignore the state that matters most.
+const GENERIC_PENDING: [&str; 2] = ["Claude needs attention", "Claude Code needs your attention"];
+
+/// What a hook payload resolved to.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HookUpdate {
+    pub state: AgentState,
+    pub cwd: String,
+}
+
+/// Map a Claude hook event name to a status.
+///
+/// `Error` is deliberately unreachable here: Claude's hook vocabulary has no
+/// turn-level failure signal. `PostToolUse` carries a per-tool `is_error`, but
+/// a failed tool call mid-turn is ordinary agent behaviour — it recovers and
+/// continues — so mapping it to `Error` would paint healthy turns red.
+fn state_from_event(event: &str) -> Option<AgentState> {
+    match event {
+        "UserPromptSubmit" | "PreToolUse" | "PostToolUse" | "SubagentStop" => {
+            Some(AgentState::Working)
+        }
+        "Notification" => Some(AgentState::Pending),
+        "Stop" => Some(AgentState::Done),
+        "SessionEnd" => Some(AgentState::Idle),
+        _ => None,
+    }
+}
+
+/// Whether the last non-blank line of `message` ends in a question mark.
+///
+/// A question mark anywhere else does not count: "Want anything else? All tests
+/// pass." is a turn that finished on a statement.
+fn ends_with_a_question(message: &str) -> bool {
+    message
+        .lines()
+        .rev()
+        .find(|line| !line.trim().is_empty())
+        .is_some_and(|line| line.trim_end().ends_with('?'))
+}
+
+/// Decide what a Claude hook payload means. `None` is a deliberate no-op.
+///
+/// `status_arg` comes from the hook registration (`notify.sh running`) and wins
+/// over the payload's own event name, so one script serves every hook.
+pub fn derive_claude(raw: &str, status_arg: Option<&str>) -> Option<HookUpdate> {
+    let payload: Value = serde_json::from_str(raw).unwrap_or(Value::Null);
+    let message = payload
+        .get("message")
+        .and_then(Value::as_str)
+        .or_else(|| {
+            payload
+                .get("last_assistant_message")
+                .and_then(Value::as_str)
+        })
+        .unwrap_or_default();
+
+    let mut state = match status_arg {
+        // Strict: an unknown `--status` is refused, never folded to idle. A
+        // typo in a hook registration would otherwise blank every row it
+        // touched, and the user would have no idea why.
+        Some(argument) => AgentState::from_wire(argument)?,
+        None => state_from_event(payload.get("hook_event_name").and_then(Value::as_str)?)?,
+    };
+
+    // A turn that ends by asking something is blocked on a human, not
+    // finished. Claude surfaces tool-permission questions as `Notification`,
+    // but a plain prose question just fires `Stop` — which would show green
+    // and read as safe to ignore.
+    if state == AgentState::Done && ends_with_a_question(message) {
+        state = AgentState::Pending;
+    }
+
+    if state == AgentState::Pending {
+        let trimmed = message.trim();
+        if trimmed.is_empty() || GENERIC_PENDING.contains(&trimmed) {
+            return None;
+        }
+    }
+
+    let cwd = payload
+        .get("cwd")
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+        .or_else(|| {
+            std::env::current_dir()
+                .ok()
+                .map(|path| path.to_string_lossy().into_owned())
+        })
+        .unwrap_or_default();
+
+    Some(HookUpdate { state, cwd })
+}
+
+/// The pane this process is running in, and the node socket to report to.
+/// `None` outside a p2pmux pane, which is what makes the hook safe to leave
+/// enabled everywhere.
+fn pane_and_socket() -> Option<(u64, PathBuf)> {
+    let pane_id = std::env::var(PANE_ID_ENV).ok()?.parse().ok()?;
+    let socket = std::env::var_os(SOCKET_ENV)?;
+    Some((pane_id, PathBuf::from(socket)))
+}
+
+/// Read the hook payload from stdin, bounded.
+fn read_payload() -> String {
+    let mut raw = String::new();
+    let _ = std::io::stdin()
+        .lock()
+        .take(MAX_STDIN_BYTES)
+        .read_to_string(&mut raw);
+    raw
+}
+
+/// Send one pushed status to the node that owns this pane.
+fn send(pane_id: u64, socket: &PathBuf, kind: AgentKind, update: HookUpdate) -> Option<()> {
+    let message = ClientMessage::AgentStatus {
+        pane_id,
+        kind: kind.wire_value().to_owned(),
+        status: update.state.wire_value().to_owned(),
+        cwd: update.cwd,
+    };
+    let mut line = serde_json::to_vec(&message).ok()?;
+    line.push(b'\n');
+
+    let stream = UnixStream::connect(socket).ok()?;
+    stream.set_write_timeout(Some(WRITE_TIMEOUT)).ok()?;
+    (&stream).write_all(&line).ok()
+}
+
+/// Run the producer for one hook invocation.
+///
+/// Always `Ok`. Every failure path is a silent no-op by design — see the module
+/// documentation.
+pub fn run(kind: AgentKind, status_arg: Option<&str>) -> Result<(), Box<dyn Error>> {
+    let Some((pane_id, socket)) = pane_and_socket() else {
+        return Ok(());
+    };
+    let raw = read_payload();
+    let update = match kind {
+        AgentKind::Claude => derive_claude(&raw, status_arg),
+        // Other agents have no hook vocabulary wired up yet, but `--status`
+        // already makes this usable from any script that knows its own state.
+        _ => status_arg
+            .and_then(AgentState::from_wire)
+            .map(|state| HookUpdate {
+                state,
+                cwd: std::env::current_dir()
+                    .map(|path| path.to_string_lossy().into_owned())
+                    .unwrap_or_default(),
+            }),
+    };
+    if let Some(update) = update {
+        let _ = send(pane_id, &socket, kind, update);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn state(raw: &str, status_arg: Option<&str>) -> Option<AgentState> {
+        derive_claude(raw, status_arg).map(|update| update.state)
+    }
+
+    #[test]
+    fn events_map_to_states_when_no_status_is_given() {
+        assert_eq!(
+            state(r#"{"hook_event_name":"UserPromptSubmit"}"#, None),
+            Some(AgentState::Working)
+        );
+        assert_eq!(
+            state(r#"{"hook_event_name":"PostToolUse"}"#, None),
+            Some(AgentState::Working)
+        );
+        assert_eq!(
+            state(
+                r#"{"hook_event_name":"Notification","message":"approve?"}"#,
+                None
+            ),
+            Some(AgentState::Pending)
+        );
+        assert_eq!(
+            state(r#"{"hook_event_name":"Stop","message":"shipped it"}"#, None),
+            Some(AgentState::Done)
+        );
+        assert_eq!(
+            state(r#"{"hook_event_name":"SessionEnd"}"#, None),
+            Some(AgentState::Idle)
+        );
+        assert_eq!(state(r#"{"hook_event_name":"Whatever"}"#, None), None);
+    }
+
+    #[test]
+    fn an_explicit_status_wins_over_the_event() {
+        assert_eq!(
+            state(r#"{"hook_event_name":"Stop"}"#, Some("running")),
+            Some(AgentState::Working)
+        );
+        // A typo'd registration is refused rather than folded to idle, which
+        // would silently blank the row it meant to update.
+        assert_eq!(state(r#"{"hook_event_name":"Stop"}"#, Some("dnoe")), None);
+    }
+
+    #[test]
+    fn a_turn_that_ends_by_asking_reads_as_blocked_not_finished() {
+        // The single most misleading state the overlay can show: a green
+        // "done" on a turn that is actually waiting for an answer.
+        assert_eq!(
+            state(
+                r#"{"hook_event_name":"Stop","last_assistant_message":"Refactored auth.\n\nShould I update the tests?"}"#,
+                Some("done"),
+            ),
+            Some(AgentState::Pending)
+        );
+        // A question mark that is not the last thing said is just prose.
+        assert_eq!(
+            state(
+                r#"{"hook_event_name":"Stop","last_assistant_message":"Want anything else?\nAll tests pass."}"#,
+                Some("done"),
+            ),
+            Some(AgentState::Done)
+        );
+        // Trailing blank lines do not hide the question.
+        assert_eq!(
+            state(
+                r#"{"hook_event_name":"Stop","last_assistant_message":"Ready to push?\n\n  \n"}"#,
+                Some("done"),
+            ),
+            Some(AgentState::Pending)
+        );
+    }
+
+    #[test]
+    fn placeholder_notifications_never_claim_to_need_you() {
+        for message in [
+            "",
+            "   ",
+            "Claude needs attention",
+            "Claude Code needs your attention",
+        ] {
+            let raw = serde_json::json!({
+                "hook_event_name": "Notification",
+                "message": message,
+            })
+            .to_string();
+            assert_eq!(state(&raw, None), None, "{message:?} must not raise a flag");
+        }
+        // A real question still does.
+        let raw = r#"{"hook_event_name":"Notification","message":"Allow git push to origin?"}"#;
+        assert_eq!(state(raw, None), Some(AgentState::Pending));
+    }
+
+    #[test]
+    fn a_malformed_payload_is_a_no_op_not_an_error() {
+        // The hook runner pipes whatever it has; garbage must never reach the
+        // agent as a failure.
+        assert_eq!(state("not json at all", None), None);
+        assert_eq!(state("", None), None);
+        assert_eq!(state("{}", None), None);
+        // …but an explicit status still works without any payload at all,
+        // which is what makes this usable from a plain shell script.
+        assert_eq!(state("", Some("working")), Some(AgentState::Working));
+    }
+
+    #[test]
+    fn cwd_comes_from_the_payload_and_falls_back_to_the_process() {
+        let update = derive_claude(
+            r#"{"hook_event_name":"Stop","message":"ok","cwd":"/home/u/repo"}"#,
+            None,
+        )
+        .expect("update");
+        assert_eq!(update.cwd, "/home/u/repo");
+
+        let update =
+            derive_claude(r#"{"hook_event_name":"Stop","message":"ok"}"#, None).expect("update");
+        assert_eq!(
+            update.cwd,
+            std::env::current_dir()
+                .expect("current dir")
+                .to_string_lossy()
+                .into_owned()
+        );
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -70,6 +70,12 @@ enum Command {
         #[command(subcommand)]
         command: ConfigCommand,
     },
+    /// Report agent status from an agent hook. Run inside a p2pmux pane; a
+    /// no-op anywhere else, so it is safe to leave registered everywhere.
+    Notify {
+        #[command(subcommand)]
+        agent: NotifyAgent,
+    },
     #[command(name = "__node", hide = true)]
     Node {
         #[arg(long)]
@@ -82,6 +88,18 @@ enum ConfigCommand {
     Set { key: String, value: String },
     Get { key: String },
     Init,
+}
+
+#[derive(Debug, Subcommand)]
+enum NotifyAgent {
+    /// Read a Claude Code hook payload on stdin.
+    Claude {
+        /// The status this hook reports, when the registration knows it
+        /// (`running`, `pending`, `done`, `idle`, `error`). Without it the
+        /// payload's own `hook_event_name` decides.
+        #[arg(long)]
+        status: Option<String>,
+    },
 }
 
 const TRUST_WARNING: &str = "TRUST WARNING: This is a fully trusted shared-shell session. Anyone with the join ticket can see every pane and may obtain interactive control of available terminals (run commands, see output, touch files reachable to that macOS user).
@@ -116,9 +134,27 @@ impl std::fmt::Display for NodeStartupError {
 
 impl Error for NodeStartupError {}
 
-/// Parse process arguments and run a command.
-pub async fn parse_and_run() -> Result<(), Box<dyn Error>> {
-    run(Cli::parse()).await
+/// Parse process arguments.
+pub fn parse() -> Cli {
+    Cli::parse()
+}
+
+/// Run the commands that must not pay for an async runtime, returning `None`
+/// for everything else.
+///
+/// `notify` is spawned by an agent hook, which fires on every tool call. It
+/// writes one line to a unix socket and exits; standing up a multi-threaded
+/// Tokio runtime — a thread per core, created and torn down — to do that would
+/// cost more than the work, on the agent's own critical path.
+pub fn run_without_runtime(cli: &Cli) -> Option<Result<(), Box<dyn Error>>> {
+    match &cli.command {
+        Some(Command::Notify { agent }) => Some(match agent {
+            NotifyAgent::Claude { status } => {
+                crate::agent_notify::run(crate::agent_detect::AgentKind::Claude, status.as_deref())
+            }
+        }),
+        _ => None,
+    }
 }
 
 /// Hand this Mac's completion tuning to the detector, once per process.
@@ -136,7 +172,10 @@ fn apply_notification_tuning() {
     });
 }
 
-async fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
+pub async fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
+    if let Some(result) = run_without_runtime(&cli) {
+        return result;
+    }
     apply_notification_tuning();
     if cli.resume {
         return resume_picker(true);
@@ -156,6 +195,9 @@ async fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
             }
             result
         }
+        // Already handled by the `run_without_runtime` call above; reaching
+        // here would mean the two dispatches disagreed.
+        Some(Command::Notify { .. }) => Ok(()),
         Some(Command::Local) => crate::tui::run_local(),
         Some(Command::Config { command }) => match command {
             ConfigCommand::Init => {

--- a/src/client.rs
+++ b/src/client.rs
@@ -872,20 +872,18 @@ fn apply_rosters(
     view.update_attached_agent_rows(
         rosters
             .into_iter()
-            .filter_map(|row| {
-                Some(AgentOverlayRow {
-                    pane_id: row.pane_id,
-                    tab_ordinal: 0,
-                    pane_ordinal: 0,
-                    tab_label: String::new(),
-                    pane_label: String::new(),
-                    kind: row.kind,
-                    cwd: row.cwd,
-                    state: AgentRosterState::try_from(row.state).ok()?,
-                    working_since_unix_ms: row.working_since_unix_ms,
-                    host: row.host,
-                    controller: row.controller,
-                })
+            .map(|row| AgentOverlayRow {
+                pane_id: row.pane_id,
+                tab_ordinal: 0,
+                pane_ordinal: 0,
+                tab_label: String::new(),
+                pane_label: String::new(),
+                kind: row.kind,
+                cwd: row.cwd,
+                state: AgentRosterState::from_wire(row.state),
+                working_since_unix_ms: row.working_since_unix_ms,
+                host: row.host,
+                controller: row.controller,
             })
             .collect(),
     )

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,7 +9,7 @@ use serde::Deserialize;
 
 static CONFIG_WRITE_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
-const DEFAULT_CONFIG_TEMPLATE: &str = "# p2pmux local configuration\n#\n# display_name is visible to peers.\n# display_name = \"your-name\"\n\n# UI chrome is local to this client and is never shared with session peers.\n[ui.theme]\n# Named colors: white, yellow, gray, dark_gray\n# Hex colors: #RRGGBB\n#\n# footer_background = \"#1e1e1e\"\n# footer_muted = \"white\"\n# footer_accent = \"#dc322f\"\n# footer_orange = \"#ff7846\"\n# tab_active_background = \"#dc322f\"\n# tab_foreground = \"white\"\n# tab_separator = \"dark_gray\"\n# copy_feedback_accent = \"#ff4500\"\n# agent_overlay_chrome = \"#ff4500\"\n# agent_overlay_selected_background = \"#2a2a2a\"\n# agent_overlay_muted = \"#919db4\"\n# agent_overlay_warm = \"#ffb84d\"\n# agent_overlay_foreground = \"white\"\n# agent_overlay_secondary = \"gray\"\n# pane_border_free_focused = \"white\"\n# pane_border_unknown_focused = \"yellow\"\n# pane_border_chord_focused = \"#ff1a1a\"\n# pane_border_hovered = \"gray\"\n# pane_border_idle = \"dark_gray\"\n# pane_border_remote_control = \"#ff4500\"\n\n[ui.notifications]\n# Set false to keep agent-completion stars without playing a sound.\nsound_enabled = true\n# sound_path = \"/path/to/custom.aiff\"\n#\n# An agent counts as finished after this many seconds of silence. Agents pause for a\n# long time mid-task (waiting on a model response, running a quiet tool), so a small\n# value reports unfinished work as finished. Clamped to 5-3600.\n# quiet_seconds = 20\n#\n# Only finish on an explicit signal from the agent (a terminal bell) and never on the\n# silence timer above. Removes every false notification, but an agent that does not\n# ring will show as working until it exits.\n# require_bell = false\n";
+const DEFAULT_CONFIG_TEMPLATE: &str = "# p2pmux local configuration\n#\n# display_name is visible to peers.\n# display_name = \"your-name\"\n\n# UI chrome is local to this client and is never shared with session peers.\n[ui.theme]\n# Named colors: white, yellow, gray, dark_gray\n# Hex colors: #RRGGBB\n#\n# footer_background = \"#1e1e1e\"\n# footer_muted = \"white\"\n# footer_accent = \"#dc322f\"\n# footer_orange = \"#ff7846\"\n# tab_active_background = \"#dc322f\"\n# tab_foreground = \"white\"\n# tab_separator = \"dark_gray\"\n# copy_feedback_accent = \"#ff4500\"\n# agent_overlay_chrome = \"#ff4500\"\n# agent_overlay_selected_background = \"#2a2a2a\"\n# agent_overlay_muted = \"#919db4\"\n# agent_overlay_warm = \"#ffb84d\"\n# agent_overlay_attention = \"#ffb000\"\n# agent_overlay_error = \"#dc322f\"\n# agent_overlay_foreground = \"white\"\n# agent_overlay_secondary = \"gray\"\n# pane_border_free_focused = \"white\"\n# pane_border_unknown_focused = \"yellow\"\n# pane_border_chord_focused = \"#ff1a1a\"\n# pane_border_hovered = \"gray\"\n# pane_border_idle = \"dark_gray\"\n# pane_border_remote_control = \"#ff4500\"\n\n[ui.notifications]\n# Set false to keep agent-completion stars without playing a sound.\nsound_enabled = true\n# sound_path = \"/path/to/custom.aiff\"\n#\n# An agent counts as finished after this many seconds of silence. Agents pause for a\n# long time mid-task (waiting on a model response, running a quiet tool), so a small\n# value reports unfinished work as finished. Clamped to 5-3600.\n# quiet_seconds = 20\n#\n# Only finish on an explicit signal from the agent (a terminal bell) and never on the\n# silence timer above. Removes every false notification, but an agent that does not\n# ring will show as working until it exits.\n# require_bell = false\n";
 
 #[derive(Debug)]
 pub enum ConfigError {
@@ -91,6 +91,8 @@ pub struct UiTheme {
     pub agent_overlay_selected_background: Color,
     pub agent_overlay_muted: Color,
     pub agent_overlay_warm: Color,
+    pub agent_overlay_attention: Color,
+    pub agent_overlay_error: Color,
     pub agent_overlay_foreground: Color,
     pub agent_overlay_secondary: Color,
     pub pane_border_free_focused: Color,
@@ -116,6 +118,8 @@ impl Default for UiTheme {
             agent_overlay_selected_background: Color::Rgb(42, 42, 42),
             agent_overlay_muted: Color::Rgb(145, 157, 180),
             agent_overlay_warm: Color::Rgb(255, 184, 77),
+            agent_overlay_attention: Color::Rgb(255, 176, 0),
+            agent_overlay_error: Color::Rgb(220, 50, 47),
             agent_overlay_foreground: Color::White,
             agent_overlay_secondary: Color::Gray,
             pane_border_free_focused: Color::White,
@@ -165,6 +169,8 @@ struct UiThemeFile {
     agent_overlay_selected_background: Option<String>,
     agent_overlay_muted: Option<String>,
     agent_overlay_warm: Option<String>,
+    agent_overlay_attention: Option<String>,
+    agent_overlay_error: Option<String>,
     agent_overlay_foreground: Option<String>,
     agent_overlay_secondary: Option<String>,
     pane_border_free_focused: Option<String>,
@@ -276,6 +282,16 @@ pub fn load_config_from(path: &Path) -> Result<Config, ConfigError> {
         &mut theme.agent_overlay_warm,
         config.ui.theme.agent_overlay_warm,
         "agent_overlay_warm",
+    )?;
+    apply_color(
+        &mut theme.agent_overlay_attention,
+        config.ui.theme.agent_overlay_attention,
+        "agent_overlay_attention",
+    )?;
+    apply_color(
+        &mut theme.agent_overlay_error,
+        config.ui.theme.agent_overlay_error,
+        "agent_overlay_error",
     )?;
     apply_color(
         &mut theme.agent_overlay_foreground,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![forbid(unsafe_code)]
 
 pub mod agent_detect;
+pub mod agent_notify;
 pub mod cli;
 pub mod client;
 pub mod config;

--- a/src/local_ipc.rs
+++ b/src/local_ipc.rs
@@ -57,6 +57,24 @@ pub enum ClientMessage {
     Rename {
         name: String,
     },
+    /// A status pushed by a producer running inside a pane — an agent hook.
+    ///
+    /// Unlike every other message here, the sender is not the attached client:
+    /// it is a short-lived process that connects, writes this one line, and
+    /// exits. It is handled like `Probe` — as a one-shot control request that
+    /// never touches the single interactive attachment slot.
+    ///
+    /// `pane_id` is a claim, not an authority. The node accepts it only for a
+    /// pane it hosts itself, which is what confines a producer to the machine
+    /// it runs on; the peer-facing half of that check already lives in
+    /// `Coordinator::accept_agent_roster`.
+    AgentStatus {
+        pane_id: u64,
+        kind: String,
+        status: String,
+        #[serde(default)]
+        cwd: String,
+    },
     Shutdown {
         generation: u64,
     },

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,20 @@
 use std::process::ExitCode;
 
-#[tokio::main]
-async fn main() -> ExitCode {
+fn main() -> ExitCode {
+    let cli = p2pmux::cli::parse();
+    // Some commands must not pay to start a runtime — see `run_without_runtime`.
+    // Everything else gets one.
+    let result = match p2pmux::cli::run_without_runtime(&cli) {
+        Some(result) => result,
+        None => match tokio::runtime::Runtime::new() {
+            Ok(runtime) => runtime.block_on(p2pmux::cli::run(cli)),
+            Err(error) => Err(error.into()),
+        },
+    };
     // Returning Result from main would print the error with Debug, which shows users
     // Rust internals like `Custom { kind: TimedOut, error: "..." }` instead of the
     // message the error actually carries. Print Display and pick the exit code here.
-    if let Err(error) = p2pmux::cli::parse_and_run().await {
+    if let Err(error) = result {
         eprintln!("Error: {error}");
         return ExitCode::FAILURE;
     }

--- a/src/node.rs
+++ b/src/node.rs
@@ -108,6 +108,9 @@ pub fn read_bootstrap(path: &std::path::Path) -> io::Result<NodeBootstrap> {
 pub async fn run_background(bootstrap: NodeBootstrap) -> Result<(), Box<dyn Error>> {
     let mut descriptor = bootstrap.descriptor.clone();
     descriptor.node_pid = std::process::id();
+    // Before the first pane spawns: every PTY this node opens inherits the
+    // socket path from here, and pane 1 is created a few lines below.
+    crate::pty_host::set_agent_socket_path(descriptor.socket_path.clone());
     let (mut node, dispatcher_task, rendezvous) = match bootstrap.kind {
         NodeBootstrapKind::Create {
             display_name,

--- a/src/node.rs
+++ b/src/node.rs
@@ -252,6 +252,20 @@ fn run_socket_loop(
                         Ok(Some(ClientMessage::Probe)) => {
                             let _ = write_message(reader.get_mut(), &NodeMessage::ProbeAck);
                         }
+                        // Like a probe: a one-shot request from a short-lived
+                        // process, not the interactive client, so it must not
+                        // contend for the single attachment slot. The producer
+                        // gets no reply — it has already exited by the time one
+                        // could be written, and a hook that blocks on the mux
+                        // is a hook that stalls the agent it is reporting on.
+                        Ok(Some(ClientMessage::AgentStatus {
+                            pane_id,
+                            kind,
+                            status,
+                            cwd,
+                        })) => {
+                            did_work |= node.apply_agent_status(pane_id, &kind, &status, &cwd);
+                        }
                         Ok(Some(ClientMessage::Shutdown { generation })) => {
                             let _ = write_message(
                                 reader.get_mut(),
@@ -1282,6 +1296,15 @@ impl SharedLayoutNode {
     }
     pub fn intent(&mut self, intent: crate::tui::UiIntent) -> Result<(), Box<dyn Error>> {
         self.runtime.node_intent(intent)
+    }
+    pub fn apply_agent_status(
+        &mut self,
+        pane_id: u64,
+        kind: &str,
+        status: &str,
+        cwd: &str,
+    ) -> bool {
+        self.runtime.apply_agent_status(pane_id, kind, status, cwd)
     }
     pub fn shutdown(self) {
         self.runtime.shutdown_node();

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -565,6 +565,22 @@ pub enum AgentRosterState {
     Done = 2,
 }
 
+impl AgentRosterState {
+    /// Decode a wire state, folding anything this build does not recognize into
+    /// `Idle`.
+    ///
+    /// A peer on a newer build may publish a state this binary has no variant
+    /// for. Refusing it is not an option: `validate_agent_roster` runs inside
+    /// `validate_envelope`, so a rejection fails `decode_frame`, and
+    /// `FrameReader::read_next` turns that into a transport error that drops the
+    /// whole peer stream. One unknown enum value would disconnect the session
+    /// rather than dim one overlay row, so unknown states degrade to the
+    /// quietest state instead.
+    pub fn from_wire(raw: i32) -> Self {
+        Self::try_from(raw).unwrap_or(Self::Idle)
+    }
+}
+
 pub fn encode_frame(envelope: &Envelope) -> Result<Vec<u8>, ProtocolError> {
     validate_envelope(envelope)?;
 
@@ -873,10 +889,7 @@ fn validate_agent_roster(roster: &AgentRoster) -> Result<(), ProtocolError> {
             entry.agent_kind.len(),
             MAX_AGENT_KIND_BYTES,
         )?;
-        if !matches!(
-            entry.agent_kind.as_str(),
-            "claude" | "codex" | "cursor" | "pi" | "opencode"
-        ) {
+        if !is_agent_kind_token(&entry.agent_kind) {
             return Err(ProtocolError::InvalidLayout(
                 "agent_roster.entry.agent_kind",
             ));
@@ -886,10 +899,26 @@ fn validate_agent_roster(roster: &AgentRoster) -> Result<(), ProtocolError> {
             entry.cwd.len(),
             MAX_AGENT_CWD_BYTES,
         )?;
-        AgentRosterState::try_from(entry.state)
-            .map_err(|_| ProtocolError::InvalidLayout("agent_roster.entry.state"))?;
+        // `entry.state` is deliberately not checked against the known variants:
+        // see `AgentRosterState::from_wire`. Readers fold an unknown state to
+        // `Idle` instead of failing the frame.
     }
     Ok(())
+}
+
+/// Whether an agent kind is a well-formed slug: non-empty lowercase ASCII
+/// letters, digits, and dashes.
+///
+/// This checks the shape rather than a closed set of known agents on purpose.
+/// The shape check is what actually protects the overlay — it keeps control
+/// characters, ANSI, and newlines out of a rendered cell — while a closed set
+/// would additionally make every newly supported agent a connection-tearing
+/// protocol break, for the same reason unknown states cannot be rejected.
+fn is_agent_kind_token(kind: &str) -> bool {
+    !kind.is_empty()
+        && kind
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
 }
 
 fn validate_id(field: &'static str, bytes: &[u8], limit: usize) -> Result<(), ProtocolError> {

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -563,9 +563,51 @@ pub enum AgentRosterState {
     Idle = 0,
     Working = 1,
     Done = 2,
+    /// The agent is blocked on a human: a permission prompt, an elicitation
+    /// dialog, or a turn that ended by asking a question. Only a producer that
+    /// hooks the agent can report this — no amount of output-timing inference
+    /// distinguishes "waiting on you" from "waiting on the model".
+    Pending = 3,
+    /// The agent's turn failed.
+    Error = 4,
 }
 
 impl AgentRosterState {
+    /// Rank for aggregation and ordering: `Error > Pending > Working > Done >
+    /// Idle`. Failures outrank everything so they never hide behind a spinner,
+    /// and a blocked agent outranks a busy one because only the first needs a
+    /// human.
+    ///
+    /// Severity is a method rather than the enum's own `Ord` because the
+    /// discriminants are wire values that predate these variants and cannot be
+    /// renumbered — `Working = 1` and `Done = 2` are already on the wire, so
+    /// declaration order and severity order are permanently divorced.
+    pub fn severity(self) -> u8 {
+        match self {
+            Self::Idle => 0,
+            Self::Done => 1,
+            Self::Working => 2,
+            Self::Pending => 3,
+            Self::Error => 4,
+        }
+    }
+
+    /// States that are actively blocked on a human. Drives the overlay's
+    /// needs-you badge. Distinct from [`Self::needs_attention`]: a finished
+    /// agent is worth a glance, but it is not holding anyone up.
+    pub fn needs_you(self) -> bool {
+        matches!(self, Self::Pending | Self::Error)
+    }
+
+    /// States worth putting a human's eyes on, including a finished turn.
+    pub fn needs_attention(self) -> bool {
+        matches!(self, Self::Pending | Self::Error | Self::Done)
+    }
+
+    /// A turn that ended, either way.
+    pub fn is_completion(self) -> bool {
+        matches!(self, Self::Done | Self::Error)
+    }
     /// Decode a wire state, folding anything this build does not recognize into
     /// `Idle`.
     ///

--- a/src/pty_host.rs
+++ b/src/pty_host.rs
@@ -4,12 +4,38 @@ use std::{
     error::Error,
     ffi::OsString,
     io::{Read, Write},
-    path::Path,
-    sync::mpsc::{self, Receiver, TryRecvError},
+    path::{Path, PathBuf},
+    sync::{
+        OnceLock,
+        mpsc::{self, Receiver, TryRecvError},
+    },
     thread::{self, JoinHandle},
 };
 
 use portable_pty::{Child, CommandBuilder, MasterPty, PtySize, native_pty_system};
+
+/// Environment variable naming the pane a process is running in.
+pub const PANE_ID_ENV: &str = "P2PMUX_PANE_ID";
+/// Environment variable naming this node's local IPC socket.
+pub const SOCKET_ENV: &str = "P2PMUX_SOCK";
+
+static AGENT_SOCKET_PATH: OnceLock<PathBuf> = OnceLock::new();
+
+/// Publish this node's local IPC socket path to every PTY spawned afterwards.
+///
+/// Together with `P2PMUX_PANE_ID`, this is what lets a program running inside a
+/// pane — an agent hook, a build script — report back to the mux: it knows
+/// which pane it is and where to say so. Both are set on the pane's PTY rather
+/// than inherited from the client, because a peer's client process is on a
+/// different machine from the node that owns the pane.
+///
+/// The path is process-global rather than a spawn argument because the socket
+/// belongs to the node, not to any one pane; this mirrors how `agent_detect`
+/// installs its notification tuning. Called once during node startup before the
+/// first pane spawns; later calls are ignored.
+pub fn set_agent_socket_path(path: PathBuf) {
+    let _ = AGENT_SOCKET_PATH.set(path);
+}
 
 /// The single local shell PTY used by the Spike 1 terminal.
 pub struct PtyHost {
@@ -60,18 +86,29 @@ impl PtyHost {
 
     /// Spawn the user's login shell, or `/bin/zsh` when `SHELL` is unset.
     pub fn spawn_default_shell(size: PtySize) -> Result<Self, Box<dyn Error>> {
-        Self::spawn_default_shell_with_cwd(size, None)
+        Self::spawn_default_shell_with_cwd(size, None, None)
     }
 
     /// Spawn the user's login shell with an optional working directory.
+    ///
+    /// `pane_id` is `None` for the shells that are not roster panes — the plain
+    /// `p2pmux local` terminal and the single-pane host runtime — so nothing
+    /// running in them can claim to be a pane that exists.
     pub fn spawn_default_shell_with_cwd(
         size: PtySize,
         cwd: Option<&Path>,
+        pane_id: Option<u64>,
     ) -> Result<Self, Box<dyn Error>> {
         let shell = std::env::var_os("SHELL").unwrap_or_else(|| OsString::from("/bin/zsh"));
         let mut command = CommandBuilder::new(shell);
         command.arg("-l");
         command.env("TERM", "xterm-256color");
+        if let Some(pane_id) = pane_id {
+            command.env(PANE_ID_ENV, pane_id.to_string());
+            if let Some(socket) = AGENT_SOCKET_PATH.get() {
+                command.env(SOCKET_ENV, socket);
+            }
+        }
         if let Some(cwd) = cwd {
             command.cwd(cwd);
         }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -3769,9 +3769,11 @@ impl SharedLocalPane {
             pixel_height: 0,
         };
         let cwd = cwd.filter(|path| path.is_dir());
-        let host = match PtyHost::spawn_default_shell_with_cwd(size, cwd) {
+        let host = match PtyHost::spawn_default_shell_with_cwd(size, cwd, Some(pane_id)) {
             Ok(host) => host,
-            Err(_) if cwd.is_some_and(|path| !path.is_dir()) => PtyHost::spawn_default_shell(size)?,
+            Err(_) if cwd.is_some_and(|path| !path.is_dir()) => {
+                PtyHost::spawn_default_shell_with_cwd(size, None, Some(pane_id))?
+            }
             Err(error) => return Err(error),
         };
         let screen = HostScreen::new(grid_rows, grid_cols)?;

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -3954,8 +3954,11 @@ impl SharedLocalPane {
     fn apply_agent_snapshot(&mut self, scan: &AgentScan<'_>, now: Instant) -> bool {
         let unix_ms_now = unix_ms_now();
         let before = self.agent_tracker.listed_agent(now, unix_ms_now);
-        let detected = self.host.process_id().and_then(|pid| scan.classify(pid));
+        let session_child = self.host.process_id();
+        let detected = session_child.and_then(|pid| scan.classify(pid));
         self.agent_tracker.update(detected, now, unix_ms_now);
+        self.agent_tracker
+            .observe_pane_liveness(session_child.is_some_and(|pid| scan.has_children(pid)), now);
         self.agent_tracker.listed_agent(now, unix_ms_now) != before
     }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -3324,11 +3324,17 @@ fn render_agents_overlay(frame: &mut Frame<'_>, tui: &MultiPaneTui, now_unix_ms:
     let area = frame.area();
     let panel = agents_overlay_panel(area);
     frame.render_widget(Clear, panel);
+    let needs_you = tui.agent_rows.iter().any(|row| row.state.needs_you());
+    let title_color = if needs_you {
+        tui.theme.agent_overlay_attention
+    } else {
+        tui.theme.agent_overlay_chrome
+    };
     let block = Block::bordered()
         .title(Line::styled(
-            " Agents ",
+            agents_overlay_title(&tui.agent_rows),
             Style::default()
-                .fg(tui.theme.agent_overlay_chrome)
+                .fg(title_color)
                 .add_modifier(Modifier::BOLD),
         ))
         .border_style(Style::default().fg(tui.theme.agent_overlay_chrome));
@@ -3506,6 +3512,30 @@ fn render_delete_tab_confirmation(frame: &mut Frame<'_>, pane_count: usize, them
     );
 }
 
+/// Colour for a state's glyph and label. `Working` keeps the chrome accent it
+/// has always had; the two states that want a human get their own roles so a
+/// blocked or failed agent never reads as ordinary muted text.
+fn agent_overlay_state_color(state: AgentRosterState, theme: &UiTheme) -> Color {
+    match state {
+        AgentRosterState::Working => theme.agent_overlay_chrome,
+        AgentRosterState::Pending => theme.agent_overlay_attention,
+        AgentRosterState::Error => theme.agent_overlay_error,
+        AgentRosterState::Idle | AgentRosterState::Done => theme.agent_overlay_muted,
+    }
+}
+
+/// Overlay title, carrying a count of agents blocked on a human when there are
+/// any. The whole point of opening the overlay is finding those, so the count
+/// belongs where it is readable before the eye reaches the cards.
+fn agents_overlay_title(rows: &[AgentOverlayRow]) -> String {
+    let needs_you = rows.iter().filter(|row| row.state.needs_you()).count();
+    match needs_you {
+        0 => String::from(" Agents "),
+        1 => String::from(" Agents · 1 needs you "),
+        count => format!(" Agents · {count} need you "),
+    }
+}
+
 fn format_agent_overlay_card(
     row: &AgentOverlayRow,
     selected: bool,
@@ -3552,7 +3582,10 @@ fn format_agent_overlay_card(
         ),
         AgentRosterState::Idle => ("○", "idle", None),
         AgentRosterState::Done => ("✓", "done", None),
+        AgentRosterState::Pending => ("◆", "needs you", None),
+        AgentRosterState::Error => ("✗", "error", None),
     };
+    let state_color = agent_overlay_state_color(row.state, theme);
     let location = format!(
         " · {} · {} · host: {}",
         truncate_trailing(&row.tab_label, usize::from(width / 3)),
@@ -3571,24 +3604,16 @@ fn format_agent_overlay_card(
     );
     let controller = (controller_width > 0)
         .then(|| truncate_trailing(&row.controller, usize::from(controller_width)));
+    let mut state_style = Style::default().fg(state_color);
+    if row.state.needs_you() {
+        // A blocked agent is the one row in the overlay that is costing someone
+        // time right now, so it gets the only weight in the state column.
+        state_style = state_style.add_modifier(Modifier::BOLD);
+    }
     let mut second_spans = vec![
-        Span::styled(
-            glyph,
-            Style::default().fg(if row.state == AgentRosterState::Working {
-                theme.agent_overlay_chrome
-            } else {
-                theme.agent_overlay_muted
-            }),
-        ),
+        Span::styled(glyph, Style::default().fg(state_color)),
         Span::raw(" "),
-        Span::styled(
-            state,
-            Style::default().fg(if row.state == AgentRosterState::Working {
-                theme.agent_overlay_foreground
-            } else {
-                theme.agent_overlay_muted
-            }),
-        ),
+        Span::styled(state, state_style),
     ];
     if let Some(elapsed) = elapsed {
         second_spans.push(Span::raw(" "));
@@ -7608,6 +7633,77 @@ mod tests {
             &UiTheme::default(),
         );
         assert!(future[1].to_string().starts_with("◐ working 0s"));
+    }
+
+    #[test]
+    fn agents_overlay_cards_mark_blocked_and_failed_agents() {
+        use crate::protocol::AgentRosterState;
+
+        let theme = UiTheme::default();
+        let mut row = agent_row(2, 2, 1);
+
+        row.state = AgentRosterState::Pending;
+        let pending =
+            super::format_agent_overlay_card(&row, false, 120, 1_725_000_000_123, 0, &theme);
+        assert!(pending[1].to_string().starts_with("◆ needs you"));
+        // A blocked agent is the one row costing someone time, so it carries
+        // the attention colour and the only weight in the state column.
+        let state_span = &pending[1].spans[2];
+        assert_eq!(state_span.style.fg, Some(theme.agent_overlay_attention));
+        assert!(state_span.style.add_modifier.contains(Modifier::BOLD));
+
+        row.state = AgentRosterState::Error;
+        let error =
+            super::format_agent_overlay_card(&row, false, 120, 1_725_000_000_123, 0, &theme);
+        assert!(error[1].to_string().starts_with("✗ error"));
+        assert_eq!(error[1].spans[2].style.fg, Some(theme.agent_overlay_error));
+
+        // Working keeps the chrome accent and stays unweighted.
+        row.state = AgentRosterState::Working;
+        let working =
+            super::format_agent_overlay_card(&row, false, 120, 1_725_000_000_123, 0, &theme);
+        assert_eq!(
+            working[1].spans[2].style.fg,
+            Some(theme.agent_overlay_chrome)
+        );
+        assert!(
+            !working[1].spans[2]
+                .style
+                .add_modifier
+                .contains(Modifier::BOLD)
+        );
+    }
+
+    #[test]
+    fn agents_overlay_title_counts_agents_blocked_on_a_human() {
+        use crate::protocol::AgentRosterState;
+
+        let working = agent_row(1, 1, 1);
+        assert_eq!(super::agents_overlay_title(&[]), " Agents ");
+        assert_eq!(
+            super::agents_overlay_title(std::slice::from_ref(&working)),
+            " Agents "
+        );
+
+        let mut pending = agent_row(2, 1, 2);
+        pending.state = AgentRosterState::Pending;
+        assert_eq!(
+            super::agents_overlay_title(&[working.clone(), pending.clone()]),
+            " Agents · 1 needs you "
+        );
+
+        // Errors count too: a failed turn is blocking whoever asked for it.
+        let mut failed = agent_row(3, 1, 3);
+        failed.state = AgentRosterState::Error;
+        assert_eq!(
+            super::agents_overlay_title(&[working.clone(), pending, failed]),
+            " Agents · 2 need you "
+        );
+
+        // A finished agent is worth a glance but is not holding anyone up.
+        let mut done = agent_row(4, 1, 4);
+        done.state = AgentRosterState::Done;
+        assert_eq!(super::agents_overlay_title(&[working, done]), " Agents ");
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -12,7 +12,7 @@ use std::{
     process::{Command, Stdio},
     sync::{
         Arc, Mutex, OnceLock,
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicU64, Ordering},
         mpsc::{self as sync_mpsc, Receiver},
     },
     thread::{self, JoinHandle},
@@ -49,8 +49,8 @@ use ratatui::{
 
 use crate::{
     agent_detect::{
-        AgentKind, AgentState, PaneAgentTracker, ProcessSnapshot, SysinfoSampler,
-        classify_pane_tree, cwd_for_pid, sample_global_snapshot,
+        AgentKind, AgentScan, AgentState, PaneAgentTracker, ProcessSnapshot, SysinfoSampler,
+        cwd_for_pid, sample_global_snapshot,
     },
     config::UiTheme,
     kitty_keyboard::KittyKeyboardTracker,
@@ -113,7 +113,14 @@ fn unix_ms_now() -> u64 {
         .map(|duration| duration.as_millis() as u64)
         .unwrap_or(0)
 }
+/// Scan cadence while any pane's agent state is being inferred from output
+/// timing. Inference has to notice silence promptly, so this is the floor.
 const AGENT_SAMPLE_INTERVAL: Duration = Duration::from_secs(1);
+/// Scan cadence when nothing needs inference — no agents at all, or every agent
+/// reporting through a hook. The scan is then only watching for a process to
+/// appear or exit, and a full `sysinfo` refresh of every process on the machine
+/// once a second to do that is most of this process's idle cost.
+const AGENT_WATCH_INTERVAL: Duration = Duration::from_secs(5);
 pub(crate) const AGENT_TOGGLE_WINDOW: Duration = Duration::from_millis(200);
 pub(crate) const AGENT_OVERLAY_ANIMATION_INTERVAL: Duration = Duration::from_millis(100);
 const AGENT_OVERLAY_CARD_LINES: usize = 3;
@@ -3944,15 +3951,19 @@ impl SharedLocalPane {
         })
     }
 
-    fn apply_agent_snapshot(&mut self, processes: &[ProcessSnapshot], now: Instant) -> bool {
+    fn apply_agent_snapshot(&mut self, scan: &AgentScan<'_>, now: Instant) -> bool {
         let unix_ms_now = unix_ms_now();
         let before = self.agent_tracker.listed_agent(now, unix_ms_now);
-        let detected = self
-            .host
-            .process_id()
-            .and_then(|pid| classify_pane_tree(pid, processes));
+        let detected = self.host.process_id().and_then(|pid| scan.classify(pid));
         self.agent_tracker.update(detected, now, unix_ms_now);
         self.agent_tracker.listed_agent(now, unix_ms_now) != before
+    }
+
+    /// Whether this pane's reported state comes from output-timing inference
+    /// rather than a producer inside it — the only case that needs the fast
+    /// sampler cadence, since only inference has to notice silence promptly.
+    fn agent_state_is_inferred(&self) -> bool {
+        self.agent_tracker.active_agent.is_some() && !self.agent_tracker.has_owning_push()
     }
 
     fn agent_roster_entry(&mut self, now: Instant) -> Option<AgentRosterEntry> {
@@ -4075,6 +4086,7 @@ struct LocalPaneDrain {
 struct AgentSamplingWorker {
     snapshots: Receiver<Vec<ProcessSnapshot>>,
     stop: Arc<AtomicBool>,
+    interval_ms: Arc<AtomicU64>,
     join: Option<JoinHandle<()>>,
 }
 
@@ -4082,7 +4094,9 @@ impl AgentSamplingWorker {
     fn spawn() -> Self {
         let (snapshot_tx, snapshots) = sync_mpsc::channel();
         let stop = Arc::new(AtomicBool::new(false));
+        let interval_ms = Arc::new(AtomicU64::new(AGENT_SAMPLE_INTERVAL.as_millis() as u64));
         let worker_stop = stop.clone();
+        let worker_interval = interval_ms.clone();
         let join = thread::spawn(move || {
             let mut sampler = SysinfoSampler::default();
             while !worker_stop.load(Ordering::Relaxed) {
@@ -4092,14 +4106,31 @@ impl AgentSamplingWorker {
                 {
                     break;
                 }
-                thread::sleep(AGENT_SAMPLE_INTERVAL);
+                thread::sleep(Duration::from_millis(
+                    worker_interval.load(Ordering::Relaxed),
+                ));
             }
         });
         Self {
             snapshots,
             stop,
+            interval_ms,
             join: Some(join),
         }
+    }
+
+    /// Set how often the global process scan runs.
+    ///
+    /// The scan is the single most expensive thing this process does when
+    /// nothing is happening — a full `sysinfo` refresh of every process on the
+    /// machine, with exe, cmdline and cwd. It only needs the fast cadence when
+    /// a pane's state is being *inferred* from output timing, which is the one
+    /// case that depends on noticing silence promptly. Panes whose agent
+    /// reports through a hook, and panes with no agent at all, only need the
+    /// scan for liveness and for spotting a new launch.
+    fn set_interval(&self, interval: Duration) {
+        self.interval_ms
+            .store(interval.as_millis() as u64, Ordering::Relaxed);
     }
 
     fn latest_snapshot(&self) -> Option<Vec<ProcessSnapshot>> {
@@ -5236,11 +5267,20 @@ impl SharedLayoutRuntime {
         self.send_pending_exit_marks()?;
         if let Some(snapshot) = self.agent_sampler.latest_snapshot() {
             let now = Instant::now();
+            // One scan for the whole session, not one per pane.
+            let scan = AgentScan::new(&snapshot);
+            let mut inferred_agents = false;
             for pane in self.local.values_mut() {
                 if !pane.exited {
-                    changed |= pane.apply_agent_snapshot(&snapshot, now);
+                    changed |= pane.apply_agent_snapshot(&scan, now);
+                    inferred_agents |= pane.agent_state_is_inferred();
                 }
             }
+            self.agent_sampler.set_interval(if inferred_agents {
+                AGENT_SAMPLE_INTERVAL
+            } else {
+                AGENT_WATCH_INTERVAL
+            });
         }
         changed |= self.publish_local_agent_roster();
         let disconnected = self

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -5291,7 +5291,7 @@ impl SharedLayoutRuntime {
                             .unwrap_or_else(|| format!("Pane #{pane_ordinal}")),
                         kind: sanitize_single_line(&entry.agent_kind),
                         cwd: sanitize_single_line(&entry.cwd),
-                        state: AgentRosterState::try_from(entry.state).ok()?,
+                        state: AgentRosterState::from_wire(entry.state),
                         working_since_unix_ms: entry.working_since_unix_ms,
                         host,
                         controller,

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -49,8 +49,8 @@ use ratatui::{
 
 use crate::{
     agent_detect::{
-        PaneAgentTracker, ProcessSnapshot, SysinfoSampler, classify_pane_tree, cwd_for_pid,
-        sample_global_snapshot,
+        AgentKind, AgentState, PaneAgentTracker, ProcessSnapshot, SysinfoSampler,
+        classify_pane_tree, cwd_for_pid, sample_global_snapshot,
     },
     config::UiTheme,
     kitty_keyboard::KittyKeyboardTracker,
@@ -61,8 +61,9 @@ use crate::{
     local_ipc::AgentOverlaySnapshotRow,
     protocol::{
         AgentRoster, AgentRosterEntry, AgentRosterState, CreatePane, CreateTab, DeletePane,
-        DeleteTab, LayoutRequest, MarkPaneExited, NewPanePosition as ProtocolNewPanePosition,
-        PaneDescriptor, PaneFailed, PaneReady, RenamePane, RenameTab, SetPaneLock, SplitAxis,
+        DeleteTab, LayoutRequest, MAX_AGENT_CWD_BYTES, MarkPaneExited,
+        NewPanePosition as ProtocolNewPanePosition, PaneDescriptor, PaneFailed, PaneReady,
+        RenamePane, RenameTab, SetPaneLock, SplitAxis,
     },
     pty_host::PtyHost,
     screen::{GuestScreen, HostScreen, SCROLLBACK_LINES, ScreenFrame, SyncGate},
@@ -3726,6 +3727,18 @@ fn sanitize_single_line(value: &str) -> String {
         .collect()
 }
 
+/// Cut `text` to at most `limit` bytes on a character boundary.
+fn truncate_bytes(mut text: String, limit: usize) -> String {
+    if text.len() > limit {
+        let end = (0..=limit)
+            .rev()
+            .find(|index| text.is_char_boundary(*index))
+            .unwrap_or(0);
+        text.truncate(end);
+    }
+    text
+}
+
 /// One fixed-grid PTY owned by this process. Its watch channels are registered with the pane
 /// service before the layout coordinator is told that the pane is ready.
 pub struct SharedLocalPane {
@@ -3952,9 +3965,11 @@ impl SharedLocalPane {
                 crate::agent_detect::AgentState::Idle => AgentRosterState::Idle as i32,
                 crate::agent_detect::AgentState::Working => AgentRosterState::Working as i32,
                 crate::agent_detect::AgentState::Done => AgentRosterState::Done as i32,
+                crate::agent_detect::AgentState::Pending => AgentRosterState::Pending as i32,
+                crate::agent_detect::AgentState::Error => AgentRosterState::Error as i32,
             },
             working_since_unix_ms: if state == crate::agent_detect::AgentState::Working {
-                self.agent_tracker.working_since_unix_ms
+                self.agent_tracker.reported_working_since_unix_ms()
             } else {
                 0
             },
@@ -4791,6 +4806,44 @@ impl SharedLayoutRuntime {
 
     pub fn node_intent(&mut self, intent: UiIntent) -> Result<(), Box<dyn Error>> {
         self.handle_intent(intent)
+    }
+
+    /// Apply a status pushed by a producer running inside one of this node's
+    /// own panes. Returns whether it was accepted.
+    ///
+    /// The pane id is a claim from an unauthenticated local process, so it is
+    /// checked against the panes this node actually hosts. That is the local
+    /// half of the containment `Coordinator::accept_agent_roster` enforces
+    /// between peers: a producer can only ever speak for a pane on the machine
+    /// it runs on, and the roster it feeds is published under this node's own
+    /// peer id.
+    ///
+    /// A kind or status this build does not know is refused rather than
+    /// coerced — a lenient parse would let a typo file status under the wrong
+    /// agent, or blank the row it meant to update.
+    pub fn apply_agent_status(
+        &mut self,
+        pane_id: PaneId,
+        kind: &str,
+        status: &str,
+        cwd: &str,
+    ) -> bool {
+        let (Some(kind), Some(state)) = (AgentKind::from_wire(kind), AgentState::from_wire(status))
+        else {
+            return false;
+        };
+        let Some(pane) = self.local.get_mut(&pane_id) else {
+            return false;
+        };
+        if pane.exited {
+            return false;
+        }
+        // Capped here rather than at publish time: an over-long cwd would fail
+        // `validate_agent_roster` and silently drop this host's whole roster.
+        let cwd = truncate_bytes(sanitize_single_line(cwd), MAX_AGENT_CWD_BYTES);
+        pane.agent_tracker
+            .record_pushed_status(kind, cwd, state, Instant::now(), unix_ms_now());
+        true
     }
 
     pub fn shutdown_node(self) {
@@ -8016,6 +8069,95 @@ mod tests {
             .await
             .expect("loopback endpoint");
         Transport::from_endpoint(endpoint)
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn pushed_agent_status_is_confined_to_panes_this_node_hosts() {
+        use crate::agent_detect::{AgentKind, AgentState};
+        use crate::protocol::MAX_AGENT_CWD_BYTES;
+
+        let host = SharedLayoutHost::new(
+            HostSession::from_transport(loopback_transport().await).expect("host session"),
+            2,
+            8,
+        )
+        .expect("shared host");
+        let pane_server = host.pane_server();
+        let host_id = host.ticket().endpoint_addr().id.as_bytes().to_vec();
+        let initial = SharedLocalPane::spawn(1, 2, 8, host_id.clone()).expect("initial pty");
+        pane_server
+            .register_local_pane(
+                PaneDescriptor {
+                    pane_id: 1,
+                    host_peer_id: host_id,
+                    grid_rows: 2,
+                    grid_cols: 8,
+                    title: None,
+                    locked: false,
+                    exited: false,
+                },
+                initial.channels(),
+            )
+            .expect("initial pane registered");
+        let state = host
+            .session_snapshot()
+            .expect("snapshot")
+            .state
+            .expect("layout state");
+        let snapshot = layout_snapshot_from_state(&state).expect("render layout");
+        let mut runtime = SharedLayoutRuntime::host(
+            host,
+            pane_server,
+            snapshot,
+            initial,
+            String::from("TESTCODE"),
+            tokio::runtime::Handle::current(),
+        )
+        .expect("runtime");
+
+        assert!(
+            runtime.apply_agent_status(1, "claude", "pending", "/repo"),
+            "a producer may report for a pane this node hosts"
+        );
+        assert_eq!(
+            runtime
+                .local
+                .get_mut(&1)
+                .expect("local pane")
+                .agent_tracker
+                .listed_agent(Instant::now(), 1_000)
+                .map(|(agent, state)| (agent.kind, state)),
+            Some((AgentKind::Claude, AgentState::Pending))
+        );
+
+        // A pane id this node does not host is refused outright. This is the
+        // local half of `Coordinator::accept_agent_roster`: without it, any
+        // process on this machine could publish status for a peer's pane under
+        // this node's authenticated peer id.
+        assert!(
+            !runtime.apply_agent_status(99, "claude", "pending", "/repo"),
+            "a producer may not report for a pane hosted elsewhere"
+        );
+
+        // Unparseable kinds and statuses are refused rather than coerced.
+        assert!(!runtime.apply_agent_status(1, "gemini", "pending", "/repo"));
+        assert!(!runtime.apply_agent_status(1, "claude", "pendign", "/repo"));
+
+        // An over-long cwd is cut at intake: letting it through would fail
+        // `validate_agent_roster` and drop this host's entire roster.
+        assert!(runtime.apply_agent_status(
+            1,
+            "claude",
+            "working",
+            &"/x".repeat(MAX_AGENT_CWD_BYTES)
+        ));
+        let cwd = runtime
+            .local
+            .get(&1)
+            .and_then(|pane| pane.agent_tracker.pushed.as_ref())
+            .map(|pushed| pushed.cwd.clone())
+            .expect("pushed status");
+        assert!(cwd.len() <= MAX_AGENT_CWD_BYTES);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,8 +1,10 @@
 use std::{
     fs,
+    io::{BufRead, BufReader, Write},
     net::SocketAddr,
+    os::unix::net::UnixListener,
     path::{Path, PathBuf},
-    process::Command,
+    process::{Command, Stdio},
     str::FromStr,
     sync::atomic::{AtomicU64, Ordering},
     time::{SystemTime, UNIX_EPOCH},
@@ -130,6 +132,107 @@ fn ticket_asks_for_a_code_when_several_sessions_are_live() {
     drop(first);
     drop(second);
     fs::remove_dir_all(cache_home).expect("temporary cache should remove");
+}
+
+/// Run `p2pmux notify` with a hook payload on stdin and the pane environment a
+/// hosted PTY would have provided.
+fn run_notify(env: &[(&str, &str)], args: &[&str], stdin: &str) -> std::process::Output {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_p2pmux"))
+        .args(args)
+        .envs(env.iter().copied())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("p2pmux binary should run");
+    child
+        .stdin
+        .take()
+        .expect("stdin is piped")
+        .write_all(stdin.as_bytes())
+        .expect("hook payload should write");
+    child.wait_with_output().expect("notify should exit")
+}
+
+#[test]
+fn notify_reports_a_blocked_agent_to_the_pane_socket() {
+    let directory = temporary_cache_home();
+    fs::create_dir_all(&directory).expect("temporary directory");
+    let socket = directory.join("node.sock");
+    let listener = UnixListener::bind(&socket).expect("socket should bind");
+
+    let accepted = std::thread::spawn(move || {
+        let (stream, _) = listener.accept().expect("producer should connect");
+        let mut line = String::new();
+        BufReader::new(stream)
+            .read_line(&mut line)
+            .expect("producer should write one line");
+        line
+    });
+
+    // A turn that ends by asking a question: Claude fires `Stop`, which would
+    // otherwise show as a finished agent nobody needs to look at.
+    let output = run_notify(
+        &[
+            ("P2PMUX_PANE_ID", "7"),
+            ("P2PMUX_SOCK", socket.to_str().expect("utf-8 path")),
+        ],
+        &["notify", "claude", "--status", "done"],
+        r#"{"hook_event_name":"Stop","last_assistant_message":"Done. Should I push?","cwd":"/repo"}"#,
+    );
+    assert!(output.status.success(), "a hook must never fail its agent");
+
+    let line = accepted.join().expect("listener thread");
+    let message: serde_json::Value = serde_json::from_str(&line).expect("valid JSON line");
+    assert_eq!(message["type"], "agent_status");
+    assert_eq!(message["pane_id"], 7);
+    assert_eq!(message["kind"], "claude");
+    assert_eq!(message["status"], "pending");
+    assert_eq!(message["cwd"], "/repo");
+    // The assistant's message decided the status but must not ride along: a
+    // session is shared with every member.
+    assert!(message.get("msg").is_none());
+    assert!(!line.contains("Should I push"));
+
+    fs::remove_dir_all(&directory).expect("temporary directory should remove");
+}
+
+#[test]
+fn notify_is_a_silent_no_op_outside_a_pane() {
+    // Registered globally in a user's Claude config, this runs everywhere. A
+    // non-zero exit or any stderr would surface as a hook failure in sessions
+    // that have nothing to do with p2pmux.
+    let output = run_notify(
+        &[],
+        &["notify", "claude", "--status", "running"],
+        r#"{"hook_event_name":"PreToolUse"}"#,
+    );
+    assert!(output.status.success());
+    assert!(output.stdout.is_empty());
+    assert!(
+        output.stderr.is_empty(),
+        "unexpected stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // A pane id with no socket, and a socket nothing is listening on, are the
+    // same silent no-op rather than a hang or an error.
+    let directory = temporary_cache_home();
+    fs::create_dir_all(&directory).expect("temporary directory");
+    let output = run_notify(
+        &[
+            ("P2PMUX_PANE_ID", "3"),
+            (
+                "P2PMUX_SOCK",
+                directory.join("absent.sock").to_str().expect("utf-8 path"),
+            ),
+        ],
+        &["notify", "claude", "--status", "running"],
+        r#"{"hook_event_name":"PreToolUse"}"#,
+    );
+    assert!(output.status.success());
+    assert!(output.stderr.is_empty());
+    fs::remove_dir_all(&directory).expect("temporary directory should remove");
 }
 
 fn minted_ticket() -> JoinTicket {

--- a/tests/local_ipc.rs
+++ b/tests/local_ipc.rs
@@ -7,6 +7,39 @@ use p2pmux::{
 };
 
 #[test]
+fn agent_status_is_tagged_and_tolerates_a_producer_that_omits_cwd() {
+    let message = ClientMessage::AgentStatus {
+        pane_id: 4,
+        kind: "claude".into(),
+        status: "pending".into(),
+        cwd: "/repo".into(),
+    };
+    let value = serde_json::to_value(&message).unwrap();
+    assert_eq!(value["type"], "agent_status");
+    assert_eq!(value["pane_id"], 4);
+    assert_eq!(
+        serde_json::from_value::<ClientMessage>(value).unwrap(),
+        message
+    );
+
+    // Producers are separate processes — a shell hook may not have a cwd worth
+    // sending. A missing field must not fail the whole message.
+    let terse: ClientMessage = serde_json::from_str(
+        r#"{"type":"agent_status","pane_id":4,"kind":"claude","status":"done"}"#,
+    )
+    .expect("cwd is optional");
+    assert_eq!(
+        terse,
+        ClientMessage::AgentStatus {
+            pane_id: 4,
+            kind: "claude".into(),
+            status: "done".into(),
+            cwd: String::new(),
+        }
+    );
+}
+
+#[test]
 fn protocol_messages_are_tagged_and_attachment_is_generation_safe() {
     let message = NodeMessage::Snapshot {
         room_name: "lisbon".into(),

--- a/tests/protocol.rs
+++ b/tests/protocol.rs
@@ -454,16 +454,52 @@ fn agent_roster_allows_zero_working_since_while_working() {
 }
 
 #[test]
+fn agent_roster_survives_states_and_kinds_from_a_newer_peer() {
+    // Both fields are open vocabularies. A peer on a newer build may name an
+    // agent this binary has never heard of, or report a state it has no variant
+    // for; neither may fail the frame, because `decode_frame` failing drops the
+    // whole peer stream in `FrameReader::read_next`. An unknown state reads as
+    // `Idle` rather than vanishing from the overlay.
+    let roster = agent_roster(vec![AgentRosterEntry {
+        agent_kind: String::from("some-future-agent"),
+        state: 99,
+        ..agent_entry(9)
+    }]);
+    let original = envelope(envelope::Body::AgentRoster(roster));
+
+    let frame = encode_frame(&original).expect("an unknown kind and state still encode");
+    assert_eq!(
+        decode_frame(&frame).expect("an unknown kind and state still decode"),
+        original
+    );
+    assert_eq!(AgentRosterState::from_wire(99), AgentRosterState::Idle);
+    assert_eq!(
+        AgentRosterState::from_wire(AgentRosterState::Done as i32),
+        AgentRosterState::Done
+    );
+}
+
+#[test]
 fn agent_roster_validation_rejects_bad_entries() {
     let cases = [
         agent_roster(vec![agent_entry(0)]),
         agent_roster(vec![agent_entry(1), agent_entry(1)]),
+        // A kind is still shape-checked, so nothing that would corrupt a
+        // rendered cell gets through: empty, uppercase, spaces, control chars.
         agent_roster(vec![AgentRosterEntry {
-            agent_kind: String::from("unknown"),
+            agent_kind: String::new(),
             ..agent_entry(1)
         }]),
         agent_roster(vec![AgentRosterEntry {
-            state: 99,
+            agent_kind: String::from("Claude"),
+            ..agent_entry(1)
+        }]),
+        agent_roster(vec![AgentRosterEntry {
+            agent_kind: String::from("claude code"),
+            ..agent_entry(1)
+        }]),
+        agent_roster(vec![AgentRosterEntry {
+            agent_kind: String::from("claude\u{1b}[2J"),
             ..agent_entry(1)
         }]),
         agent_roster(vec![AgentRosterEntry {

--- a/tests/protocol.rs
+++ b/tests/protocol.rs
@@ -480,6 +480,60 @@ fn agent_roster_survives_states_and_kinds_from_a_newer_peer() {
 }
 
 #[test]
+fn agent_roster_state_severity_ranks_failures_over_waiting_over_work() {
+    // Severity is deliberately not the enum's own ordering: `Working = 1` and
+    // `Done = 2` are frozen wire values, so declaration order says Done is more
+    // severe than Working, which is backwards. `severity()` is the real order.
+    let mut by_severity = [
+        AgentRosterState::Pending,
+        AgentRosterState::Idle,
+        AgentRosterState::Error,
+        AgentRosterState::Done,
+        AgentRosterState::Working,
+    ];
+    by_severity.sort_by_key(|state| state.severity());
+    assert_eq!(
+        by_severity,
+        [
+            AgentRosterState::Idle,
+            AgentRosterState::Done,
+            AgentRosterState::Working,
+            AgentRosterState::Pending,
+            AgentRosterState::Error,
+        ]
+    );
+
+    // needs_you is the blocked set; needs_attention adds a finished turn.
+    assert!(AgentRosterState::Pending.needs_you());
+    assert!(AgentRosterState::Error.needs_you());
+    assert!(!AgentRosterState::Done.needs_you());
+    assert!(!AgentRosterState::Working.needs_you());
+    assert!(!AgentRosterState::Idle.needs_you());
+
+    assert!(AgentRosterState::Done.needs_attention());
+    assert!(!AgentRosterState::Working.needs_attention());
+    assert!(!AgentRosterState::Idle.needs_attention());
+
+    assert!(AgentRosterState::Done.is_completion());
+    assert!(AgentRosterState::Error.is_completion());
+    assert!(!AgentRosterState::Pending.is_completion());
+}
+
+#[test]
+fn agent_roster_carries_the_new_states_over_the_wire() {
+    for state in [AgentRosterState::Pending, AgentRosterState::Error] {
+        let roster = agent_roster(vec![AgentRosterEntry {
+            state: state as i32,
+            ..agent_entry(9)
+        }]);
+        let original = envelope(envelope::Body::AgentRoster(roster));
+        let frame = encode_frame(&original).expect("new states encode");
+        assert_eq!(decode_frame(&frame).expect("new states decode"), original);
+        assert_eq!(AgentRosterState::from_wire(state as i32), state);
+    }
+}
+
+#[test]
 fn agent_roster_validation_rejects_bad_entries() {
     let cases = [
         agent_roster(vec![agent_entry(0)]),

--- a/tests/pty_host.rs
+++ b/tests/pty_host.rs
@@ -126,6 +126,7 @@ fn pty_host_default_shell_uses_explicit_working_directory() {
             pixel_height: 0,
         },
         Some(&directory),
+        None,
     )
     .expect("PTY should spawn");
 
@@ -139,4 +140,34 @@ fn pty_host_default_shell_uses_explicit_working_directory() {
 
     host.shutdown().expect("PTY should shut down cleanly");
     fs::remove_dir(&directory).expect("remove temporary directory");
+}
+
+#[test]
+fn pane_shells_learn_their_pane_id_and_plain_shells_do_not() {
+    let size = PtySize {
+        rows: 24,
+        cols: 80,
+        pixel_width: 0,
+        pixel_height: 0,
+    };
+
+    // A roster pane's shell can identify itself, which is what lets an agent
+    // hook running inside it report status back for the right pane.
+    let mut pane =
+        PtyHost::spawn_default_shell_with_cwd(size, None, Some(42)).expect("pane PTY should spawn");
+    thread::sleep(Duration::from_millis(100));
+    pane.write_input(b"printf 'pane=[%s]\\n' \"$P2PMUX_PANE_ID\"\n")
+        .expect("PTY should accept input");
+    assert!(read_until(&mut pane, "pane=[42]").contains("pane=[42]"));
+    pane.shutdown().expect("PTY should shut down cleanly");
+
+    // `p2pmux local` and the single-pane host runtime are not roster panes, so
+    // nothing inside them can claim to be a pane that exists.
+    let mut plain = PtyHost::spawn_default_shell(size).expect("plain PTY should spawn");
+    thread::sleep(Duration::from_millis(100));
+    plain
+        .write_input(b"printf 'pane=[%s]\\n' \"$P2PMUX_PANE_ID\"\n")
+        .expect("PTY should accept input");
+    assert!(read_until(&mut plain, "pane=[]").contains("pane=[]"));
+    plain.shutdown().expect("PTY should shut down cleanly");
 }


### PR DESCRIPTION
Ports the push-based status model from [zj-radar](https://github.com/marktoda/zj-radar) into the Ctrl+A overlay, adapted for a multi-user mux.

## The problem

`Ctrl+A` could report `idle`, `working`, and `done` — all three inferred from PTY output timing in `agent_detect.rs`. It had no way to report the one state that actually needs a human: **the agent is blocked, waiting on a permission prompt or a question.** That state is not inferable in principle. Silence looks identical whether an agent is thinking or waiting on you.

## The approach

Hooks are not an addition to the process scanner — they are what lets us turn it down. The scanner stays as the zero-config fallback (it covers all five agents with no setup); a hook, when present, is authoritative for the pane it runs in.

```
Claude hook → p2pmux notify claude → $P2PMUX_SOCK → node validates the pane
            → PaneAgentTracker → existing roster publish → peers
```

The push lands *upstream* of every existing multi-user mechanism: generation counter, edge-gate, heartbeat, coordinator fan-out, and `accept_agent_roster`'s authentication check are all unchanged.

## Multi-user notes

- **Producer containment.** A hook runs on the pane's host machine, inside its PTY, so it can only claim panes on that machine. The node enforces this locally (`apply_agent_status` refuses a pane it does not host), mirroring the peer-facing check in `Coordinator::accept_agent_roster`. Covered by a test.
- **Privacy.** The assistant's messages and the user's prompts are read to decide the status but never go on the wire. Only state, kind, and cwd reach the session — cwd was already shared. A session is shared with every member; the agent's conversation is not the mux's to publish.
- **Wire compatibility.** `validate_agent_roster` used to reject unknown `AgentRosterState` values, and `FrameReader::read_next` turns a decode failure into a dropped peer connection — so shipping a fourth state would have disconnected older peers rather than dimming one row. That is fixed in the first commit, before any new variant is emitted. `agent_kind`'s closed allowlist had the same hazard and is now a shape check.

## Performance

Net cost goes **down**, despite two new states:

- The sampler ran a full `sysinfo` refresh of every process on the machine every second, forever, on an idle session with no agents. It now drops to 5s whenever no pane's state is being inferred.
- Classification ran every agent matcher over every process *per pane*. `AgentScan` does that pass once per snapshot, so per-pane work is now proportional to the number of agents, not the size of the process table. Asserted to agree with the old path verdict-for-verdict.
- `main` parses before starting a runtime, so a hook firing on every tool call does not spin up a thread-per-core Tokio runtime to write 90 bytes.

No roster coalescing turned out to be needed: because the message never rides the roster, consecutive hook events produce byte-identical entries and the existing edge-gate already drops them.

## Correctness

Nothing fires a hook when an agent is killed, so a pushed `working` or `needs you` would otherwise stand forever. A pushed status is retired 20s after its pane falls back to a shell prompt — a check that is deliberately not agent-aware, so it holds even for launchers the matchers miss. Repeat sightings do not reset the clock; the pane coming back to life, or any fresh push, does.

## Commits

1. `fix(protocol)` — unknown roster values no longer drop the peer stream *(must land first)*
2. `feat(agents)` — `Pending`/`Error` with severity ranking and `needs_you`/`needs_attention`/`is_completion`
3. `feat(pty)` — `P2PMUX_PANE_ID` / `P2PMUX_SOCK` on pane shells
4. `feat(node)` — accept pushed status over the local IPC socket
5. `feat(cli)` — `p2pmux notify claude` producer
6. `perf(agents)` — one scan per snapshot; fast cadence only while inferring
7. `fix(agents)` — retire a pushed status once its producer is gone
8. `docs(readme)` — hook setup and what a session does/does not learn

## Testing

`cargo fmt --check`, `cargo clippy --all-targets --all-features -D warnings`, `cargo test --all-features` (445 passing), and `cargo check --all-targets` all pass locally. New coverage: forward-compat wire behaviour, severity ordering, overlay rendering and the needs-you badge, PTY env injection, pane-ownership containment, the Claude hook derivation table, the shared scan's equivalence, and the grace clock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B9gWu3cXmw36JX5K8UtK3m
