### PR TITLE
Presence: see where every member is looking

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,20 @@ revisioned tab/split tree, including authoritative split ratios. Every pane is a
 the member that created it, and its host publishes the absolute grid for that host's window.
 Each process serves its own locally hosted panes directly to the other admitted members.
 
-This is still a dogfooding spike: relay/internet validation, disconnect grace, coordinator
-failover and presence remain later work. Shared ratios are portable while absolute pane grids are
+Presence shows where every other member is looking. Each member gets a color from their slot
+in the session's member list, and that color identifies them everywhere: a dot per member on
+each tab they are on, their initial on the bottom border of the pane they are watching, and a
+members block in the agents overlay listing everyone with their tab and pane. Watching is not
+controlling — the pane border keeps meaning focus and control state, and the member holding
+the control lease is drawn as a reversed chip.
+
+Presence is silent when nobody moves. A member publishes their focus only when it changes, the
+coordinator caches the latest one per member and replays it to joiners, and there is no
+heartbeat or timer in the path. Detached members report no location rather than leaving a
+marker behind.
+
+This is still a dogfooding spike: relay/internet validation, disconnect grace and coordinator
+failover remain later work. Shared ratios are portable while absolute pane grids are
 host-owned: guests consume the host's resized screen stream and never resize a remote PTY.
 
 ## Local Spike 1
@@ -76,6 +88,12 @@ optional, and omitted keys retain today's built-in colors; the template document
 its default. Colors accept lowercase named values (`white`, `yellow`, `gray`, `dark_gray`) or
 case-insensitive `#RRGGBB` values. The theme is client-local and is never synchronized over P2P;
 detach and reattach after editing the file to reload it.
+
+`member_colors` under `[ui.theme]` is a list of up to eight colors, one per member slot in join
+order, used for the presence dots and chips. Listing fewer than eight overrides from the front
+and leaves the rest at their built-in color. The defaults are cool hues on purpose: warm colors
+are reserved for the active tab and for a pane under remote control, so a member tinted like
+either would read as an alert.
 
 Agent-completion notifications live under `[ui.notifications]`. `sound_enabled = false` keeps
 the local unread stars while silencing sound. By default p2pmux plays

--- a/docs/MVP_DESIGN.md
+++ b/docs/MVP_DESIGN.md
@@ -139,9 +139,33 @@ The dark contextual footer uses red key accents: normal mode shows
 `Ctrl+ <p> PANE   <t> TAB   <q> QUIT    type to claim when free`; pane and tab modes show their
 focus/switch, new, close, and back commands. Direct | relayed indicator.
 
+Presence identifies each member by a color taken from their slot in the authoritative member
+list, so every client derives the same colors from state they already hold and no wire field
+carries them. Slots shift when a member leaves; every color is drawn beside that member's
+initial, so an identity is recolored rather than lost. Three surfaces use it: a dot per other
+member on each tab label, that member's initial right-aligned on the bottom border of the pane
+they are watching, and a members block above the agent rows in the overlay.
+
+Watching is not controlling. The pane border keeps its existing five-way meaning — a single
+color could not express several watchers on one pane, and tinting it per member would make
+watching look like the one state that matters in a shared shell. The member holding the control
+lease is drawn as a reversed chip instead.
+
 ## 6. Wire sketch
 
 Membership, `LayoutCommit` revisions, presence, control lease / Take control, Snapshot/Delta, SessionSnapshot bootstrap for joiners. Split/close → coordinator commit (except during coordinator grace freeze).
+
+Presence is two messages. A member sends `Presence` (its focused tab and pane, plus whether it
+is attached at all) to the coordinator, which caches the latest one per member and re-broadcasts
+the whole set as a `PresenceRoster`. Carrying every member is what makes the broadcast safe to
+coalesce: a peer's outbound presence slot keeps only the newest message, so per-member updates
+sharing one slot would silently overwrite each other. Because the newest message is always the
+complete truth, presence needs no heartbeat, and an idle session produces no presence traffic.
+
+Focus deliberately does not touch the layout revision. Focus changes are frequent, and bumping
+the revision for each would reject every in-flight `LayoutRequest` as stale, so the coordinator
+counts presence separately. That counter is also how the coordinator's own renderer notices a
+member moved, since the coordinator is the authority and never receives its own broadcasts.
 
 ## 7. Failure modes
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -192,6 +192,7 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
                         screens: next_screens,
                         leases,
                         rosters,
+                        presence,
                         local_peer_id: next_local_peer_id,
                         tab_id,
                         pane_id,
@@ -216,6 +217,7 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
                             &mut history_refresh,
                         )?;
                         apply_leases(view, leases);
+                        view.set_presence(presence);
                         apply_focus(view, &mut pending_focus, tab_id, pane_id)?;
                         announce_agent_completions(
                             apply_rosters(view, rosters),
@@ -372,6 +374,11 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
                         if let Some(view) = tui.as_mut() {
                             apply_focus(view, &mut pending_focus, tab_id, pane_id)?;
                             dirty = true;
+                        }
+                    }
+                    NodeMessage::Presence { presence } => {
+                        if let Some(view) = tui.as_mut() {
+                            dirty |= view.set_presence(presence);
                         }
                     }
                     _ => {}

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,7 +9,7 @@ use serde::Deserialize;
 
 static CONFIG_WRITE_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
