### PR TITLE
fix: stop scrollback from stalling the mux once history fills

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -112,6 +112,29 @@ fn take_matching_pending(
     pending.remove(&pane_id)
 }
 
+const PANE_SCROLL_WHEEL_STEP: usize = 3;
+
+/// Where one wheel notch should land, measured from the furthest point already asked
+/// for rather than from what is on screen.
+///
+/// Reaching history costs a round trip to the node, so mid-burst the visible offset is
+/// always several notches behind the wheel. Stepping from it made every notch of a
+/// flick ask for the same row, so a gesture worth sixty rows travelled three — and each
+/// of those identical queries still cost the node a full scrollback viewport.
+fn next_scroll_target(
+    visible: usize,
+    requested: Option<usize>,
+    max_rows: usize,
+    up: bool,
+) -> usize {
+    let base = requested.unwrap_or(visible);
+    if up {
+        base.saturating_add(PANE_SCROLL_WHEEL_STEP).min(max_rows)
+    } else {
+        base.saturating_sub(PANE_SCROLL_WHEEL_STEP)
+    }
+}
+
 pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Error>> {
     let config_path = crate::config::config_path()?;
     let config = crate::config::load_config_from(&config_path).map_err(|error| {
@@ -156,6 +179,10 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
     let mut screens = BTreeMap::new();
     let mut history = BTreeMap::new();
     let mut pending_scroll: BTreeMap<u64, PendingScroll> = BTreeMap::new();
+    // Where the wheel has reached for panes whose query is still out. Holding it here
+    // keeps one query per pane in flight, so a burst costs the node one viewport
+    // instead of one per notch.
+    let mut desired_scroll: BTreeMap<u64, usize> = BTreeMap::new();
     let mut next_scrollback_request_id = 1_u64;
     let mut copied_lines = None;
     let mut footer_notice = None;
@@ -314,6 +341,9 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
                             continue;
                         };
                         let Some(snapshot) = snapshot else {
+                            // No history to reach, so anything the burst queued behind this
+                            // is unreachable too.
+                            desired_scroll.remove(&pane_id);
                             footer_notice = unavailable;
                             dirty = true;
                             continue;
@@ -335,6 +365,29 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
                             );
                         }
                         dirty = true;
+                        // Notches that arrived while this query was out were folded into a
+                        // single desired offset. Settle it now: one follow-up for wherever
+                        // the wheel actually ended up, not one per notch.
+                        if let Some(target) = desired_scroll.remove(&pane_id) {
+                            let target = target.min(total_rows as usize);
+                            if history
+                                .get(&pane_id)
+                                .is_some_and(|cache| cache.viewports.contains_key(&target))
+                            {
+                                if let Some(view) = tui.as_mut() {
+                                    view.set_pane_scrollback_offset(pane_id, target);
+                                }
+                            } else {
+                                request_scrollback(
+                                    &mut stream,
+                                    pane_id,
+                                    target,
+                                    &history,
+                                    &mut pending_scroll,
+                                    &mut next_scrollback_request_id,
+                                )?;
+                            }
+                        }
                     }
                     NodeMessage::Leases { leases } => {
                         if let Some(view) = tui.as_mut() {
@@ -520,6 +573,7 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
                             write_message(&mut stream, &ClientMessage::Input { bytes, perf_id })?;
                             history.remove(&tui.focused_pane());
                             pending_scroll.remove(&tui.focused_pane());
+                            desired_scroll.remove(&tui.focused_pane());
                             tui.set_pane_scrollback_offset(tui.focused_pane(), 0);
                         }
                     }
@@ -540,6 +594,7 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
                     )?;
                     history.remove(&tui.focused_pane());
                     pending_scroll.remove(&tui.focused_pane());
+                    desired_scroll.remove(&tui.focused_pane());
                     tui.set_pane_scrollback_offset(tui.focused_pane(), 0);
                 }
                 dirty = true;
