### PR TITLE
Close the protocol window: a signed layout ledger and a key roster

### DIFF
--- a/docs/MVP_DESIGN.md
+++ b/docs/MVP_DESIGN.md
@@ -156,6 +156,21 @@ lease is drawn as a reversed chip instead.
 
 Membership, `LayoutCommit` revisions, presence, control lease / Take control, Snapshot/Delta, SessionSnapshot bootstrap for joiners. Split/close → coordinator commit (except during coordinator grace freeze).
 
+Every `LayoutCommit` seals a `LedgerEntry`: a numbered, hash-chained record naming the key that
+asked for the change, carrying the request they made, signed by that key and then by the
+coordinator. The layout state still travels beside it as a checkpoint — that is what renderers
+draw, and what lets a joiner start without replaying from the beginning — but the entry is the
+record. A member verifies each entry as it arrives and drops the connection rather than render a
+layout it cannot account for.
+
+This is deliberately the control plane only. PTY bytes and screen deltas stay a plain stream;
+putting them through the ledger would buy nothing and cost the latency the whole product rests
+on.
+
+Admission is a roster of endpoint public keys, not a shared secret. The ticket gets a stranger
+considered; the roster decides. A revoked key is turned away on its own account, whatever the
+session lock says, so a refusal survives both an unlock and a ticket that has been forwarded.
+
 Presence is two messages. A member sends `Presence` (its focused tab and pane, plus whether it
 is attached at all) to the coordinator, which caches the latest one per member and re-broadcasts
 the whole set as a `PresenceRoster`. Carrying every member is what makes the broadcast safe to

--- a/src/ledger.rs
+++ b/src/ledger.rs
@@ -1,0 +1,519 @@
+//! The append-only, authenticated record of everything that happened to a session's layout.
+//!
+//! A `LayoutCommit` used to be a bare snapshot: the whole layout, again, stamped with a
+//! revision number. That form cannot answer the two questions that matter once a session
+//! outlives the people watching it -- *who did this* and *is this the whole story* -- because
+//! a snapshot has no author and no predecessor. Worse, the coordinator relays commits under
+//! its own name, so a member had no way to attribute a change to anyone at all.
+//!
+//! Entries fix both. Each names its author, carries the request that author made, and hashes
+//! the entry before it, so the sequence a member receives is checkable rather than merely
+//! plausible: a dropped, reordered, or rewritten entry breaks the chain, and a forged one
+//! fails a signature. The materialized layout still travels alongside as a checkpoint,
+//! because that is what renderers draw, but the entry is the thing that is true.
+
+use blake3::Hasher;
+use iroh::{PublicKey, SecretKey, Signature};
+
+use crate::protocol::{
+    LEDGER_HASH_BYTES, LEDGER_SIGNATURE_BYTES, LedgerEntry, LedgerEntryKind,
+    MAX_LEDGER_PAYLOAD_BYTES,
+};
+
+/// What `prev_hash` holds in the first entry, which has nothing behind it.
+pub const GENESIS_PREV_HASH: [u8; LEDGER_HASH_BYTES] = [0; LEDGER_HASH_BYTES];
+
+/// Domain tag for the hash the coordinator signs to fix an entry's position.
+const ENTRY_DOMAIN: &[u8] = b"p2pmux/ledger/entry/v1";
+/// Domain tag for the hash an author signs to prove it asked for a change.
+///
+/// Deliberately different from `ENTRY_DOMAIN`: the two hashes cover different fields and
+/// mean different things, and a signature obtained for one must never be replayable as the
+/// other.
+const INTENT_DOMAIN: &[u8] = b"p2pmux/ledger/intent/v1";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum LedgerError {
+    /// A field was missing, the wrong length, or an unknown enum value.
+    Malformed(&'static str),
+    /// The chain skipped, repeated, or rewound.
+    OutOfOrder { expected: u64, found: u64 },
+    /// The right position, but not built on the entry the verifier last saw.
+    Forked,
+    /// Not signed by the coordinator this member joined.
+    BadCoordinatorSignature,
+    /// The named author did not sign the request the entry attributes to them.
+    BadAuthorSignature,
+}
+
+impl std::fmt::Display for LedgerError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Malformed(field) => write!(formatter, "malformed ledger entry: {field}"),
+            Self::OutOfOrder { expected, found } => {
+                write!(
+                    formatter,
+                    "ledger entry {found} arrived where {expected} was expected"
+                )
+            }
+            Self::Forked => formatter.write_str("ledger entry does not follow the one before it"),
+            Self::BadCoordinatorSignature => {
+                formatter.write_str("ledger entry was not signed by this session's coordinator")
+            }
+            Self::BadAuthorSignature => {
+                formatter.write_str("ledger entry's author did not sign the change it claims")
+            }
+        }
+    }
+}
+
+impl std::error::Error for LedgerError {}
+
+/// The coordinator's end of the ledger: assigns positions and signs them.
+pub struct LedgerWriter {
+    session_id: Vec<u8>,
+    secret: SecretKey,
+    next_seq: u64,
+    prev_hash: [u8; LEDGER_HASH_BYTES],
+}
+
+impl LedgerWriter {
+    pub fn new(session_id: Vec<u8>, secret: SecretKey) -> Self {
+        Self {
+            session_id,
+            secret,
+            next_seq: 1,
+            prev_hash: GENESIS_PREV_HASH,
+        }
+    }
+
+    /// The position the next entry will take, and the hash it will name as its predecessor.
+    pub fn head(&self) -> (u64, [u8; LEDGER_HASH_BYTES]) {
+        (self.next_seq, self.prev_hash)
+    }
+
+    /// Seal one change into the ledger.
+    ///
+    /// `author_signature` is the author's own proof that it asked for this, forwarded
+    /// unchanged from the request that carried it. It is empty for the changes nobody
+    /// requested -- a member's connection dropping, a reservation timing out -- which the
+    /// coordinator authors on its own account.
+    pub fn append(
+        &mut self,
+        author_peer_id: Vec<u8>,
+        kind: LedgerEntryKind,
+        payload: Vec<u8>,
+        author_signature: Vec<u8>,
+    ) -> LedgerEntry {
+        let mut entry = LedgerEntry {
+            seq: self.next_seq,
+            prev_hash: self.prev_hash.to_vec(),
+            author_peer_id,
+            kind: kind as i32,
+            payload,
+            author_signature,
+            coordinator_signature: Vec::new(),
+        };
+        let hash = entry_hash(&self.session_id, &entry);
+        entry.coordinator_signature = self.secret.sign(&hash).to_bytes().to_vec();
+        self.next_seq = self.next_seq.saturating_add(1);
+        self.prev_hash = hash;
+        entry
+    }
+}
+
+/// A member's end of the ledger: checks that what arrives is what the coordinator wrote.
+///
+/// The verifier starts trusting nothing but the coordinator's public key, which the join
+/// handshake already tied to the ticket, and builds its position from the first entry it
+/// sees. A member that joins mid-session cannot check the entries it was never sent, so it
+/// anchors on the first one it receives and verifies every one after that.
+pub struct LedgerVerifier {
+    session_id: Vec<u8>,
+    coordinator: PublicKey,
+    expected_seq: Option<u64>,
+    prev_hash: Option<[u8; LEDGER_HASH_BYTES]>,
+}
+
+impl LedgerVerifier {
+    pub fn new(session_id: Vec<u8>, coordinator: PublicKey) -> Self {
+        Self {
+            session_id,
+            coordinator,
+            expected_seq: None,
+            prev_hash: None,
+        }
+    }
+
+    /// Check one entry and, if it holds up, advance to it.
+    ///
+    /// A rejected entry leaves the verifier where it was, so a caller that drops the
+    /// connection and a caller that ignores the entry both stay consistent.
+    pub fn accept(&mut self, entry: &LedgerEntry) -> Result<(), LedgerError> {
+        let hash = self.check(entry)?;
+        self.expected_seq = Some(entry.seq.saturating_add(1));
+        self.prev_hash = Some(hash);
+        Ok(())
+    }
+
+    fn check(&self, entry: &LedgerEntry) -> Result<[u8; LEDGER_HASH_BYTES], LedgerError> {
+        if entry.seq == 0 {
+            return Err(LedgerError::Malformed("seq"));
+        }
+        if entry.prev_hash.len() != LEDGER_HASH_BYTES {
+            return Err(LedgerError::Malformed("prev_hash"));
+        }
+        if entry.author_peer_id.is_empty() {
+            return Err(LedgerError::Malformed("author_peer_id"));
+        }
+        if entry.payload.len() > MAX_LEDGER_PAYLOAD_BYTES {
+            return Err(LedgerError::Malformed("payload"));
+        }
+        let kind =
+            LedgerEntryKind::try_from(entry.kind).map_err(|_| LedgerError::Malformed("kind"))?;
+        if let Some(expected) = self.expected_seq
+            && entry.seq != expected
+        {
+            return Err(LedgerError::OutOfOrder {
+                expected,
+                found: entry.seq,
+            });
+        }
+        if let Some(prev_hash) = self.prev_hash
+            && entry.prev_hash != prev_hash
+        {
+            return Err(LedgerError::Forked);
+        }
+
+        if !entry.author_signature.is_empty() {
+            let author = public_key(&entry.author_peer_id)
+                .ok_or(LedgerError::Malformed("author_peer_id"))?;
+            let signature = signature(&entry.author_signature)
+                .ok_or(LedgerError::Malformed("author_signature"))?;
+            let intent = intent_hash(
+                &self.session_id,
+                &entry.author_peer_id,
+                kind,
+                &entry.payload,
+            );
+            author
+                .verify(&intent, &signature)
+                .map_err(|_| LedgerError::BadAuthorSignature)?;
+        }
+
+        let hash = entry_hash(&self.session_id, entry);
+        let signature = signature(&entry.coordinator_signature)
+            .ok_or(LedgerError::Malformed("coordinator_signature"))?;
+        self.coordinator
+            .verify(&hash, &signature)
+            .map_err(|_| LedgerError::BadCoordinatorSignature)?;
+        Ok(hash)
+    }
+}
+
+/// The bytes an author signs to prove it asked for a change.
+///
+/// Position is deliberately absent: an author cannot know which sequence number its request
+/// will land on, and the coordinator's own signature is what fixes that. The session id is
+/// present so a signature harvested from one session cannot be replanted in another.
+pub fn intent_hash(
+    session_id: &[u8],
+    author_peer_id: &[u8],
+    kind: LedgerEntryKind,
+    payload: &[u8],
+) -> [u8; LEDGER_HASH_BYTES] {
+    let mut hasher = Hasher::new();
+    hasher.update(INTENT_DOMAIN);
+    absorb(&mut hasher, session_id);
+    absorb(&mut hasher, author_peer_id);
+    hasher.update(&(kind as i32).to_le_bytes());
+    absorb(&mut hasher, payload);
+    *hasher.finalize().as_bytes()
+}
+
+/// The bytes the coordinator signs to fix an entry's place in the chain.
+///
+/// Covers the author's signature as well as the change, so an entry cannot be re-attributed
+/// by swapping one signature for another and keeping the coordinator's.
+pub fn entry_hash(session_id: &[u8], entry: &LedgerEntry) -> [u8; LEDGER_HASH_BYTES] {
+    let mut hasher = Hasher::new();
+    hasher.update(ENTRY_DOMAIN);
+    absorb(&mut hasher, session_id);
+    hasher.update(&entry.seq.to_le_bytes());
+    absorb(&mut hasher, &entry.prev_hash);
+    absorb(&mut hasher, &entry.author_peer_id);
+    hasher.update(&entry.kind.to_le_bytes());
+    absorb(&mut hasher, &entry.payload);
+    absorb(&mut hasher, &entry.author_signature);
+    *hasher.finalize().as_bytes()
+}
+
+/// Feed one variable-length field, length first.
+///
+/// Without the length, `("ab", "c")` and `("a", "bc")` would hash the same and two different
+/// entries could share a signature.
+fn absorb(hasher: &mut Hasher, bytes: &[u8]) {
+    hasher.update(&(bytes.len() as u64).to_le_bytes());
+    hasher.update(bytes);
+}
+
+fn public_key(bytes: &[u8]) -> Option<PublicKey> {
+    let bytes: [u8; 32] = bytes.try_into().ok()?;
+    PublicKey::from_bytes(&bytes).ok()
+}
+
+fn signature(bytes: &[u8]) -> Option<Signature> {
+    let bytes: [u8; LEDGER_SIGNATURE_BYTES] = bytes.try_into().ok()?;
+    Some(Signature::from_bytes(&bytes))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(seed: u8) -> SecretKey {
+        SecretKey::from_bytes(&[seed; 32])
+    }
+
+    fn writer(seed: u8) -> LedgerWriter {
+        LedgerWriter::new(b"session".to_vec(), key(seed))
+    }
+
+    fn verifier(seed: u8) -> LedgerVerifier {
+        LedgerVerifier::new(b"session".to_vec(), key(seed).public())
+    }
+
+    fn append(writer: &mut LedgerWriter, payload: &[u8]) -> LedgerEntry {
+        writer.append(
+            key(9).public().as_bytes().to_vec(),
+            LedgerEntryKind::LayoutChange,
+            payload.to_vec(),
+            Vec::new(),
+        )
+    }
+
+    #[test]
+    fn a_chain_the_coordinator_wrote_verifies_end_to_end() {
+        let mut writer = writer(1);
+        let mut verifier = verifier(1);
+
+        for step in 0..4u8 {
+            let entry = append(&mut writer, &[step]);
+            assert_eq!(entry.seq, u64::from(step) + 1);
+            assert_eq!(verifier.accept(&entry), Ok(()));
+        }
+    }
+
+    #[test]
+    fn the_first_entry_is_anchored_to_nothing() {
+        let mut writer = writer(1);
+        let entry = append(&mut writer, b"first");
+
+        assert_eq!(entry.seq, 1);
+        assert_eq!(entry.prev_hash, GENESIS_PREV_HASH.to_vec());
+    }
+
+    #[test]
+    fn a_skipped_entry_is_refused_rather_than_quietly_accepted() {
+        let mut writer = writer(1);
+        let mut verifier = verifier(1);
+        let first = append(&mut writer, b"one");
+        let _dropped = append(&mut writer, b"two");
+        let third = append(&mut writer, b"three");
+
+        verifier.accept(&first).expect("first entry");
+        assert_eq!(
+            verifier.accept(&third),
+            Err(LedgerError::OutOfOrder {
+                expected: 2,
+                found: 3
+            })
+        );
+    }
+
+    #[test]
+    fn an_entry_rewritten_in_place_breaks_the_chain() {
+        // The coordinator re-signs a different history from the same position. Sequence
+        // numbers still line up; only the hash of what came before gives it away.
+        let mut writer = writer(1);
+        let mut verifier = verifier(1);
+        let first = append(&mut writer, b"one");
+        verifier.accept(&first).expect("first entry");
+
+        let mut rival = LedgerWriter::new(b"session".to_vec(), key(1));
+        let _other_first = append(&mut rival, b"something else");
+        let rival_second = append(&mut rival, b"two");
+
+        assert_eq!(rival_second.seq, 2);
+        assert_eq!(verifier.accept(&rival_second), Err(LedgerError::Forked));
+    }
+
+    #[test]
+    fn an_entry_signed_by_anybody_else_is_refused() {
+        let mut impostor = writer(2);
+        let mut verifier = verifier(1);
+        let entry = append(&mut impostor, b"one");
+
+        assert_eq!(
+            verifier.accept(&entry),
+            Err(LedgerError::BadCoordinatorSignature)
+        );
+    }
+
+    #[test]
+    fn editing_a_sealed_entry_invalidates_it() {
+        let mut writer = writer(1);
+        let mut verifier = verifier(1);
+        let mut entry = append(&mut writer, b"delete pane 4");
+        entry.payload = b"delete pane 7".to_vec();
+
+        assert_eq!(
+            verifier.accept(&entry),
+            Err(LedgerError::BadCoordinatorSignature)
+        );
+    }
+
+    #[test]
+    fn reattributing_an_entry_invalidates_it() {
+        // The interesting forgery is not editing the change but changing who is on record
+        // as having asked for it.
+        let mut writer = writer(1);
+        let mut verifier = verifier(1);
+        let mut entry = append(&mut writer, b"delete pane 4");
+        entry.author_peer_id = key(8).public().as_bytes().to_vec();
+
+        assert_eq!(
+            verifier.accept(&entry),
+            Err(LedgerError::BadCoordinatorSignature)
+        );
+    }
+
+    #[test]
+    fn a_rejected_entry_does_not_move_the_verifier_on() {
+        let mut writer = writer(1);
+        let mut verifier = verifier(1);
+        let first = append(&mut writer, b"one");
+        verifier.accept(&first).expect("first entry");
+
+        let mut tampered = append(&mut writer, b"two");
+        let good = tampered.clone();
+        tampered.payload = b"forged".to_vec();
+        assert!(verifier.accept(&tampered).is_err());
+
+        // The real entry 2 still fits: a refusal must not have consumed its position.
+        assert_eq!(verifier.accept(&good), Ok(()));
+    }
+
+    #[test]
+    fn a_chain_from_another_session_does_not_verify_here() {
+        let mut writer = LedgerWriter::new(b"other-session".to_vec(), key(1));
+        let mut verifier = verifier(1);
+        let entry = append(&mut writer, b"one");
+
+        assert_eq!(
+            verifier.accept(&entry),
+            Err(LedgerError::BadCoordinatorSignature)
+        );
+    }
+
+    #[test]
+    fn an_author_signature_proves_who_asked() {
+        let author = key(9);
+        let mut writer = writer(1);
+        let mut verifier = verifier(1);
+        let payload = b"delete pane 4".to_vec();
+        let intent = intent_hash(
+            b"session",
+            author.public().as_bytes(),
+            LedgerEntryKind::LayoutChange,
+            &payload,
+        );
+        let entry = writer.append(
+            author.public().as_bytes().to_vec(),
+            LedgerEntryKind::LayoutChange,
+            payload,
+            author.sign(&intent).to_bytes().to_vec(),
+        );
+
+        assert_eq!(verifier.accept(&entry), Ok(()));
+    }
+
+    #[test]
+    fn a_coordinator_cannot_pin_a_change_on_a_member_who_did_not_sign_it() {
+        let author = key(9);
+        let bystander = key(8);
+        let mut writer = writer(1);
+        let mut verifier = verifier(1);
+        let payload = b"delete pane 4".to_vec();
+        // A signature the bystander really did make, for a change it really did ask for --
+        // reused here under someone else's name.
+        let intent = intent_hash(
+            b"session",
+            bystander.public().as_bytes(),
+            LedgerEntryKind::LayoutChange,
+            &payload,
+        );
+        let entry = writer.append(
+            author.public().as_bytes().to_vec(),
+            LedgerEntryKind::LayoutChange,
+            payload,
+            bystander.sign(&intent).to_bytes().to_vec(),
+        );
+
+        assert_eq!(
+            verifier.accept(&entry),
+            Err(LedgerError::BadAuthorSignature)
+        );
+    }
+
+    #[test]
+    fn an_intent_signature_does_not_double_as_a_position_signature() {
+        // If the two hashes shared a domain, a member's own request signature would be a
+        // valid coordinator signature for the same entry, and any member could seal
+        // entries. The domain tags are what stop that.
+        let payload = b"delete pane 4".to_vec();
+        let author = key(9).public();
+        let intent = intent_hash(
+            b"session",
+            author.as_bytes(),
+            LedgerEntryKind::LayoutChange,
+            &payload,
+        );
+        let entry = LedgerEntry {
+            seq: 1,
+            prev_hash: GENESIS_PREV_HASH.to_vec(),
+            author_peer_id: author.as_bytes().to_vec(),
+            kind: LedgerEntryKind::LayoutChange as i32,
+            payload,
+            author_signature: Vec::new(),
+            coordinator_signature: Vec::new(),
+        };
+
+        assert_ne!(intent, entry_hash(b"session", &entry));
+    }
+
+    #[test]
+    fn fields_cannot_be_slid_across_each_other() {
+        // Length-prefixing is the only thing separating these two entries; without it the
+        // concatenated bytes -- and so the signature -- would be identical.
+        let left = LedgerEntry {
+            seq: 1,
+            prev_hash: GENESIS_PREV_HASH.to_vec(),
+            author_peer_id: b"ab".to_vec(),
+            kind: LedgerEntryKind::LayoutChange as i32,
+            payload: b"c".to_vec(),
+            author_signature: Vec::new(),
+            coordinator_signature: Vec::new(),
+        };
+        let right = LedgerEntry {
+            author_peer_id: b"a".to_vec(),
+            payload: b"bc".to_vec(),
+            ..left.clone()
+        };
+
+        assert_ne!(
+            entry_hash(b"session", &left),
+            entry_hash(b"session", &right)
+        );
+    }
+}