-const DEFAULT_CONFIG_TEMPLATE: &str = "# p2pmux local configuration\n#\n# display_name is visible to peers.\n# display_name = \"your-name\"\n\n# UI chrome is local to this client and is never shared with session peers.\n[ui.theme]\n# Named colors: white, yellow, gray, dark_gray\n# Hex colors: #RRGGBB\n#\n# footer_background = \"#1e1e1e\"\n# footer_muted = \"white\"\n# footer_accent = \"#dc322f\"\n# footer_orange = \"#ff7846\"\n# tab_active_background = \"#dc322f\"\n# tab_foreground = \"white\"\n# tab_separator = \"dark_gray\"\n# copy_feedback_accent = \"#ff4500\"\n# agent_overlay_chrome = \"#ff4500\"\n# agent_overlay_selected_background = \"#2a2a2a\"\n# agent_overlay_muted = \"#919db4\"\n# agent_overlay_warm = \"#ffb84d\"\n# agent_overlay_attention = \"#ffb000\"\n# agent_overlay_error = \"#dc322f\"\n# agent_overlay_foreground = \"white\"\n# agent_overlay_secondary = \"gray\"\n# pane_border_free_focused = \"white\"\n# pane_border_unknown_focused = \"yellow\"\n# pane_border_chord_focused = \"#ff1a1a\"\n# pane_border_hovered = \"gray\"\n# pane_border_idle = \"dark_gray\"\n# pane_border_remote_control = \"#ff4500\"\n\n[ui.notifications]\n# Set false to keep agent-completion stars without playing a sound.\nsound_enabled = true\n# sound_path = \"/path/to/custom.aiff\"\n#\n# An agent counts as finished after this many seconds of silence. Agents pause for a\n# long time mid-task (waiting on a model response, running a quiet tool), so a small\n# value reports unfinished work as finished. Clamped to 5-3600.\n# quiet_seconds = 20\n#\n# Only finish on an explicit signal from the agent (a terminal bell) and never on the\n# silence timer above. Removes every false notification, but an agent that does not\n# ring will show as working until it exits.\n# require_bell = false\n";
+const DEFAULT_CONFIG_TEMPLATE: &str = "# p2pmux local configuration\n#\n# display_name is visible to peers.\n# display_name = \"your-name\"\n\n# UI chrome is local to this client and is never shared with session peers.\n[ui.theme]\n# Named colors: white, yellow, gray, dark_gray\n# Hex colors: #RRGGBB\n#\n# footer_background = \"#1e1e1e\"\n# footer_muted = \"white\"\n# footer_accent = \"#dc322f\"\n# footer_orange = \"#ff7846\"\n# tab_active_background = \"#dc322f\"\n# tab_foreground = \"white\"\n# tab_separator = \"dark_gray\"\n# copy_feedback_accent = \"#ff4500\"\n# agent_overlay_chrome = \"#ff4500\"\n# agent_overlay_selected_background = \"#2a2a2a\"\n# agent_overlay_muted = \"#919db4\"\n# agent_overlay_warm = \"#ffb84d\"\n# agent_overlay_attention = \"#ffb000\"\n# agent_overlay_error = \"#dc322f\"\n# agent_overlay_foreground = \"white\"\n# agent_overlay_secondary = \"gray\"\n# pane_border_free_focused = \"white\"\n# pane_border_unknown_focused = \"yellow\"\n# pane_border_chord_focused = \"#ff1a1a\"\n# pane_border_hovered = \"gray\"\n# pane_border_idle = \"dark_gray\"\n# pane_border_remote_control = \"#ff4500\"\n#\n# One color per member, in join order, identifying who is watching which tab and pane.\n# List up to 8; the slots you leave out keep their built-in color.\n# member_colors = [\"#4fc3f7\", \"#7ed67e\", \"#f06292\", \"#7986cb\", \"#4db6ac\", \"#ba68c8\", \"#c0ca33\", \"#90a4ae\"]\n\n[ui.notifications]\n# Set false to keep agent-completion stars without playing a sound.\nsound_enabled = true\n# sound_path = \"/path/to/custom.aiff\"\n#\n# An agent counts as finished after this many seconds of silence. Agents pause for a\n# long time mid-task (waiting on a model response, running a quiet tool), so a small\n# value reports unfinished work as finished. Clamped to 5-3600.\n# quiet_seconds = 20\n#\n# Only finish on an explicit signal from the agent (a terminal bell) and never on the\n# silence timer above. Removes every false notification, but an agent that does not\n# ring will show as working until it exits.\n# require_bell = false\n";
 
 #[derive(Debug)]
 pub enum ConfigError {
@@ -101,7 +101,30 @@ pub struct UiTheme {
     pub pane_border_hovered: Color,
     pub pane_border_idle: Color,
     pub pane_border_remote_control: Color,
+    /// One color per member slot, used to identify who is where. Identity only: the
+    /// reds and oranges stay reserved for control and alert state, so no entry here
+    /// may collide with `pane_border_remote_control`.
+    pub member_colors: [Color; MEMBER_COLOR_SLOTS],
 }
+
+/// One color per admitted member, so a live session never has to recycle a slot.
+/// Kept in step with `crate::layout::MAX_MEMBERS` by a unit test.
+pub const MEMBER_COLOR_SLOTS: usize = 8;
+
+/// Cool hues only. Warm colors are taken: the active tab is `#dc322f` and an actively
+/// controlled pane border is `#ff4500`, and a member tinted like either reads as an
+/// alert. Every color here also carries the member's initial at the call site, so the
+/// palette never has to survive on hue alone.
+const DEFAULT_MEMBER_COLORS: [Color; MEMBER_COLOR_SLOTS] = [
+    Color::Rgb(79, 195, 247),
+    Color::Rgb(126, 214, 126),
+    Color::Rgb(240, 98, 146),
+    Color::Rgb(121, 134, 203),
+    Color::Rgb(77, 182, 172),
+    Color::Rgb(186, 104, 200),
+    Color::Rgb(192, 202, 51),
+    Color::Rgb(144, 164, 174),
+];
 
 impl Default for UiTheme {
     fn default() -> Self {
@@ -128,6 +151,7 @@ impl Default for UiTheme {
             pane_border_hovered: Color::Gray,
             pane_border_idle: Color::DarkGray,
             pane_border_remote_control: Color::Rgb(255, 69, 0),
+            member_colors: DEFAULT_MEMBER_COLORS,
         }
     }
 }
@@ -179,6 +203,7 @@ struct UiThemeFile {
     pane_border_hovered: Option<String>,
     pane_border_idle: Option<String>,
     pane_border_remote_control: Option<String>,
+    member_colors: Option<Vec<String>>,
 }
 
 pub fn config_path() -> Result<PathBuf, ConfigError> {
@@ -333,6 +358,7 @@ pub fn load_config_from(path: &Path) -> Result<Config, ConfigError> {
         config.ui.theme.pane_border_remote_control,
         "pane_border_remote_control",
     )?;
+    apply_member_colors(&mut theme.member_colors, config.ui.theme.member_colors)?;
     let defaults = NotificationsConfig::default();
     let notifications = NotificationsConfig {
         sound_enabled: config.ui.notifications.sound_enabled.unwrap_or(true),
@@ -365,6 +391,31 @@ fn apply_color(
 ) -> Result<(), ConfigError> {
     if let Some(value) = value {
         *color = parse_color(&value).ok_or(ConfigError::InvalidColor { key, value })?;
+    }
+    Ok(())
+}
+
+/// Override member colors from the front of the list, so a short list keeps the
+/// built-in colors for the slots it does not mention -- the same "omitted keys keep
+/// today's colors" rule every other theme key follows.
+fn apply_member_colors(
+    colors: &mut [Color; MEMBER_COLOR_SLOTS],
+    values: Option<Vec<String>>,
+) -> Result<(), ConfigError> {
+    let Some(values) = values else {
+        return Ok(());
+    };
+    if values.len() > MEMBER_COLOR_SLOTS {
+        return Err(ConfigError::InvalidColor {
+            key: "member_colors",
+            value: format!("at most {MEMBER_COLOR_SLOTS} colors, got {}", values.len()),
+        });
+    }
+    for (slot, value) in colors.iter_mut().zip(values) {
+        *slot = parse_color(&value).ok_or(ConfigError::InvalidColor {
+            key: "member_colors",
+            value,
+        })?;
     }
     Ok(())
 }
@@ -595,6 +646,61 @@ mod tests {
                 .pane_border_chord_focused,
             Color::Rgb(1, 2, 3)
         );
+
+        fs::remove_dir_all(path.parent().unwrap()).unwrap();
+    }
+
+    #[test]
+    fn member_color_slots_cover_every_admissible_member() {
+        assert_eq!(MEMBER_COLOR_SLOTS, crate::layout::MAX_MEMBERS);
+    }
+
+    #[test]
+    fn member_colors_override_from_the_front_and_keep_the_rest() {
+        assert!(DEFAULT_CONFIG_TEMPLATE.contains("# member_colors = [\"#4fc3f7\""));
+
+        let path = temp_config_path();
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(
+            &path,
+            "[ui.theme]\nmember_colors = [\"#010203\", \"yellow\"]\n",
+        )
+        .unwrap();
+
+        let colors = load_config_from(&path).unwrap().ui.theme.member_colors;
+        assert_eq!(colors[0], Color::Rgb(1, 2, 3));
+        assert_eq!(colors[1], Color::Yellow);
+        assert_eq!(
+            colors[2],
+            UiTheme::default().member_colors[2],
+            "slots the file leaves out keep their built-in color"
+        );
+
+        fs::remove_dir_all(path.parent().unwrap()).unwrap();
+    }
+
+    #[test]
+    fn member_colors_reject_an_oversized_list_and_a_bad_entry() {
+        let path = temp_config_path();
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let too_many = ["\"white\""; MEMBER_COLOR_SLOTS + 1].join(", ");
+        fs::write(&path, format!("[ui.theme]\nmember_colors = [{too_many}]\n")).unwrap();
+        assert!(matches!(
+            load_config_from(&path),
+            Err(ConfigError::InvalidColor {
+                key: "member_colors",
+                ..
+            })
+        ));
+
+        fs::write(&path, "[ui.theme]\nmember_colors = [\"#gggggg\"]\n").unwrap();
+        assert!(matches!(
+            load_config_from(&path),
+            Err(ConfigError::InvalidColor {
+                key: "member_colors",
+                ..
+            })
+        ));
 
         fs::remove_dir_all(path.parent().unwrap()).unwrap();
     }

--- a/src/local_ipc.rs
+++ b/src/local_ipc.rs
@@ -98,6 +98,8 @@ pub enum NodeMessage {
         screens: Vec<PaneScreenSnapshot>,
         leases: Vec<PaneLeaseSnapshot>,
         rosters: Vec<AgentOverlaySnapshotRow>,
+        #[serde(default)]
+        presence: Vec<PresenceRow>,
         local_peer_id: Vec<u8>,
         tab_id: u64,
         pane_id: u64,
@@ -130,6 +132,11 @@ pub enum NodeMessage {
     },
     Rosters {
         rosters: Vec<AgentOverlaySnapshotRow>,
+    },
+    /// Where the other members are looking. Only the node holds the session's control
+    /// stream, so an attached client cannot learn this any other way.
+    Presence {
+        presence: Vec<PresenceRow>,
     },
     /// Operator-facing runtime status, e.g. a lost coordinator or a pane that is retrying.
     /// The node owns the session, so this is the only way an attached client can learn
@@ -193,6 +200,18 @@ impl From<&crate::tui::AgentOverlayRow> for AgentOverlaySnapshotRow {
             controller: row.controller.clone(),
         }
     }
+}
+
+/// Where one other member is looking, ready to draw.
+///
+/// Only attached members appear, so the renderer never has to reason about what a
+/// detached member's location means -- they are simply absent. Colors and labels are
+/// derived from the layout's member list that the client already holds.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct PresenceRow {
+    pub peer_id: Vec<u8>,
+    pub tab_id: u64,
+    pub pane_id: u64,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
@@ -379,6 +398,7 @@ mod tests {
             screens: vec![],
             leases: vec![],
             rosters: vec![],
+            presence: vec![],
             local_peer_id: vec![],
             tab_id: 1,
             pane_id: 1,

--- a/src/node.rs
+++ b/src/node.rs
@@ -24,7 +24,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     local_ipc::{
         AgentOverlaySnapshotRow, AttachmentGate, ClientMessage, NodeMessage, PaneLeaseSnapshot,
-        PaneScreenSnapshot, ScreenUpdate, SessionSummary,
+        PaneScreenSnapshot, PresenceRow, ScreenUpdate, SessionSummary,
     },
     rendezvous::LocalRendezvous,
     session::{
@@ -766,6 +766,7 @@ fn write_snapshot(
     publish.leases = Some(leases);
     publish.rosters = Some(rosters);
     publish.focus = Some(node.local_focus());
+    publish.presence = Some(node.presence_rows());
     update_screen_sequences(&mut publish.screen_sequences, &screens);
     publish.last_screen_publish = Some(Instant::now());
     publish.force_screens = false;
@@ -852,6 +853,7 @@ fn snapshot_message(
         screens: screens.clone(),
         leases: leases.clone(),
         rosters: rosters.clone(),
+        presence: node.presence_rows(),
         local_peer_id,
         tab_id,
         pane_id,
@@ -901,6 +903,7 @@ struct AttachmentPublishState {
     paths: Option<Vec<crate::transport::PeerPath>>,
     session_locked: Option<bool>,
     focus: Option<(u64, u64)>,
+    presence: Option<Vec<PresenceRow>>,
     screen_sequences: BTreeMap<u64, u64>,
     last_screen_publish: Option<Instant>,
     pending_screens: bool,
@@ -922,6 +925,7 @@ impl AttachmentPublishState {
         self.paths = None;
         self.session_locked = None;
         self.focus = None;
+        self.presence = None;
         self.screen_sequences.clear();
         self.pending_screens = true;
         self.force_screens = true;
@@ -1032,6 +1036,20 @@ fn queue_updates(
             return Ok(published);
         }
         publish.rosters = Some(rosters);
+        published = true;
+    }
+    let presence = node.presence_rows();
+    if publish.presence.as_ref() != Some(&presence) {
+        if !queue_update(
+            writer,
+            publish,
+            NodeMessage::Presence {
+                presence: presence.clone(),
+            },
+        )? {
+            return Ok(published);
+        }
+        publish.presence = Some(presence);
         published = true;
     }
     if publish.focus != Some(focus) {
@@ -1259,6 +1277,11 @@ impl SharedLayoutNode {
     }
     pub fn local_focus(&self) -> (u64, u64) {
         self.runtime.local_focus()
+    }
+
+    /// Where the other members are looking, for the attached client to draw.
+    pub fn presence_rows(&self) -> Vec<PresenceRow> {
+        self.runtime.presence_rows()
     }
     pub(crate) fn status(&self) -> String {
         self.runtime.status().to_owned()
@@ -1732,6 +1755,7 @@ mod tests {
                 }],
                 leases: vec![],
                 rosters: vec![],
+                presence: vec![],
                 local_peer_id: vec![],
                 tab_id: 1,
                 pane_id: 1,

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -14,6 +14,9 @@ pub const MAX_INPUT_BYTES: usize = 8 * 1024;
 pub const MAX_SNAPSHOT_BYTES: usize = 512 * 1024;
 pub const MAX_DELTA_BYTES: usize = 64 * 1024;
 pub const MAX_AGENT_ROSTER_ENTRIES: usize = 32;
+/// One presence entry per admittable member. Kept in step with `crate::layout::MAX_MEMBERS`
+/// by a unit test rather than an import, so the wire limits stay readable in one place.
+pub const MAX_PRESENCE_ENTRIES: usize = 8;
 pub const MAX_AGENT_KIND_BYTES: usize = 32;
 pub const MAX_AGENT_CWD_BYTES: usize = 512;
 pub const MAX_LAYOUT_TITLE_BYTES: usize = 128;
@@ -113,7 +116,7 @@ pub struct Envelope {
     pub sender_peer_id: Vec<u8>,
     #[prost(
         oneof = "envelope::Body",
-        tags = "10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27"
+        tags = "10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28"
     )]
     pub body: Option<envelope::Body>,
 }
@@ -157,6 +160,8 @@ pub mod envelope {
         AgentRoster(super::AgentRoster),
         #[prost(message, tag = "27")]
         Presence(super::Presence),
+        #[prost(message, tag = "28")]
+        PresenceRoster(super::PresenceRoster),
     }
 }
 
@@ -625,13 +630,12 @@ impl AgentRosterState {
     }
 }
 
-/// Where one member is looking, so the others can see it.
+/// Where one member is looking, sent by that member to the coordinator.
 ///
 /// This is deliberately the smallest thing that answers "where is everyone": the pane a
 /// member has focused and whether they are attached at all. It carries no timestamp,
-/// because nothing here decays -- the coordinator caches the latest one per member and
-/// replays it to joiners, so there is no periodic heartbeat to repair a lost update and
-/// no timer anywhere in the presence path.
+/// because nothing here decays -- the coordinator caches the latest one per member, so
+/// there is no timer anywhere in the presence path.
 ///
 /// Watching is not controlling. A member appears here the moment they focus a pane;
 /// whether they may type into it is the control lease's business, and only the lease
@@ -651,6 +655,20 @@ pub struct Presence {
     pub pane_id: u64,
     #[prost(bool, tag = "5")]
     pub attached: bool,
+}
+
+/// Every member's presence at once, sent by the coordinator to everyone.
+///
+/// The full set rather than the one entry that changed, because a peer's outbound
+/// presence slot keeps only the newest message while its writer catches up. One member's
+/// update would otherwise overwrite another's and be lost for good -- the agent roster
+/// survives the same coalescing only because it heartbeats every five seconds to repair
+/// itself. Carrying everyone makes the newest message always the complete truth, which is
+/// what lets presence cost nothing when nobody is moving.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PresenceRoster {
+    #[prost(message, repeated, tag = "1")]
+    pub entries: Vec<Presence>,
 }
 
 pub fn encode_frame(envelope: &Envelope) -> Result<Vec<u8>, ProtocolError> {
@@ -932,9 +950,8 @@ fn validate_envelope(envelope: &Envelope) -> Result<(), ProtocolError> {
             validate_nonzero("pane_subscribe.pane_id", subscribe.pane_id)?;
         }
         envelope::Body::AgentRoster(roster) => validate_agent_roster(roster)?,
-        envelope::Body::Presence(presence) => {
-            validate_id("presence.peer_id", &presence.peer_id, MAX_PEER_ID_BYTES)?;
-        }
+        envelope::Body::Presence(presence) => validate_presence(presence)?,
+        envelope::Body::PresenceRoster(roster) => validate_presence_roster(roster)?,
     }
 
     Ok(())
@@ -994,6 +1011,39 @@ fn is_agent_kind_token(kind: &str) -> bool {
         && kind
             .bytes()
             .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+}
+
+fn validate_presence(presence: &Presence) -> Result<(), ProtocolError> {
+    validate_id("presence.peer_id", &presence.peer_id, MAX_PEER_ID_BYTES)?;
+    // A detached member reports no location at all, and an attached one is always
+    // looking at some pane in some tab. Anything else is a half-built update.
+    if presence.attached {
+        validate_nonzero("presence.tab_id", presence.tab_id)?;
+        validate_nonzero("presence.pane_id", presence.pane_id)?;
+    } else if presence.tab_id != 0 || presence.pane_id != 0 {
+        return Err(ProtocolError::InvalidLayout("presence.attached"));
+    }
+    Ok(())
+}
+
+fn validate_presence_roster(roster: &PresenceRoster) -> Result<(), ProtocolError> {
+    if roster.entries.len() > MAX_PRESENCE_ENTRIES {
+        return Err(ProtocolError::FieldTooLarge {
+            field: "presence_roster.entries",
+            limit: MAX_PRESENCE_ENTRIES,
+            actual: roster.entries.len(),
+        });
+    }
+    let mut peer_ids = HashSet::new();
+    for entry in &roster.entries {
+        validate_presence(entry)?;
+        if !peer_ids.insert(entry.peer_id.as_slice()) {
+            return Err(ProtocolError::InvalidLayout(
+                "presence_roster.entry.peer_id",
+            ));
+        }
+    }
+    Ok(())
 }
 
 fn validate_id(field: &'static str, bytes: &[u8], limit: usize) -> Result<(), ProtocolError> {

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -113,7 +113,7 @@ pub struct Envelope {
     pub sender_peer_id: Vec<u8>,
     #[prost(
         oneof = "envelope::Body",
-        tags = "10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26"
+        tags = "10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27"
     )]
     pub body: Option<envelope::Body>,
 }
@@ -155,6 +155,8 @@ pub mod envelope {
         ReleaseControl(super::ReleaseControl),
         #[prost(message, tag = "26")]
         AgentRoster(super::AgentRoster),
+        #[prost(message, tag = "27")]
+        Presence(super::Presence),
     }
 }
 
@@ -623,6 +625,34 @@ impl AgentRosterState {
     }
 }
 
+/// Where one member is looking, so the others can see it.
+///
+/// This is deliberately the smallest thing that answers "where is everyone": the pane a
+/// member has focused and whether they are attached at all. It carries no timestamp,
+/// because nothing here decays -- the coordinator caches the latest one per member and
+/// replays it to joiners, so there is no periodic heartbeat to repair a lost update and
+/// no timer anywhere in the presence path.
+///
+/// Watching is not controlling. A member appears here the moment they focus a pane;
+/// whether they may type into it is the control lease's business, and only the lease
+/// paints the alert-colored border.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Presence {
+    #[prost(bytes = "vec", tag = "1")]
+    pub peer_id: Vec<u8>,
+    #[prost(uint64, tag = "2")]
+    pub generation: u64,
+    /// The focused tab and pane. Both are `0` when `attached` is false: a detached node
+    /// keeps its panes alive but its member is looking at nothing, and drawing them
+    /// somewhere would be a ghost.
+    #[prost(uint64, tag = "3")]
+    pub tab_id: u64,
+    #[prost(uint64, tag = "4")]
+    pub pane_id: u64,
+    #[prost(bool, tag = "5")]
+    pub attached: bool,
+}
+
 pub fn encode_frame(envelope: &Envelope) -> Result<Vec<u8>, ProtocolError> {
     validate_envelope(envelope)?;
 
@@ -902,6 +932,9 @@ fn validate_envelope(envelope: &Envelope) -> Result<(), ProtocolError> {
             validate_nonzero("pane_subscribe.pane_id", subscribe.pane_id)?;
         }
         envelope::Body::AgentRoster(roster) => validate_agent_roster(roster)?,
+        envelope::Body::Presence(presence) => {
+            validate_id("presence.peer_id", &presence.peer_id, MAX_PEER_ID_BYTES)?;
+        }
     }
 
     Ok(())