@@ -583,16 +638,31 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
                             .get(&pane_id)
                             .map(HistoryCache::available_rows)
                             .unwrap_or(1_000);
-                        let current = tui.pane_scrollback_offset(pane_id);
-                        let target = if up {
-                            current.saturating_add(3)
+                        let target = next_scroll_target(
+                            tui.pane_scrollback_offset(pane_id),
+                            desired_scroll.get(&pane_id).copied().or_else(|| {
+                                pending_scroll.get(&pane_id).map(|pending| pending.target)
+                            }),
+                            scrollback_len,
+                            up,
+                        );
+                        let held = target == 0
+                            || history
+                                .get(&pane_id)
+                                .is_some_and(|history| history.viewports.contains_key(&target));
+                        if held {
+                            // The rows are already here, or the wheel is back at the live
+                            // edge. Move now and abandon whatever the burst had queued.
+                            desired_scroll.remove(&pane_id);
+                            pending_scroll.remove(&pane_id);
+                            tui.set_pane_scrollback_offset(pane_id, target);
+                            if target == 0 {
+                                history.remove(&pane_id);
+                            }
+                        } else if pending_scroll.contains_key(&pane_id) {
+                            desired_scroll.insert(pane_id, target);
                         } else {
-                            current.saturating_sub(3)
-                        };
-                        let cached = history
-                            .get(&pane_id)
-                            .is_some_and(|history| history.viewports.contains_key(&target));
-                        if target > 0 && !cached {
+                            desired_scroll.remove(&pane_id);
                             request_scrollback(
                                 &mut stream,
                                 pane_id,
@@ -601,17 +671,6 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
                                 &mut pending_scroll,
                                 &mut next_scrollback_request_id,
                             )?;
-                        } else {
-                            tui.scroll_mouse_pane(
-                                mouse.column,
-                                mouse.row,
-                                area,
-                                scrollback_len,
-                                up,
-                            );
-                            if !up && tui.pane_scrollback_offset(pane_id) == 0 {
-                                history.remove(&pane_id);
-                            }
                         }
                     }
                 } else {
@@ -641,6 +700,7 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
                     tui.set_agent_overlay_viewport(Rect::new(0, 0, cols, rows));
                     history.clear();
                     pending_scroll.clear();
+                    desired_scroll.clear();
                     write_message(&mut stream, &ClientMessage::Resize { cols, rows })?;
                 }
                 dirty = true;
@@ -1354,6 +1414,32 @@ mod tests {
         assert!(pending.is_empty());
         // The answer is claimed once; a duplicate must not re-apply it.
         assert!(take_matching_pending(&mut pending, 1, 4).is_none());
+    }
+
+    /// A burst has to accumulate. Stepping from the visible offset made every notch ask
+    /// for the same row, because the visible offset cannot move until a reply lands.
+    #[test]
+    fn a_wheel_burst_accumulates_instead_of_asking_for_the_same_row() {
+        // Nothing outstanding: step from what is on screen.
+        assert_eq!(next_scroll_target(0, None, 1_000, true), 3);
+        assert_eq!(next_scroll_target(9, None, 1_000, false), 6);
+
+        // Mid-burst the visible offset lags, so each notch steps from the request.
+        let mut requested = None;
+        for expected in [3, 6, 9, 12] {
+            let target = next_scroll_target(0, requested, 1_000, true);
+            assert_eq!(target, expected);
+            requested = Some(target);
+        }
+
+        // Reversing mid-burst walks the same accumulated position back down.
+        assert_eq!(next_scroll_target(0, Some(12), 1_000, false), 9);
+
+        // Bounds: never past the retained history, never below the live edge.
+        assert_eq!(next_scroll_target(0, Some(9), 10, true), 10);
+        assert_eq!(next_scroll_target(0, Some(10), 10, true), 10);
+        assert_eq!(next_scroll_target(0, Some(2), 10, false), 0);
+        assert_eq!(next_scroll_target(0, Some(0), 10, false), 0);
     }
 
     #[test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -95,6 +95,23 @@ struct PendingScroll {
     target: usize,
 }
 