--- a/src/ledger.rs
+++ b/src/ledger.rs
@@ -87,6 +87,12 @@ impl LedgerWriter {
         }
     }
 
+    /// The session these entries belong to, which the coordinator also needs in order to
+    /// check the intent signatures it is about to seal.
+    pub fn session_id(&self) -> &[u8] {
+        &self.session_id
+    }
+
     /// The position the next entry will take, and the hash it will name as its predecessor.
     pub fn head(&self) -> (u64, [u8; LEDGER_HASH_BYTES]) {
         (self.next_seq, self.prev_hash)
@@ -120,6 +126,54 @@ impl LedgerWriter {
         self.prev_hash = hash;
         entry
     }
+}
+
+/// A peer's own end of authorship: signs what it asks for, so the record of who asked
+/// rests on its key rather than on the coordinator's word.
+///
+/// The coordinator signs one of these too. It authors changes like every other member, and
+/// exempting it would leave exactly one identity in the session whose entries nobody could
+/// check.
+#[derive(Clone)]
+pub struct IntentSigner {
+    session_id: Vec<u8>,
+    secret: SecretKey,
+}
+
+impl IntentSigner {
+    pub fn new(session_id: Vec<u8>, secret: SecretKey) -> Self {
+        Self { session_id, secret }
+    }
+
+    /// Sign a change this peer is about to ask for.
+    ///
+    /// `payload` must be the encoded request with its own signature field cleared, which is
+    /// what the coordinator will reconstruct before checking this.
+    pub fn sign(&self, kind: LedgerEntryKind, payload: &[u8]) -> Vec<u8> {
+        let hash = intent_hash(
+            &self.session_id,
+            self.secret.public().as_bytes(),
+            kind,
+            payload,
+        );
+        self.secret.sign(&hash).to_bytes().to_vec()
+    }
+}
+
+/// Whether `author_peer_id` really did ask for this change.
+pub fn verify_intent(
+    session_id: &[u8],
+    author_peer_id: &[u8],
+    kind: LedgerEntryKind,
+    payload: &[u8],
+    author_signature: &[u8],
+) -> bool {
+    let (Some(author), Some(parsed)) = (public_key(author_peer_id), signature(author_signature))
+    else {
+        return false;
+    };
+    let hash = intent_hash(session_id, author_peer_id, kind, payload);
+    author.verify(&hash, &parsed).is_ok()
 }
 
 /// A member's end of the ledger: checks that what arrives is what the coordinator wrote.
@@ -185,22 +239,17 @@ impl LedgerVerifier {
             return Err(LedgerError::Forked);
         }
 