--- a/src/session.rs
+++ b/src/session.rs
@@ -33,9 +33,9 @@ use crate::{
         Input, Join, LayoutCommit, LayoutNode, LayoutReject, LayoutRejectReason, LayoutRequest,
         LayoutSplit, LayoutState, MarkPaneExited, MemberDescriptor,
         NewPanePosition as ProtocolNewPanePosition, PROTOCOL_VERSION, PaneDescriptor, PaneFailed,
-        PaneReady, PaneReservation, PaneSubscribe, ReleaseControl, RenamePane, RenameTab,
-        SessionSnapshot, SetPaneLock, SetSplitRatio, Snapshot, SplitAxis, TabDescriptor,
-        TakeControl, UpdatePaneGrids, Welcome, envelope,
+        PaneReady, PaneReservation, PaneSubscribe, Presence, PresenceRoster, ReleaseControl,
+        RenamePane, RenameTab, SessionSnapshot, SetPaneLock, SetSplitRatio, Snapshot, SplitAxis,
+        TabDescriptor, TakeControl, UpdatePaneGrids, Welcome, envelope,
     },
     screen::ScreenFrame,
     ticket::{JoinTicket, TicketError},
@@ -51,6 +51,8 @@ pub struct LayoutCoordinator {
     state: SessionState,
     reservations: BTreeMap<u64, ReservationContext>,
     agent_rosters: BTreeMap<Vec<u8>, AgentRoster>,
+    presence: BTreeMap<Vec<u8>, Presence>,
+    presence_epoch: u64,
     reservation_timeout: Duration,
     locked: bool,
     admitted: BTreeSet<Vec<u8>>,
@@ -195,6 +197,8 @@ impl LayoutCoordinator {
             )?,
             reservations: BTreeMap::new(),
             agent_rosters: BTreeMap::new(),
+            presence: BTreeMap::new(),
+            presence_epoch: 0,
             reservation_timeout,
             locked: false,
             admitted: BTreeSet::new(),
@@ -286,6 +290,57 @@ impl LayoutCoordinator {
         Some(roster)
     }
 
+    /// Return the cached presence of every member in deterministic peer order.
+    pub fn presence(&self) -> Vec<Presence> {
+        self.presence.values().cloned().collect()
+    }
+
+    /// Counts accepted presence updates. The coordinator does not receive its own
+    /// broadcasts, so its renderer polls this to notice that somebody else moved.
+    pub fn presence_epoch(&self) -> u64 {
+        self.presence_epoch
+    }
+
+    /// Accept a member's latest focus after checking it against the authoritative layout.
+    ///
+    /// Like the agent roster, the authenticated connection identity always wins over the
+    /// message's claimed peer id, and a stale generation is dropped. Unlike the roster,
+    /// the location is not required to exist: a member can focus a pane in the same breath
+    /// another member deletes it, and rejecting that would strand them nowhere. An unknown
+    /// tab or pane simply draws no marker until their next update.
+    pub fn accept_presence(
+        &mut self,
+        authenticated_peer_id: &[u8],
+        mut presence: Presence,
+    ) -> Option<Presence> {
+        if !self
+            .state
+            .members()
+            .iter()
+            .any(|member| member.peer_id == authenticated_peer_id)
+        {
+            return None;
+        }
+        if self
+            .presence
+            .get(authenticated_peer_id)
+            .is_some_and(|current| presence.generation <= current.generation)
+        {
+            return None;
+        }
+        presence.peer_id = authenticated_peer_id.to_vec();
+        if !presence.attached {
+            // A detached member is looking at nothing. Normalize here so no renderer has
+            // to remember that the location is meaningless when the flag is false.
+            presence.tab_id = 0;
+            presence.pane_id = 0;
+        }
+        self.presence
+            .insert(authenticated_peer_id.to_vec(), presence.clone());
+        self.presence_epoch = self.presence_epoch.saturating_add(1);
+        Some(presence)
+    }
+
     pub fn admit(
         &mut self,
         peer_id: Vec<u8>,
@@ -327,6 +382,9 @@ impl LayoutCoordinator {
     pub fn remove_member(&mut self, peer_id: &[u8]) -> Result<MembershipChange, CoordinatorError> {
         let invalidated = self.state.remove_member(peer_id)?;
         self.prune_agent_rosters();
+        if self.presence.remove(peer_id).is_some() {
+            self.presence_epoch = self.presence_epoch.saturating_add(1);
+        }
         self.membership_change(invalidated)
     }
 
@@ -1910,6 +1968,7 @@ pub struct SharedLayoutHost {
 pub enum LayoutControlEvent {
     Snapshot(SessionSnapshot),
     AgentRoster(AgentRoster),
+    Presence(PresenceRoster),
     Reservation(PaneReservation),
     Commit(LayoutCommit),
     Reject(LayoutReject),
@@ -1933,6 +1992,7 @@ impl PaneLayoutReconciler {
             LayoutControlEvent::Snapshot(snapshot) => snapshot.state.as_ref(),
             LayoutControlEvent::Commit(commit) => commit.state.as_ref(),
             LayoutControlEvent::AgentRoster(_)
+            | LayoutControlEvent::Presence(_)
             | LayoutControlEvent::Reservation(_)
             | LayoutControlEvent::Reject(_)
             | LayoutControlEvent::Disconnected => None,
@@ -1955,15 +2015,25 @@ enum LayoutClientMessage {
     Ready(PaneReady),
     Failed(PaneFailed),
     AgentRoster(AgentRoster),
+    Presence(Presence),
 }
 
 const TARGETED_CONTROL_QUEUE_CAPACITY: usize = 16;
+
+/// Latest-wins outbound classes, in the order their slots appear in `pending_watch`.
+/// Each is its own watch channel so a newer message of one class never discards a
+/// pending message of another.
+const WATCH_STATE: usize = 0;
+const WATCH_ROSTER: usize = 1;
+const WATCH_PRESENCE: usize = 2;
+const WATCH_CLASSES: usize = 3;
 
 #[derive(Clone)]
 struct ControlMailbox {
     initial_tx: mpsc::Sender<Envelope>,
     state_tx: watch::Sender<Option<SequencedEnvelope>>,
     roster_tx: watch::Sender<Option<SequencedEnvelope>>,
+    presence_tx: watch::Sender<Option<SequencedEnvelope>>,
     targeted_tx: mpsc::Sender<SequencedEnvelope>,
     next_sequence: Arc<AtomicU64>,
 }
@@ -1972,6 +2042,7 @@ struct ControlMailboxReceivers {
     initial_rx: mpsc::Receiver<Envelope>,
     state_rx: watch::Receiver<Option<SequencedEnvelope>>,
     roster_rx: watch::Receiver<Option<SequencedEnvelope>>,
+    presence_rx: watch::Receiver<Option<SequencedEnvelope>>,
     targeted_rx: mpsc::Receiver<SequencedEnvelope>,
 }
 
@@ -1986,12 +2057,14 @@ impl ControlMailbox {
         let (initial_tx, initial_rx) = mpsc::channel(33);
         let (state_tx, state_rx) = watch::channel(None);
         let (roster_tx, roster_rx) = watch::channel(None);
+        let (presence_tx, presence_rx) = watch::channel(None);
         let (targeted_tx, targeted_rx) = mpsc::channel(TARGETED_CONTROL_QUEUE_CAPACITY);
         (
             Self {
                 initial_tx,
                 state_tx,
                 roster_tx,
+                presence_tx,
                 targeted_tx,
                 next_sequence: Arc::new(AtomicU64::new(1)),
             },
@@ -1999,6 +2072,7 @@ impl ControlMailbox {
                 initial_rx,
                 state_rx,
                 roster_rx,
+                presence_rx,
                 targeted_rx,
             },
         )
@@ -2014,6 +2088,11 @@ impl ControlMailbox {
 
     fn publish_roster(&self, envelope: Envelope) {
         self.roster_tx.send_replace(Some(self.sequenced(envelope)));
+    }
+
+    fn publish_presence(&self, envelope: Envelope) {
+        self.presence_tx
+            .send_replace(Some(self.sequenced(envelope)));
     }
 
     fn enqueue_targeted(&self, envelope: Envelope) -> bool {
@@ -2130,6 +2209,13 @@ impl SharedLayoutMember {
     pub fn try_agent_roster(&self, roster: AgentRoster) -> Result<(), LayoutControlQueueError> {
         self.outbound
             .try_send(LayoutClientMessage::AgentRoster(roster))
+            .map_err(layout_queue_error)
+    }
+
+    /// Publish where this member is now looking to the coordinator.
+    pub fn try_presence(&self, presence: Presence) -> Result<(), LayoutControlQueueError> {
+        self.outbound
+            .try_send(LayoutClientMessage::Presence(presence))
             .map_err(layout_queue_error)
     }
 
@@ -2259,6 +2345,50 @@ impl SharedLayoutHost {
             );
         }
         Ok(())
+    }
+
+    /// The full presence set, but only if it changed since the caller last saw it.
+    ///
+    /// The coordinator is the authority and never receives its own broadcasts, so this is
+    /// how its renderer learns that a member moved. Returns the epoch to poll with next.
+    pub fn presence_if_newer(&self, seen_epoch: u64) -> Option<(u64, PresenceRoster)> {
+        let coordinator = self.coordinator.lock().ok()?;
+        let epoch = coordinator.presence_epoch();
+        (epoch > seen_epoch).then(|| {
+            (
+                epoch,
+                PresenceRoster {
+                    entries: coordinator.presence(),
+                },
+            )
+        })
+    }
+
+    /// Publish the coordinator host's own focus through the same relay path.
+    ///
+    /// Returns the resulting full roster so the coordinator's renderer can show itself in
+    /// the same place its peers will, without a round trip.
+    pub fn publish_local_presence(
+        &self,
+        presence: Presence,
+    ) -> Result<Option<PresenceRoster>, SessionError> {
+        let peer_id = self.host.transport.endpoint_id().as_bytes().to_vec();
+        let mut coordinator = self
+            .coordinator
+            .lock()
+            .map_err(|_| SessionError::PeerTask)?;
+        let Some(_) = coordinator.accept_presence(&peer_id, presence) else {
+            return Ok(None);
+        };
+        let roster = PresenceRoster {
+            entries: coordinator.presence(),
+        };
+        drop(coordinator);
+        broadcast_presence(
+            &self.peers,
+            coordinator_envelope(&peer_id, envelope::Body::PresenceRoster(roster.clone())),
+        );
+        Ok(Some(roster))
     }
 
     /// Applies a request made by the coordinator process itself. Remote peers receive the same
@@ -2489,6 +2619,21 @@ impl SharedLayoutHost {
                     .enqueue_initial(coordinator_envelope(
                         self.host.ticket().endpoint_addr().id.as_bytes(),
                         envelope::Body::AgentRoster(roster),
+                    ))
+                    .then_some(())
+                    .ok_or(SessionError::PeerTask)?;
+            }
+            // A joiner sees where everyone already is without waiting for them to move.
+            let presence = self
+                .coordinator
+                .lock()
+                .map_err(|_| SessionError::PeerTask)?
+                .presence();
+            if !presence.is_empty() {
+                mailbox
+                    .enqueue_initial(coordinator_envelope(
+                        self.host.ticket().endpoint_addr().id.as_bytes(),
+                        envelope::Body::PresenceRoster(PresenceRoster { entries: presence }),
                     ))
                     .then_some(())
                     .ok_or(SessionError::PeerTask)?;
@@ -2734,6 +2879,18 @@ fn broadcast_roster(peers: &Arc<Mutex<BTreeMap<Vec<u8>, ControlPeer>>>, envelope
     }
 }
 
+fn broadcast_presence(peers: &Arc<Mutex<BTreeMap<Vec<u8>, ControlPeer>>>, envelope: Envelope) {
+    let peers = match peers.lock() {
+        Ok(peers) => peers,
+        Err(_) => return,
+    };
+    for peer in peers.values() {
+        // Safe to supersede an older presence roster because each one carries every
+        // member, so the newest is always the whole truth.
+        peer.mailbox.publish_presence(envelope.clone());
+    }
+}
+
 fn send_to_peer(
     peers: &Arc<Mutex<BTreeMap<Vec<u8>, ControlPeer>>>,
     peer_id: &[u8],
@@ -2863,6 +3020,7 @@ async fn layout_peer_writer_task<W>(
         mut initial_rx,
         mut state_rx,
         mut roster_rx,
+        mut presence_rx,
         mut targeted_rx,
     }: ControlMailboxReceivers,
     peer_id: Vec<u8>,
@@ -2888,9 +3046,12 @@ async fn layout_peer_writer_task<W>(
     let mut targeted_open = true;
     let mut state_open = true;
     let mut roster_open = true;
+    let mut presence_open = true;
     let mut pending_targeted = None;
-    let mut pending_state = None;
-    let mut pending_roster = None;
+    // Every latest-wins class shares one shape, so the send order below stays a
+    // min-by-sequence over an array. Adding a class is one more slot here, not another
+    // branch in a hand-written comparison that has to stay in sync with itself.
+    let mut pending_watch: [Option<SequencedEnvelope>; WATCH_CLASSES] = [None, None, None];
     loop {
         if pending_targeted.is_none() {
             match targeted_rx.try_recv() {
@@ -2899,48 +3060,66 @@ async fn layout_peer_writer_task<W>(
                 Err(mpsc::error::TryRecvError::Empty) => {}
             }
         }
-        if pending_state.is_none() && state_open && state_rx.has_changed().unwrap_or(false) {
-            pending_state = state_rx.borrow_and_update().clone();
+        if pending_watch[WATCH_STATE].is_none()
+            && state_open
+            && state_rx.has_changed().unwrap_or(false)
+        {
+            pending_watch[WATCH_STATE] = state_rx.borrow_and_update().clone();
         }
-        if pending_roster.is_none() && roster_open && roster_rx.has_changed().unwrap_or(false) {
-            pending_roster = roster_rx.borrow_and_update().clone();
+        if pending_watch[WATCH_ROSTER].is_none()
+            && roster_open
+            && roster_rx.has_changed().unwrap_or(false)
+        {
+            pending_watch[WATCH_ROSTER] = roster_rx.borrow_and_update().clone();
+        }
+        if pending_watch[WATCH_PRESENCE].is_none()
+            && presence_open
+            && presence_rx.has_changed().unwrap_or(false)
+        {
+            pending_watch[WATCH_PRESENCE] = presence_rx.borrow_and_update().clone();
         }
 
+        let earliest_watch = pending_watch
+            .iter()
+            .enumerate()
+            .filter_map(|(class, pending)| pending.as_ref().map(|item| (item.sequence, class)))
+            .min();
         let next = match (
-            pending_state.as_ref().map(|item| item.sequence),
-            pending_roster.as_ref().map(|item| item.sequence),
-            pending_targeted.as_ref().map(|item| item.sequence),
+            earliest_watch,
+            pending_targeted.as_ref().map(|i| i.sequence),
         ) {
-            (None, None, None) => {
+            (None, None) => {
                 tokio::select! {
                     targeted = targeted_rx.recv(), if targeted_open => match targeted {
                         Some(targeted) => pending_targeted = Some(targeted),
                         None => targeted_open = false,
                     },
                     changed = state_rx.changed(), if state_open => match changed {
-                        Ok(()) => pending_state = state_rx.borrow_and_update().clone(),
+                        Ok(()) => pending_watch[WATCH_STATE] = state_rx.borrow_and_update().clone(),
                         Err(_) => state_open = false,
                     },
                     changed = roster_rx.changed(), if roster_open => match changed {
-                        Ok(()) => pending_roster = roster_rx.borrow_and_update().clone(),
+                        Ok(()) => pending_watch[WATCH_ROSTER] = roster_rx.borrow_and_update().clone(),
                         Err(_) => roster_open = false,
+                    },
+                    changed = presence_rx.changed(), if presence_open => match changed {
+                        Ok(()) => {
+                            pending_watch[WATCH_PRESENCE] =
+                                presence_rx.borrow_and_update().clone();
+                        }
+                        Err(_) => presence_open = false,
                     },
                     else => return,
                 }
                 continue;
             }
-            (state, roster, targeted) => {
-                let state = state.unwrap_or(u64::MAX);
-                let roster = roster.unwrap_or(u64::MAX);
-                let targeted = targeted.unwrap_or(u64::MAX);
-                if targeted <= state && targeted <= roster {
-                    pending_targeted.take()
-                } else if state <= roster {
-                    pending_state.take()
-                } else {
-                    pending_roster.take()
-                }
+            // Targeted messages win ties: they are point-to-point replies whose ordering a
+            // peer is waiting on, while every watch class is latest-wins state.
+            (Some((watch_sequence, _)), Some(targeted)) if targeted <= watch_sequence => {
+                pending_targeted.take()
             }
+            (None, Some(_)) => pending_targeted.take(),
+            (Some((_, class)), _) => pending_watch[class].take(),
         };
         let Some(next) = next else {
             continue;
@@ -2963,6 +3142,7 @@ async fn layout_member_writer_task(
             LayoutClientMessage::Ready(ready) => envelope::Body::PaneReady(ready),
             LayoutClientMessage::Failed(failed) => envelope::Body::PaneFailed(failed),
             LayoutClientMessage::AgentRoster(roster) => envelope::Body::AgentRoster(roster),
+            LayoutClientMessage::Presence(presence) => envelope::Body::Presence(presence),
         };
         if writer
             .write_next(&coordinator_envelope(&peer_id, body))
@@ -2988,6 +3168,7 @@ async fn layout_member_reader_task(
                 LayoutControlEvent::Snapshot(snapshot)
             }
             Some(envelope::Body::AgentRoster(roster)) => LayoutControlEvent::AgentRoster(roster),
+            Some(envelope::Body::PresenceRoster(roster)) => LayoutControlEvent::Presence(roster),
             Some(envelope::Body::PaneReservation(reservation)) => {
                 LayoutControlEvent::Reservation(reservation)
             }
@@ -3088,6 +3269,30 @@ async fn layout_host_reader_task(
                         coordinator_envelope(
                             &coordinator_peer_id,
                             envelope::Body::AgentRoster(roster),
+                        ),
+                    );
+                }
+            }
+            Some(envelope::Body::Presence(presence)) => {
+                // Re-broadcast the whole set rather than the one entry that moved, so a
+                // peer whose writer is behind can drop all but the newest message and
+                // still be correct about everybody.
+                let roster = match coordinator.lock() {
+                    Ok(mut coordinator) => {
+                        coordinator
+                            .accept_presence(&peer_id, presence)
+                            .map(|_| PresenceRoster {
+                                entries: coordinator.presence(),
+                            })
+                    }
+                    Err(_) => break,
+                };
+                if let Some(roster) = roster {
+                    broadcast_presence(
+                        &peers,
+                        coordinator_envelope(
+                            &coordinator_peer_id,
+                            envelope::Body::PresenceRoster(roster),
                         ),
                     );
                 }
@@ -3762,6 +3967,21 @@ mod control_queue_tests {
         )
     }
 
+    fn presence_envelope(pane_id: u64) -> Envelope {
+        coordinator_envelope(
+            b"coordinator",
+            envelope::Body::PresenceRoster(PresenceRoster {
+                entries: vec![Presence {
+                    peer_id: b"member".to_vec(),
+                    generation: pane_id,
+                    tab_id: 1,
+                    pane_id,
+                    attached: true,
+                }],
+            }),
+        )
+    }
+
     fn roster(generation: u64) -> Envelope {
         coordinator_envelope(
             b"coordinator",
@@ -4049,6 +4269,58 @@ mod control_queue_tests {
                 ..
             })
         ));
+        remove_control_peer(&peers, b"member");
+        writer_task.abort();
+    }
+
+    #[tokio::test]
+    async fn presence_watch_never_swallows_a_pending_commit_or_roster() {
+        // Each latest-wins class owns its own slot. A presence burst is the cheapest way
+        // to prove it: if presence shared the roster slot, the roster below would vanish
+        // and, having no heartbeat of its own, presence would too.
+        let peers = Arc::new(Mutex::new(BTreeMap::new()));
+        let (mailbox, receivers) = ControlMailbox::new();
+        let reader = tokio::spawn(std::future::pending::<()>());
+        peers.lock().unwrap().insert(
+            b"member".to_vec(),
+            ControlPeer::new(mailbox.clone(), reader.abort_handle(), None),
+        );
+        assert!(mailbox.enqueue_initial(commit(1)), "initial frame queues");
+        mailbox.publish_roster(roster(1));
+        mailbox.publish_presence(presence_envelope(1));
+        mailbox.publish_presence(presence_envelope(2));
+        mailbox.publish_state(commit(2));
+
+        let (recorded_tx, mut recorded_rx) = mpsc::unbounded_channel();
+        let writer_task = tokio::spawn(layout_peer_writer_task(
+            RecordingWriter(recorded_tx),
+            receivers,
+            b"member".to_vec(),
+            peers.clone(),
+            None,
+        ));
+
+        let _initial = recorded_rx.recv().await.expect("initial output");
+        let mut saw_roster = false;
+        let mut saw_commit = false;
+        let mut presence_pane_id = None;
+        for _ in 0..3 {
+            match recorded_rx.recv().await.expect("coalesced update").body {
+                Some(envelope::Body::AgentRoster(_)) => saw_roster = true,
+                Some(envelope::Body::LayoutCommit(_)) => saw_commit = true,
+                Some(envelope::Body::PresenceRoster(roster)) => {
+                    presence_pane_id = roster.entries.first().map(|entry| entry.pane_id);
+                }
+                other => panic!("unexpected body {other:?}"),
+            }
+        }
+        assert!(saw_roster, "an agent roster must survive a presence burst");
+        assert!(saw_commit, "a layout commit must survive a presence burst");
+        assert_eq!(
+            presence_pane_id,
+            Some(2),
+            "only the newest presence is sent, and it carries the whole session"
+        );
         remove_control_peer(&peers, b"member");
         writer_task.abort();
     }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -595,6 +595,23 @@ impl MultiPaneTui {
         true
     }
 
+    /// The other members on a tab, in member-list order so the dots never reshuffle.
+    fn tab_watchers(&self, tab_id: TabId) -> Vec<&crate::local_ipc::PresenceRow> {
+        let mut watchers = self
+            .presence
+            .iter()
+            .filter(|row| row.tab_id == tab_id)
+            .collect::<Vec<_>>();
+        watchers.sort_by_key(|row| {
+            self.snapshot
+                .members
+                .iter()
+                .position(|member| member.peer_id == row.peer_id)
+                .unwrap_or(usize::MAX)
+        });
+        watchers
+    }
+
     pub fn set_agent_rows(&mut self, mut rows: Vec<AgentOverlayRow>) -> bool {
         rows.retain_mut(|row| {
             let Some((tab_ordinal, pane_ordinal)) = self.pane_location(row.pane_id) else {
@@ -1232,7 +1249,8 @@ impl MultiPaneTui {
                     index + 1,
                     tab.tab_id == self.current_tab,
                     self.tab_has_unread_agent_pane(tab),
-                ));
+                ))
+                .saturating_add(tab_presence_width(self.tab_watchers(tab.tab_id).len()));
                 let width = right.saturating_sub(x).min(label_width);
                 let rect = Rect::new(x, tab_bar.y, width, tab_bar.height);
                 x = x.saturating_add(label_width);
@@ -2206,6 +2224,20 @@ fn tab_label(title: Option<&str>, index: usize, active: bool, unread: bool) -> S
     if active { format!(" {label} ") } else { label }
 }
 
+/// A dot per other member on the tab: a separator space, then one cell each.
+///
+/// Measured by `tab_label_rects` and drawn by the renderer from this one function, so a
+/// tab's click target can never drift from what is on screen.
+fn tab_presence_width(watchers: usize) -> u16 {
+    match u16::try_from(watchers) {
+        Ok(0) => 0,
+        Ok(watchers) => watchers.saturating_add(1),
+        Err(_) => 0,
+    }
+}
+
+const PRESENCE_WATCHING: &str = "●";
+
 #[allow(clippy::too_many_arguments)]
 fn pane_title(
     custom_title: Option<&str>,
@@ -3177,6 +3209,15 @@ fn render_shared_multi_pane(
                     })
                     .bg(theme.footer_background)
             };
+            let label_rect = geometry.tab_labels[&tab.tab_id];
+            if label_rect.width == 0 {
+                continue;
+            }
+            // Dots first: they are the whole point of glancing at a tab you are not on,
+            // so when the bar runs out of room the tab name gives way, not the presence.
+            let watchers = tui.tab_watchers(tab.tab_id);
+            let presence_width = tab_presence_width(watchers.len()).min(label_rect.width);
+            let name_width = label_rect.width.saturating_sub(presence_width);
             let label = truncate_trailing(
                 &tab_label(
                     tab.title.as_deref(),
@@ -3184,20 +3225,31 @@ fn render_shared_multi_pane(
                     active,
                     tui.tab_has_unread_agent_pane(tab),
                 ),
-                usize::from(geometry.tab_labels[&tab.tab_id].width),
+                usize::from(name_width),
             );
-            let label_rect = geometry.tab_labels[&tab.tab_id];
-            if label_rect.width == 0 {
-                continue;
-            }
-            buffer.set_stringn(
+            let (mut cursor, _) = buffer.set_stringn(
                 label_rect.x,
                 label_rect.y,
                 &label,
-                usize::from(label_rect.width),
+                usize::from(name_width),
                 style,
             );
-            x = x.saturating_add(text_width(&label));
+            if presence_width > 0 {
+                cursor = buffer.set_stringn(cursor, label_rect.y, " ", 1, style).0;
+                for watcher in watchers
+                    .iter()
+                    .take(usize::from(presence_width.saturating_sub(1)))
+                {
+                    let color = member_color(&watcher.peer_id, &tui.snapshot.members, theme)
+                        .unwrap_or(theme.tab_foreground);
+                    cursor = buffer
+                        .set_stringn(cursor, label_rect.y, PRESENCE_WATCHING, 1, style.fg(color))
+                        .0;
+                }
+            }
+            x = x
+                .saturating_add(text_width(&label))
+                .saturating_add(presence_width);
         }
         // `direct 35ms` / `relayed 120ms ×3`, right-aligned. Lives in the tab bar rather
         // than the footer because the footer is transient -- chords, copy feedback and
@@ -7338,16 +7390,16 @@ mod tests {
     use super::{
         AGENT_TOGGLE_WINDOW, CHORD_IDLE_TIMEOUT, ChordMode, ESC_PREFIX_WINDOW, FooterMouseInput,
         FooterSegment, HostControlEvent, HostPaneChannels, HostPaneRuntime, KeyHandling,
-        LayoutControlEvent, MultiPaneTui, PaneMouseProtocol, PaneTextSelection, PaneViewState,
-        PendingEscape, RemoteInput, RemoteSubscriptionState, ScreenCell, SharedLayoutRuntime,
-        SharedLocalPane, UiIntent, VtScreen, allocate_node_with_preview, area_from_terminal_size,
-        chord_footer_badge, contextual_footer, copied_line_count, encode_key, encode_mouse,
-        encode_paste, grid_for_pane, initial_root_pane_grid, is_chord_command, is_chord_navigation,
-        lease_allows_held_input, member_color, member_initial, member_label, mouse_to_screen_cell,
-        pane_border_color, pane_title, pane_wire_id, reconcile_remote_control_attempt,
-        remote_input_decision, render_guest_screen, render_multi_pane,
-        render_multi_pane_with_copy_feedback, render_shared_multi_pane, selection_text, text_width,
-        viewed_screen, visible_leaf_panes,
+        LayoutControlEvent, MultiPaneTui, PRESENCE_WATCHING, PaneMouseProtocol, PaneTextSelection,
+        PaneViewState, PendingEscape, RemoteInput, RemoteSubscriptionState, ScreenCell,
+        SharedLayoutRuntime, SharedLocalPane, UiIntent, VtScreen, allocate_node_with_preview,
+        area_from_terminal_size, chord_footer_badge, contextual_footer, copied_line_count,
+        encode_key, encode_mouse, encode_paste, grid_for_pane, initial_root_pane_grid,
+        is_chord_command, is_chord_navigation, lease_allows_held_input, member_color,
+        member_initial, member_label, mouse_to_screen_cell, pane_border_color, pane_title,
+        pane_wire_id, reconcile_remote_control_attempt, remote_input_decision, render_guest_screen,
+        render_multi_pane, render_multi_pane_with_copy_feedback, render_shared_multi_pane,
+        selection_text, text_width, viewed_screen, visible_leaf_panes,
     };
 
     fn mouse_protocol(
@@ -11385,6 +11437,120 @@ mod tests {
         let footer = terminal.backend().buffer();
         assert_eq!(footer[(0, 3)].bg, theme.footer_background);
         assert_eq!(footer[(0, 3)].fg, theme.footer_orange);
+    }
+
+    fn two_tab_presence_tui() -> MultiPaneTui {
+        let mut snapshot = layout(
+            vec![
+                Tab {
+                    tab_id: 10,
+                    root: Node::Leaf { pane_id: 1 },
+                    title: None,
+                },
+                Tab {
+                    tab_id: 20,
+                    root: Node::Leaf { pane_id: 2 },
+                    title: None,
+                },
+            ],
+            &[(1, 2, 2), (2, 2, 2)],
+        );
+        snapshot.members.push(crate::layout::Member {
+            peer_id: b"tis".to_vec(),
+            endpoint_addr: b"endpoint-tis".to_vec(),
+            display_name: "tis".into(),
+        });
+        MultiPaneTui::new(snapshot).expect("valid layout")
+    }
+
+    #[test]
+    fn a_tab_shows_a_colored_dot_per_other_member_on_it() {
+        let mut tui = two_tab_presence_tui();
+        assert!(tui.set_presence(vec![crate::local_ipc::PresenceRow {
+            peer_id: b"tis".to_vec(),
+            tab_id: 20,
+            pane_id: 2,
+        }]));
+        let mut terminal = Terminal::new(TestBackend::new(40, 4)).expect("test terminal");
+
+        terminal
+            .draw(|frame| render_multi_pane(frame, &tui, &BTreeMap::new()))
+            .expect("render");
+        let buffer = terminal.backend().buffer();
+        let tab_bar = (0..40).map(|x| buffer[(x, 0)].symbol()).collect::<String>();
+
+        assert!(
+            tab_bar.starts_with("p2pmux │  Tab #1  · Tab #2 ●"),
+            "the dot belongs to the tab that member is on: {tab_bar:?}"
+        );
+        let dots = (0..40)
+            .filter(|x| buffer[(*x, 0)].symbol() == PRESENCE_WATCHING)
+            .collect::<Vec<u16>>();
+        assert_eq!(dots.len(), 1, "one member on one tab draws one dot");
+        assert_eq!(
+            buffer[(dots[0], 0)].fg,
+            UiTheme::default().member_colors[1],
+            "a member's dot uses their own slot color"
+        );
+    }
+
+    #[test]
+    fn presence_dots_stay_inside_the_tabs_click_target() {
+        // The tab bar measures click targets from tab_label_rects and draws from the
+        // render path. If the dots were added to only one of them, every tab click after
+        // a member moved would land on the wrong tab.
+        let mut tui = two_tab_presence_tui();
+        let area = Rect::new(0, 0, 40, 4);
+        let before = tui.geometry(area).tab_labels[&20];
+
+        assert!(tui.set_presence(vec![crate::local_ipc::PresenceRow {
+            peer_id: b"tis".to_vec(),
+            tab_id: 10,
+            pane_id: 1,
+        }]));
+        let after = tui.geometry(area).tab_labels[&20];
+
+        assert_eq!(
+            after.x,
+            before.x.saturating_add(2),
+            "a dot on tab one shifts tab two's click target by the space plus the dot"
+        );
+
+        let mut terminal = Terminal::new(TestBackend::new(40, 4)).expect("test terminal");
+        terminal
+            .draw(|frame| render_multi_pane(frame, &tui, &BTreeMap::new()))
+            .expect("render");
+        let buffer = terminal.backend().buffer();
+        let drawn = (after.x..after.right())
+            .map(|x| buffer[(x, 0)].symbol())
+            .collect::<String>();
+        assert_eq!(
+            drawn, "Tab #2",
+            "the click target has to cover exactly the label that was drawn"
+        );
+    }
+
+    #[test]
+    fn a_tab_too_narrow_for_both_keeps_the_dot_and_drops_the_name() {
+        let mut tui = two_tab_presence_tui();
+        assert!(tui.set_presence(vec![crate::local_ipc::PresenceRow {
+            peer_id: b"tis".to_vec(),
+            tab_id: 20,
+            pane_id: 2,
+        }]));
+        // Wide enough for the brand and the active tab, and then almost nothing.
+        let mut terminal = Terminal::new(TestBackend::new(24, 4)).expect("test terminal");
+
+        terminal
+            .draw(|frame| render_multi_pane(frame, &tui, &BTreeMap::new()))
+            .expect("render");
+        let buffer = terminal.backend().buffer();
+        let tab_bar = (0..24).map(|x| buffer[(x, 0)].symbol()).collect::<String>();
+
+        assert!(
+            tab_bar.contains('●'),
+            "presence outranks the tab name when the bar runs out of room: {tab_bar:?}"
+        );
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -8488,7 +8488,10 @@ mod tests {
             .host
             .write_input(format!("cd -- {}\n", directory.display()).as_bytes())
             .expect("change source PTY directory");
-        let source_cwd = (0..20).find_map(|_| {
+        // A real shell has to boot and process the `cd` before its cwd moves. Half a
+        // second is enough on an idle Mac and not enough on a loaded CI runner, which
+        // made this fail for reasons that had nothing to do with pane lifecycle.
+        let source_cwd = (0..200).find_map(|_| {
             let cwd = cwd_for_pid(source_pid);
             if cwd
                 .as_ref()

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -63,7 +63,7 @@ use crate::{
         AgentRoster, AgentRosterEntry, AgentRosterState, CreatePane, CreateTab, DeletePane,
         DeleteTab, LayoutRequest, MAX_AGENT_CWD_BYTES, MarkPaneExited,
         NewPanePosition as ProtocolNewPanePosition, PaneDescriptor, PaneFailed, PaneReady,
-        RenamePane, RenameTab, SetPaneLock, SplitAxis,
+        Presence, PresenceRoster, RenamePane, RenameTab, SetPaneLock, SplitAxis,
     },
     pty_host::PtyHost,
     screen::{GuestScreen, HostScreen, SCROLLBACK_LINES, ScreenFrame, SyncGate},
@@ -474,6 +474,7 @@ pub struct MultiPaneTui {
     selection: Option<PaneTextSelection>,
     selection_dragging: bool,
     agent_rows: Vec<AgentOverlayRow>,
+    presence: Vec<crate::local_ipc::PresenceRow>,
     prior_agent_states: BTreeMap<PaneId, AgentRosterState>,
     /// Start of the working interval last seen for a pane. An idle row carries the `0`
     /// sentinel, so the episode a completion refers to has to be remembered while it runs.
@@ -529,6 +530,7 @@ impl MultiPaneTui {
             selection: None,
             selection_dragging: false,
             agent_rows: Vec::new(),
+            presence: Vec::new(),
             prior_agent_states: BTreeMap::new(),
             prior_agent_episodes: BTreeMap::new(),
             notified_agent_episodes: BTreeMap::new(),
@@ -581,6 +583,16 @@ impl MultiPaneTui {
             self.modal,
             ModalState::Rename(_) | ModalState::ConfirmDeleteTab { .. }
         )
+    }
+
+    /// Replace where the other members are looking. Returns whether anything moved, so a
+    /// presence update that changes nothing never costs a repaint.
+    pub fn set_presence(&mut self, presence: Vec<crate::local_ipc::PresenceRow>) -> bool {
+        if self.presence == presence {
+            return false;
+        }
+        self.presence = presence;
+        true
     }
 
     pub fn set_agent_rows(&mut self, mut rows: Vec<AgentOverlayRow>) -> bool {
@@ -4469,21 +4481,47 @@ impl SharedControl {
         }
     }
 
-    fn try_event(&mut self, current_revision: u64) -> Option<LayoutControlEvent> {
+    /// Publishes this member's focus. The coordinator applies it locally and gets the
+    /// resulting full roster back; a member has to wait for the broadcast.
+    fn try_presence(&self, presence: Presence) -> Result<Option<PresenceRoster>, String> {
+        match self {
+            Self::Host(host) => host
+                .publish_local_presence(presence)
+                .map_err(|error| error.to_string()),
+            Self::Member(member) => member
+                .try_presence(presence)
+                .map(|()| None)
+                .map_err(layout_queue_message),
+        }
+    }
+
+    fn try_event(
+        &mut self,
+        current_revision: u64,
+        seen_presence_epoch: &mut u64,
+    ) -> Option<LayoutControlEvent> {
         match self {
             // The coordinator is the authority, so it does not receive its own broadcasts. Poll
             // its tiny in-memory snapshot to observe joins, departures, and member-originated
             // commits without adding a second internal control stream.
-            Self::Host(host) => host
-                .session_snapshot()
-                .ok()
-                .filter(|snapshot| {
-                    snapshot
-                        .state
-                        .as_ref()
-                        .is_some_and(|state| state.revision > current_revision)
-                })
-                .map(LayoutControlEvent::Snapshot),
+            Self::Host(host) => {
+                // Presence has its own counter because it deliberately does not touch the
+                // layout revision: focus changes are frequent, and bumping the revision
+                // for one would reject every in-flight layout request as stale.
+                if let Some((epoch, roster)) = host.presence_if_newer(*seen_presence_epoch) {
+                    *seen_presence_epoch = epoch;
+                    return Some(LayoutControlEvent::Presence(roster));
+                }
+                host.session_snapshot()
+                    .ok()
+                    .filter(|snapshot| {
+                        snapshot
+                            .state
+                            .as_ref()
+                            .is_some_and(|state| state.revision > current_revision)
+                    })
+                    .map(LayoutControlEvent::Snapshot)
+            }
             Self::Member(member) => member.events.try_recv().ok(),
         }
     }
@@ -4606,6 +4644,10 @@ pub struct SharedLayoutRuntime {
     last_local_agent_entries: Vec<AgentRosterEntry>,
     next_agent_roster_heartbeat: Instant,
     last_agent_overlay_animation: Instant,
+    presence_generation: u64,
+    last_local_presence: Option<Presence>,
+    seen_presence_epoch: u64,
+    presence: Vec<Presence>,
 }
 
 impl SharedLayoutRuntime {
@@ -4714,6 +4756,10 @@ impl SharedLayoutRuntime {
             last_local_agent_entries: Vec::new(),
             next_agent_roster_heartbeat: Instant::now(),
             last_agent_overlay_animation: Instant::now(),
+            presence_generation: 0,
+            last_local_presence: None,
+            seen_presence_epoch: 0,
+            presence: Vec::new(),
         };
         value.refresh_local_views();
         Ok(value)
@@ -4901,6 +4947,7 @@ impl SharedLayoutRuntime {
         self.tui
             .set_focus(tab_id, pane_id)
             .map_err(|error| io::Error::other(format!("invalid node focus: {error:?}")))?;
+        self.maybe_publish_presence();
         self.release_blurred_pane(previous)
     }
 
@@ -5304,10 +5351,15 @@ impl SharedLayoutRuntime {
     fn drain(&mut self) -> Result<bool, Box<dyn Error>> {
         let mut changed = false;
         self.retry_tick = self.retry_tick.saturating_add(1);
-        while let Some(event) = self.control.try_event(self.tui.snapshot().revision) {
+        let mut seen_presence_epoch = self.seen_presence_epoch;
+        while let Some(event) = self
+            .control
+            .try_event(self.tui.snapshot().revision, &mut seen_presence_epoch)
+        {
             self.handle_control_event(event)?;
             changed = true;
         }
+        self.seen_presence_epoch = seen_presence_epoch;
         while let Ok((pane_id, result)) = self.subscription_rx.try_recv() {
             match result {
                 Ok(pane) => {
@@ -5352,6 +5404,9 @@ impl SharedLayoutRuntime {
             });
         }
         changed |= self.publish_local_agent_roster();
+        // Cheap: returns immediately unless the focused pane actually moved since the last
+        // drain, and a keypress cannot move focus more than once per drain.
+        changed |= self.maybe_publish_presence();
         let disconnected = self
             .remote
             .iter_mut()
@@ -5423,6 +5478,52 @@ impl SharedLayoutRuntime {
 
     fn refresh_agent_rows(&mut self) -> bool {
         self.tui.set_agent_rows(self.agent_overlay_rows())
+    }
+
+    /// Tell the session where this member is now looking, if it moved.
+    ///
+    /// Called after anything that can change focus. There is no heartbeat and no timer:
+    /// a human moving is the only thing that produces traffic here, so an idle session
+    /// costs nothing.
+    fn maybe_publish_presence(&mut self) -> bool {
+        let presence = Presence {
+            peer_id: self.control.peer_id(),
+            generation: self.presence_generation.saturating_add(1),
+            tab_id: self.tui.current_tab(),
+            pane_id: self.tui.focused_pane(),
+            attached: true,
+        };
+        if self
+            .last_local_presence
+            .as_ref()
+            .is_some_and(|last| last.tab_id == presence.tab_id && last.pane_id == presence.pane_id)
+        {
+            return false;
+        }
+        match self.control.try_presence(presence.clone()) {
+            // The coordinator never receives its own broadcast, so it applies the roster
+            // its own update produced rather than waiting for one to come back.
+            Ok(Some(roster)) => self.presence = roster.entries,
+            Ok(None) => {}
+            Err(_) => return false,
+        }
+        self.presence_generation = presence.generation;
+        self.last_local_presence = Some(presence);
+        true
+    }
+
+    /// Presence of every member other than this one, ready for the renderer.
+    pub fn presence_rows(&self) -> Vec<crate::local_ipc::PresenceRow> {
+        let local_peer_id = self.control.peer_id();
+        self.presence
+            .iter()
+            .filter(|entry| entry.attached && entry.peer_id != local_peer_id)
+            .map(|entry| crate::local_ipc::PresenceRow {
+                peer_id: entry.peer_id.clone(),
+                tab_id: entry.tab_id,
+                pane_id: entry.pane_id,
+            })
+            .collect()
     }
 
     pub fn agent_overlay_rows(&self) -> Vec<AgentOverlayRow> {
@@ -5500,6 +5601,7 @@ impl SharedLayoutRuntime {
                 self.agent_rosters
                     .insert(roster.host_peer_id.clone(), roster);
             }
+            LayoutControlEvent::Presence(roster) => self.presence = roster.entries,
             LayoutControlEvent::Commit(commit) => {
                 self.apply_layout_state(commit.state.as_ref().ok_or("missing layout state")?)?;
             }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -595,6 +595,25 @@ impl MultiPaneTui {
         true
     }
 
+    /// The other members watching a pane, in member-list order so chips never reshuffle.
+    fn pane_watchers(&self, pane_id: PaneId) -> Vec<&crate::local_ipc::PresenceRow> {
+        let mut watchers = self
+            .presence
+            .iter()
+            .filter(|row| row.pane_id == pane_id)
+            .collect::<Vec<_>>();
+        watchers.sort_by_key(|row| self.member_slot(&row.peer_id));
+        watchers
+    }
+
+    fn member_slot(&self, peer_id: &[u8]) -> usize {
+        self.snapshot
+            .members
+            .iter()
+            .position(|member| member.peer_id == peer_id)
+            .unwrap_or(usize::MAX)
+    }
+
     /// The other members on a tab, in member-list order so the dots never reshuffle.
     fn tab_watchers(&self, tab_id: TabId) -> Vec<&crate::local_ipc::PresenceRow> {
         let mut watchers = self
@@ -602,13 +621,7 @@ impl MultiPaneTui {
             .iter()
             .filter(|row| row.tab_id == tab_id)
             .collect::<Vec<_>>();
-        watchers.sort_by_key(|row| {
-            self.snapshot
-                .members
-                .iter()
-                .position(|member| member.peer_id == row.peer_id)
-                .unwrap_or(usize::MAX)
-        });
+        watchers.sort_by_key(|row| self.member_slot(&row.peer_id));
         watchers
     }
 
@@ -2238,6 +2251,53 @@ fn tab_presence_width(watchers: usize) -> u16 {
 
 const PRESENCE_WATCHING: &str = "●";
 
+/// Right-aligned chips for the members watching a pane, one initial each.
+///
+/// This lives on the bottom border because the top one is already carrying
+/// `host: … control: …` and a right-aligned `(locked by …)` badge. The border color is
+/// left alone: it encodes focus and control state, one pane can have several watchers,
+/// and recoloring it per member would make watching look like controlling.
+///
+/// The member holding the control lease is drawn reversed rather than in a second glyph,
+/// so "someone is watching" and "someone can type here" differ without costing a column.
+fn pane_presence_chips(
+    watchers: &[&crate::local_ipc::PresenceRow],
+    controller_peer_id: Option<&[u8]>,
+    members: &[crate::layout::Member],
+    theme: &UiTheme,
+    available_width: usize,
+) -> Option<Line<'static>> {
+    if watchers.is_empty() || available_width < 3 {
+        return None;
+    }
+    let mut spans = Vec::new();
+    let mut width = 0;
+    for watcher in watchers {
+        if width + 2 > available_width.saturating_sub(1) {
+            break;
+        }
+        let color = member_color(&watcher.peer_id, members, theme).unwrap_or(theme.footer_muted);
+        let controlling =
+            controller_peer_id.is_some_and(|controller| controller == watcher.peer_id);
+        let style = if controlling {
+            Style::default().fg(theme.footer_background).bg(color)
+        } else {
+            Style::default().fg(color)
+        };
+        spans.push(Span::raw(" "));
+        spans.push(Span::styled(
+            member_initial(&watcher.peer_id, members).to_string(),
+            style,
+        ));
+        width += 2;
+    }
+    if spans.is_empty() {
+        return None;
+    }
+    spans.push(Span::raw(" "));
+    Some(Line::from(spans).alignment(Alignment::Right))
+}
+
 #[allow(clippy::too_many_arguments)]
 fn pane_title(
     custom_title: Option<&str>,
@@ -3347,6 +3407,15 @@ fn render_shared_multi_pane(
             block = block.title(
                 Line::from(truncate_trailing(&badge, badge_width)).alignment(Alignment::Right),
             );
+        }
+        if let Some(chips) = pane_presence_chips(
+            &tui.pane_watchers(pane_id),
+            view.controller_peer_id.as_deref(),
+            &tui.snapshot.members,
+            theme,
+            title_width,
+        ) {
+            block = block.title_bottom(chips);
         }
         let content = pane_content_rect(rect);
         frame.render_widget(block, rect);
@@ -7396,10 +7465,10 @@ mod tests {
         area_from_terminal_size, chord_footer_badge, contextual_footer, copied_line_count,
         encode_key, encode_mouse, encode_paste, grid_for_pane, initial_root_pane_grid,
         is_chord_command, is_chord_navigation, lease_allows_held_input, member_color,
-        member_initial, member_label, mouse_to_screen_cell, pane_border_color, pane_title,
-        pane_wire_id, reconcile_remote_control_attempt, remote_input_decision, render_guest_screen,
-        render_multi_pane, render_multi_pane_with_copy_feedback, render_shared_multi_pane,
-        selection_text, text_width, viewed_screen, visible_leaf_panes,
+        member_initial, member_label, mouse_to_screen_cell, pane_border_color, pane_presence_chips,
+        pane_title, pane_wire_id, reconcile_remote_control_attempt, remote_input_decision,
+        render_guest_screen, render_multi_pane, render_multi_pane_with_copy_feedback,
+        render_shared_multi_pane, selection_text, text_width, viewed_screen, visible_leaf_panes,
     };
 
     fn mouse_protocol(
@@ -11551,6 +11620,137 @@ mod tests {
             tab_bar.contains('●'),
             "presence outranks the tab name when the bar runs out of room: {tab_bar:?}"
         );
+    }
+
+    fn watcher(peer_id: &[u8], tab_id: u64, pane_id: u64) -> crate::local_ipc::PresenceRow {
+        crate::local_ipc::PresenceRow {
+            peer_id: peer_id.to_vec(),
+            tab_id,
+            pane_id,
+        }
+    }
+
+    fn named_members() -> Vec<crate::layout::Member> {
+        vec![
+            crate::layout::Member {
+                peer_id: b"host".to_vec(),
+                endpoint_addr: b"endpoint".to_vec(),
+                display_name: "pelazas".into(),
+            },
+            crate::layout::Member {
+                peer_id: b"tis".to_vec(),
+                endpoint_addr: b"endpoint-tis".to_vec(),
+                display_name: "tis".into(),
+            },
+            crate::layout::Member {
+                peer_id: b"ana".to_vec(),
+                endpoint_addr: b"endpoint-ana".to_vec(),
+                display_name: "ana".into(),
+            },
+        ]
+    }
+
+    #[test]
+    fn pane_chips_mark_the_controller_apart_from_plain_watchers() {
+        let theme = UiTheme::default();
+        let members = named_members();
+        let rows = [watcher(b"tis", 1, 1), watcher(b"ana", 1, 1)];
+        let watchers = rows.iter().collect::<Vec<_>>();
+
+        let chips = pane_presence_chips(&watchers, Some(b"ana"), &members, &theme, 40)
+            .expect("two watchers draw chips");
+        let initials = chips
+            .spans
+            .iter()
+            .filter(|span| span.content.trim() != "")
+            .collect::<Vec<_>>();
+
+        assert_eq!(initials.len(), 2);
+        assert_eq!(initials[0].content, "T");
+        assert_eq!(initials[1].content, "A");
+        // Watching is foreground-only; holding the lease reverses the chip. Nothing here
+        // may borrow the alert color that means "this pane is under remote control".
+        assert_eq!(initials[0].style.fg, Some(theme.member_colors[1]));
+        assert_eq!(initials[0].style.bg, None);
+        assert_eq!(initials[1].style.bg, Some(theme.member_colors[2]));
+        assert_ne!(initials[1].style.bg, Some(theme.pane_border_remote_control));
+    }
+
+    #[test]
+    fn pane_chips_stand_down_when_the_pane_is_too_narrow() {
+        let theme = UiTheme::default();
+        let members = named_members();
+        let rows = [watcher(b"tis", 1, 1), watcher(b"ana", 1, 1)];
+        let watchers = rows.iter().collect::<Vec<_>>();
+
+        assert!(pane_presence_chips(&watchers, None, &members, &theme, 2).is_none());
+        let cramped = pane_presence_chips(&watchers, None, &members, &theme, 4)
+            .expect("a narrow pane still shows who it can");
+        assert_eq!(
+            cramped
+                .spans
+                .iter()
+                .filter(|span| span.content.trim() != "")
+                .count(),
+            1,
+            "chips are dropped from the end rather than overflowing the border"
+        );
+    }
+
+    #[test]
+    fn watcher_chips_reach_the_pane_bottom_border() {
+        let mut snapshot = layout(
+            vec![Tab {
+                tab_id: 1,
+                root: Node::Leaf { pane_id: 1 },
+                title: None,
+            }],
+            &[(1, 4, 20)],
+        );
+        snapshot.members = named_members();
+        let mut tui = MultiPaneTui::new(snapshot).expect("valid layout");
+        assert!(tui.set_presence(vec![watcher(b"tis", 1, 1)]));
+        let mut terminal = Terminal::new(TestBackend::new(24, 8)).expect("test terminal");
+
+        terminal
+            .draw(|frame| render_multi_pane(frame, &tui, &BTreeMap::new()))
+            .expect("render");
+        let buffer = terminal.backend().buffer();
+        let bottom = buffer.area.bottom().saturating_sub(2);
+        let border = (0..24)
+            .map(|x| buffer[(x, bottom)].symbol())
+            .collect::<String>();
+
+        assert!(
+            border.contains('T'),
+            "the watcher's initial belongs on the bottom border: {border:?}"
+        );
+        let chip_x = (0..24)
+            .find(|x| buffer[(*x, bottom)].symbol() == "T")
+            .expect("chip column");
+        assert_eq!(
+            buffer[(chip_x, bottom)].fg,
+            UiTheme::default().member_colors[1]
+        );
+    }
+
+    #[test]
+    fn a_pane_border_keeps_its_meaning_when_somebody_watches_it() {
+        // Presence must not repaint the border: it encodes focus and control, and one
+        // pane can have several watchers that a single color could not express.
+        let theme = UiTheme::default();
+        let watched = pane_border_color(
+            &theme,
+            false,
+            Some(&[]),
+            false,
+            true,
+            false,
+            ChordMode::None,
+        );
+
+        assert_eq!(watched, theme.pane_border_free_focused);
+        assert_ne!(watched, theme.pane_border_remote_control);
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -3481,16 +3481,19 @@ fn render_agents_overlay(frame: &mut Frame<'_>, tui: &MultiPaneTui, now_unix_ms:
         .border_style(Style::default().fg(tui.theme.agent_overlay_chrome));
     let content = agents_overlay_content(area);
     frame.render_widget(block, panel);
+    // The overlay is already the place you look to answer "what is happening in this
+    // session". Who is here and where belongs in the same glance, above the agents.
+    let members = presence_overlay_lines(tui);
     if tui.agent_rows.is_empty() {
-        frame.render_widget(
-            Paragraph::new(Line::styled(
-                "No agents running",
-                Style::default().fg(tui.theme.agent_overlay_muted),
-            )),
-            content,
-        );
+        let mut lines = members;
+        lines.push(Line::styled(
+            "No agents running",
+            Style::default().fg(tui.theme.agent_overlay_muted),
+        ));
+        frame.render_widget(Paragraph::new(lines), content);
     } else {
-        let mut lines = Vec::with_capacity(tui.agent_rows.len().saturating_mul(3));
+        let mut lines = members;
+        lines.reserve(tui.agent_rows.len().saturating_mul(3));
         let animation_phase = agent_overlay_animation_phase(now_unix_ms);
         for (index, row) in tui.agent_rows.iter().enumerate() {
             lines.extend(format_agent_overlay_card(
@@ -3516,6 +3519,50 @@ fn render_agents_overlay(frame: &mut Frame<'_>, tui: &MultiPaneTui, now_unix_ms:
         );
     }
     render_agents_overlay_help(frame.buffer_mut(), &tui.theme, agents_overlay_help(area));
+}
+
+/// One line per other member: their dot, their name, and where they are.
+///
+/// Empty in a solo session, so a single-player overlay gains no header for nobody. The
+/// tab and pane ordinals come from the same lookup the agent rows use, so a member on a
+/// pane this client cannot resolve is reported honestly rather than placed at a guess.
+fn presence_overlay_lines(tui: &MultiPaneTui) -> Vec<Line<'static>> {
+    let watchers = tui.presence.iter().collect::<Vec<_>>();
+    if watchers.is_empty() {
+        return Vec::new();
+    }
+    let mut watchers = watchers;
+    watchers.sort_by_key(|row| tui.member_slot(&row.peer_id));
+    let mut lines = vec![Line::styled(
+        "Members",
+        Style::default()
+            .fg(tui.theme.agent_overlay_muted)
+            .add_modifier(Modifier::BOLD),
+    )];
+    for row in watchers {
+        let color = member_color(&row.peer_id, &tui.snapshot.members, &tui.theme)
+            .unwrap_or(tui.theme.agent_overlay_muted);
+        let location = match tui.pane_location(row.pane_id) {
+            Some((tab_ordinal, pane_ordinal)) => {
+                format!("Tab {tab_ordinal} · Pane {pane_ordinal}")
+            }
+            None => String::from("elsewhere"),
+        };
+        lines.push(Line::from(vec![
+            Span::styled(PRESENCE_WATCHING, Style::default().fg(color)),
+            Span::raw(" "),
+            Span::styled(
+                sanitize_single_line(&member_label(&row.peer_id, &tui.snapshot.members)),
+                Style::default().fg(tui.theme.agent_overlay_foreground),
+            ),
+            Span::styled(
+                format!(" · {location}"),
+                Style::default().fg(tui.theme.agent_overlay_muted),
+            ),
+        ]));
+    }
+    lines.push(Line::raw(""));
+    lines
 }
 
 fn agents_overlay_panel(area: Rect) -> Rect {
@@ -7466,9 +7513,10 @@ mod tests {
         encode_key, encode_mouse, encode_paste, grid_for_pane, initial_root_pane_grid,
         is_chord_command, is_chord_navigation, lease_allows_held_input, member_color,
         member_initial, member_label, mouse_to_screen_cell, pane_border_color, pane_presence_chips,
-        pane_title, pane_wire_id, reconcile_remote_control_attempt, remote_input_decision,
-        render_guest_screen, render_multi_pane, render_multi_pane_with_copy_feedback,
-        render_shared_multi_pane, selection_text, text_width, viewed_screen, visible_leaf_panes,
+        pane_title, pane_wire_id, presence_overlay_lines, reconcile_remote_control_attempt,
+        remote_input_decision, render_guest_screen, render_multi_pane,
+        render_multi_pane_with_copy_feedback, render_shared_multi_pane, selection_text, text_width,
+        viewed_screen, visible_leaf_panes,
     };
 
     fn mouse_protocol(
@@ -11694,6 +11742,55 @@ mod tests {
                 .count(),
             1,
             "chips are dropped from the end rather than overflowing the border"
+        );
+    }
+
+    #[test]
+    fn the_overlay_lists_who_is_here_and_where() {
+        let mut snapshot = layout(
+            vec![
+                Tab {
+                    tab_id: 1,
+                    root: Node::Leaf { pane_id: 1 },
+                    title: None,
+                },
+                Tab {
+                    tab_id: 2,
+                    root: Node::Leaf { pane_id: 2 },
+                    title: None,
+                },
+            ],
+            &[(1, 2, 2), (2, 2, 2)],
+        );
+        snapshot.members = named_members();
+        let mut tui = MultiPaneTui::new(snapshot).expect("valid layout");
+
+        assert!(
+            presence_overlay_lines(&tui).is_empty(),
+            "a solo session gains no header for nobody"
+        );
+
+        assert!(tui.set_presence(vec![watcher(b"tis", 2, 2), watcher(b"ana", 1, 404)]));
+        let lines = presence_overlay_lines(&tui);
+        let rendered = lines
+            .iter()
+            .map(|line| {
+                line.spans
+                    .iter()
+                    .map(|span| span.content.as_ref())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(rendered[0], "Members");
+        assert_eq!(rendered[1], "● tis · Tab 2 · Pane 1");
+        assert_eq!(
+            rendered[2], "● ana · elsewhere",
+            "a pane this client cannot resolve is reported, not guessed at"
+        );
+        assert_eq!(
+            rendered[3], "",
+            "the agents below get their own breathing room"
         );
     }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -7165,6 +7165,41 @@ fn member_label(peer_id: &[u8], members: &[crate::layout::Member]) -> String {
     }
 }
 
+/// The color identifying a member everywhere presence is drawn.
+///
+/// The slot is the member's position in the authoritative member list, which every
+/// client receives at the same revision, so all of them agree on who is which color
+/// without a wire field to carry it. The cost is that slots shift when a member
+/// leaves; the initial from [`member_initial`] rides alongside every color so an
+/// identity is only ever recolored, never lost.
+pub fn member_color(
+    peer_id: &[u8],
+    members: &[crate::layout::Member],
+    theme: &UiTheme,
+) -> Option<Color> {
+    let slot = members
+        .iter()
+        .position(|member| member.peer_id == peer_id)?;
+    Some(theme.member_colors[slot % theme.member_colors.len()])
+}
+
+/// The one-character stand-in for a member, for terminals and eyes that cannot separate
+/// eight hues. Falls back to the peer id when a display name is missing or unprintable.
+pub fn member_initial(peer_id: &[u8], members: &[crate::layout::Member]) -> char {
+    members
+        .iter()
+        .find(|member| member.peer_id == peer_id)
+        .and_then(|member| {
+            member
+                .display_name
+                .chars()
+                .find(|character| character.is_alphanumeric())
+        })
+        .or_else(|| short_peer(peer_id).chars().next())
+        .map(|character| character.to_ascii_uppercase())
+        .unwrap_or('?')
+}
+
 #[cfg(test)]
 mod tests {
     use std::{
@@ -7206,10 +7241,11 @@ mod tests {
         SharedLocalPane, UiIntent, VtScreen, allocate_node_with_preview, area_from_terminal_size,
         chord_footer_badge, contextual_footer, copied_line_count, encode_key, encode_mouse,
         encode_paste, grid_for_pane, initial_root_pane_grid, is_chord_command, is_chord_navigation,
-        lease_allows_held_input, member_label, mouse_to_screen_cell, pane_border_color, pane_title,
-        pane_wire_id, reconcile_remote_control_attempt, remote_input_decision, render_guest_screen,
-        render_multi_pane, render_multi_pane_with_copy_feedback, render_shared_multi_pane,
-        selection_text, text_width, viewed_screen, visible_leaf_panes,
+        lease_allows_held_input, member_color, member_initial, member_label, mouse_to_screen_cell,
+        pane_border_color, pane_title, pane_wire_id, reconcile_remote_control_attempt,
+        remote_input_decision, render_guest_screen, render_multi_pane,
+        render_multi_pane_with_copy_feedback, render_shared_multi_pane, selection_text, text_width,
+        viewed_screen, visible_leaf_panes,
     };
 
     fn mouse_protocol(
@@ -11326,6 +11362,78 @@ mod tests {
             "sam · aabbccdd"
         );
         assert_eq!(member_label(&members[2].peer_id, &members), "pat");
+    }
+
+    fn presence_members(count: usize) -> Vec<crate::layout::Member> {
+        (0..count)
+            .map(|index| crate::layout::Member {
+                peer_id: vec![index as u8; 4],
+                endpoint_addr: vec![index as u8],
+                display_name: format!("member{index}"),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn member_colors_are_distinct_per_slot_and_agree_across_clients() {
+        let theme = UiTheme::default();
+        let members = presence_members(crate::config::MEMBER_COLOR_SLOTS);
+
+        let colors = members
+            .iter()
+            .map(|member| member_color(&member.peer_id, &members, &theme))
+            .collect::<Option<Vec<_>>>()
+            .expect("every member has a color");
+        for (slot, color) in colors.iter().enumerate() {
+            assert!(
+                !colors[..slot].contains(color),
+                "a full session must never show two members the same color"
+            );
+        }
+
+        // A second client holding the same authoritative member list derives the same
+        // colors: that agreement is what lets presence ship without a wire color field.
+        let mirrored = members.clone();
+        for member in &members {
+            assert_eq!(
+                member_color(&member.peer_id, &members, &theme),
+                member_color(&member.peer_id, &mirrored, &theme)
+            );
+        }
+    }
+
+    #[test]
+    fn member_colors_avoid_the_reserved_control_and_alert_colors() {
+        let theme = UiTheme::default();
+        for color in theme.member_colors {
+            assert_ne!(
+                color, theme.pane_border_remote_control,
+                "a member color must not read as an actively controlled pane"
+            );
+            assert_ne!(color, theme.tab_active_background);
+            assert_ne!(color, theme.footer_accent);
+        }
+    }
+
+    #[test]
+    fn member_color_is_none_for_a_departed_peer() {
+        let theme = UiTheme::default();
+        let members = presence_members(2);
+
+        assert_eq!(
+            member_color(&[0xff, 0xff, 0xff, 0xff], &members, &theme),
+            None
+        );
+    }
+
+    #[test]
+    fn member_initials_fall_back_to_the_peer_id() {
+        let mut members = presence_members(2);
+        members[1].display_name = "  ".into();
+
+        assert_eq!(member_initial(&members[0].peer_id, &members), 'M');
+        assert_eq!(member_initial(&members[1].peer_id, &members), '0');
+        assert_eq!(member_initial(&[0x9a], &members), '9');
     }
 
     #[test]

--- a/tests/local_ipc.rs
+++ b/tests/local_ipc.rs
@@ -54,6 +54,7 @@ fn protocol_messages_are_tagged_and_attachment_is_generation_safe() {
         screens: Default::default(),
         leases: Default::default(),
         rosters: vec![],
+        presence: vec![],
         local_peer_id: vec![],
         tab_id: 2,
         pane_id: 3,

--- a/tests/protocol.rs
+++ b/tests/protocol.rs
@@ -6,8 +6,9 @@ use p2pmux::protocol::{
     MAX_ENVELOPE_BYTES, MAX_FRAME_BYTES, MAX_INPUT_BYTES, MAX_PANE_ID_BYTES, MAX_PEER_ID_BYTES,
     MAX_SESSION_ID_BYTES, MAX_SNAPSHOT_BYTES, MarkPaneExited, MemberDescriptor, NewPanePosition,
     PROTOCOL_VERSION, PaneDescriptor, PaneFailed, PaneGrid, PaneReady, PaneReservation,
-    PaneSubscribe, ProtocolError, SessionSnapshot, SetPaneLock, SetSplitRatio, Snapshot, SplitAxis,
-    TabDescriptor, TakeControl, UpdatePaneGrids, Welcome, decode_frame, encode_frame, envelope,
+    PaneSubscribe, Presence, ProtocolError, SessionSnapshot, SetPaneLock, SetSplitRatio, Snapshot,
+    SplitAxis, TabDescriptor, TakeControl, UpdatePaneGrids, Welcome, decode_frame, encode_frame,
+    envelope,
 };
 use prost::Message;
 
@@ -431,6 +432,65 @@ fn agent_roster_uses_tag_26_and_round_trips() {
         decode_frame(&frame).expect("valid roster decodes"),
         original
     );
+}
+
+#[test]
+fn presence_uses_tag_27_and_round_trips() {
+    let original = envelope(envelope::Body::Presence(Presence {
+        peer_id: b"peer-a".to_vec(),
+        generation: 4,
+        tab_id: 2,
+        pane_id: 9,
+        attached: true,
+    }));
+    let wire = original.encode_to_vec();
+    assert_eq!(
+        field_shape(&parse_fields(&wire)),
+        vec![(1, 0), (2, 2), (27, 2)]
+    );
+    assert_eq!(Envelope::decode(wire.as_slice()).unwrap(), original);
+    let frame = encode_frame(&original).expect("valid presence encodes");
+    assert_eq!(
+        decode_frame(&frame).expect("valid presence decodes"),
+        original
+    );
+}
+
+#[test]
+fn detached_presence_round_trips_as_an_empty_location() {
+    // A detached member has no focus at all. The zero tab/pane is the wire's way of
+    // saying so, and prost elides both fields -- the whole update is a few bytes.
+    let original = envelope(envelope::Body::Presence(Presence {
+        peer_id: b"peer-a".to_vec(),
+        generation: 5,
+        tab_id: 0,
+        pane_id: 0,
+        attached: false,
+    }));
+    let frame = encode_frame(&original).expect("detached presence encodes");
+    assert_eq!(
+        decode_frame(&frame).expect("detached presence decodes"),
+        original
+    );
+}
+
+#[test]
+fn presence_rejects_an_oversized_peer_id() {
+    let presence = Presence {
+        peer_id: vec![0; MAX_PEER_ID_BYTES + 1],
+        generation: 1,
+        tab_id: 1,
+        pane_id: 1,
+        attached: true,
+    };
+
+    assert!(matches!(
+        encode_frame(&envelope(envelope::Body::Presence(presence))),
+        Err(ProtocolError::FieldTooLarge {
+            field: "presence.peer_id",
+            ..
+        })
+    ));
 }
 
 #[test]

--- a/tests/protocol.rs
+++ b/tests/protocol.rs
@@ -4,11 +4,11 @@ use p2pmux::protocol::{
     LayoutRejectReason, LayoutRequest, LayoutSplit, LayoutState, MAX_AGENT_CWD_BYTES,
     MAX_AGENT_KIND_BYTES, MAX_AGENT_ROSTER_ENTRIES, MAX_DELTA_BYTES, MAX_ENDPOINT_ADDR_BYTES,
     MAX_ENVELOPE_BYTES, MAX_FRAME_BYTES, MAX_INPUT_BYTES, MAX_PANE_ID_BYTES, MAX_PEER_ID_BYTES,
-    MAX_SESSION_ID_BYTES, MAX_SNAPSHOT_BYTES, MarkPaneExited, MemberDescriptor, NewPanePosition,
-    PROTOCOL_VERSION, PaneDescriptor, PaneFailed, PaneGrid, PaneReady, PaneReservation,
-    PaneSubscribe, Presence, ProtocolError, SessionSnapshot, SetPaneLock, SetSplitRatio, Snapshot,
-    SplitAxis, TabDescriptor, TakeControl, UpdatePaneGrids, Welcome, decode_frame, encode_frame,
-    envelope,
+    MAX_PRESENCE_ENTRIES, MAX_SESSION_ID_BYTES, MAX_SNAPSHOT_BYTES, MarkPaneExited,
+    MemberDescriptor, NewPanePosition, PROTOCOL_VERSION, PaneDescriptor, PaneFailed, PaneGrid,
+    PaneReady, PaneReservation, PaneSubscribe, Presence, PresenceRoster, ProtocolError,
+    SessionSnapshot, SetPaneLock, SetSplitRatio, Snapshot, SplitAxis, TabDescriptor, TakeControl,
+    UpdatePaneGrids, Welcome, decode_frame, encode_frame, envelope,
 };
 use prost::Message;
 
@@ -434,15 +434,19 @@ fn agent_roster_uses_tag_26_and_round_trips() {
     );
 }
 
+fn presence(peer_id: &[u8], tab_id: u64, pane_id: u64) -> Presence {
+    Presence {
+        peer_id: peer_id.to_vec(),
+        generation: 4,
+        tab_id,
+        pane_id,
+        attached: true,
+    }
+}
+
 #[test]
 fn presence_uses_tag_27_and_round_trips() {
-    let original = envelope(envelope::Body::Presence(Presence {
-        peer_id: b"peer-a".to_vec(),
-        generation: 4,
-        tab_id: 2,
-        pane_id: 9,
-        attached: true,
-    }));
+    let original = envelope(envelope::Body::Presence(presence(b"peer-a", 2, 9)));
     let wire = original.encode_to_vec();
     assert_eq!(
         field_shape(&parse_fields(&wire)),
@@ -475,19 +479,90 @@ fn detached_presence_round_trips_as_an_empty_location() {
 }
 
 #[test]
-fn presence_rejects_an_oversized_peer_id() {
-    let presence = Presence {
-        peer_id: vec![0; MAX_PEER_ID_BYTES + 1],
-        generation: 1,
-        tab_id: 1,
-        pane_id: 1,
-        attached: true,
-    };
+fn presence_roster_uses_tag_28_and_round_trips() {
+    let original = envelope(envelope::Body::PresenceRoster(PresenceRoster {
+        entries: vec![
+            presence(b"peer-a", 2, 9),
+            Presence {
+                peer_id: b"peer-b".to_vec(),
+                generation: 1,
+                tab_id: 0,
+                pane_id: 0,
+                attached: false,
+            },
+        ],
+    }));
+    let wire = original.encode_to_vec();
+    assert_eq!(
+        field_shape(&parse_fields(&wire)),
+        vec![(1, 0), (2, 2), (28, 2)]
+    );
+    let frame = encode_frame(&original).expect("valid presence roster encodes");
+    assert_eq!(
+        decode_frame(&frame).expect("valid presence roster decodes"),
+        original
+    );
+}
 
+#[test]
+fn presence_entry_limit_matches_the_member_limit() {
+    assert_eq!(MAX_PRESENCE_ENTRIES, p2pmux::layout::MAX_MEMBERS);
+}
+
+#[test]
+fn presence_validation_rejects_bad_shapes() {
+    let oversized_peer = Presence {
+        peer_id: vec![0; MAX_PEER_ID_BYTES + 1],
+        ..presence(b"peer-a", 1, 1)
+    };
     assert!(matches!(
-        encode_frame(&envelope(envelope::Body::Presence(presence))),
+        encode_frame(&envelope(envelope::Body::Presence(oversized_peer))),
         Err(ProtocolError::FieldTooLarge {
             field: "presence.peer_id",
+            ..
+        })
+    ));
+
+    // An attached member is always somewhere; a detached one is always nowhere.
+    let attached_nowhere = Presence {
+        tab_id: 0,
+        ..presence(b"peer-a", 0, 1)
+    };
+    assert!(encode_frame(&envelope(envelope::Body::Presence(attached_nowhere))).is_err());
+    let detached_somewhere = Presence {
+        attached: false,
+        ..presence(b"peer-a", 1, 1)
+    };
+    assert!(encode_frame(&envelope(envelope::Body::Presence(detached_somewhere))).is_err());
+}
+
+#[test]
+fn presence_roster_rejects_duplicate_members_and_an_oversized_set() {
+    let duplicated = PresenceRoster {
+        entries: vec![presence(b"peer-a", 1, 1), presence(b"peer-a", 1, 2)],
+    };
+    assert!(matches!(
+        encode_frame(&envelope(envelope::Body::PresenceRoster(duplicated))),
+        Err(ProtocolError::InvalidLayout(
+            "presence_roster.entry.peer_id"
+        ))
+    ));
+
+    let too_many = PresenceRoster {
+        entries: (0..=u64::try_from(MAX_PRESENCE_ENTRIES).unwrap())
+            .map(|index| Presence {
+                peer_id: format!("peer-{index}").into_bytes(),
+                generation: 1,
+                tab_id: 1,
+                pane_id: index + 1,
+                attached: true,
+            })
+            .collect(),
+    };
+    assert!(matches!(
+        encode_frame(&envelope(envelope::Body::PresenceRoster(too_many))),
+        Err(ProtocolError::FieldTooLarge {
+            field: "presence_roster.entries",
             ..
         })
     ));

--- a/tests/session_layout.rs
+++ b/tests/session_layout.rs
@@ -3,8 +3,8 @@ use p2pmux::{
     protocol::{
         AgentRoster, AgentRosterEntry, AgentRosterState, CreatePane, CreateTab, DeletePane,
         DeleteTab, LayoutCommit, LayoutRejectReason, LayoutRequest, MarkPaneExited,
-        NewPanePosition, PaneFailed, PaneGrid, PaneReady, SetPaneLock, SetSplitRatio, SplitAxis,
-        UpdatePaneGrids,
+        NewPanePosition, PaneFailed, PaneGrid, PaneReady, Presence, SetPaneLock, SetSplitRatio,
+        SplitAxis, UpdatePaneGrids,
     },
     session::{CoordinatorError, CoordinatorResponse, LayoutCoordinator},
 };
@@ -242,6 +242,104 @@ fn admission_advances_revision_and_publishes_the_member_endpoint() {
     let state = commit.commit.state.expect("state present");
     assert!(state.members.iter().any(|member| member.peer_id == host_b()
         && member.endpoint_addr == serde_json::to_vec(&addr_b()).unwrap()));
+}
+
+fn presence(peer_id: Vec<u8>, generation: u64, tab_id: u64, pane_id: u64) -> Presence {
+    Presence {
+        peer_id,
+        generation,
+        tab_id,
+        pane_id,
+        attached: true,
+    }
+}
+
+#[test]
+fn presence_is_keyed_by_the_authenticated_peer_and_ignores_stale_generations() {
+    let mut coordinator = coordinator();
+    coordinator
+        .admit(host_b(), addr_b())
+        .expect("guest admitted");
+
+    // The claimed peer id never wins: a member cannot move somebody else's marker.
+    let accepted = coordinator
+        .accept_presence(&host_b(), presence(host_a(), 1, 1, 1))
+        .expect("presence accepted");
+    assert_eq!(accepted.peer_id, host_b());
+    assert_eq!(coordinator.presence(), vec![accepted.clone()]);
+    assert_eq!(coordinator.presence_epoch(), 1);
+
+    // A replayed or reordered update is dropped, and costs no epoch.
+    assert_eq!(
+        coordinator.accept_presence(&host_b(), presence(host_b(), 1, 2, 2)),
+        None
+    );
+    assert_eq!(coordinator.presence(), vec![accepted]);
+    assert_eq!(coordinator.presence_epoch(), 1);
+
+    let moved = coordinator
+        .accept_presence(&host_b(), presence(host_b(), 2, 2, 2))
+        .expect("newer generation accepted");
+    assert_eq!((moved.tab_id, moved.pane_id), (2, 2));
+    assert_eq!(coordinator.presence_epoch(), 2);
+}
+
+#[test]
+fn presence_from_a_stranger_is_refused() {
+    let mut coordinator = coordinator();
+
+    assert_eq!(
+        coordinator.accept_presence(&host_b(), presence(host_b(), 1, 1, 1)),
+        None
+    );
+    assert!(coordinator.presence().is_empty());
+    assert_eq!(coordinator.presence_epoch(), 0);
+}
+
+#[test]
+fn detaching_clears_a_location_and_departure_drops_the_member() {
+    let mut coordinator = coordinator();
+    coordinator
+        .admit(host_b(), addr_b())
+        .expect("guest admitted");
+    coordinator
+        .accept_presence(&host_b(), presence(host_b(), 1, 1, 1))
+        .expect("presence accepted");
+
+    // A detached member is looking at nothing, whatever location they sent.
+    let detached = coordinator
+        .accept_presence(
+            &host_b(),
+            Presence {
+                attached: false,
+                ..presence(host_b(), 2, 1, 1)
+            },
+        )
+        .expect("detach accepted");
+    assert_eq!((detached.tab_id, detached.pane_id), (0, 0));
+
+    let epoch = coordinator.presence_epoch();
+    coordinator.remove_member(&host_b()).expect("guest removed");
+    assert!(coordinator.presence().is_empty());
+    assert!(
+        coordinator.presence_epoch() > epoch,
+        "a departure has to reach the coordinator's own renderer"
+    );
+}
+
+#[test]
+fn presence_survives_the_pane_it_points_at_being_deleted() {
+    let mut coordinator = coordinator();
+    coordinator
+        .admit(host_b(), addr_b())
+        .expect("guest admitted");
+
+    // Focusing a pane in the same breath somebody deletes it must not strand the
+    // member: the location simply draws nothing until their next update.
+    let accepted = coordinator
+        .accept_presence(&host_b(), presence(host_b(), 1, 99, 99))
+        .expect("unknown location accepted");
+    assert_eq!((accepted.tab_id, accepted.pane_id), (99, 99));
 }
 
 #[test]


### PR DESCRIPTION
Answers "where is everyone" in a shared session. Each member takes a color, and that color identifies them on three surfaces.

## What you see

- **Tabs** — a dot per other member on each tab they are on. Your own marker is never drawn.
- **Panes** — that member's initial, right-aligned on the pane's **bottom** border. The top border was already full (`host: … control: …` plus `(locked by …)`).
- **Overlay** — a members block above the agent rows: dot, name, `Tab N · Pane M`.

**Watching is not controlling.** The pane border keeps its existing five-way meaning. One color could not express several watchers on one pane, and tinting it per member would make watching look like the one state that actually matters in a shared shell. The control-lease holder gets a reversed chip instead.

## Cost

Presence is silent when nobody moves. No heartbeat, no timer, no periodic broadcast — a human moving focus is the only thing that generates traffic. For comparison, screen deltas already publish every 16ms.

Two decisions carry that:

1. **Colors are derived, not sent.** The slot is the member's position in the authoritative member list, which every client already holds at the same revision. Slots shift when a member leaves, so every color is drawn beside that member's initial — an identity is recolored, never lost. Also the colorblind and low-color-terminal fallback. Themeable via `member_colors` in `[ui.theme]`.
2. **The coordinator broadcasts the whole set.** A peer's outbound presence slot is latest-wins, so per-member updates sharing one slot would silently overwrite each other — the agent roster survives that only by heartbeating every 5s. Carrying everyone makes the newest message the complete truth, which is what removes the heartbeat.

Focus deliberately does **not** touch the layout revision: focus changes are frequent and bumping the revision would reject every in-flight `LayoutRequest` as stale. The coordinator counts presence separately, which is also how its own renderer notices a member moved — it is the authority and never receives its own broadcasts.

## Risk

The one hot-path change is `layout_peer_writer_task`: its send order was a hand-written three-way comparison and is now a min-by-sequence over an array of latest-wins classes, so a fourth class is data rather than another branch. Covered by a test that a presence burst cannot swallow a pending commit or agent roster.

`08e8d32` is unrelated to presence: the pane lifecycle test polled a real PTY's cwd for 500ms after writing `cd`, which fails under load on this branch and on main alike. Widened to 5s; it still exits as soon as the cwd moves.

## Not included, on purpose

Idle fade — the only piece of the design that needs a repaint timer or periodic traffic. Presence answers where everyone is; how long since they typed is a different question, and the overlay is the place for it if you want it later.

Docs: README status + config, `docs/MVP_DESIGN.md` §5 and §6, and a dated implementation note on the Notion *MVP Design (consolidated)* page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QNL68VFmSwsSx8ZJKkTije