+/// Claims the outstanding request for `pane_id` only when this reply answers it.
+///
+/// The obvious spelling — remove, then compare — throws away a live request every
+/// time a stale reply lands first, and the reply that would have satisfied it then
+/// finds nothing to claim. A wheel burst is exactly the case that produces stale
+/// replies, so scrolling would stall precisely when it was asked to move most.
+fn take_matching_pending(
+    pending: &mut BTreeMap<u64, PendingScroll>,
+    pane_id: u64,
+    request_id: u64,
+) -> Option<PendingScroll> {
+    if pending.get(&pane_id)?.request_id != request_id {
+        return None;
+    }
+    pending.remove(&pane_id)
+}
+
 pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Error>> {
     let config_path = crate::config::config_path()?;
     let config = crate::config::load_config_from(&config_path).map_err(|error| {
@@ -291,12 +308,11 @@ pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Err
                         snapshot,
                         unavailable,
                     } => {
-                        let Some(pending) = pending_scroll.remove(&pane_id) else {
+                        let Some(pending) =
+                            take_matching_pending(&mut pending_scroll, pane_id, request_id)
+                        else {
                             continue;
                         };
-                        if pending.request_id != request_id {
-                            continue;
-                        }
                         let Some(snapshot) = snapshot else {
                             footer_notice = unavailable;
                             dirty = true;
@@ -1308,6 +1324,36 @@ mod tests {
             client_key_bytes(KeyCode::Enter, KeyModifiers::CONTROL, true),
             Some(b"\r".to_vec())
         );
+    }
+
+    /// A wheel burst leaves older replies in flight behind the newest request. Those
+    /// stale replies have to pass through without disturbing the request still waiting,
+    /// or the pane stops moving for as long as the user keeps scrolling.
+    #[test]
+    fn a_stale_scroll_reply_leaves_the_live_request_waiting() {
+        let mut pending = BTreeMap::new();
+        pending.insert(
+            1,
+            PendingScroll {
+                request_id: 4,
+                target: 12,
+            },
+        );
+
+        assert!(take_matching_pending(&mut pending, 1, 1).is_none());
+        assert!(take_matching_pending(&mut pending, 1, 3).is_none());
+        assert!(take_matching_pending(&mut pending, 2, 4).is_none());
+        assert_eq!(
+            pending.get(&1).map(|pending| pending.request_id),
+            Some(4),
+            "stale and cross-pane replies must not consume the live request"
+        );
+
+        let claimed = take_matching_pending(&mut pending, 1, 4).expect("live reply claims");
+        assert_eq!(claimed.target, 12);
+        assert!(pending.is_empty());
+        // The answer is claimed once; a duplicate must not re-apply it.
+        assert!(take_matching_pending(&mut pending, 1, 4).is_none());
     }
 
     #[test]

--- a/src/node.rs
+++ b/src/node.rs
@@ -433,7 +433,7 @@ fn run_socket_loop(
                 })) => {
                     let (history_id, result) = if let Some(history_id) = history_id {
                         let result = frozen_scrollback
-                            .get(&history_id)
+                            .get_mut(&history_id)
                             .filter(|frozen| frozen.pane_id == pane_id)
                             .map(|frozen| frozen.viewport(offset));
                         (history_id, result)
@@ -447,14 +447,20 @@ fn run_socket_loop(
                         let history_id = next_history_id;
                         next_history_id = next_history_id.wrapping_add(1).max(1);
                         let result = node.node_local_scrollback(pane_id).map(|window| {
-                            let frozen = FrozenScrollback {
-                                pane_id,
-                                total_rows: window.total_rows,
-                                screen: window.screen,
-                            };
-                            let viewport = frozen.viewport(offset);
-                            frozen_scrollback.insert(history_id, frozen);
-                            viewport
+                            // Freeze first, then read through the map: `viewport` needs `&mut`
+                            // now that it moves the stored screen instead of copying it.
+                            frozen_scrollback.insert(
+                                history_id,
+                                FrozenScrollback {
+                                    pane_id,
+                                    total_rows: window.total_rows,
+                                    screen: window.screen,
+                                },
+                            );
+                            frozen_scrollback
+                                .get_mut(&history_id)
+                                .expect("the frozen session was just inserted")
+                                .viewport(offset)
                         });
                         (history_id, result)
                     };
@@ -588,10 +594,18 @@ struct FrozenScrollback {
 }
 
 impl FrozenScrollback {
-    fn viewport(&self, offset: u64) -> (u64, Vec<u8>) {
-        let mut screen = self.screen.clone();
-        screen.set_scrollback(offset.min(self.total_rows) as usize);
-        let snapshot = crate::screen::snapshot_payload(&screen)
+    /// Moves the frozen screen's own offset rather than cloning it.
+    ///
+    /// The clone this replaces copied every retained row — up to `SCROLLBACK_LINES`
+    /// separate `Vec<Cell>` allocations — on a screen the session already owns and
+    /// nothing else can observe. That is 1.4ms at 24x80 and 5.7ms at 50x200 once
+    /// history fills, paid on the socket loop for every wheel notch, while
+    /// `set_scrollback` itself is a field write. Offsets are absolute, so
+    /// successive calls need no restore.
+    fn viewport(&mut self, offset: u64) -> (u64, Vec<u8>) {
+        self.screen
+            .set_scrollback(offset.min(self.total_rows) as usize);
+        let snapshot = crate::screen::snapshot_payload(&self.screen)
             .expect("host scrollback viewport must fit the screen codec")
             .as_ref()
             .to_vec();
@@ -1660,7 +1674,7 @@ mod tests {
         let mut host = HostScreen::new(2, 6).unwrap();
         host.process_pty(b"one\r\ntwo\r\nthree\r\nfour").unwrap();
         let (total_rows, _) = host.history_metadata();
-        let frozen = FrozenScrollback {
+        let mut frozen = FrozenScrollback {
             pane_id: 1,
             total_rows,
             screen: host.screen().clone(),
@@ -1673,6 +1687,52 @@ mod tests {
         assert_eq!(
             guest.screen().unwrap().state_formatted(),
             expected.state_formatted()
+        );
+    }
+
+    /// `viewport` moves the frozen screen's own offset instead of cloning it, so the
+    /// session has to stay reusable: a wheel burst asks the same `FrozenScrollback`
+    /// for many offsets, out of order, and every answer must still match a screen
+    /// parked at that offset.
+    #[test]
+    fn frozen_scrollback_viewport_is_reusable_across_offsets() {
+        let mut host = HostScreen::new(2, 6).unwrap();
+        host.process_pty(b"one\r\ntwo\r\nthree\r\nfour\r\nfive\r\nsix")
+            .unwrap();
+        let (total_rows, _) = host.history_metadata();
+        assert!(
+            total_rows >= 3,
+            "expected retained history, got {total_rows}"
+        );
+        let mut frozen = FrozenScrollback {
+            pane_id: 1,
+            total_rows,
+            screen: host.screen().clone(),
+        };
+        let expected = |offset: usize| {
+            let mut screen = host.screen().clone();
+            screen.set_scrollback(offset);
+            screen.state_formatted()
+        };
+        // Ascend, descend, then repeat an offset already served.
+        for offset in [1_u64, 2, 3, 2, 0, 3, 3] {
+            let (rows, payload) = frozen.viewport(offset);
+            assert_eq!(rows, total_rows);
+            let mut guest = crate::screen::GuestScreen::new();
+            guest.apply_snapshot(1, &payload).unwrap();
+            assert_eq!(
+                guest.screen().unwrap().state_formatted(),
+                expected(offset as usize),
+                "viewport at offset {offset} drifted"
+            );
+        }
+        // An offset past the retained history clamps rather than wrapping.
+        let (_, clamped) = frozen.viewport(total_rows + 50);
+        let mut guest = crate::screen::GuestScreen::new();
+        guest.apply_snapshot(1, &clamped).unwrap();
+        assert_eq!(
+            guest.screen().unwrap().state_formatted(),
+            expected(total_rows as usize)
         );
     }
 

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -315,6 +315,15 @@ impl HostScreen {
         self.kitty_keyboard.active()
     }
 
+    /// Rows the parser is holding, tracked as output arrives.
+    ///
+    /// Callers used to read this by cloning the screen and clamping the offset, which
+    /// copies every retained row — milliseconds per call once history fills. The count
+    /// is already maintained by `process_pty`, so hand it over directly.
+    pub fn retained_scrollback(&self) -> usize {
+        self.retained_scrollback
+    }
+
     /// Number of audible bells since the last call. An agent that rings when it finishes gives
     /// a far better completion signal than inferring one from how long the pane stayed quiet.
     pub fn take_bell_count(&mut self) -> u64 {
@@ -560,6 +569,30 @@ mod tests {
             }
         }
         batches
+    }
+
+    #[test]
+    /// Locks `retained_scrollback` to the clone-and-clamp reading the wheel handler used
+    /// to do, across the two paths that touch the parser: output and resize.
+    fn retained_scrollback_matches_a_clone_and_clamp_reading() {
+        let clone_and_clamp = |screen: &vt100::Screen| {
+            let mut screen = screen.clone();
+            screen.set_scrollback(super::SCROLLBACK_LINES);
+            screen.scrollback()
+        };
+        let mut host = HostScreen::new(24, 80).expect("valid dimensions");
+        assert_eq!(host.retained_scrollback(), 0);
+        for (index, batch) in agent_like_batches(400).into_iter().enumerate() {
+            host.process_pty(&batch).expect("processed");
+            assert_eq!(
+                host.retained_scrollback(),
+                clone_and_clamp(host.screen()),
+                "retained rows diverged at batch {index}",
+            );
+        }
+        assert!(host.retained_scrollback() > 0, "expected retained history");
+        host.resize(30, 100).expect("valid dimensions");
+        assert_eq!(host.retained_scrollback(), clone_and_clamp(host.screen()));
     }
 
     #[test]

--- a/src/tui/render/panes.rs
+++ b/src/tui/render/panes.rs
@@ -448,7 +448,7 @@ pub(in crate::tui) fn render_shared_multi_pane(
             let viewport = fixed_grid_viewport(content, pane.grid_rows, pane.grid_cols);
             let screen = viewed_screen(screen, tui.scrollback_offset(pane_id));
             frame.render_widget(
-                VtScreen::new(&screen).with_selection(
+                VtScreen::new(screen.as_ref()).with_selection(
                     tui.selection()
                         .filter(|selection| selection.pane_id == pane_id),
                 ),

--- a/src/tui/render/vt.rs
+++ b/src/tui/render/vt.rs
@@ -1,6 +1,8 @@
 //! Drawing a `vt100` screen — and the two legacy fixed-grid views — into a
 //! ratatui buffer.
 
+use std::borrow::Cow;
+
 use ratatui::{
     Frame,
     buffer::Buffer,
@@ -31,10 +33,23 @@ impl<'a> VtScreen<'a> {
         self
     }
 }
-pub(in crate::tui) fn viewed_screen(screen: &vt100::Screen, scrollback: usize) -> vt100::Screen {
-    let mut screen = screen.clone();
-    screen.set_scrollback(scrollback);
-    screen
+/// The screen as seen from `scrollback` rows back, copying only when it has to.
+///
+/// Panes render every frame and almost all of them sit at the live edge, where the
+/// screen already shows what the caller asked for. Cloning to say so costs a deep copy
+/// of every retained row — 2.8ms per pane at 30x100 with a full buffer, which four
+/// panes turn into most of the 16ms frame budget. Borrow when the offsets already
+/// agree; a scrolled-back pane still pays for its own copy.
+pub(in crate::tui) fn viewed_screen(
+    screen: &vt100::Screen,
+    scrollback: usize,
+) -> Cow<'_, vt100::Screen> {
+    if screen.scrollback() == scrollback {
+        return Cow::Borrowed(screen);
+    }
+    let mut owned = screen.clone();
+    owned.set_scrollback(scrollback);
+    Cow::Owned(owned)
 }
 pub(in crate::tui) fn available_scrollback(screen: &vt100::Screen) -> usize {
     let mut screen = screen.clone();
@@ -129,6 +144,8 @@ pub(in crate::tui) fn render_host_screen(
 
 #[cfg(test)]
 mod tests {
+    use std::borrow::Cow;
+
     use ratatui::{
         Terminal,
         backend::TestBackend,
@@ -252,6 +269,31 @@ mod tests {
         assert_eq!(buffer[(0, 2)].symbol(), " ");
     }
 
+    /// The live edge is the common case and it renders every frame, so it must not
+    /// copy the row buffer. Only a genuine move off the current offset may.
+    #[test]
+    fn the_live_view_is_borrowed_and_only_a_scrolled_view_is_copied() {
+        let mut parser = vt100::Parser::new(1, 3, 10);
+        parser.process(b"one\r\ntwo\r\nsix");
+
+        assert!(matches!(
+            viewed_screen(parser.screen(), 0),
+            Cow::Borrowed(_)
+        ));
+        assert!(matches!(viewed_screen(parser.screen(), 2), Cow::Owned(_)));
+
+        // Borrowing must not leave the caller looking at the wrong rows, and the
+        // copy must not disturb the screen it came from.
+        parser.screen_mut().set_scrollback(2);
+        assert!(matches!(
+            viewed_screen(parser.screen(), 2),
+            Cow::Borrowed(_)
+        ));
+        let live = viewed_screen(parser.screen(), 0);
+        assert_eq!(live.scrollback(), 0);
+        assert_eq!(parser.screen().scrollback(), 2);
+    }
+
     #[test]
     fn renderer_uses_the_requested_scrollback_view() {
         let mut parser = vt100::Parser::new(1, 3, 10);
@@ -266,7 +308,7 @@ mod tests {
         let mut terminal = Terminal::new(TestBackend::new(3, 1)).expect("test terminal");
 
         terminal
-            .draw(|frame| frame.render_widget(VtScreen::new(&history), frame.area()))
+            .draw(|frame| frame.render_widget(VtScreen::new(history.as_ref()), frame.area()))
             .expect("render should work");
 
         assert_eq!(

--- a/src/tui/runtime/run.rs
+++ b/src/tui/runtime/run.rs
@@ -355,14 +355,17 @@ impl SharedLayoutRuntime {
             .local
             .get(&selection.pane_id)
             .and_then(|pane| {
-                selection_text(&viewed_screen(pane.screen.screen(), scrollback), selection)
+                selection_text(
+                    viewed_screen(pane.screen.screen(), scrollback).as_ref(),
+                    selection,
+                )
             })
             .or_else(|| {
                 self.remote
                     .get(&selection.pane_id)
                     .and_then(|pane| pane.screen.screen())
                     .and_then(|screen| {
-                        selection_text(&viewed_screen(screen, scrollback), selection)
+                        selection_text(viewed_screen(screen, scrollback).as_ref(), selection)
                     })
             });
         let Some(text) = text else {

--- a/src/tui/runtime/run.rs
+++ b/src/tui/runtime/run.rs
@@ -312,7 +312,10 @@ impl SharedLayoutRuntime {
                 let scrollback_len = self
                     .local
                     .get(&pane_id)
-                    .map(|pane| available_scrollback(pane.screen.screen()))
+                    // A local pane owns a `HostScreen`, which already counts its retained
+                    // rows; `available_scrollback` would clone the whole buffer to learn
+                    // the same number, once per wheel notch.
+                    .map(|pane| pane.screen.retained_scrollback())
                     .or_else(|| {
                         self.remote
                             .get(&pane_id)

--- a/src/tui/selection.rs
+++ b/src/tui/selection.rs
@@ -101,7 +101,10 @@ mod tests {
             cursor: ScreenCell { row: 0, col: 1 },
         };
 
-        assert_eq!(selection_text(&screen, selection), Some("on".to_owned()));
+        assert_eq!(
+            selection_text(screen.as_ref(), selection),
+            Some("on".to_owned())
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #50.

Scrolling degraded the whole multiplexer once a session had been alive long
enough to fill its scrollback, and got worse with more panes. Two independent
causes, both in the scroll path rather than the P2P layer.

## 1. Reading history meant copying it

`vt100::Screen::clone` deep-copies the retained row buffer — up to
`SCROLLBACK_LINES` (10,000) rows, each its own `Vec<Cell>`. Three places read
through a clone. Measured on a release build:

| geometry | fresh session | full 10k buffer |
| --- | --- | --- |
| 24x80 | 1.5 µs | **1.38 ms** |
| 30x100 | ~2 µs | **2.80 ms** |
| 50x200 | ~6 µs | **5.66 ms** |

`set_scrollback` itself is a field write (1 ns), so the copy was the entire cost,
and it grew ~900x over the life of a session. That is why the lag arrives only
after "a long chat and enough time passes".

- `FrozenScrollback::viewport` paid it **per wheel notch**, on the node's socket
  loop — the same loop that drains PTYs and forwards frames to peers.
- `viewed_screen` paid it **per pane, per frame**, even at the live edge where
  the screen already showed what was asked for. At 30x100 with four panes that
  is 11.2 ms of the 16 ms frame budget spent on `memcpy`.
- The legacy wheel handler cloned a local pane's screen just to read back a row
  count `HostScreen` already tracks.

Each now reads without copying: the frozen session moves its own offset,
`viewed_screen` returns a `Cow` and borrows when the offsets already agree, and
`HostScreen::retained_scrollback` hands over the counter it maintains anyway.

## 2. A wheel burst cancelled itself and stalled

Two bugs in `client.rs` compounded:

- The `ScrollbackWindow` arm removed the pane's pending entry **before** checking
  the request id, so a stale reply threw away the request still waiting, and the
  reply that would have satisfied it then found nothing to claim.
- Each notch computed its target from the *visible* offset, which cannot move
  until a reply lands. Mid-burst every notch therefore asked for the same row.

Together: during a flick, all N queries asked for offset 3, every reply was
discarded, and the pane did not move at all while the node ground through N full
scrollback viewports. Scrolling harder made it worse.

Now the reply is claimed only by the request it answers, notches step from the
furthest point already requested, and one query per pane stays in flight with the
rest of the burst folded into a desired offset settled by a single follow-up. A
flick costs two queries instead of one per notch and lands where the wheel
stopped.

## Notes

- Fixes 1 and 2 are independent; either alone leaves the issue reproducible.
- The `Cow` change affects the local render path (`local`, `host`, `guest`, legacy
  foreground). An attached client's guest screens retain no history — `state_diff`
  repaints in place and never scrolls — so they were already copying next to
  nothing.
- `MultiPaneTui::scroll_mouse_pane` now has no production caller (the client
  resolves the pane itself for the query, and the mouse arm's own `modal_open`
  guard still blocks scrolling behind a modal). Left in place rather than widening
  this diff — say the word and I will remove it.
- New coverage: viewport reuse across offsets, `retained_scrollback` locked to the
  old clone-and-clamp reading, `Cow` borrow-vs-copy, stale-reply matching, and
  burst accumulation with its bounds.

Gates run locally on macOS: `cargo fmt --check`, `clippy --all-targets
--all-features -D warnings`, `cargo test --all-features` (307 lib tests plus all
integration suites, green on two consecutive full runs), `cargo check
--all-targets --all-features`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0135J6dsjPv86K1oZcGmpaAM