-        if !entry.author_signature.is_empty() {
-            let author = public_key(&entry.author_peer_id)
-                .ok_or(LedgerError::Malformed("author_peer_id"))?;
-            let signature = signature(&entry.author_signature)
-                .ok_or(LedgerError::Malformed("author_signature"))?;
-            let intent = intent_hash(
+        if !entry.author_signature.is_empty()
+            && !verify_intent(
                 &self.session_id,
                 &entry.author_peer_id,
                 kind,
                 &entry.payload,
-            );
-            author
-                .verify(&intent, &signature)
-                .map_err(|_| LedgerError::BadAuthorSignature)?;
+                &entry.author_signature,
+            )
+        {
+            return Err(LedgerError::BadAuthorSignature);
         }
-
         let hash = entry_hash(&self.session_id, entry);
         let signature = signature(&entry.coordinator_signature)
             .ok_or(LedgerError::Malformed("coordinator_signature"))?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub mod hosted_rendezvous;
 pub mod kitty_keyboard;
 pub mod layout;
 pub mod lease;
+pub mod ledger;
 pub mod local_ipc;
 pub mod node;
 pub mod notify_sound;

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -3,7 +3,7 @@
 use prost::Message;
 use std::{collections::HashSet, fmt};
 
-pub const PROTOCOL_VERSION: u32 = 8;
+pub const PROTOCOL_VERSION: u32 = 9;
 pub const MAX_FRAME_BYTES: usize = 1_048_576;
 pub const MAX_ENVELOPE_BYTES: usize = 1_048_560;
 pub const MAX_PEER_ID_BYTES: usize = 64;
@@ -21,6 +21,13 @@ pub const MAX_AGENT_KIND_BYTES: usize = 32;
 pub const MAX_AGENT_CWD_BYTES: usize = 512;
 pub const MAX_LAYOUT_TITLE_BYTES: usize = 128;
 pub const MAX_SESSION_NAME_BYTES: usize = 48;
+/// Length of a BLAKE3 ledger hash.
+pub const LEDGER_HASH_BYTES: usize = 32;
+/// Length of an ed25519 signature, which is what every endpoint key produces.
+pub const LEDGER_SIGNATURE_BYTES: usize = 64;
+/// A ledger payload is one encoded request, so it is bounded by the largest of those
+/// rather than by the frame.
+pub const MAX_LEDGER_PAYLOAD_BYTES: usize = 4 * 1024;
 
 #[derive(Debug)]
 pub enum ProtocolError {
@@ -499,6 +506,72 @@ pub struct LayoutCommit {
     pub revision: u64,
     #[prost(message, optional, tag = "2")]
     pub state: Option<LayoutState>,
+    /// The ledger entry this commit is the materialization of.
+    ///
+    /// `state` is a checkpoint -- convenient, and what every renderer actually draws --
+    /// but the entry is the record. It says who asked for the change and chains to the one
+    /// before it, so a member can tell that the history it was handed is the history that
+    /// happened rather than whatever the relay felt like sending.
+    #[prost(message, optional, tag = "3")]
+    pub entry: Option<LedgerEntry>,
+}
+
+/// One link in a session's append-only layout ledger.
+///
+/// Entries are numbered from 1 with no gaps and each names the hash of its predecessor, so
+/// a member that has been following along can detect a dropped, reordered or rewritten
+/// entry rather than having to trust that none of that happened.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct LedgerEntry {
+    #[prost(uint64, tag = "1")]
+    pub seq: u64,
+    /// BLAKE3 of the previous entry, or 32 zero bytes at `seq` 1.
+    #[prost(bytes = "vec", tag = "2")]
+    pub prev_hash: Vec<u8>,
+    /// The endpoint public key that asked for this change.
+    #[prost(bytes = "vec", tag = "3")]
+    pub author_peer_id: Vec<u8>,
+    #[prost(enumeration = "LedgerEntryKind", tag = "4")]
+    pub kind: i32,
+    /// The authored message itself, encoded: a `LayoutRequest`, a `PaneReady`, or a
+    /// `MembershipRecord` depending on `kind`.
+    #[prost(bytes = "vec", tag = "5")]
+    pub payload: Vec<u8>,
+    /// The author's own signature over its request, empty when the coordinator is the
+    /// author of a change nobody asked for (a member's connection dropping, say).
+    #[prost(bytes = "vec", tag = "6")]
+    pub author_signature: Vec<u8>,
+    /// The coordinator's signature over this entry, which is what fixes its position.
+    #[prost(bytes = "vec", tag = "7")]
+    pub coordinator_signature: Vec<u8>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum LedgerEntryKind {
+    /// A member's `LayoutRequest` that the coordinator accepted.
+    LayoutChange = 1,
+    /// A member reporting that a reserved pane is live.
+    PaneReady = 2,
+    /// Somebody joining, leaving, or moving to a new address.
+    Membership = 3,
+}
+
+/// The payload of a [`LedgerEntryKind::Membership`] entry.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MembershipRecord {
+    #[prost(bytes = "vec", tag = "1")]
+    pub peer_id: Vec<u8>,
+    #[prost(enumeration = "MembershipEvent", tag = "2")]
+    pub event: i32,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum MembershipEvent {
+    Joined = 1,
+    Left = 2,
+    EndpointChanged = 3,
 }
 
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -936,6 +1009,11 @@ fn validate_envelope(envelope: &Envelope) -> Result<(), ProtocolError> {
             if state.revision != commit.revision {
                 return Err(ProtocolError::InvalidLayout("layout_commit.revision"));
             }
+            let entry = commit
+                .entry
+                .as_ref()
+                .ok_or(ProtocolError::InvalidLayout("layout_commit.entry"))?;
+            validate_ledger_entry(entry)?;
         }
         envelope::Body::LayoutReject(reject) => {
             validate_nonzero("layout_reject.request_id", reject.request_id)?;
@@ -1082,6 +1160,39 @@ fn validate_axis(field: &'static str, axis: Option<i32>) -> Result<(), ProtocolE
 fn validate_pane_position(field: &'static str, position: Option<i32>) -> Result<(), ProtocolError> {
     if let Some(position) = position {
         NewPanePosition::try_from(position).map_err(|_| ProtocolError::InvalidLayout(field))?;
+    }
+    Ok(())
+}
+
+fn validate_ledger_entry(entry: &LedgerEntry) -> Result<(), ProtocolError> {
+    validate_nonzero("ledger_entry.seq", entry.seq)?;
+    if entry.prev_hash.len() != LEDGER_HASH_BYTES {
+        return Err(ProtocolError::InvalidLayout("ledger_entry.prev_hash"));
+    }
+    validate_id(
+        "ledger_entry.author_peer_id",
+        &entry.author_peer_id,
+        MAX_PEER_ID_BYTES,
+    )?;
+    LedgerEntryKind::try_from(entry.kind)
+        .map_err(|_| ProtocolError::InvalidLayout("ledger_entry.kind"))?;
+    validate_field_size(
+        "ledger_entry.payload",
+        entry.payload.len(),
+        MAX_LEDGER_PAYLOAD_BYTES,
+    )?;
+    // The author's signature is optional -- a departure has no author to sign it -- but a
+    // present one has to be the right size, and the coordinator always signs.
+    if !entry.author_signature.is_empty() && entry.author_signature.len() != LEDGER_SIGNATURE_BYTES
+    {
+        return Err(ProtocolError::InvalidLayout(
+            "ledger_entry.author_signature",
+        ));
+    }
+    if entry.coordinator_signature.len() != LEDGER_SIGNATURE_BYTES {
+        return Err(ProtocolError::InvalidLayout(
+            "ledger_entry.coordinator_signature",
+        ));
     }
     Ok(())
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -378,6 +378,12 @@ pub struct LayoutRequest {
     pub set_pane_lock: Option<SetPaneLock>,
     #[prost(message, optional, tag = "12")]
     pub mark_pane_exited: Option<MarkPaneExited>,
+    /// The requester's signature over this request with its `author_signature` cleared.
+    ///
+    /// Carried into the ledger entry the coordinator seals, so the record of who asked for
+    /// a change rests on the asker's own key rather than on the coordinator's word.
+    #[prost(bytes = "vec", tag = "13")]
+    pub author_signature: Vec<u8>,
 }
 
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -488,6 +494,9 @@ pub struct PaneReady {
     pub base_revision: u64,
     #[prost(uint64, tag = "3")]
     pub request_id: u64,
+    /// As on `LayoutRequest`: the reporter's signature over this message unsigned.
+    #[prost(bytes = "vec", tag = "4")]
+    pub author_signature: Vec<u8>,
 }
 
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -604,6 +613,11 @@ pub enum LayoutRejectReason {
     /// while a revocation names one public key and survives both an unlock and a reshared
     /// ticket. The joiner is told which so it does not sit there retrying.
     Revoked = 10,
+    /// The request carried no usable signature from the peer that sent it.
+    ///
+    /// The connection is authentic -- QUIC saw to that -- but the ledger records authorship
+    /// for readers who were never on it, and that needs the author's own signature.
+    Unsigned = 11,
 }
 
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -993,6 +1007,7 @@ fn validate_envelope(envelope: &Envelope) -> Result<(), ProtocolError> {
             validate_nonzero("pane_ready.reservation_id", ready.reservation_id)?;
             validate_nonzero("pane_ready.base_revision", ready.base_revision)?;
             validate_nonzero("pane_ready.request_id", ready.request_id)?;
+            validate_author_signature("pane_ready.author_signature", &ready.author_signature)?;
         }
         envelope::Body::PaneFailed(failed) => {
             validate_nonzero("pane_failed.reservation_id", failed.reservation_id)?;
@@ -1197,9 +1212,21 @@ fn validate_ledger_entry(entry: &LedgerEntry) -> Result<(), ProtocolError> {
     Ok(())
 }
 
+/// Framing only checks that a signature is the right shape. Whether it is *there*, and
+/// whether it means anything, is the coordinator's business -- so a peer that forgets to
+/// sign gets a `LayoutRejectReason::Unsigned` it can act on rather than a dropped
+/// connection it cannot.
+fn validate_author_signature(field: &'static str, signature: &[u8]) -> Result<(), ProtocolError> {
+    if !signature.is_empty() && signature.len() != LEDGER_SIGNATURE_BYTES {
+        return Err(ProtocolError::InvalidLayout(field));
+    }
+    Ok(())
+}
+
 fn validate_layout_request(request: &LayoutRequest) -> Result<(), ProtocolError> {
     validate_nonzero("layout_request.request_id", request.request_id)?;
     validate_nonzero("layout_request.base_revision", request.base_revision)?;
+    validate_author_signature("layout_request.author_signature", &request.author_signature)?;
 
     let actions = usize::from(request.create_pane.is_some())
         + usize::from(request.delete_pane.is_some())

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -525,6 +525,12 @@ pub enum LayoutRejectReason {
     /// Distinct from `Limit`: a full session may have room again later, a locked one is a
     /// deliberate refusal, and the joiner must be told which so it can say something true.
     Locked = 9,
+    /// The host revoked this endpoint's place on the roster.
+    ///
+    /// Distinct from `Locked`: a lock is about the door and lifts for everyone at once,
+    /// while a revocation names one public key and survives both an unlock and a reshared
+    /// ticket. The joiner is told which so it does not sit there retrying.
+    Revoked = 10,
 }
 
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/src/session.rs
+++ b/src/session.rs
@@ -29,7 +29,7 @@ use crate::{
         NewPanePosition as LayoutNewPanePosition, Node, Pane, SessionState, Tab,
     },
     lease::LeaseState,
-    ledger::{LedgerVerifier, LedgerWriter},
+    ledger::{IntentSigner, LedgerVerifier, LedgerWriter, verify_intent},
     protocol::{
         AgentRoster, ControlLease, CreatePane, CreateTab, DeletePane, DeleteTab, Delta, Envelope,
         Input, Join, LayoutCommit, LayoutNode, LayoutReject, LayoutRejectReason, LayoutRequest,
@@ -511,7 +511,7 @@ impl LayoutCoordinator {
     pub fn handle_request_at(
         &mut self,
         authenticated_peer_id: &[u8],
-        request: LayoutRequest,
+        mut request: LayoutRequest,
         now: Instant,
     ) -> CoordinatorResponse {
         let request_id = request.request_id;
@@ -529,9 +529,21 @@ impl LayoutCoordinator {
         if request_id == 0 || request.base_revision == 0 || action_count != 1 {
             return reject(request_id, LayoutRejectReason::Malformed);
         }
-        // Captured before the request is taken apart: the ledger records what was asked
-        // for, not a reconstruction of it after the fact.
+        // Taken out before encoding, so the bytes hashed here are the bytes the author
+        // hashed: a signature cannot cover itself. Then captured before the request is
+        // pulled apart, because the ledger records what was asked for rather than a
+        // reconstruction of it after the fact.
+        let author_signature = std::mem::take(&mut request.author_signature);
         let payload = request.encode_to_vec();
+        if !verify_intent(
+            self.ledger.session_id(),
+            authenticated_peer_id,
+            LedgerEntryKind::LayoutChange,
+            &payload,
+            &author_signature,
+        ) {
+            return reject(request_id, LayoutRejectReason::Unsigned);
+        }
 
         let result = if let Some(create) = request.create_pane {
             self.reserve_pane(
@@ -577,7 +589,7 @@ impl LayoutCoordinator {
                     authenticated_peer_id.to_vec(),
                     LedgerEntryKind::LayoutChange,
                     payload,
-                    Vec::new(),
+                    author_signature,
                 ) {
                     Ok(commit) => CoordinatorResponse::Commit(commit),
                     Err(error) => reject(request_id, reject_reason(&layout_error(error))),
@@ -590,10 +602,21 @@ impl LayoutCoordinator {
     pub fn handle_pane_ready(
         &mut self,
         authenticated_peer_id: &[u8],
-        ready: PaneReady,
+        mut ready: PaneReady,
     ) -> CoordinatorResponse {
         if ready.reservation_id == 0 || ready.base_revision == 0 || ready.request_id == 0 {
             return reject(ready.request_id, LayoutRejectReason::Malformed);
+        }
+        let author_signature = std::mem::take(&mut ready.author_signature);
+        let payload = ready.encode_to_vec();
+        if !verify_intent(
+            self.ledger.session_id(),
+            authenticated_peer_id,
+            LedgerEntryKind::PaneReady,
+            &payload,
+            &author_signature,
+        ) {
+            return reject(ready.request_id, LayoutRejectReason::Unsigned);
         }
         let Some(context) = self.reservations.get(&ready.reservation_id) else {
             return reject(ready.request_id, LayoutRejectReason::ReservationFailure);
@@ -608,12 +631,11 @@ impl LayoutCoordinator {
         ) {
             Ok(_) => {
                 self.reservations.remove(&ready.reservation_id);
-                let payload = ready.encode_to_vec();
                 match self.layout_commit(
                     authenticated_peer_id.to_vec(),
                     LedgerEntryKind::PaneReady,
                     payload,
-                    Vec::new(),
+                    author_signature,
                 ) {
                     Ok(commit) => CoordinatorResponse::Commit(commit),
                     Err(error) => reject(ready.request_id, reject_reason(&layout_error(error))),
@@ -992,6 +1014,22 @@ impl LayoutCoordinator {
             true
         });
     }
+}
+
+/// Sign a request the way the coordinator will check it: over the encoded message with the
+/// signature field cleared, since a signature cannot cover itself.
+fn sign_request(signer: &IntentSigner, mut request: LayoutRequest) -> LayoutRequest {
+    request.author_signature = Vec::new();
+    let signature = signer.sign(LedgerEntryKind::LayoutChange, &request.encode_to_vec());
+    request.author_signature = signature;
+    request
+}
+
+fn sign_ready(signer: &IntentSigner, mut ready: PaneReady) -> PaneReady {
+    ready.author_signature = Vec::new();
+    let signature = signer.sign(LedgerEntryKind::PaneReady, &ready.encode_to_vec());
+    ready.author_signature = signature;
+    ready
 }
 
 fn serialized_endpoint(
@@ -2110,6 +2148,9 @@ pub struct SharedLayoutHost {
     coordinator: Arc<Mutex<LayoutCoordinator>>,
     peers: Arc<Mutex<BTreeMap<Vec<u8>, ControlPeer>>>,
     reservation_timeout: Duration,
+    /// The coordinator signs its own requests like anybody else. Exempting it would leave
+    /// exactly one identity in the session whose entries nobody could check.
+    signer: IntentSigner,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -2159,7 +2200,9 @@ pub enum LayoutControlQueueError {
 }
 
 enum LayoutClientMessage {
-    Request(LayoutRequest),
+    /// Boxed because a signed request dwarfs every other message in this queue, and an
+    /// unboxed variant would make each of them pay for it.
+    Request(Box<LayoutRequest>),
     Ready(PaneReady),
     Failed(PaneFailed),
     AgentRoster(AgentRoster),
@@ -2317,6 +2360,7 @@ pub struct SharedLayoutMember {
     pub coordinator_peer_id: Vec<u8>,
     pub session_name: String,
     pub events: mpsc::Receiver<LayoutControlEvent>,
+    signer: IntentSigner,
     outbound: mpsc::Sender<LayoutClientMessage>,
     transport: Transport,
     connection: Connection,
@@ -2337,13 +2381,16 @@ impl SharedLayoutMember {
 
     pub fn try_request(&self, request: LayoutRequest) -> Result<(), LayoutControlQueueError> {
         self.outbound
-            .try_send(LayoutClientMessage::Request(request))
+            .try_send(LayoutClientMessage::Request(Box::new(sign_request(
+                &self.signer,
+                request,
+            ))))
             .map_err(layout_queue_error)
     }
 
     pub fn try_ready(&self, ready: PaneReady) -> Result<(), LayoutControlQueueError> {
         self.outbound
-            .try_send(LayoutClientMessage::Ready(ready))
+            .try_send(LayoutClientMessage::Ready(sign_ready(&self.signer, ready)))
             .map_err(layout_queue_error)
     }
 
@@ -2454,12 +2501,17 @@ impl SharedLayoutHost {
             reservation_timeout,
             Instant::now(),
         )?;
+        let signer = IntentSigner::new(
+            host.ticket().session_id().to_vec(),
+            host.transport.secret_key(),
+        );
         Ok(Self {
             host,
             pane_server,
             coordinator: Arc::new(Mutex::new(coordinator)),
             peers: Arc::new(Mutex::new(BTreeMap::new())),
             reservation_timeout,
+            signer,
         })
     }
 
@@ -2553,6 +2605,7 @@ impl SharedLayoutHost {
         &self,
         request: LayoutRequest,
     ) -> Result<CoordinatorResponse, SessionError> {
+        let request = sign_request(&self.signer, request);
         let peer_id = self.host.transport.endpoint_id().as_bytes().to_vec();
         let response = self
             .coordinator
@@ -2568,6 +2621,7 @@ impl SharedLayoutHost {
         &self,
         ready: PaneReady,
     ) -> Result<CoordinatorResponse, SessionError> {
+        let ready = sign_ready(&self.signer, ready);
         let peer_id = self.host.transport.endpoint_id().as_bytes().to_vec();
         let response = self
             .coordinator
@@ -3218,6 +3272,7 @@ pub async fn join_layout_with_display_name(
             coordinator_peer_id,
             session_name,
             events,
+            signer: IntentSigner::new(ticket.session_id().to_vec(), transport.secret_key()),
             outbound,
             transport: transport.clone(),
             connection: connection.clone(),
@@ -3356,7 +3411,7 @@ async fn layout_member_writer_task(
 ) {
     while let Some(message) = outbound.recv().await {
         let body = match message {
-            LayoutClientMessage::Request(request) => envelope::Body::LayoutRequest(request),
+            LayoutClientMessage::Request(request) => envelope::Body::LayoutRequest(*request),
             LayoutClientMessage::Ready(ready) => envelope::Body::PaneReady(ready),
             LayoutClientMessage::Failed(failed) => envelope::Body::PaneFailed(failed),
             LayoutClientMessage::AgentRoster(roster) => envelope::Body::AgentRoster(roster),

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,7 +1,7 @@
 //! Authenticated Join/Welcome session handshakes over Iroh bi-streams.
 
 use std::{
-    collections::{BTreeMap, BTreeSet},
+    collections::BTreeMap,
     error::Error,
     fmt,
     future::Future,
@@ -55,7 +55,67 @@ pub struct LayoutCoordinator {
     presence_epoch: u64,
     reservation_timeout: Duration,
     locked: bool,
-    admitted: BTreeSet<Vec<u8>>,
+    roster: MemberRoster,
+}
+
+/// Which endpoint public keys the coordinator will let into this session.
+///
+/// The ticket secret is what gets a stranger *considered*; this roster is what decides. The
+/// two used to be the same thing, which made refusal impossible to express: a ticket that
+/// had been forwarded once could not be un-forwarded, and the only lever -- the session
+/// lock -- shut the door on everybody at once. Naming keys instead means a refusal can be
+/// about one person, and it outlives both an unlock and a reshared ticket.
+///
+/// Entries are keyed by the raw endpoint public key, which QUIC has already authenticated
+/// by the time anything here is consulted, so a peer cannot claim to be someone else's
+/// entry.
+#[derive(Clone, Debug, Default)]
+pub struct MemberRoster {
+    entries: BTreeMap<Vec<u8>, RosterStatus>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RosterStatus {
+    /// Admitted at least once, and welcome back through a locked door.
+    Admitted,
+    /// Turned away by name, whatever the lock says.
+    Revoked,
+}
+
+impl MemberRoster {
+    /// Record a key as admitted. A revoked key stays revoked: the whole point of revoking
+    /// is that the holder cannot undo it by knocking again.
+    pub fn admit(&mut self, peer_id: Vec<u8>) -> bool {
+        if self.is_revoked(&peer_id) {
+            return false;
+        }
+        self.entries.insert(peer_id, RosterStatus::Admitted);
+        true
+    }
+
+    /// Turn one key away for the rest of the session. Returns whether this changed anything.
+    pub fn revoke(&mut self, peer_id: Vec<u8>) -> bool {
+        self.entries.insert(peer_id, RosterStatus::Revoked) != Some(RosterStatus::Revoked)
+    }
+
+    pub fn status(&self, peer_id: &[u8]) -> Option<RosterStatus> {
+        self.entries.get(peer_id).copied()
+    }
+
+    pub fn is_admitted(&self, peer_id: &[u8]) -> bool {
+        self.status(peer_id) == Some(RosterStatus::Admitted)
+    }
+
+    pub fn is_revoked(&self, peer_id: &[u8]) -> bool {
+        self.status(peer_id) == Some(RosterStatus::Revoked)
+    }
+
+    /// Every key this session has an opinion about, in deterministic key order.
+    pub fn entries(&self) -> impl Iterator<Item = (&[u8], RosterStatus)> {
+        self.entries
+            .iter()
+            .map(|(peer_id, status)| (peer_id.as_slice(), *status))
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -201,7 +261,7 @@ impl LayoutCoordinator {
             presence_epoch: 0,
             reservation_timeout,
             locked: false,
-            admitted: BTreeSet::new(),
+            roster: MemberRoster::default(),
         })
     }
 
@@ -235,12 +295,32 @@ impl LayoutCoordinator {
     /// Kept separately from the member list because a member who drops off the roster
     /// during a disconnect must still be able to come back through a locked door.
     pub fn is_admitted(&self, peer_id: &[u8]) -> bool {
-        self.admitted.contains(peer_id)
+        self.roster.is_admitted(peer_id)
     }
 
     /// Record a peer as admitted, so a later lock cannot shut it out of its own session.
     pub fn remember_admitted(&mut self, peer_id: Vec<u8>) {
-        self.admitted.insert(peer_id);
+        self.roster.admit(peer_id);
+    }
+
+    /// Whether this peer has been turned away by name.
+    pub fn is_revoked(&self, peer_id: &[u8]) -> bool {
+        self.roster.is_revoked(peer_id)
+    }
+
+    /// Strike one key off the roster. Returns whether this changed anything.
+    ///
+    /// Only the roster is touched here. Evicting the member that key is currently using --
+    /// dropping its control connection and committing its departure -- is the caller's job,
+    /// because only the caller can reach the connection; see
+    /// [`SharedLayoutHost::revoke_member`].
+    pub fn revoke(&mut self, peer_id: Vec<u8>) -> bool {
+        self.roster.revoke(peer_id)
+    }
+
+    /// The roster as the coordinator sees it, for callers that want to show or audit it.
+    pub fn roster(&self) -> &MemberRoster {
+        &self.roster
     }
 
     pub fn session_snapshot(&self) -> Result<SessionSnapshot, CoordinatorError> {
@@ -1633,6 +1713,7 @@ pub enum SessionError {
     PeerTask,
     SessionFull,
     SessionLocked,
+    MembershipRevoked,
     JoinRefused,
     Coordinator(CoordinatorError),
 }
@@ -1660,6 +1741,9 @@ impl fmt::Display for SessionError {
             Self::SessionLocked => {
                 formatter.write_str("this session is locked; ask the host to unlock it")
             }
+            Self::MembershipRevoked => {
+                formatter.write_str("the host removed this device from the session")
+            }
             Self::JoinRefused => formatter.write_str("the session coordinator refused the join"),
             Self::Coordinator(error) => write!(formatter, "layout coordinator error: {error}"),
         }
@@ -1681,6 +1765,7 @@ impl Error for SessionError {
             | Self::PeerTask
             | Self::SessionFull
             | Self::SessionLocked
+            | Self::MembershipRevoked
             | Self::JoinRefused => None,
             Self::Coordinator(error) => Some(error),
         }
@@ -2477,6 +2562,57 @@ impl SharedLayoutHost {
             .is_locked())
     }
 
+    /// Strike one endpoint key off the roster and put its member out of the session.
+    ///
+    /// Returns whether the roster changed, so a caller can stay quiet about a key that was
+    /// already revoked. Revoking a key that is not currently connected is allowed and
+    /// meaningful: it is how a host refuses a device before it ever knocks.
+    ///
+    /// Revoking the coordinator's own key is refused. It would leave a session whose only
+    /// authority cannot rejoin it, and the coordinator is not a peer it can turn away.
+    pub fn revoke_member(&self, peer_id: &[u8]) -> Result<bool, SessionError> {
+        if peer_id == self.host.ticket().endpoint_addr().id.as_bytes() {
+            return Ok(false);
+        }
+        let change = {
+            let mut coordinator = self
+                .coordinator
+                .lock()
+                .map_err(|_| SessionError::PeerTask)?;
+            if !coordinator.revoke(peer_id.to_vec()) {
+                return Ok(false);
+            }
+            // A revoked key that never joined has no member record to remove; the roster
+            // entry alone is the whole effect.
+            coordinator.remove_member(peer_id).ok()
+        };
+        // Drop the control connection before announcing the departure, so the evicted peer
+        // cannot act on the very commit that removes it.
+        remove_control_peer(&self.peers, peer_id);
+        if let Some(change) = change {
+            if let Some(state) = change.commit.state.as_ref() {
+                self.pane_server.replace_roster_from_layout(state)?;
+            }
+            self.broadcast_commit(change.commit);
+            if let Some(reject) = change.invalidated_reservation {
+                self.send_reject(reject);
+            }
+        }
+        Ok(true)
+    }
+
+    /// Every endpoint key this session has admitted or revoked, for display and audit.
+    pub fn roster(&self) -> Result<Vec<(Vec<u8>, RosterStatus)>, SessionError> {
+        Ok(self
+            .coordinator
+            .lock()
+            .map_err(|_| SessionError::PeerTask)?
+            .roster()
+            .entries()
+            .map(|(peer_id, status)| (peer_id.to_vec(), status))
+            .collect())
+    }
+
     pub fn incoming_dispatcher(
         &self,
         panes: PaneServer,
@@ -2514,25 +2650,32 @@ impl SharedLayoutHost {
     ) -> Result<JoinReceipt, SessionError> {
         let mut admitted_peer_id = None;
         let result = async {
-            // A locked session turns away peers it has never admitted, before the
-            // handshake can welcome them. Peers already admitted are let back through, so
-            // locking never strands someone mid-session over a transient reconnect.
-            // Resolved into a plain bool first: the lock guard must not be alive across
+            // The roster decides before the handshake can welcome anybody. A revoked key is
+            // turned away whatever the lock says -- that is what makes revoking durable
+            // once the ticket has been forwarded. A locked session then turns away peers it
+            // has never admitted, while letting admitted ones back through, so locking
+            // never strands someone mid-session over a transient reconnect.
+            // Resolved into a plain enum first: the lock guard must not be alive across
             // the refusal's await, or this whole accept future stops being `Send`.
-            let shut_out = {
+            let refusal = {
                 let coordinator_guard = self
                     .coordinator
                     .lock()
                     .map_err(|_| SessionError::PeerTask)?;
-                coordinator_guard.is_locked()
-                    && !coordinator_guard.is_admitted(connection.remote_id().as_bytes())
+                let remote_id = connection.remote_id();
+                let peer_id = remote_id.as_bytes();
+                if coordinator_guard.is_revoked(peer_id) {
+                    Some((LayoutRejectReason::Revoked, SessionError::MembershipRevoked))
+                } else if coordinator_guard.is_locked() && !coordinator_guard.is_admitted(peer_id) {
+                    Some((LayoutRejectReason::Locked, SessionError::SessionLocked))
+                } else {
+                    None
+                }
             };
-            if shut_out {
-                self.host
-                    .refuse_join(join_writer, LayoutRejectReason::Locked)
-                    .await?;
+            if let Some((reason, error)) = refusal {
+                self.host.refuse_join(join_writer, reason).await?;
                 self.host.drain_refusal(&connection).await;
-                return Err(SessionError::SessionLocked);
+                return Err(error);
             }
             // Refuse a full session *before* welcoming it. `admit_with_display_name`
             // below enforces the same limit, but only after `Welcome` has gone out --
@@ -3775,6 +3918,7 @@ async fn join_handshake_with_display_name(
             return Err(match LayoutRejectReason::try_from(reject.reason) {
                 Ok(LayoutRejectReason::Limit) => SessionError::SessionFull,
                 Ok(LayoutRejectReason::Locked) => SessionError::SessionLocked,
+                Ok(LayoutRejectReason::Revoked) => SessionError::MembershipRevoked,
                 _ => SessionError::JoinRefused,
             });
         }

--- a/src/session.rs
+++ b/src/session.rs
@@ -17,6 +17,7 @@ use iroh::{
     EndpointAddr, EndpointId,
     endpoint::{ConnectingError, Connection, Incoming, SendStream},
 };
+use prost::Message as _;
 use tokio::{
     sync::{broadcast, mpsc, watch},
     time::{interval, timeout},
@@ -28,14 +29,16 @@ use crate::{
         NewPanePosition as LayoutNewPanePosition, Node, Pane, SessionState, Tab,
     },
     lease::LeaseState,
+    ledger::{LedgerVerifier, LedgerWriter},
     protocol::{
         AgentRoster, ControlLease, CreatePane, CreateTab, DeletePane, DeleteTab, Delta, Envelope,
         Input, Join, LayoutCommit, LayoutNode, LayoutReject, LayoutRejectReason, LayoutRequest,
-        LayoutSplit, LayoutState, MarkPaneExited, MemberDescriptor,
-        NewPanePosition as ProtocolNewPanePosition, PROTOCOL_VERSION, PaneDescriptor, PaneFailed,
-        PaneReady, PaneReservation, PaneSubscribe, Presence, PresenceRoster, ReleaseControl,
-        RenamePane, RenameTab, SessionSnapshot, SetPaneLock, SetSplitRatio, Snapshot, SplitAxis,
-        TabDescriptor, TakeControl, UpdatePaneGrids, Welcome, envelope,
+        LayoutSplit, LayoutState, LedgerEntryKind, MarkPaneExited, MemberDescriptor,
+        MembershipEvent, MembershipRecord, NewPanePosition as ProtocolNewPanePosition,
+        PROTOCOL_VERSION, PaneDescriptor, PaneFailed, PaneReady, PaneReservation, PaneSubscribe,
+        Presence, PresenceRoster, ReleaseControl, RenamePane, RenameTab, SessionSnapshot,
+        SetPaneLock, SetSplitRatio, Snapshot, SplitAxis, TabDescriptor, TakeControl,
+        UpdatePaneGrids, Welcome, envelope,
     },
     screen::ScreenFrame,
     ticket::{JoinTicket, TicketError},
@@ -49,6 +52,8 @@ pub const DEFAULT_RESERVATION_TIMEOUT: Duration = Duration::from_secs(30);
 /// their protocol messages to this type.
 pub struct LayoutCoordinator {
     state: SessionState,
+    coordinator_peer_id: Vec<u8>,
+    ledger: LedgerWriter,
     reservations: BTreeMap<u64, ReservationContext>,
     agent_rosters: BTreeMap<Vec<u8>, AgentRoster>,
     presence: BTreeMap<Vec<u8>, Presence>,
@@ -56,6 +61,19 @@ pub struct LayoutCoordinator {
     reservation_timeout: Duration,
     locked: bool,
     roster: MemberRoster,
+}
+
+/// What applying one request did to the layout, before the ledger seals it.
+///
+/// Handlers used to build their own commit, which meant every one of them had to be handed
+/// the author and the request bytes to record. Reporting what happened instead leaves a
+/// single place where a change becomes an entry, so no path can quietly commit without
+/// writing one.
+enum Applied {
+    /// The layout changed and the change needs sealing.
+    Changed,
+    /// A pane was reserved. Nothing is committed until its creator reports it live.
+    Reserved(PaneReservation),
 }
 
 /// Which endpoint public keys the coordinator will let into this session.
@@ -188,12 +206,14 @@ impl LayoutCoordinator {
     pub fn new(
         coordinator_peer_id: Vec<u8>,
         endpoint_addr: EndpointAddr,
+        ledger: LedgerWriter,
         grid_rows: u16,
         grid_cols: u16,
     ) -> Result<Self, CoordinatorError> {
         Self::new_with_display_name(
             coordinator_peer_id,
             endpoint_addr,
+            ledger,
             String::new(),
             grid_rows,
             grid_cols,
@@ -203,6 +223,7 @@ impl LayoutCoordinator {
     pub fn new_with_display_name(
         coordinator_peer_id: Vec<u8>,
         endpoint_addr: EndpointAddr,
+        ledger: LedgerWriter,
         display_name: String,
         grid_rows: u16,
         grid_cols: u16,
@@ -210,6 +231,7 @@ impl LayoutCoordinator {
         Self::with_reservation_timeout_and_display_name(
             coordinator_peer_id,
             endpoint_addr,
+            ledger,
             display_name,
             grid_rows,
             grid_cols,
@@ -221,6 +243,7 @@ impl LayoutCoordinator {
     pub fn with_reservation_timeout(
         coordinator_peer_id: Vec<u8>,
         endpoint_addr: EndpointAddr,
+        ledger: LedgerWriter,
         grid_rows: u16,
         grid_cols: u16,
         reservation_timeout: Duration,
@@ -229,6 +252,7 @@ impl LayoutCoordinator {
         Self::with_reservation_timeout_and_display_name(
             coordinator_peer_id,
             endpoint_addr,
+            ledger,
             String::new(),
             grid_rows,
             grid_cols,
@@ -237,9 +261,11 @@ impl LayoutCoordinator {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn with_reservation_timeout_and_display_name(
         coordinator_peer_id: Vec<u8>,
         endpoint_addr: EndpointAddr,
+        ledger: LedgerWriter,
         display_name: String,
         grid_rows: u16,
         grid_cols: u16,
@@ -249,12 +275,14 @@ impl LayoutCoordinator {
         let endpoint_addr = serialized_endpoint(&coordinator_peer_id, endpoint_addr)?;
         Ok(Self {
             state: SessionState::new_with_display_name(
-                coordinator_peer_id,
+                coordinator_peer_id.clone(),
                 endpoint_addr,
                 display_name,
                 grid_rows,
                 grid_cols,
             )?,
+            coordinator_peer_id,
+            ledger,
             reservations: BTreeMap::new(),
             agent_rosters: BTreeMap::new(),
             presence: BTreeMap::new(),
@@ -438,11 +466,11 @@ impl LayoutCoordinator {
         let endpoint_addr = serialized_endpoint(&peer_id, endpoint_addr)?;
         let invalidated = self.state.add_member_with_display_name(
             self.state.revision(),
-            peer_id,
+            peer_id.clone(),
             endpoint_addr,
             display_name,
         )?;
-        self.membership_change(invalidated)
+        self.membership_change(peer_id, MembershipEvent::Joined, invalidated)
     }
 
     pub fn update_member_endpoint(
@@ -456,7 +484,11 @@ impl LayoutCoordinator {
             authenticated_peer_id,
             endpoint_addr,
         )?;
-        self.membership_change(invalidated)
+        self.membership_change(
+            authenticated_peer_id.to_vec(),
+            MembershipEvent::EndpointChanged,
+            invalidated,
+        )
     }
 
     pub fn remove_member(&mut self, peer_id: &[u8]) -> Result<MembershipChange, CoordinatorError> {
@@ -465,7 +497,7 @@ impl LayoutCoordinator {
         if self.presence.remove(peer_id).is_some() {
             self.presence_epoch = self.presence_epoch.saturating_add(1);
         }
-        self.membership_change(invalidated)
+        self.membership_change(peer_id.to_vec(), MembershipEvent::Left, invalidated)
     }
 
     pub fn handle_request(
@@ -497,6 +529,9 @@ impl LayoutCoordinator {
         if request_id == 0 || request.base_revision == 0 || action_count != 1 {
             return reject(request_id, LayoutRejectReason::Malformed);
         }
+        // Captured before the request is taken apart: the ledger records what was asked
+        // for, not a reconstruction of it after the fact.
+        let payload = request.encode_to_vec();
 
         let result = if let Some(create) = request.create_pane {
             self.reserve_pane(
@@ -535,11 +570,18 @@ impl LayoutCoordinator {
         };
 
         match result {
-            Ok(response) => {
-                if matches!(response, CoordinatorResponse::Commit(_)) {
-                    self.prune_agent_rosters();
+            Ok(Applied::Reserved(reservation)) => CoordinatorResponse::Reservation(reservation),
+            Ok(Applied::Changed) => {
+                self.prune_agent_rosters();
+                match self.layout_commit(
+                    authenticated_peer_id.to_vec(),
+                    LedgerEntryKind::LayoutChange,
+                    payload,
+                    Vec::new(),
+                ) {
+                    Ok(commit) => CoordinatorResponse::Commit(commit),
+                    Err(error) => reject(request_id, reject_reason(&layout_error(error))),
                 }
-                response
             }
             Err(error) => reject(request_id, reject_reason(&error)),
         }
@@ -566,7 +608,13 @@ impl LayoutCoordinator {
         ) {
             Ok(_) => {
                 self.reservations.remove(&ready.reservation_id);
-                match self.layout_commit() {
+                let payload = ready.encode_to_vec();
+                match self.layout_commit(
+                    authenticated_peer_id.to_vec(),
+                    LedgerEntryKind::PaneReady,
+                    payload,
+                    Vec::new(),
+                ) {
                     Ok(commit) => CoordinatorResponse::Commit(commit),
                     Err(error) => reject(ready.request_id, reject_reason(&layout_error(error))),
                 }
@@ -681,7 +729,7 @@ impl LayoutCoordinator {
         create: CreatePane,
         request_id: u64,
         now: Instant,
-    ) -> Result<CoordinatorResponse, LayoutError> {
+    ) -> Result<Applied, LayoutError> {
         let axis = protocol_axis(create.axis)?;
         let position = protocol_pane_position(create.position)?;
         let (grid_rows, grid_cols) = protocol_grid(create.grid_rows, create.grid_cols)?;
@@ -705,9 +753,7 @@ impl LayoutCoordinator {
                 deadline: now + self.reservation_timeout,
             },
         );
-        Ok(CoordinatorResponse::Reservation(protocol_reservation(
-            reservation,
-        )))
+        Ok(Applied::Reserved(protocol_reservation(reservation)))
     }
 
     fn reserve_tab(
@@ -717,7 +763,7 @@ impl LayoutCoordinator {
         create: CreateTab,
         request_id: u64,
         now: Instant,
-    ) -> Result<CoordinatorResponse, LayoutError> {
+    ) -> Result<Applied, LayoutError> {
         let (grid_rows, grid_cols) = protocol_grid(create.grid_rows, create.grid_cols)?;
         let reservation =
             self.state
@@ -730,9 +776,7 @@ impl LayoutCoordinator {
                 deadline: now + self.reservation_timeout,
             },
         );
-        Ok(CoordinatorResponse::Reservation(protocol_reservation(
-            reservation,
-        )))
+        Ok(Applied::Reserved(protocol_reservation(reservation)))
     }
 
     fn delete_pane(
@@ -740,15 +784,13 @@ impl LayoutCoordinator {
         authenticated_peer_id: &[u8],
         base_revision: u64,
         delete: DeletePane,
-    ) -> Result<CoordinatorResponse, LayoutError> {
+    ) -> Result<Applied, LayoutError> {
         if delete.pane_id == 0 {
             return Err(LayoutError::InvalidSnapshot);
         }
         self.state
             .delete_pane(authenticated_peer_id, base_revision, delete.pane_id)?;
-        Ok(CoordinatorResponse::Commit(
-            self.layout_commit().map_err(layout_error)?,
-        ))
+        Ok(Applied::Changed)
     }
 
     fn delete_tab(
@@ -756,15 +798,13 @@ impl LayoutCoordinator {
         authenticated_peer_id: &[u8],
         base_revision: u64,
         delete: DeleteTab,
-    ) -> Result<CoordinatorResponse, LayoutError> {
+    ) -> Result<Applied, LayoutError> {
         if delete.tab_id == 0 {
             return Err(LayoutError::InvalidSnapshot);
         }
         self.state
             .delete_tab(authenticated_peer_id, base_revision, delete.tab_id)?;
-        Ok(CoordinatorResponse::Commit(
-            self.layout_commit().map_err(layout_error)?,
-        ))
+        Ok(Applied::Changed)
     }
 
     fn set_split_ratio(
@@ -772,7 +812,7 @@ impl LayoutCoordinator {
         authenticated_peer_id: &[u8],
         base_revision: u64,
         ratio: SetSplitRatio,
-    ) -> Result<CoordinatorResponse, LayoutError> {
+    ) -> Result<Applied, LayoutError> {
         let axis = protocol_axis(ratio.axis)?;
         let first_share_bps =
             u16::try_from(ratio.first_share_bps).map_err(|_| LayoutError::InvalidSplitRatio)?;
@@ -783,9 +823,7 @@ impl LayoutCoordinator {
             axis,
             first_share_bps,
         )?;
-        Ok(CoordinatorResponse::Commit(
-            self.layout_commit().map_err(layout_error)?,
-        ))
+        Ok(Applied::Changed)
     }
 
     fn update_pane_grids(
@@ -793,7 +831,7 @@ impl LayoutCoordinator {
         authenticated_peer_id: &[u8],
         base_revision: u64,
         update: UpdatePaneGrids,
-    ) -> Result<CoordinatorResponse, LayoutError> {
+    ) -> Result<Applied, LayoutError> {
         let grids = update
             .panes
             .into_iter()
@@ -807,9 +845,7 @@ impl LayoutCoordinator {
             .collect::<Result<Vec<_>, LayoutError>>()?;
         self.state
             .update_pane_grids(authenticated_peer_id, base_revision, &grids)?;
-        Ok(CoordinatorResponse::Commit(
-            self.layout_commit().map_err(layout_error)?,
-        ))
+        Ok(Applied::Changed)
     }
 
     fn rename_pane(
@@ -817,15 +853,13 @@ impl LayoutCoordinator {
         peer: &[u8],
         revision: u64,
         rename: RenamePane,
-    ) -> Result<CoordinatorResponse, LayoutError> {
+    ) -> Result<Applied, LayoutError> {
         if rename.pane_id == 0 {
             return Err(LayoutError::InvalidSnapshot);
         }
         self.state
             .rename_pane(peer, revision, rename.pane_id, rename.title)?;
-        Ok(CoordinatorResponse::Commit(
-            self.layout_commit().map_err(layout_error)?,
-        ))
+        Ok(Applied::Changed)
     }
 
     fn rename_tab(
@@ -833,15 +867,13 @@ impl LayoutCoordinator {
         peer: &[u8],
         revision: u64,
         rename: RenameTab,
-    ) -> Result<CoordinatorResponse, LayoutError> {
+    ) -> Result<Applied, LayoutError> {
         if rename.tab_id == 0 {
             return Err(LayoutError::InvalidSnapshot);
         }
         self.state
             .rename_tab(peer, revision, rename.tab_id, rename.title)?;
-        Ok(CoordinatorResponse::Commit(
-            self.layout_commit().map_err(layout_error)?,
-        ))
+        Ok(Applied::Changed)
     }
 
     fn set_pane_lock(
@@ -849,15 +881,13 @@ impl LayoutCoordinator {
         peer: &[u8],
         revision: u64,
         lock: SetPaneLock,
-    ) -> Result<CoordinatorResponse, LayoutError> {
+    ) -> Result<Applied, LayoutError> {
         if lock.pane_id == 0 {
             return Err(LayoutError::InvalidSnapshot);
         }
         self.state
             .set_pane_lock(peer, revision, lock.pane_id, lock.locked)?;
-        Ok(CoordinatorResponse::Commit(
-            self.layout_commit().map_err(layout_error)?,
-        ))
+        Ok(Applied::Changed)
     }
 
     fn mark_pane_exited(
@@ -865,23 +895,54 @@ impl LayoutCoordinator {
         peer: &[u8],
         revision: u64,
         exited: MarkPaneExited,
-    ) -> Result<CoordinatorResponse, LayoutError> {
+    ) -> Result<Applied, LayoutError> {
         if exited.pane_id == 0 {
             return Err(LayoutError::InvalidSnapshot);
         }
         self.state
             .mark_pane_exited(peer, revision, exited.pane_id)?;
-        Ok(CoordinatorResponse::Commit(
-            self.layout_commit().map_err(layout_error)?,
-        ))
+        Ok(Applied::Changed)
     }
 
-    fn layout_commit(&self) -> Result<LayoutCommit, CoordinatorError> {
+    /// Seal one change into the ledger and publish the layout it produced.
+    ///
+    /// The entry is the record and the state is the checkpoint beside it: a member that has
+    /// been following can verify the entry chains onto the last one it saw, and a member
+    /// that just arrived can draw the state while it starts its own chain from here.
+    fn layout_commit(
+        &mut self,
+        author_peer_id: Vec<u8>,
+        kind: LedgerEntryKind,
+        payload: Vec<u8>,
+        author_signature: Vec<u8>,
+    ) -> Result<LayoutCommit, CoordinatorError> {
         let state = self.protocol_layout_state()?;
+        let entry = self
+            .ledger
+            .append(author_peer_id, kind, payload, author_signature);
         Ok(LayoutCommit {
             revision: state.revision,
             state: Some(state),
+            entry: Some(entry),
         })
+    }
+
+    /// Seal a change the coordinator made on its own account.
+    ///
+    /// Nobody asked for these -- a connection dropped, a member moved to a new address --
+    /// so there is no member signature to carry and the coordinator is honestly the author.
+    fn membership_commit(
+        &mut self,
+        peer_id: Vec<u8>,
+        event: MembershipEvent,
+    ) -> Result<LayoutCommit, CoordinatorError> {
+        let payload = MembershipRecord {
+            peer_id,
+            event: event as i32,
+        }
+        .encode_to_vec();
+        let author = self.coordinator_peer_id.clone();
+        self.layout_commit(author, LedgerEntryKind::Membership, payload, Vec::new())
     }
 
     fn protocol_layout_state(&self) -> Result<LayoutState, CoordinatorError> {
@@ -892,6 +953,8 @@ impl LayoutCoordinator {
 
     fn membership_change(
         &mut self,
+        peer_id: Vec<u8>,
+        event: MembershipEvent,
         invalidated: Option<crate::layout::InvalidatedReservation>,
     ) -> Result<MembershipChange, CoordinatorError> {
         let invalidated_reservation = invalidated.and_then(|reservation| {
@@ -906,7 +969,7 @@ impl LayoutCoordinator {
                 })
         });
         Ok(MembershipChange {
-            commit: self.layout_commit()?,
+            commit: self.membership_commit(peer_id, event)?,
             invalidated_reservation,
         })
     }
@@ -2375,9 +2438,16 @@ impl SharedLayoutHost {
     ) -> Result<Self, SessionError> {
         let pane_server = host.pane_server();
         let coordinator_peer_id = host.ticket().endpoint_addr().id.as_bytes().to_vec();
+        // The ledger is signed with the same endpoint key the joiners already authenticated
+        // through the ticket, so no separate trust root has to be established for it.
+        let ledger = LedgerWriter::new(
+            host.ticket().session_id().to_vec(),
+            host.transport.secret_key(),
+        );
         let coordinator = LayoutCoordinator::with_reservation_timeout_and_display_name(
             coordinator_peer_id,
             host.ticket().endpoint_addr().clone(),
+            ledger,
             display_name,
             grid_rows,
             grid_cols,
@@ -3126,11 +3196,16 @@ pub async fn join_layout_with_display_name(
         let peer_id = transport.endpoint_id().as_bytes().to_vec();
         let coordinator_peer_id = receipt.coordinator_peer_id;
         let session_name = receipt.session_name;
+        // Anchored on the endpoint key the ticket named and QUIC proved on this very
+        // connection, rather than on the coordinator id the Welcome claimed: a peer that
+        // could lie about the latter is exactly the one this verifier exists to catch.
+        let verifier = LedgerVerifier::new(ticket.session_id().to_vec(), ticket.endpoint_addr().id);
         let tasks = vec![
             tokio::spawn(layout_member_reader_task(
                 reader,
                 events_tx,
                 coordinator_peer_id.clone(),
+                verifier,
             )),
             tokio::spawn(layout_member_writer_task(
                 writer,
@@ -3301,6 +3376,7 @@ async fn layout_member_reader_task(
     mut reader: crate::transport::FrameReader,
     events_tx: mpsc::Sender<LayoutControlEvent>,
     coordinator_peer_id: Vec<u8>,
+    mut verifier: LedgerVerifier,
 ) {
     while let Ok(Some(envelope)) = reader.read_next().await {
         if envelope.sender_peer_id != coordinator_peer_id {
@@ -3315,7 +3391,18 @@ async fn layout_member_reader_task(
             Some(envelope::Body::PaneReservation(reservation)) => {
                 LayoutControlEvent::Reservation(reservation)
             }
-            Some(envelope::Body::LayoutCommit(commit)) => LayoutControlEvent::Commit(commit),
+            Some(envelope::Body::LayoutCommit(commit)) => {
+                // An unverifiable commit ends the session rather than being skipped. A
+                // member that quietly ignored one would keep drawing a layout it can no
+                // longer account for, which is worse than visibly losing the connection.
+                let Some(entry) = commit.entry.as_ref() else {
+                    break;
+                };
+                if verifier.accept(entry).is_err() {
+                    break;
+                }
+                LayoutControlEvent::Commit(commit)
+            }
             Some(envelope::Body::LayoutReject(reject)) => LayoutControlEvent::Reject(reject),
             _ => break,
         };
@@ -4107,6 +4194,7 @@ mod control_queue_tests {
             envelope::Body::LayoutCommit(LayoutCommit {
                 revision,
                 state: None,
+                entry: None,
             }),
         )
     }

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use iroh::{
-    Endpoint, EndpointAddr, EndpointId, TransportAddr,
+    Endpoint, EndpointAddr, EndpointId, SecretKey, TransportAddr,
     endpoint::{
         ClosedStream, ConnectingError, Connection, ConnectionError, Incoming, ReadError,
         ReadToEndError, RecvStream, SendStream, WriteError, presets,
@@ -292,6 +292,15 @@ impl Transport {
 
     pub fn endpoint_id(&self) -> EndpointId {
         self.endpoint.id()
+    }
+
+    /// This endpoint's signing key.
+    ///
+    /// The same key QUIC already proves ownership of on every connection, handed out so
+    /// that what a peer says can be authenticated after the fact too -- a relayed ledger
+    /// entry is read by members who were never on the connection that carried it.
+    pub fn secret_key(&self) -> SecretKey {
+        self.endpoint.secret_key().clone()
     }
 
     pub fn endpoint_addr(&self) -> EndpointAddr {

--- a/src/tui/runtime/layout.rs
+++ b/src/tui/runtime/layout.rs
@@ -214,6 +214,7 @@ impl SharedLayoutRuntime {
                 rename_tab: None,
                 set_pane_lock: None,
                 mark_pane_exited: None,
+                author_signature: Vec::new(),
             })?;
         }
         Ok(())
@@ -263,6 +264,7 @@ impl SharedLayoutRuntime {
                 rename_tab: None,
                 set_pane_lock: None,
                 mark_pane_exited: Some(MarkPaneExited { pane_id }),
+                author_signature: Vec::new(),
             })?;
         }
         Ok(())
@@ -311,6 +313,7 @@ impl SharedLayoutRuntime {
                     rename_tab: None,
                     set_pane_lock: None,
                     mark_pane_exited: None,
+                    author_signature: Vec::new(),
                 })?
             }
             UiIntent::DeleteTab { tab_id } => {
@@ -329,6 +332,7 @@ impl SharedLayoutRuntime {
                     rename_tab: None,
                     set_pane_lock: None,
                     mark_pane_exited: None,
+                    author_signature: Vec::new(),
                 })?
             }
             UiIntent::SetSplitRatio {
@@ -358,6 +362,7 @@ impl SharedLayoutRuntime {
                     rename_tab: None,
                     set_pane_lock: None,
                     mark_pane_exited: None,
+                    author_signature: Vec::new(),
                 })?;
             }
             UiIntent::RenamePane { pane_id, title } => {
@@ -375,6 +380,7 @@ impl SharedLayoutRuntime {
                     rename_tab: None,
                     set_pane_lock: None,
                     mark_pane_exited: None,
+                    author_signature: Vec::new(),
                 })?;
             }
             UiIntent::RenameTab { tab_id, title } => {
@@ -392,6 +398,7 @@ impl SharedLayoutRuntime {
                     rename_tab: Some(RenameTab { tab_id, title }),
                     set_pane_lock: None,
                     mark_pane_exited: None,
+                    author_signature: Vec::new(),
                 })?;
             }
             UiIntent::SetPaneLock { pane_id, locked } => {
@@ -472,6 +479,7 @@ impl SharedLayoutRuntime {
             rename_tab: None,
             set_pane_lock: None,
             mark_pane_exited: None,
+            author_signature: Vec::new(),
         })
     }
 
@@ -512,6 +520,7 @@ impl SharedLayoutRuntime {
             rename_tab: None,
             set_pane_lock: Some(SetPaneLock { pane_id, locked }),
             mark_pane_exited: None,
+            author_signature: Vec::new(),
         };
         if let Err(error) = self.send_request(request) {
             self.pending_locks.remove(&request_id);
@@ -598,6 +607,7 @@ impl SharedLayoutRuntime {
             reservation_id: reservation.reservation_id,
             request_id: pending.request_id,
             base_revision: pending.base_revision,
+            author_signature: Vec::new(),
         })? {
             Some(CoordinatorResponse::Commit(commit)) => {
                 self.handle_control_event(LayoutControlEvent::Commit(commit))?

--- a/tests/module_surface.rs
+++ b/tests/module_surface.rs
@@ -17,5 +17,5 @@ fn exposes_the_scaffold_module_boundaries() {
     let _: Option<JoinTicket> = None;
     let _: Option<HostSession> = None;
     let _: Option<Envelope> = None;
-    assert_eq!(PROTOCOL_VERSION, 8);
+    assert_eq!(PROTOCOL_VERSION, 9);
 }

--- a/tests/protocol.rs
+++ b/tests/protocol.rs
@@ -1,14 +1,15 @@
 use p2pmux::protocol::{
     AgentRoster, AgentRosterEntry, AgentRosterState, ControlLease, CreatePane, CreateTab,
-    DeletePane, DeleteTab, Delta, Envelope, Input, Join, LayoutCommit, LayoutNode, LayoutReject,
-    LayoutRejectReason, LayoutRequest, LayoutSplit, LayoutState, MAX_AGENT_CWD_BYTES,
-    MAX_AGENT_KIND_BYTES, MAX_AGENT_ROSTER_ENTRIES, MAX_DELTA_BYTES, MAX_ENDPOINT_ADDR_BYTES,
-    MAX_ENVELOPE_BYTES, MAX_FRAME_BYTES, MAX_INPUT_BYTES, MAX_PANE_ID_BYTES, MAX_PEER_ID_BYTES,
-    MAX_PRESENCE_ENTRIES, MAX_SESSION_ID_BYTES, MAX_SNAPSHOT_BYTES, MarkPaneExited,
-    MemberDescriptor, NewPanePosition, PROTOCOL_VERSION, PaneDescriptor, PaneFailed, PaneGrid,
-    PaneReady, PaneReservation, PaneSubscribe, Presence, PresenceRoster, ProtocolError,
-    SessionSnapshot, SetPaneLock, SetSplitRatio, Snapshot, SplitAxis, TabDescriptor, TakeControl,
-    UpdatePaneGrids, Welcome, decode_frame, encode_frame, envelope,
+    DeletePane, DeleteTab, Delta, Envelope, Input, Join, LEDGER_HASH_BYTES, LEDGER_SIGNATURE_BYTES,
+    LayoutCommit, LayoutNode, LayoutReject, LayoutRejectReason, LayoutRequest, LayoutSplit,
+    LayoutState, LedgerEntry, LedgerEntryKind, MAX_AGENT_CWD_BYTES, MAX_AGENT_KIND_BYTES,
+    MAX_AGENT_ROSTER_ENTRIES, MAX_DELTA_BYTES, MAX_ENDPOINT_ADDR_BYTES, MAX_ENVELOPE_BYTES,
+    MAX_FRAME_BYTES, MAX_INPUT_BYTES, MAX_LEDGER_PAYLOAD_BYTES, MAX_PANE_ID_BYTES,
+    MAX_PEER_ID_BYTES, MAX_PRESENCE_ENTRIES, MAX_SESSION_ID_BYTES, MAX_SNAPSHOT_BYTES,
+    MarkPaneExited, MemberDescriptor, NewPanePosition, PROTOCOL_VERSION, PaneDescriptor,
+    PaneFailed, PaneGrid, PaneReady, PaneReservation, PaneSubscribe, Presence, PresenceRoster,
+    ProtocolError, SessionSnapshot, SetPaneLock, SetSplitRatio, Snapshot, SplitAxis, TabDescriptor,
+    TakeControl, UpdatePaneGrids, Welcome, decode_frame, encode_frame, envelope,
 };
 use prost::Message;
 
@@ -17,6 +18,30 @@ struct ParsedField {
     field_number: u32,
     wire_type: u8,
     value: Vec<u8>,
+}
+
+/// A structurally valid ledger entry. The signatures are the right shape and nothing more:
+/// `validate_envelope` checks framing, and only [`p2pmux::ledger::LedgerVerifier`] checks
+/// that a signature means anything.
+fn ledger_entry() -> LedgerEntry {
+    LedgerEntry {
+        seq: 1,
+        prev_hash: vec![0; LEDGER_HASH_BYTES],
+        author_peer_id: b"peer-a".to_vec(),
+        kind: LedgerEntryKind::LayoutChange as i32,
+        payload: b"payload".to_vec(),
+        author_signature: Vec::new(),
+        coordinator_signature: vec![7; LEDGER_SIGNATURE_BYTES],
+    }
+}
+
+/// A commit whose state is valid, so only the entry can be what a case is testing.
+fn commit_with(entry: LedgerEntry) -> LayoutCommit {
+    LayoutCommit {
+        revision: 1,
+        state: Some(layout_state(leaf(1))),
+        entry: Some(entry),
+    }
 }
 
 fn envelope(body: envelope::Body) -> Envelope {
@@ -28,8 +53,8 @@ fn envelope(body: envelope::Body) -> Envelope {
 }
 
 #[test]
-fn protocol_version_is_v8() {
-    assert_eq!(PROTOCOL_VERSION, 8);
+fn protocol_version_is_v9() {
+    assert_eq!(PROTOCOL_VERSION, 9);
 }
 
 #[test]
@@ -787,6 +812,7 @@ fn v2_envelopes() -> Vec<Envelope> {
         envelope(envelope::Body::LayoutCommit(LayoutCommit {
             revision: 1,
             state: Some(state),
+            entry: Some(ledger_entry()),
         })),
         envelope(envelope::Body::LayoutReject(LayoutReject {
             request_id: 1,
@@ -812,7 +838,8 @@ fn envelope_exposes_each_v2_layout_body_with_stable_tags() {
         &[(1, 0), (2, 0), (3, 2)],
         &[(1, 0), (2, 0)],
         &[(1, 0), (2, 0), (3, 0)],
-        &[(1, 0), (2, 2)],
+        // LayoutCommit: revision, state, and the ledger entry the state materializes.
+        &[(1, 0), (2, 2), (3, 2)],
         &[(1, 0), (2, 0)],
         &[(1, 2), (2, 2), (3, 0)],
         &[(1, 0), (2, 0), (3, 0)],
@@ -963,6 +990,7 @@ fn layout_messages_reject_invalid_shapes_and_bounds() {
     let invalid_commit = LayoutCommit {
         revision: 2,
         state: Some(state.clone()),
+        entry: Some(ledger_entry()),
     };
 
     let cases = vec![
@@ -994,6 +1022,41 @@ fn layout_messages_reject_invalid_shapes_and_bounds() {
             state: Some(zero_pane_grid),
         })),
         envelope(envelope::Body::LayoutCommit(invalid_commit)),
+        // A commit with no entry is a snapshot with nothing vouching for it, which is the
+        // shape this protocol version exists to stop accepting.
+        envelope(envelope::Body::LayoutCommit(LayoutCommit {
+            revision: 1,
+            state: Some(state.clone()),
+            entry: None,
+        })),
+        envelope(envelope::Body::LayoutCommit(commit_with(LedgerEntry {
+            seq: 0,
+            ..ledger_entry()
+        }))),
+        envelope(envelope::Body::LayoutCommit(commit_with(LedgerEntry {
+            prev_hash: vec![0; LEDGER_HASH_BYTES - 1],
+            ..ledger_entry()
+        }))),
+        envelope(envelope::Body::LayoutCommit(commit_with(LedgerEntry {
+            author_peer_id: Vec::new(),
+            ..ledger_entry()
+        }))),
+        envelope(envelope::Body::LayoutCommit(commit_with(LedgerEntry {
+            kind: 99,
+            ..ledger_entry()
+        }))),
+        envelope(envelope::Body::LayoutCommit(commit_with(LedgerEntry {
+            payload: vec![0; MAX_LEDGER_PAYLOAD_BYTES + 1],
+            ..ledger_entry()
+        }))),
+        envelope(envelope::Body::LayoutCommit(commit_with(LedgerEntry {
+            author_signature: vec![3; LEDGER_SIGNATURE_BYTES - 1],
+            ..ledger_entry()
+        }))),
+        envelope(envelope::Body::LayoutCommit(commit_with(LedgerEntry {
+            coordinator_signature: Vec::new(),
+            ..ledger_entry()
+        }))),
         envelope(envelope::Body::PaneReservation(PaneReservation {
             reservation_id: 0,
             pane_id: 1,

--- a/tests/protocol.rs
+++ b/tests/protocol.rs
@@ -100,6 +100,7 @@ fn ratio_and_grid_actions_validate_strictly() {
         rename_tab: None,
         set_pane_lock: None,
         mark_pane_exited: None,
+        author_signature: Vec::new(),
     };
     let encoded = encode_frame(&envelope(envelope::Body::LayoutRequest(request.clone())))
         .expect("valid request");
@@ -128,6 +129,7 @@ fn ratio_and_grid_actions_validate_strictly() {
                 rename_tab: None,
                 set_pane_lock: None,
                 mark_pane_exited: None,
+                author_signature: Vec::new(),
             }
         };
         assert!(encode_frame(&envelope(envelope::Body::LayoutRequest(invalid))).is_err());
@@ -153,6 +155,7 @@ fn ratio_and_grid_actions_validate_strictly() {
         rename_tab: None,
         set_pane_lock: None,
         mark_pane_exited: None,
+        author_signature: Vec::new(),
     };
     assert!(
         decode_frame(
@@ -180,6 +183,7 @@ fn pane_lock_action_round_trips_and_is_the_only_action() {
             locked: true,
         }),
         mark_pane_exited: None,
+        author_signature: Vec::new(),
     };
     let encoded = encode_frame(&envelope(envelope::Body::LayoutRequest(request.clone())))
         .expect("valid lock request");
@@ -204,6 +208,7 @@ fn mark_pane_exited_round_trips_and_is_the_only_action() {
         rename_tab: None,
         set_pane_lock: None,
         mark_pane_exited: Some(MarkPaneExited { pane_id: 1 }),
+        author_signature: Vec::new(),
     };
     let encoded = encode_frame(&envelope(envelope::Body::LayoutRequest(request.clone())))
         .expect("valid exited request");
@@ -798,6 +803,7 @@ fn v2_envelopes() -> Vec<Envelope> {
             rename_tab: None,
             set_pane_lock: None,
             mark_pane_exited: None,
+            author_signature: Vec::new(),
         })),
         envelope(envelope::Body::PaneReservation(PaneReservation {
             reservation_id: 1,
@@ -808,6 +814,7 @@ fn v2_envelopes() -> Vec<Envelope> {
             reservation_id: 1,
             base_revision: 1,
             request_id: 1,
+            author_signature: Vec::new(),
         })),
         envelope(envelope::Body::LayoutCommit(LayoutCommit {
             revision: 1,
@@ -889,6 +896,7 @@ fn layout_messages_reject_invalid_shapes_and_bounds() {
         rename_tab: None,
         set_pane_lock: None,
         mark_pane_exited: None,
+        author_signature: Vec::new(),
     };
     let multiple_actions = LayoutRequest {
         create_pane: Some(CreatePane {
@@ -1066,6 +1074,7 @@ fn layout_messages_reject_invalid_shapes_and_bounds() {
             reservation_id: 0,
             base_revision: 1,
             request_id: 1,
+            author_signature: Vec::new(),
         })),
         envelope(envelope::Body::LayoutReject(LayoutReject {
             request_id: 1,
@@ -1098,11 +1107,13 @@ fn join_endpoint_and_reservation_lifecycle_identifiers_are_required() {
         reservation_id: 1,
         base_revision: 0,
         request_id: 1,
+        author_signature: Vec::new(),
     }));
     let missing_ready_request = envelope(envelope::Body::PaneReady(PaneReady {
         reservation_id: 1,
         base_revision: 1,
         request_id: 0,
+        author_signature: Vec::new(),
     }));
     let missing_failed_request = envelope(envelope::Body::PaneFailed(PaneFailed {
         reservation_id: 1,
@@ -1151,6 +1162,7 @@ fn create_pane_axis_and_position_are_validated() {
             rename_tab: None,
             set_pane_lock: None,
             mark_pane_exited: None,
+            author_signature: Vec::new(),
         }))
     }
 
@@ -1263,6 +1275,7 @@ fn layout_grids_must_fit_the_reducer_u16_grid() {
         rename_tab: None,
         set_pane_lock: None,
         mark_pane_exited: None,
+        author_signature: Vec::new(),
     };
 
     for valid in [

--- a/tests/session_layout.rs
+++ b/tests/session_layout.rs
@@ -1,13 +1,15 @@
 use iroh::{EndpointAddr, SecretKey};
 use p2pmux::{
+    ledger::{GENESIS_PREV_HASH, LedgerVerifier, LedgerWriter},
     protocol::{
         AgentRoster, AgentRosterEntry, AgentRosterState, CreatePane, CreateTab, DeletePane,
-        DeleteTab, LayoutCommit, LayoutRejectReason, LayoutRequest, MarkPaneExited,
-        NewPanePosition, PaneFailed, PaneGrid, PaneReady, Presence, SetPaneLock, SetSplitRatio,
-        SplitAxis, UpdatePaneGrids,
+        DeleteTab, LayoutCommit, LayoutRejectReason, LayoutRequest, LedgerEntry, LedgerEntryKind,
+        MarkPaneExited, MembershipEvent, MembershipRecord, NewPanePosition, PaneFailed, PaneGrid,
+        PaneReady, Presence, RenamePane, SetPaneLock, SetSplitRatio, SplitAxis, UpdatePaneGrids,
     },
     session::{CoordinatorError, CoordinatorResponse, LayoutCoordinator, RosterStatus},
 };
+use prost::Message;
 use std::{
     net::SocketAddr,
     time::{Duration, Instant},
@@ -32,7 +34,13 @@ fn addr_b() -> EndpointAddr {
 }
 
 fn coordinator() -> LayoutCoordinator {
-    LayoutCoordinator::new(host_a(), addr_a(), 24, 80).expect("valid coordinator")
+    LayoutCoordinator::new(host_a(), addr_a(), ledger(), 24, 80).expect("valid coordinator")
+}
+
+/// A ledger signed with the same key `host_a` is derived from, so entries a test reads back
+/// verify against the coordinator it thinks wrote them.
+fn ledger() -> LedgerWriter {
+    LedgerWriter::new(b"test-session".to_vec(), SecretKey::from_bytes(&[1; 32]))
 }
 
 fn request(request_id: u64, base_revision: u64) -> LayoutRequest {
@@ -750,6 +758,7 @@ fn reservation_expiry_is_deterministic_and_unwedges_new_requests() {
     let mut coordinator = LayoutCoordinator::with_reservation_timeout(
         host_a(),
         addr_a(),
+        ledger(),
         24,
         80,
         Duration::from_secs(5),
@@ -828,13 +837,14 @@ fn pane_failure_clears_its_creator_reservation_immediately() {
 #[test]
 fn endpoints_and_ready_request_ids_must_match_authenticated_reservations() {
     assert!(matches!(
-        LayoutCoordinator::new(host_a(), addr_b(), 24, 80),
+        LayoutCoordinator::new(host_a(), addr_b(), ledger(), 24, 80),
         Err(CoordinatorError::EndpointIdentityMismatch)
     ));
     assert!(matches!(
         LayoutCoordinator::new(
             host_a(),
             EndpointAddr::new(SecretKey::from_bytes(&[1; 32]).public()),
+            ledger(),
             24,
             80
         ),
@@ -1006,4 +1016,137 @@ fn a_revoked_refusal_is_distinct_from_a_locked_one() {
         LayoutRejectReason::try_from(LayoutRejectReason::Revoked as i32),
         Ok(LayoutRejectReason::Revoked)
     );
+}
+
+fn ledger_verifier() -> LedgerVerifier {
+    LedgerVerifier::new(
+        b"test-session".to_vec(),
+        SecretKey::from_bytes(&[1; 32]).public(),
+    )
+}
+
+fn entry(commit: &LayoutCommit) -> LedgerEntry {
+    commit.entry.clone().expect("every commit seals an entry")
+}
+
+#[test]
+fn the_chain_a_session_writes_verifies_against_its_coordinator_key() {
+    let mut coordinator = coordinator();
+    let mut verifier = ledger_verifier();
+
+    let admission = coordinator.admit(host_b(), addr_b()).expect("admitted");
+    let first = entry(&admission.commit);
+    assert_eq!(first.seq, 1);
+    assert_eq!(first.prev_hash, GENESIS_PREV_HASH.to_vec());
+    assert_eq!(verifier.accept(&first), Ok(()));
+
+    for (step, request_id) in (2..=4u64).enumerate() {
+        let renamed = commit(coordinator.handle_request(
+            &host_a(),
+            LayoutRequest {
+                rename_pane: Some(RenamePane {
+                    pane_id: 1,
+                    title: format!("pass {request_id}"),
+                }),
+                ..request(request_id, renamed_base_revision(step))
+            },
+        ));
+        let sealed = entry(&renamed);
+        assert_eq!(sealed.seq, request_id);
+        assert_eq!(verifier.accept(&sealed), Ok(()));
+    }
+}
+
+/// Each rename advances the revision by one, starting from the admission at revision 2.
+fn renamed_base_revision(step: usize) -> u64 {
+    2 + step as u64
+}
+
+#[test]
+fn the_ledger_records_the_request_that_was_made() {
+    let mut coordinator = coordinator();
+    let renamed = commit(coordinator.handle_request(
+        &host_a(),
+        LayoutRequest {
+            rename_pane: Some(RenamePane {
+                pane_id: 1,
+                title: String::from("build"),
+            }),
+            ..request(7, 1)
+        },
+    ));
+
+    let sealed = entry(&renamed);
+    assert_eq!(sealed.kind, LedgerEntryKind::LayoutChange as i32);
+    assert_eq!(sealed.author_peer_id, host_a());
+    // The entry holds the request itself, not a summary of it: a reader a week later has to
+    // be able to see what was asked for, not what somebody later decided it meant.
+    let recorded =
+        LayoutRequest::decode(sealed.payload.as_slice()).expect("the payload is the request");
+    assert_eq!(recorded.request_id, 7);
+    assert_eq!(recorded.rename_pane.expect("rename").title, "build");
+}
+
+#[test]
+fn a_change_is_recorded_under_the_key_that_asked_for_it() {
+    let mut coordinator = coordinator();
+    coordinator
+        .admit(host_b(), addr_b())
+        .expect("member admitted");
+
+    let reservation = match coordinator.handle_request(
+        &host_b(),
+        LayoutRequest {
+            create_tab: Some(CreateTab {
+                grid_rows: 24,
+                grid_cols: 80,
+            }),
+            ..request(1, 2)
+        },
+    ) {
+        CoordinatorResponse::Reservation(value) => value,
+        other => panic!("expected reservation, got {other:?}"),
+    };
+    let ready = commit(coordinator.handle_pane_ready(
+        &host_b(),
+        PaneReady {
+            reservation_id: reservation.reservation_id,
+            base_revision: 2,
+            request_id: 1,
+        },
+    ));
+
+    let sealed = entry(&ready);
+    assert_eq!(sealed.author_peer_id, host_b());
+    assert_eq!(sealed.kind, LedgerEntryKind::PaneReady as i32);
+    // A reservation is not a change, so it must not have taken a place in the chain: the
+    // admission is 1 and this is 2.
+    assert_eq!(sealed.seq, 2);
+}
+
+#[test]
+fn a_departure_is_authored_by_the_coordinator_because_nobody_asked_for_it() {
+    let mut coordinator = coordinator();
+    coordinator
+        .admit(host_b(), addr_b())
+        .expect("member admitted");
+
+    let departure = coordinator
+        .remove_member(&host_b())
+        .expect("member removed");
+    let sealed = entry(&departure.commit);
+
+    assert_eq!(
+        sealed.author_peer_id,
+        host_a(),
+        "a dropped connection is the coordinator's own observation, not a member's request"
+    );
+    assert!(
+        sealed.author_signature.is_empty(),
+        "there is no member intent to carry"
+    );
+    let record = MembershipRecord::decode(sealed.payload.as_slice())
+        .expect("payload is a membership record");
+    assert_eq!(record.peer_id, host_b());
+    assert_eq!(record.event, MembershipEvent::Left as i32);
 }

--- a/tests/session_layout.rs
+++ b/tests/session_layout.rs
@@ -6,7 +6,7 @@ use p2pmux::{
         NewPanePosition, PaneFailed, PaneGrid, PaneReady, Presence, SetPaneLock, SetSplitRatio,
         SplitAxis, UpdatePaneGrids,
     },
-    session::{CoordinatorError, CoordinatorResponse, LayoutCoordinator},
+    session::{CoordinatorError, CoordinatorResponse, LayoutCoordinator, RosterStatus},
 };
 use std::{
     net::SocketAddr,
@@ -937,5 +937,73 @@ fn a_locked_refusal_is_distinct_from_a_full_one() {
     assert_eq!(
         LayoutRejectReason::try_from(LayoutRejectReason::Locked as i32),
         Ok(LayoutRejectReason::Locked)
+    );
+}
+
+#[test]
+fn a_revoked_key_stays_revoked_when_it_knocks_again() {
+    let mut coordinator = coordinator();
+    coordinator.remember_admitted(host_b());
+    assert!(coordinator.is_admitted(&host_b()));
+
+    assert!(
+        coordinator.revoke(host_b()),
+        "first revoke changes the roster"
+    );
+    assert!(coordinator.is_revoked(&host_b()));
+    assert!(!coordinator.is_admitted(&host_b()));
+
+    // Knocking again is exactly what a revoked peer does next. Honouring it would make
+    // revoking a suggestion rather than a decision.
+    coordinator.remember_admitted(host_b());
+    assert!(coordinator.is_revoked(&host_b()));
+    assert!(!coordinator.is_admitted(&host_b()));
+    assert!(
+        !coordinator.revoke(host_b()),
+        "revoking an already-revoked key changes nothing"
+    );
+}
+
+#[test]
+fn the_roster_names_every_key_the_session_has_an_opinion_about() {
+    let mut coordinator = coordinator();
+    let stranger = endpoint(5, 4105).id.as_bytes().to_vec();
+    coordinator.remember_admitted(host_b());
+    coordinator.revoke(stranger.clone());
+
+    let roster: Vec<(Vec<u8>, RosterStatus)> = coordinator
+        .roster()
+        .entries()
+        .map(|(peer_id, status)| (peer_id.to_vec(), status))
+        .collect();
+
+    assert_eq!(roster.len(), 2);
+    assert_eq!(
+        roster
+            .iter()
+            .find(|(peer_id, _)| peer_id == &host_b())
+            .map(|(_, status)| *status),
+        Some(RosterStatus::Admitted)
+    );
+    assert_eq!(
+        roster
+            .iter()
+            .find(|(peer_id, _)| peer_id == &stranger)
+            .map(|(_, status)| *status),
+        Some(RosterStatus::Revoked)
+    );
+}
+
+#[test]
+fn a_revoked_refusal_is_distinct_from_a_locked_one() {
+    // A lock lifts for everybody at once; a revocation names one key and survives the
+    // unlock. A joiner that cannot tell them apart will keep retrying forever.
+    assert_ne!(
+        LayoutRejectReason::Revoked as i32,
+        LayoutRejectReason::Locked as i32
+    );
+    assert_eq!(
+        LayoutRejectReason::try_from(LayoutRejectReason::Revoked as i32),
+        Ok(LayoutRejectReason::Revoked)
     );
 }

--- a/tests/session_layout.rs
+++ b/tests/session_layout.rs
@@ -1,6 +1,6 @@
 use iroh::{EndpointAddr, SecretKey};
 use p2pmux::{
-    ledger::{GENESIS_PREV_HASH, LedgerVerifier, LedgerWriter},
+    ledger::{GENESIS_PREV_HASH, IntentSigner, LedgerVerifier, LedgerWriter},
     protocol::{
         AgentRoster, AgentRosterEntry, AgentRosterState, CreatePane, CreateTab, DeletePane,
         DeleteTab, LayoutCommit, LayoutRejectReason, LayoutRequest, LedgerEntry, LedgerEntryKind,
@@ -33,6 +33,64 @@ fn addr_b() -> EndpointAddr {
     endpoint(2, 4102)
 }
 
+/// Ask the coordinator for something the way a real peer does: signed.
+///
+/// Every test here used to hand the coordinator a bare request, which the coordinator now
+/// refuses -- it records who asked for a change, and an unsigned request names nobody. The
+/// signing is mechanical, so it lives here rather than in twenty call sites.
+trait AsPeer {
+    fn ask(&mut self, peer_id: &[u8], request: LayoutRequest) -> CoordinatorResponse;
+    fn ask_at(
+        &mut self,
+        peer_id: &[u8],
+        request: LayoutRequest,
+        now: Instant,
+    ) -> CoordinatorResponse;
+    fn report_ready(&mut self, peer_id: &[u8], ready: PaneReady) -> CoordinatorResponse;
+}
+
+impl AsPeer for LayoutCoordinator {
+    fn ask(&mut self, peer_id: &[u8], request: LayoutRequest) -> CoordinatorResponse {
+        self.handle_request(peer_id, sign_request(peer_id, request))
+    }
+
+    fn ask_at(
+        &mut self,
+        peer_id: &[u8],
+        request: LayoutRequest,
+        now: Instant,
+    ) -> CoordinatorResponse {
+        self.handle_request_at(peer_id, sign_request(peer_id, request), now)
+    }
+
+    fn report_ready(&mut self, peer_id: &[u8], ready: PaneReady) -> CoordinatorResponse {
+        self.handle_pane_ready(peer_id, sign_ready(peer_id, ready))
+    }
+}
+
+fn sign_request(peer_id: &[u8], mut request: LayoutRequest) -> LayoutRequest {
+    request.author_signature = Vec::new();
+    request.author_signature =
+        signer(peer_id).sign(LedgerEntryKind::LayoutChange, &request.encode_to_vec());
+    request
+}
+
+fn sign_ready(peer_id: &[u8], mut ready: PaneReady) -> PaneReady {
+    ready.author_signature = Vec::new();
+    ready.author_signature =
+        signer(peer_id).sign(LedgerEntryKind::PaneReady, &ready.encode_to_vec());
+    ready
+}
+
+/// Every test identity comes from `endpoint(seed, _)`, so the seed can be recovered from
+/// the public key rather than threaded through each call.
+fn signer(peer_id: &[u8]) -> IntentSigner {
+    let seed = (0..=u8::MAX)
+        .find(|seed| SecretKey::from_bytes(&[*seed; 32]).public().as_bytes() == peer_id)
+        .expect("test peers are all derived from a single-byte seed");
+    IntentSigner::new(b"test-session".to_vec(), SecretKey::from_bytes(&[seed; 32]))
+}
+
 fn coordinator() -> LayoutCoordinator {
     LayoutCoordinator::new(host_a(), addr_a(), ledger(), 24, 80).expect("valid coordinator")
 }
@@ -57,6 +115,7 @@ fn request(request_id: u64, base_revision: u64) -> LayoutRequest {
         rename_tab: None,
         set_pane_lock: None,
         mark_pane_exited: None,
+        author_signature: Vec::new(),
     }
 }
 
@@ -67,7 +126,7 @@ fn admitted_members_set_ratios_and_hosts_reconcile_their_grids() {
         .admit(host_b(), addr_b())
         .expect("member admitted");
     // Create through the established reservation flow so pane 2 is hosted by B.
-    let reservation = coordinator.handle_request(
+    let reservation = coordinator.ask(
         &host_b(),
         LayoutRequest {
             create_pane: Some(p2pmux::protocol::CreatePane {
@@ -84,15 +143,16 @@ fn admitted_members_set_ratios_and_hosts_reconcile_their_grids() {
         CoordinatorResponse::Reservation(value) => value,
         other => panic!("reservation: {other:?}"),
     };
-    let _ = commit(coordinator.handle_pane_ready(
+    let _ = commit(coordinator.report_ready(
         &host_b(),
         PaneReady {
             reservation_id: reservation.reservation_id,
             base_revision: 2,
             request_id: 1,
+            author_signature: Vec::new(),
         },
     ));
-    let ratio = commit(coordinator.handle_request(
+    let ratio = commit(coordinator.ask(
         &host_a(),
         LayoutRequest {
             set_split_ratio: Some(SetSplitRatio {
@@ -104,7 +164,7 @@ fn admitted_members_set_ratios_and_hosts_reconcile_their_grids() {
         },
     ));
     assert_eq!(ratio.revision, 4);
-    let grids = commit(coordinator.handle_request(
+    let grids = commit(coordinator.ask(
         &host_b(),
         LayoutRequest {
             update_pane_grids: Some(UpdatePaneGrids {
@@ -137,7 +197,7 @@ fn pane_host_can_set_lock_and_guest_is_rejected() {
         .admit(host_b(), addr_b())
         .expect("member admitted");
 
-    let commit = commit(coordinator.handle_request(
+    let commit = commit(coordinator.ask(
         &host_a(),
         LayoutRequest {
             set_pane_lock: Some(SetPaneLock {
@@ -149,7 +209,7 @@ fn pane_host_can_set_lock_and_guest_is_rejected() {
     ));
     assert!(commit.state.expect("state").panes[0].locked);
 
-    let rejection = reject(coordinator.handle_request(
+    let rejection = reject(coordinator.ask(
         &host_b(),
         LayoutRequest {
             set_pane_lock: Some(SetPaneLock {
@@ -169,29 +229,32 @@ fn pane_host_marks_exit_idempotently_and_guests_are_rejected() {
         .admit(host_b(), addr_b())
         .expect("member admitted");
     let revision = 2;
-    let first = commit(coordinator.handle_request(
+    let first = commit(coordinator.ask(
         &host_a(),
         LayoutRequest {
             mark_pane_exited: Some(MarkPaneExited { pane_id: 1 }),
+            author_signature: Vec::new(),
             ..request(1, revision)
         },
     ));
     assert_eq!(first.revision, revision + 1);
     assert!(first.state.expect("state").panes[0].exited);
 
-    let repeated = commit(coordinator.handle_request(
+    let repeated = commit(coordinator.ask(
         &host_a(),
         LayoutRequest {
             mark_pane_exited: Some(MarkPaneExited { pane_id: 1 }),
+            author_signature: Vec::new(),
             ..request(2, revision + 1)
         },
     ));
     assert_eq!(repeated.revision, revision + 1);
     assert_eq!(
-        reject(coordinator.handle_request(
+        reject(coordinator.ask(
             &host_b(),
             LayoutRequest {
                 mark_pane_exited: Some(MarkPaneExited { pane_id: 1 }),
+                author_signature: Vec::new(),
                 ..request(3, revision + 1)
             },
         ))
@@ -415,7 +478,7 @@ fn pane_creation_is_hidden_until_its_creator_marks_the_reservation_ready() {
         position: None,
     });
 
-    let reservation = match coordinator.handle_request(&host_a(), create) {
+    let reservation = match coordinator.ask(&host_a(), create) {
         CoordinatorResponse::Reservation(reservation) => reservation,
         other => panic!("expected reservation, got {other:?}"),
     };
@@ -430,12 +493,13 @@ fn pane_creation_is_hidden_until_its_creator_marks_the_reservation_ready() {
         1
     );
 
-    let commit = commit(coordinator.handle_pane_ready(
+    let commit = commit(coordinator.report_ready(
         &host_a(),
         PaneReady {
             reservation_id: reservation.reservation_id,
             base_revision: 1,
             request_id: 10,
+            author_signature: Vec::new(),
         },
     ));
     let state = commit.state.expect("state present");
@@ -459,17 +523,18 @@ fn pane_creation_maps_protocol_placement_to_authoritative_child_order() {
         grid_cols: 80,
         position: Some(NewPanePosition::First as i32),
     });
-    let reservation = match coordinator.handle_request(&host_a(), create) {
+    let reservation = match coordinator.ask(&host_a(), create) {
         CoordinatorResponse::Reservation(reservation) => reservation,
         other => panic!("expected reservation, got {other:?}"),
     };
 
-    let state = commit(coordinator.handle_pane_ready(
+    let state = commit(coordinator.report_ready(
         &host_a(),
         PaneReady {
             reservation_id: reservation.reservation_id,
             base_revision: 1,
             request_id: 15,
+            author_signature: Vec::new(),
         },
     ))
     .state
@@ -499,7 +564,7 @@ fn ready_cannot_commit_a_reservation_after_membership_advances_its_revision() {
         grid_cols: 100,
         position: None,
     });
-    let reservation = match coordinator.handle_request(&host_a(), create) {
+    let reservation = match coordinator.ask(&host_a(), create) {
         CoordinatorResponse::Reservation(reservation) => reservation,
         other => panic!("expected reservation, got {other:?}"),
     };
@@ -511,12 +576,13 @@ fn ready_cannot_commit_a_reservation_after_membership_advances_its_revision() {
     assert_eq!(invalidation.reject.request_id, 101);
     assert_eq!(invalidation.reject.reason, LayoutRejectReason::Stale as i32);
 
-    let rejection = reject(coordinator.handle_pane_ready(
+    let rejection = reject(coordinator.report_ready(
         &host_a(),
         PaneReady {
             reservation_id: reservation.reservation_id,
             base_revision: 2,
             request_id: 101,
+            author_signature: Vec::new(),
         },
     ));
     assert_eq!(rejection.request_id, 101);
@@ -534,7 +600,7 @@ fn ready_cannot_commit_a_reservation_after_membership_advances_its_revision() {
         grid_cols: 80,
     });
     assert!(matches!(
-        coordinator.handle_request(&host_a(), next),
+        coordinator.ask(&host_a(), next),
         CoordinatorResponse::Reservation(_)
     ));
 }
@@ -551,17 +617,18 @@ fn admitted_guest_hosts_its_own_pane_after_ready() {
         grid_cols: 101,
         position: None,
     });
-    let reservation = match coordinator.handle_request(&host_b(), create) {
+    let reservation = match coordinator.ask(&host_b(), create) {
         CoordinatorResponse::Reservation(reservation) => reservation,
         other => panic!("expected reservation, got {other:?}"),
     };
 
-    let commit = commit(coordinator.handle_pane_ready(
+    let commit = commit(coordinator.report_ready(
         &host_b(),
         PaneReady {
             reservation_id: reservation.reservation_id,
             base_revision: 2,
             request_id: 11,
+            author_signature: Vec::new(),
         },
     ));
     let state = commit.state.unwrap();
@@ -583,7 +650,7 @@ fn stale_request_is_rejected_without_a_layout_change() {
         grid_cols: 80,
     });
 
-    let rejection = reject(coordinator.handle_request(&host_a(), create));
+    let rejection = reject(coordinator.ask(&host_a(), create));
     assert_eq!(rejection.reason, LayoutRejectReason::Stale as i32);
     let state = coordinator.session_snapshot().unwrap().state.unwrap();
     assert_eq!(state.revision, 1);
@@ -597,7 +664,7 @@ fn foreign_pane_deletion_is_rejected() {
     let mut delete = request(13, 2);
     delete.delete_pane = Some(DeletePane { pane_id: 1 });
 
-    let rejection = reject(coordinator.handle_request(&host_b(), delete));
+    let rejection = reject(coordinator.ask(&host_b(), delete));
     assert_eq!(rejection.reason, LayoutRejectReason::NotHost as i32);
     assert_eq!(
         coordinator
@@ -622,16 +689,17 @@ fn mixed_host_tab_deletion_is_rejected() {
         grid_cols: 80,
         position: None,
     });
-    let reservation = match coordinator.handle_request(&host_b(), create) {
+    let reservation = match coordinator.ask(&host_b(), create) {
         CoordinatorResponse::Reservation(reservation) => reservation,
         other => panic!("expected reservation, got {other:?}"),
     };
-    commit(coordinator.handle_pane_ready(
+    commit(coordinator.report_ready(
         &host_b(),
         PaneReady {
             reservation_id: reservation.reservation_id,
             base_revision: 2,
             request_id: 14,
+            author_signature: Vec::new(),
         },
     ));
     let mut create_tab = request(15, 3);
@@ -639,22 +707,23 @@ fn mixed_host_tab_deletion_is_rejected() {
         grid_rows: 24,
         grid_cols: 80,
     });
-    let reservation = match coordinator.handle_request(&host_a(), create_tab) {
+    let reservation = match coordinator.ask(&host_a(), create_tab) {
         CoordinatorResponse::Reservation(reservation) => reservation,
         other => panic!("expected reservation, got {other:?}"),
     };
-    commit(coordinator.handle_pane_ready(
+    commit(coordinator.report_ready(
         &host_a(),
         PaneReady {
             reservation_id: reservation.reservation_id,
             base_revision: 3,
             request_id: 15,
+            author_signature: Vec::new(),
         },
     ));
     let mut delete = request(16, 4);
     delete.delete_tab = Some(DeleteTab { tab_id: 1 });
 
-    let rejection = reject(coordinator.handle_request(&host_a(), delete));
+    let rejection = reject(coordinator.ask(&host_a(), delete));
     assert_eq!(rejection.reason, LayoutRejectReason::MixedTab as i32);
 }
 
@@ -668,16 +737,17 @@ fn limits_are_rejected_without_creating_visible_layout() {
             grid_rows: 24,
             grid_cols: 80,
         });
-        let reservation = match coordinator.handle_request(&host_a(), create) {
+        let reservation = match coordinator.ask(&host_a(), create) {
             CoordinatorResponse::Reservation(reservation) => reservation,
             other => panic!("expected reservation, got {other:?}"),
         };
-        commit(coordinator.handle_pane_ready(
+        commit(coordinator.report_ready(
             &host_a(),
             PaneReady {
                 reservation_id: reservation.reservation_id,
                 base_revision: revision,
                 request_id,
+                author_signature: Vec::new(),
             },
         ));
         revision += 1;
@@ -688,7 +758,7 @@ fn limits_are_rejected_without_creating_visible_layout() {
         grid_cols: 80,
     });
 
-    let rejection = reject(coordinator.handle_request(&host_a(), one_too_many));
+    let rejection = reject(coordinator.ask(&host_a(), one_too_many));
     assert_eq!(rejection.reason, LayoutRejectReason::Limit as i32);
     assert_eq!(
         coordinator
@@ -711,17 +781,18 @@ fn wrong_creator_and_ready_revision_are_rejected_with_the_original_request_id() 
         grid_rows: 24,
         grid_cols: 80,
     });
-    let reservation = match coordinator.handle_request(&host_a(), create) {
+    let reservation = match coordinator.ask(&host_a(), create) {
         CoordinatorResponse::Reservation(reservation) => reservation,
         other => panic!("expected reservation, got {other:?}"),
     };
 
-    let wrong_creator = reject(coordinator.handle_pane_ready(
+    let wrong_creator = reject(coordinator.report_ready(
         &host_b(),
         PaneReady {
             reservation_id: reservation.reservation_id,
             base_revision: 2,
             request_id: 18,
+            author_signature: Vec::new(),
         },
     ));
     assert_eq!(wrong_creator.request_id, 18);
@@ -730,12 +801,13 @@ fn wrong_creator_and_ready_revision_are_rejected_with_the_original_request_id() 
         LayoutRejectReason::ReservationFailure as i32
     );
 
-    let stale_ready = reject(coordinator.handle_pane_ready(
+    let stale_ready = reject(coordinator.report_ready(
         &host_a(),
         PaneReady {
             reservation_id: reservation.reservation_id,
             base_revision: 1,
             request_id: 18,
+            author_signature: Vec::new(),
         },
     ));
     assert_eq!(stale_ready.request_id, 18);
@@ -770,7 +842,7 @@ fn reservation_expiry_is_deterministic_and_unwedges_new_requests() {
         grid_rows: 24,
         grid_cols: 80,
     });
-    match coordinator.handle_request_at(&host_a(), create, now) {
+    match coordinator.ask_at(&host_a(), create, now) {
         CoordinatorResponse::Reservation(reservation) => reservation,
         other => panic!("expected reservation, got {other:?}"),
     };
@@ -796,7 +868,7 @@ fn reservation_expiry_is_deterministic_and_unwedges_new_requests() {
         grid_cols: 80,
     });
     assert!(matches!(
-        coordinator.handle_request_at(&host_a(), next, now),
+        coordinator.ask_at(&host_a(), next, now),
         CoordinatorResponse::Reservation(_)
     ));
 }
@@ -809,7 +881,7 @@ fn pane_failure_clears_its_creator_reservation_immediately() {
         grid_rows: 24,
         grid_cols: 80,
     });
-    let reservation = match coordinator.handle_request(&host_a(), create) {
+    let reservation = match coordinator.ask(&host_a(), create) {
         CoordinatorResponse::Reservation(reservation) => reservation,
         other => panic!("expected reservation, got {other:?}"),
     };
@@ -829,7 +901,7 @@ fn pane_failure_clears_its_creator_reservation_immediately() {
         grid_cols: 80,
     });
     assert!(matches!(
-        coordinator.handle_request(&host_a(), next),
+        coordinator.ask(&host_a(), next),
         CoordinatorResponse::Reservation(_)
     ));
 }
@@ -867,16 +939,17 @@ fn endpoints_and_ready_request_ids_must_match_authenticated_reservations() {
         grid_rows: 24,
         grid_cols: 80,
     });
-    let reservation = match coordinator.handle_request(&host_a(), create) {
+    let reservation = match coordinator.ask(&host_a(), create) {
         CoordinatorResponse::Reservation(reservation) => reservation,
         other => panic!("expected reservation, got {other:?}"),
     };
-    let rejected = reject(coordinator.handle_pane_ready(
+    let rejected = reject(coordinator.report_ready(
         &host_a(),
         PaneReady {
             reservation_id: reservation.reservation_id,
             base_revision: 1,
             request_id: 206,
+            author_signature: Vec::new(),
         },
     ));
     assert_eq!(rejected.request_id, 206);
@@ -1041,7 +1114,7 @@ fn the_chain_a_session_writes_verifies_against_its_coordinator_key() {
     assert_eq!(verifier.accept(&first), Ok(()));
 
     for (step, request_id) in (2..=4u64).enumerate() {
-        let renamed = commit(coordinator.handle_request(
+        let renamed = commit(coordinator.ask(
             &host_a(),
             LayoutRequest {
                 rename_pane: Some(RenamePane {
@@ -1065,7 +1138,7 @@ fn renamed_base_revision(step: usize) -> u64 {
 #[test]
 fn the_ledger_records_the_request_that_was_made() {
     let mut coordinator = coordinator();
-    let renamed = commit(coordinator.handle_request(
+    let renamed = commit(coordinator.ask(
         &host_a(),
         LayoutRequest {
             rename_pane: Some(RenamePane {
@@ -1094,7 +1167,7 @@ fn a_change_is_recorded_under_the_key_that_asked_for_it() {
         .admit(host_b(), addr_b())
         .expect("member admitted");
 
-    let reservation = match coordinator.handle_request(
+    let reservation = match coordinator.ask(
         &host_b(),
         LayoutRequest {
             create_tab: Some(CreateTab {
@@ -1107,12 +1180,13 @@ fn a_change_is_recorded_under_the_key_that_asked_for_it() {
         CoordinatorResponse::Reservation(value) => value,
         other => panic!("expected reservation, got {other:?}"),
     };
-    let ready = commit(coordinator.handle_pane_ready(
+    let ready = commit(coordinator.report_ready(
         &host_b(),
         PaneReady {
             reservation_id: reservation.reservation_id,
             base_revision: 2,
             request_id: 1,
+            author_signature: Vec::new(),
         },
     ));
 
@@ -1149,4 +1223,96 @@ fn a_departure_is_authored_by_the_coordinator_because_nobody_asked_for_it() {
         .expect("payload is a membership record");
     assert_eq!(record.peer_id, host_b());
     assert_eq!(record.event, MembershipEvent::Left as i32);
+}
+
+fn rename_pane_request(request_id: u64, base_revision: u64, title: &str) -> LayoutRequest {
+    LayoutRequest {
+        rename_pane: Some(RenamePane {
+            pane_id: 1,
+            title: String::from(title),
+        }),
+        ..request(request_id, base_revision)
+    }
+}
+
+#[test]
+fn an_unsigned_request_is_refused_because_it_names_nobody() {
+    let mut coordinator = coordinator();
+
+    // Deliberately not through `ask`: this is the raw request a peer would send if it
+    // skipped signing. The connection is authentic, but the ledger records authorship for
+    // readers who were never on it, and there is nothing here to record.
+    let rejection =
+        reject(coordinator.handle_request(&host_a(), rename_pane_request(1, 1, "build")));
+
+    assert_eq!(rejection.reason, LayoutRejectReason::Unsigned as i32);
+    assert_eq!(rejection.request_id, 1);
+}
+
+#[test]
+fn a_request_signed_by_somebody_else_is_refused() {
+    let mut coordinator = coordinator();
+    coordinator
+        .admit(host_b(), addr_b())
+        .expect("member admitted");
+
+    // B's signature, presented over A's authenticated connection. Either half alone looks
+    // fine; the point is that they have to be the same peer.
+    let borrowed = sign_request(&host_b(), rename_pane_request(1, 2, "build"));
+    let rejection = reject(coordinator.handle_request(&host_a(), borrowed));
+
+    assert_eq!(rejection.reason, LayoutRejectReason::Unsigned as i32);
+}
+
+#[test]
+fn a_request_edited_after_signing_is_refused() {
+    let mut coordinator = coordinator();
+    let mut tampered = sign_request(&host_a(), rename_pane_request(1, 1, "build"));
+    tampered.rename_pane = Some(RenamePane {
+        pane_id: 1,
+        title: String::from("something else"),
+    });
+
+    let rejection = reject(coordinator.handle_request(&host_a(), tampered));
+
+    assert_eq!(rejection.reason, LayoutRejectReason::Unsigned as i32);
+}
+
+#[test]
+fn the_sealed_entry_carries_the_authors_own_signature() {
+    let mut coordinator = coordinator();
+    let mut verifier = ledger_verifier();
+    let renamed = commit(coordinator.ask(&host_a(), rename_pane_request(1, 1, "build")));
+
+    let sealed = entry(&renamed);
+    assert!(
+        !sealed.author_signature.is_empty(),
+        "the record of who asked has to rest on the asker's key, not the coordinator's word"
+    );
+    // The verifier checks that signature against the payload, so this passing is the whole
+    // claim: even the coordinator could not have pinned this change on somebody else.
+    assert_eq!(verifier.accept(&sealed), Ok(()));
+}
+
+#[test]
+fn a_reattributed_entry_fails_the_members_check() {
+    let mut coordinator = coordinator();
+    coordinator
+        .admit(host_b(), addr_b())
+        .expect("member admitted");
+    let mut verifier = ledger_verifier();
+    verifier
+        .accept(&entry(&commit(
+            coordinator.ask(&host_a(), rename_pane_request(1, 2, "build")),
+        )))
+        .expect("the coordinator's own record verifies");
+
+    // A coordinator that wanted to blame B for A's change would have to produce B's
+    // signature over it, and it cannot.
+    let mut forged = entry(&commit(
+        coordinator.ask(&host_a(), rename_pane_request(2, 3, "deploy")),
+    ));
+    forged.author_peer_id = host_b();
+
+    assert!(verifier.accept(&forged).is_err());
 }

--- a/tests/session_layout_control.rs
+++ b/tests/session_layout_control.rs
@@ -11,8 +11,9 @@ use p2pmux::{
     },
     screen::HostScreen,
     session::{
-        GuestEvent, HostPaneChannels, HostSession, LayoutControlEvent, RosterStatus, SessionError,
-        SharedLayoutHost, join_layout, layout_snapshot_from_state, pane_wire_id, subscribe_pane,
+        CoordinatorResponse, GuestEvent, HostPaneChannels, HostSession, LayoutControlEvent,
+        RosterStatus, SessionError, SharedLayoutHost, join_layout, layout_snapshot_from_state,
+        pane_wire_id, subscribe_pane,
     },
     transport::{ALPN, Transport},
 };
@@ -1155,5 +1156,45 @@ async fn a_member_receives_a_chained_ledger_alongside_every_commit() {
 
     drop(second);
     first.shutdown().await;
+    coordinator.close().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn the_coordinators_own_request_is_signed_and_recorded_under_its_key() {
+    // The host's own UI goes through `handle_local_request` rather than the wire, so it is
+    // the one path where a signing mistake would show up as "splits stopped working" with
+    // nothing else to see.
+    let host = HostSession::from_transport(loopback_transport().await).expect("host");
+    let coordinator = SharedLayoutHost::new(host, 24, 80).expect("shared host");
+    let own_key = coordinator.ticket().endpoint_addr().id.as_bytes().to_vec();
+
+    let reservation = match coordinator
+        .handle_local_request(create_request(1, 1))
+        .expect("the host may split its own layout")
+    {
+        CoordinatorResponse::Reservation(reservation) => reservation,
+        other => panic!("expected a reservation, got {other:?}"),
+    };
+    let commit = match coordinator
+        .handle_local_ready(PaneReady {
+            reservation_id: reservation.reservation_id,
+            base_revision: 1,
+            request_id: 1,
+            author_signature: Vec::new(),
+        })
+        .expect("the host may report its own pane live")
+    {
+        CoordinatorResponse::Commit(commit) => commit,
+        other => panic!("expected a commit, got {other:?}"),
+    };
+
+    let sealed = commit.entry.expect("the host's own change is sealed too");
+    assert_eq!(sealed.author_peer_id, own_key);
+    assert!(
+        !sealed.author_signature.is_empty(),
+        "the coordinator signs its own requests; otherwise one identity in the session \
+         writes entries nobody can check"
+    );
+
     coordinator.close().await;
 }

--- a/tests/session_layout_control.rs
+++ b/tests/session_layout_control.rs
@@ -3,10 +3,11 @@ use std::{net::Ipv4Addr, time::Duration};
 use iroh::{Endpoint, RelayMode, endpoint::presets};
 use p2pmux::{
     lease::LeaseState,
+    ledger::entry_hash,
     protocol::{
         AgentRoster, AgentRosterEntry, AgentRosterState, CreatePane, CreateTab, DeletePane,
-        DeleteTab, Envelope, Join, LayoutRejectReason, LayoutRequest, PROTOCOL_VERSION,
-        PaneDescriptor, PaneReady, SplitAxis, envelope,
+        DeleteTab, Envelope, Join, LayoutRejectReason, LayoutRequest, MembershipRecord,
+        PROTOCOL_VERSION, PaneDescriptor, PaneReady, SplitAxis, envelope,
     },
     screen::HostScreen,
     session::{
@@ -15,6 +16,7 @@ use p2pmux::{
     },
     transport::{ALPN, Transport},
 };
+use prost::Message;
 use tokio::time::timeout;
 
 const TEST_TIMEOUT: Duration = Duration::from_secs(5);
@@ -1078,5 +1080,69 @@ async fn revoking_the_coordinators_own_key_is_refused() {
     );
     assert!(coordinator.roster().expect("roster").is_empty());
 
+    coordinator.close().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_member_receives_a_chained_ledger_alongside_every_commit() {
+    let host = HostSession::from_transport(loopback_transport().await).expect("host");
+    let coordinator = SharedLayoutHost::new(host, 24, 80).expect("shared host");
+
+    let accept_first = {
+        let coordinator = coordinator.clone();
+        tokio::spawn(async move { coordinator.accept_one_member().await })
+    };
+    let mut first = join_layout(loopback_transport().await, coordinator.ticket().clone())
+        .await
+        .expect("first joins");
+    accept_first
+        .await
+        .expect("accept task")
+        .expect("accept first");
+    assert!(matches!(
+        next_event(&mut first).await,
+        LayoutControlEvent::Snapshot(_)
+    ));
+
+    // A second member joining, then leaving, is two changes the coordinator authored on its
+    // own account -- the pair the first member has to be able to follow.
+    let accept_second = {
+        let coordinator = coordinator.clone();
+        tokio::spawn(async move { coordinator.accept_one_member().await })
+    };
+    let second = join_layout(loopback_transport().await, coordinator.ticket().clone())
+        .await
+        .expect("second joins");
+    accept_second
+        .await
+        .expect("accept task")
+        .expect("accept second");
+    let second_id = second.peer_id.clone();
+
+    let LayoutControlEvent::Commit(admission) = next_event(&mut first).await else {
+        panic!("the first member should see the second arrive");
+    };
+    coordinator.revoke_member(&second_id).expect("revoke");
+    let LayoutControlEvent::Commit(departure) = next_event(&mut first).await else {
+        panic!("the first member should see the second leave");
+    };
+
+    let admission = admission.entry.expect("admission is sealed");
+    let departure = departure.entry.expect("departure is sealed");
+    assert_eq!(departure.seq, admission.seq + 1);
+    assert_eq!(
+        departure.prev_hash,
+        entry_hash(coordinator.ticket().session_id(), &admission).to_vec(),
+        "each entry names the one before it, so a dropped commit cannot pass unnoticed"
+    );
+    assert_eq!(
+        MembershipRecord::decode(departure.payload.as_slice())
+            .expect("payload is a membership record")
+            .peer_id,
+        second_id
+    );
+
+    drop(second);
+    first.shutdown().await;
     coordinator.close().await;
 }

--- a/tests/session_layout_control.rs
+++ b/tests/session_layout_control.rs
@@ -10,8 +10,8 @@ use p2pmux::{
     },
     screen::HostScreen,
     session::{
-        GuestEvent, HostPaneChannels, HostSession, LayoutControlEvent, SharedLayoutHost,
-        join_layout, layout_snapshot_from_state, pane_wire_id, subscribe_pane,
+        GuestEvent, HostPaneChannels, HostSession, LayoutControlEvent, RosterStatus, SessionError,
+        SharedLayoutHost, join_layout, layout_snapshot_from_state, pane_wire_id, subscribe_pane,
     },
     transport::{ALPN, Transport},
 };
@@ -998,5 +998,85 @@ async fn admission_invalidates_a_member_reservation_and_notifies_its_creator() {
 
     first.shutdown().await;
     second.shutdown().await;
+    coordinator.close().await;
+}
+
+/// Drain control events until the member's stream reports it has been dropped.
+///
+/// The eviction is announced by closing the connection, and whatever commits were already
+/// in flight arrive first, so the test cannot assume `Disconnected` is the very next event.
+async fn next_disconnect(member: &mut p2pmux::session::SharedLayoutMember) {
+    for _ in 0..16 {
+        if matches!(next_event(member).await, LayoutControlEvent::Disconnected) {
+            return;
+        }
+    }
+    panic!("member should have been disconnected");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn revoking_a_member_evicts_it_and_refuses_the_key_afterwards() {
+    let host = HostSession::from_transport(loopback_transport().await).expect("host");
+    let coordinator = SharedLayoutHost::new(host, 24, 80).expect("shared host");
+    let accept = {
+        let coordinator = coordinator.clone();
+        tokio::spawn(async move { coordinator.accept_one_member().await })
+    };
+    let member_transport = loopback_transport().await;
+    let mut member = join_layout(member_transport.clone(), coordinator.ticket().clone())
+        .await
+        .expect("member joins");
+    accept.await.expect("accept task").expect("accept member");
+    let member_id = member.peer_id.clone();
+
+    assert!(
+        coordinator.revoke_member(&member_id).expect("revoke"),
+        "revoking a seated member changes the roster"
+    );
+    next_disconnect(&mut member).await;
+
+    // The session is never locked in this test: a revoked key has to be turned away on its
+    // own account, or "kick" would only work while the door was shut to everyone.
+    assert!(!coordinator.is_session_locked().expect("lock state"));
+    let accept_again = {
+        let coordinator = coordinator.clone();
+        tokio::spawn(async move { coordinator.accept_one_member().await })
+    };
+    let rejoin = join_layout(member_transport.clone(), coordinator.ticket().clone()).await;
+    assert!(
+        matches!(rejoin, Err(SessionError::MembershipRevoked)),
+        "a revoked key must be told why, not merely dropped"
+    );
+    assert!(matches!(
+        accept_again.await.expect("accept task"),
+        Err(SessionError::MembershipRevoked)
+    ));
+
+    assert_eq!(
+        coordinator
+            .roster()
+            .expect("roster")
+            .into_iter()
+            .find(|(peer_id, _)| peer_id == &member_id)
+            .map(|(_, status)| status),
+        Some(RosterStatus::Revoked)
+    );
+
+    drop(member);
+    coordinator.close().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn revoking_the_coordinators_own_key_is_refused() {
+    let host = HostSession::from_transport(loopback_transport().await).expect("host");
+    let coordinator = SharedLayoutHost::new(host, 24, 80).expect("shared host");
+    let own_key = coordinator.ticket().endpoint_addr().id.as_bytes().to_vec();
+
+    assert!(
+        !coordinator.revoke_member(&own_key).expect("revoke"),
+        "a session whose only authority cannot rejoin it is not a session"
+    );
+    assert!(coordinator.roster().expect("roster").is_empty());
+
     coordinator.close().await;
 }

--- a/tests/session_layout_control.rs
+++ b/tests/session_layout_control.rs
@@ -117,6 +117,7 @@ fn create_request(request_id: u64, base_revision: u64) -> LayoutRequest {
         rename_tab: None,
         set_pane_lock: None,
         mark_pane_exited: None,
+        author_signature: Vec::new(),
     }
 }
 
@@ -192,6 +193,7 @@ async fn agent_roster_relays_to_members_and_bootstraps_late_joiners() {
             reservation_id: reservation.reservation_id,
             base_revision: 2,
             request_id: 1,
+            author_signature: Vec::new(),
         })
         .expect("first marks pane ready");
     assert!(matches!(
@@ -517,6 +519,7 @@ async fn forged_post_welcome_sender_is_rejected_without_a_layout_mutation() {
                 rename_tab: None,
                 set_pane_lock: None,
                 mark_pane_exited: None,
+                author_signature: Vec::new(),
             })),
         })
         .await
@@ -589,6 +592,7 @@ async fn deleting_a_member_owned_tab_broadcasts_the_full_commit() {
             rename_tab: None,
             set_pane_lock: None,
             mark_pane_exited: None,
+            author_signature: Vec::new(),
         })
         .expect("queue tab request");
     let reservation = match next_event(&mut second).await {
@@ -600,6 +604,7 @@ async fn deleting_a_member_owned_tab_broadcasts_the_full_commit() {
             reservation_id: reservation.reservation_id,
             base_revision: 3,
             request_id: 12,
+            author_signature: Vec::new(),
         })
         .expect("ready tab");
     let commit = match next_event(&mut first).await {
@@ -627,6 +632,7 @@ async fn deleting_a_member_owned_tab_broadcasts_the_full_commit() {
             rename_tab: None,
             set_pane_lock: None,
             mark_pane_exited: None,
+            author_signature: Vec::new(),
         })
         .expect("queue tab delete");
     for member in [&mut first, &mut second] {
@@ -685,6 +691,7 @@ async fn reservation_is_targeted_and_ready_broadcasts_the_commit() {
             reservation_id: reservation.reservation_id,
             base_revision: 3,
             request_id: 7,
+            author_signature: Vec::new(),
         })
         .expect("queue ready");
     assert!(
@@ -711,6 +718,7 @@ async fn reservation_is_targeted_and_ready_broadcasts_the_commit() {
             rename_tab: None,
             set_pane_lock: None,
             mark_pane_exited: None,
+            author_signature: Vec::new(),
         })
         .expect("queue deletion");
     assert!(
@@ -735,6 +743,7 @@ async fn reservation_is_targeted_and_ready_broadcasts_the_commit() {
             rename_tab: None,
             set_pane_lock: None,
             mark_pane_exited: None,
+            author_signature: Vec::new(),
         })
         .expect("queue foreign deletion");
     assert!(matches!(
@@ -850,6 +859,7 @@ async fn simultaneous_member_requests_publish_only_monotonic_commits() {
                     reservation_id: reservation.reservation_id,
                     base_revision: 3,
                     request_id: 31,
+                    author_signature: Vec::new(),
                 })
                 .expect("first ready");
             reservation
@@ -860,6 +870,7 @@ async fn simultaneous_member_requests_publish_only_monotonic_commits() {
                     reservation_id: reservation.reservation_id,
                     base_revision: 3,
                     request_id: 32,
+                    author_signature: Vec::new(),
                 })
                 .expect("second ready");
             reservation


### PR DESCRIPTION
p2pmux/2 has ~zero external users and v0.1.0 shipped days ago. This makes the two wire changes that are expensive to make later and free to make now. Per-member invite credentials are deliberately left out: they are additive (a new `Join` field plus a v4 ticket, and the ticket format has already versioned three times), so they can land after there are users.

## What changes

**A commit is a link in a chain, not a snapshot.** `LayoutCommit` used to be the whole layout again with a revision number. It had no author -- and since the coordinator relays commits under its own identity, a member could not attribute a change to anyone at all -- and no predecessor, so a dropped or reordered commit was indistinguishable from a quiet moment. Every commit now seals a `LedgerEntry`: numbered from 1 with no gaps, naming the BLAKE3 hash of the one before it, carrying the key that asked and the request they made, signed. Members verify as they read and drop the connection rather than draw a layout they cannot account for.

**Peers sign what they ask for.** The entry's author no longer rests on the coordinator's word. A request carries an ed25519 signature over itself unsigned; the coordinator checks it against the identity QUIC proved on that connection and forwards it into the entry. Unsigned, borrowed, or edited-after-signing is refused with a new `Unsigned` reason the sender can act on. The coordinator signs its own requests through the same path -- exempting it would leave one identity in the session whose entries nobody could check.

**Admission is a roster of keys.** The ticket got a stranger considered; now the roster decides. `SharedLayoutHost::revoke_member` strikes one key, removes the member, and drops its control connection before announcing the departure. A revoked key is turned away whatever the session lock says, so the refusal survives both an unlock and a ticket that has been forwarded.

The layout state still travels beside each entry as a checkpoint -- it is what renderers draw and what lets a joiner start without replaying from genesis. That split is what keeps this to the control plane: PTY bytes and screen deltas are untouched, and the TUI is not rewritten.

## Protocol version 9

The wire break is the point. Old and new binaries will not talk to each other.

## Reviewing

Four commits, each green on its own:

1. `338cd10` the roster and revocation
2. `22136eb` the entry chain and the coordinator's seal
3. `0521314` author signatures end to end
4. `31bde1a` coverage for the host's own layout path, plus the design doc

Worth a look: `src/ledger.rs` is the whole trust story in one file, including why the intent hash and the entry hash are domain-separated. `LedgerVerifier` anchors on the first entry a member sees rather than replaying from genesis -- a late joiner cannot check what it was never sent, and that limit is documented rather than papered over.

## Known-flaky

`session_store::tests::a_node_too_busy_to_answer_keeps_its_record` failed once under full-suite load and passes 5/5 in isolation. It is a probe-timing test in a file this branch does not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0122yYoacHbnU185NFfqnrAz