### PR TITLE
docs: short brew install name, and the Homebrew 6 trust step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,6 +102,7 @@ jobs:
 
             ```sh
             brew tap pelazas/tap
+            brew trust pelazas/tap   # Homebrew 6+ refuses untrusted third-party taps
             brew install p2pmux
             ```
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,8 @@ jobs:
             or
 
             ```sh
-            brew install pelazas/tap/p2pmux
+            brew tap pelazas/tap
+            brew install p2pmux
             ```
 
             Prefer to build it yourself:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Example: Pelazas starts Claude Code in his pane (his subscription). Tis takes co
 
 **Is**
 
-- Lightweight local binary (`brew install pelazas/tap/p2pmux`)
+- Lightweight local binary (`brew tap pelazas/tap && brew install p2pmux`)
 - Zellij-like tabs, panes, and nested splits
 - Real-time multiplayer presence (who’s on which tab/pane)
 - End-to-end encrypted peer-to-peer pane streaming (+ relay when NAT requires it)
@@ -41,8 +41,12 @@ Processes and credential *files* stay on the pane host’s Mac (not uploaded to 
 ## Install
 
 ```text
-brew install pelazas/tap/p2pmux
+brew tap pelazas/tap
+brew install p2pmux
 ```
+
+Tapping once is what buys the short name; `brew install pelazas/tap/p2pmux` is the same thing in
+one line for anyone who would rather not tap.
 
 or, without Homebrew:
 

--- a/README.md
+++ b/README.md
@@ -42,11 +42,14 @@ Processes and credential *files* stay on the pane host’s Mac (not uploaded to 
 
 ```text
 brew tap pelazas/tap
+brew trust pelazas/tap
 brew install p2pmux
 ```
 
-Tapping once is what buys the short name; `brew install pelazas/tap/p2pmux` is the same thing in
-one line for anyone who would rather not tap.
+Tapping once is what buys the short name. `brew trust` is Homebrew 6 and newer: it refuses to
+load a formula from a third-party tap until you say you trust that tap, so without it the
+install stops with `Refusing to load formula … from untrusted tap`. On Homebrew 5 the command
+does not exist and is not needed — skip that line.
 
 or, without Homebrew:
 

--- a/services/site/public/index.html
+++ b/services/site/public/index.html
@@ -62,6 +62,10 @@
     <a href="/install.sh">read it first</a>. It downloads a binary and its SHA256 from GitHub
     Releases, checks the hash, and copies one file into place.
   </p>
+  <p class="note">Or with Homebrew:</p>
+  <pre><code>brew tap pelazas/tap
+brew install p2pmux</code></pre>
+
   <p class="note">Or build it yourself:</p>
   <pre><code>cargo install --git https://github.com/pelazas/p2pmux --locked</code></pre>
 

--- a/services/site/public/index.html
+++ b/services/site/public/index.html
@@ -64,7 +64,12 @@
   </p>
   <p class="note">Or with Homebrew:</p>
   <pre><code>brew tap pelazas/tap
+brew trust pelazas/tap
 brew install p2pmux</code></pre>
+  <p class="note">
+    Homebrew 6 will not load a formula from a third-party tap until you trust it, so the middle
+    line is not optional there. On Homebrew 5 that command does not exist — skip it.
+  </p>
 
   <p class="note">Or build it yourself:</p>
   <pre><code>cargo install --git https://github.com/pelazas/p2pmux --locked</code></pre>


### PR DESCRIPTION
\`brew install pelazas/tap/p2pmux\` returned 404: the repo had no tags or releases, so the tap's formula still carried \`version "0.0.0-PLACEHOLDER"\` and pointed at a release URL that did not exist.

Fixed outside this PR:
- Tagged and released [v0.1.0](https://github.com/pelazas/p2pmux/releases/tag/v0.1.0) — the existing release workflow built, signed and published both macOS arches.
- Pointed the tap formula at it (pelazas/homebrew-tap@1d2897d) via \`update-formula.sh v0.1.0\`.

This PR is the docs half:
- Lead with \`brew tap pelazas/tap\` + \`brew install p2pmux\`, so the short name is what people copy.
- Document \`brew trust pelazas/tap\`. Homebrew 6 refuses to load a formula from an untrusted third-party tap, so even a correct formula stops with \`Refusing to load formula … from untrusted tap\`. Homebrew 5 has no such command.
- Add the Homebrew path to the site, which only offered \`install.sh\` and \`cargo install\`.

Verified from a clean state on Homebrew 6.0.12: untapped, cleared \`~/.homebrew/trust.json\`, then ran the three documented commands — installs 0.1.0 and \`p2pmux --help\` runs. \`curl -fsSL https://p2pmux.com/install.sh | sh\` also works now that a release exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LfkRAjVHwGyonN5Qxquwb2