### PR TITLE
fix(install): fall back to ~/.local/bin when sudo exists but cannot be used

### DIFF
--- a/services/site/public/install.sh
+++ b/services/site/public/install.sh
@@ -97,20 +97,30 @@ ACTUAL="$(sha256_of "$TMP/$ASSET" | cut -d' ' -f1)"
 tar -xzf "$TMP/$ASSET" -C "$TMP"
 [ -f "$TMP/p2pmux" ] || die "the archive did not contain a p2pmux binary"
 
+# Having `sudo` on PATH is not the same as being able to use it. A locked-down work
+# laptop or a stock container ships the binary without a sudoers entry for you, and a
+# piped installer has no terminal to type a password into. So run it inside an `if`
+# rather than as a bare command: `set -e` would abort on the failure and never reach
+# the home-directory branch that exists for exactly these machines.
+sudo_install() {
+  command -v sudo >/dev/null 2>&1 || return 1
+  say "$INSTALL_DIR is not writable; using sudo."
+  sudo mkdir -p "$INSTALL_DIR" || return 1
+  sudo install -m 0755 "$TMP/p2pmux" "$INSTALL_DIR/p2pmux" || return 1
+}
+
 if mkdir -p "$INSTALL_DIR" 2>/dev/null && [ -w "$INSTALL_DIR" ]; then
   install -m 0755 "$TMP/p2pmux" "$INSTALL_DIR/p2pmux"
-elif command -v sudo >/dev/null 2>&1; then
-  say "$INSTALL_DIR is not writable; using sudo."
-  sudo mkdir -p "$INSTALL_DIR"
-  sudo install -m 0755 "$TMP/p2pmux" "$INSTALL_DIR/p2pmux"
+elif sudo_install; then
+  : # installed with elevated privileges
 else
   # /usr/local/bin is root-owned on most Linux systems, and plenty of the machines
-  # someone would run this on — a container, a locked-down work laptop — have no sudo at
-  # all. A home directory needs no privileges, and the PATH note below covers the
-  # distributions that do not already add this one.
+  # someone would run this on — a container, a locked-down work laptop — either have no
+  # sudo at all or have one you are not allowed to use. A home directory needs no
+  # privileges, and the PATH note below covers the distributions that do not already add
+  # this one.
   INSTALL_DIR="$HOME/.local/bin"
-  say "the install directory is not writable and sudo is not available;"
-  say "installing to $INSTALL_DIR instead."
+  say "could not install to a system directory; falling back to $INSTALL_DIR."
   mkdir -p "$INSTALL_DIR"
   install -m 0755 "$TMP/p2pmux" "$INSTALL_DIR/p2pmux"
 fi


### PR DESCRIPTION
## The bug

Verified on a clean Ubuntu 22.04 droplet: **a user with the `sudo` binary on PATH but no sudoers entry got exit 1 and no binary at all.**

```
/usr/local/bin is not writable; using sudo.
sudo: a terminal is required to read the password
sudo: a password is required
EXIT=1
```

`command -v sudo` succeeded, so the script took the sudo branch, sudo refused, and `set -e` killed the run before reaching the `$HOME/.local/bin` fallback — the fallback whose own comment names "a container, a locked-down work laptop" as the cases it exists for. Those machines usually *have* sudo; they just won't let you use it. A piped installer has no terminal to type a password into either.

## The fix

Run sudo inside an `if` so a refusal falls through to the home-directory branch instead of aborting.

## Verified on real droplets

Two throwaway DigitalOcean boxes, destroyed after the run: Ubuntu 24.04 (glibc 2.39) and 22.04 (glibc 2.35 — the oldest target the README claims).

| Scenario | Before | After |
| --- | --- | --- |
| root, dir writable | ✅ `/usr/local/bin` | ✅ `/usr/local/bin` |
| sudo present, **not** a sudoer | ❌ exit 1, nothing installed | ✅ `~/.local/bin` |
| sudo binary not executable | ✅ `~/.local/bin` | ✅ `~/.local/bin` |
| real passwordless sudoer | ✅ `/usr/local/bin` | ✅ `/usr/local/bin` (no regression) |

Also confirmed on both boxes: checksum enforcement rejects a missing asset, the script is served as `text/plain`, and the installed binary runs (`--version`, `--help`, `ls`, `doctor`).

`sh -n`, `bash -n` and `zsh -n` all clean.

## Not covered

**Linux arm64 is still unverified** — DigitalOcean has no ARM droplets, so `p2pmux-aarch64-unknown-linux-gnu` has never been run by anyone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MW4UW5i1XXTjYa2FaqHc5a