### PR TITLE
feat: coordinator failover

### DIFF
--- a/docs/MVP_DESIGN.md
+++ b/docs/MVP_DESIGN.md
@@ -39,8 +39,9 @@ Installable macOS and Linux terminal mux: each pane’s process runs on its host
 - **Pane lock:** a pane host may toggle its own pane to host-only. All members still see its
   screen, but only its host may input or claim control. Locking clears a guest controller and does
   not claim control for the host.
-- **Later-spike disconnect behavior:** 5-minute unavailable placeholders and coordinator failover
-  are MVP goals, not implemented by Spike 3.
+- **Later-spike disconnect behavior:** coordinator failover landed in Spike 5 (2026-08-02); the
+  5-minute reaping of an absent host's panes is still open — they stay in the layout as
+  unavailable placeholders instead.
 - **Layout:** nested binary 50/50; **depth ≤ 4**; **≤ 8 panes/tab**; max **9 tabs**.
 - **Latency:** ≈ same-region SSH; relay normal
 - **Non-goals:** cloud VM execution, sandbox/ACL tiers, Win/Linux, drag-resize, mosh prediction, private panes, per-person ticket revocation in v1
@@ -55,7 +56,9 @@ Installable macOS and Linux terminal mux: each pane’s process runs on its host
 4. Any member can split an available pane or create a tab; the requester hosts the new PTY, but is
    not its controller and the new pane starts free. Only the host can delete a pane. A member can
    delete a tab only when it owns every pane in that tab.
-5. Spike 3 is localhost layout/control work. Disconnect grace and coordinator failover remain later spikes.
+5. If the coordinator's machine goes away, the session stays up: panes on other machines keep
+   running and keep taking input, structural edits pause, and after a grace window the
+   earliest-joined survivor takes the role over and reissues the invite.
 
 ## 4. Architecture
 
@@ -82,8 +85,10 @@ without stopping the node. `--resume` shows live sessions and `attach <name>` re
 The durable finder descriptor lives in `~/Library/Application Support/p2pmux/sessions` on macOS
 and `$XDG_STATE_HOME/p2pmux/sessions` (default `~/.local/state`) on Linux; its socket lives in
 `$XDG_RUNTIME_DIR/p2pmux` where Linux provides one and `/tmp/p2pmux-$UID` otherwise. Finder records contain no ticket, PTY, screen, layout, or focus state.
-There is no local-client takeover, launchd registration, disk screen restore, coordinator failover,
-or offline-pane grace in this implementation. Offline host placeholders/grace remain follow-up work.
+There is no local-client takeover, launchd registration, disk screen restore, or offline-pane
+grace in this implementation. Offline host placeholders remain, but are not reaped on a timer.
+Coordinator failover is implemented (Spike 5); a promoted node rewrites its own durable record,
+so `--resume`, `ls` and `ticket <name>` follow the role across a takeover.
 
 **Screen:** pane host keeps vt100 canonical state; sequenced snapshot+deltas to all members; gap → resync; never stall PTY on slow viewers.
 
@@ -102,6 +107,21 @@ If coordinator disconnects:
 - During **5-minute grace:** pane-level control on *available* panes still works; **structural edits paused** (split/close/join admission).
 - If coordinator returns within grace → they remain coordinator; structural edits resume.
 - If grace expires: promote connected member with **earliest join order** as coordinator in a new **coordinator epoch**. Returning old coordinator rejoins as ordinary member (does not auto-reclaim).
+
+**As built (2026-08-02), three refinements to the above:**
+
+- *"Connected"* is not knowable. A member hosting no panes may hold no connections to its peers
+  at all, so there is no shared view of who survived to take a vote over. Join order becomes
+  staggered time instead: earliest survivor acts at the end of grace, each one behind it waits
+  another few seconds, and a takeover arriving first is what stops the rest from starting their
+  own. If the earliest survivor is gone too, the next one's turn simply comes.
+- *The coordinator's panes are not evicted at promotion.* They stay in the layout as unavailable
+  placeholders. Removing them would rearrange the layout under people mid-sentence, and in a
+  two-person session where only the coordinator hosted anything it would leave no layout at all.
+- *The invite does not survive.* The join code is sealed under a secret only the session's
+  creator holds, so the successor mints a new ticket and a new code; an invite already pasted
+  into a chat stops working. Replicating that secret to every member would hand each of them the
+  power to redirect the session's invite, which contradicts §0.
 
 ### Input control
 

--- a/docs/SPIKE_PLAN.md
+++ b/docs/SPIKE_PLAN.md
@@ -122,8 +122,32 @@ Everything below is already automated against the droplet; this is the part only
 
 ### Spike 5 — Disconnect grace + coordinator failover
 
-5-minute placeholders; structural freeze during coordinator grace; earliest-join promotion.
-Minimal reconnect lands early, in Spike 4, so internet tests are not read as failures.
+**Done (2026-08-02).** Structural freeze during grace, earliest-join promotion, and a
+deposed coordinator that rejoins as an ordinary member. Panes hosted by machines that are
+still up keep running and keep taking input throughout — they always did, because a pane
+runs on its host and settles its own lease; what was permanent before was the freeze.
+
+Three decisions worth knowing, each recorded at its call site:
+
+- **Nobody hands the role over.** A departed coordinator cannot nominate a successor, so
+  the decision has to be derivable identically by every member from the committed layout.
+  Join order is that ranking, turned into staggered time rather than a vote because members
+  have no shared view of who is still reachable. `src/failover.rs`.
+- **A claim proves nothing.** Every ledger entry carries the coordinator epoch that sealed
+  it, and a verifier only rotates onto a new key when its own election already agreed. A
+  peer answering the door proves it is alive, not that the room elected it.
+- **The invite is reissued, not inherited.** The short code is sealed under a secret only
+  the session's creator holds, so a successor mints a new one and an already-pasted invite
+  stops working. Replicating that secret to every member would hand each of them the power
+  to redirect the session's invite.
+
+Departed hosts' panes stay in the layout as unavailable placeholders rather than being
+evicted at promotion; the 5-minute reaping of them is still open. `p2pmux ticket <name>`
+and `p2pmux ls` follow the role across a takeover.
+
+Verified by `tests/failover.rs` over loopback endpoints and by
+`scripts/e2e/scenario_v_failover.py` across two droplets and this Mac, which kills the
+coordinator with `pkill -9` so the survivors get no departure notice.
 
 ### Spike 6 — Brew formula
 

--- a/scripts/e2e/scenario_v_failover.py
+++ b/scripts/e2e/scenario_v_failover.py
@@ -1,0 +1,273 @@
+"""Scenario V -- the coordinator's machine dies and the room keeps working.
+
+Every other scenario assumes the coordinator stays up. This one kills it, and asks the
+two questions a user would ask next: *is my terminal still there*, and *can we carry on*.
+
+They are separate questions and they fail separately. Panes survive a lost coordinator
+for free -- each one runs on its own host and settles its own control lease -- so the
+first answer was already yes before any of this was built. The second was no: layout
+edits, joins and presence all run through the coordinator, and losing it froze them
+permanently. What is under test is the unfreezing.
+
+The kill is deliberately violent. `pkill -9` leaves no departure notice, so the
+survivors learn about it the way a real crash or a closed laptop teaches them: their
+control stream stops answering and nothing explains why. A graceful `p2pmux kill` would
+take the coordinator out of the roster on its way past and test nothing.
+
+  panes survive     fra can still type into the Mac's pane with nobody coordinating;
+  frozen, not dead  a split is refused with a notice rather than hanging;
+  somebody takes over  the earliest surviving member promotes itself;
+  the room follows  the other survivor reattaches without being handed anything;
+  edits work again  a split committed by the new coordinator lands on both machines.
+
+Grace is cut to `GRACE_SECS` through the environment. Five real minutes per run is the
+difference between a check that gets run and one that gets skipped.
+
+Run:  scripts/e2e/provision_droplets.sh create
+      cargo build --release
+      python3 scripts/e2e/scenario_v_failover.py
+"""
+
+from __future__ import annotations
+
+import re
+import socket
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from driver import BINARY, Harness  # noqa: E402
+from remote import RemoteError, hosts_from_manifest, spawn_remote  # noqa: E402
+
+CTRL_P = b"\x10"
+COLS, ROWS = 180, 44
+GRACE_SECS = 20
+# Grace, plus the stagger the second-ranked survivor waits, plus room for a dial across
+# an ocean and a fresh snapshot to come back.
+FAILOVER_TIMEOUT = GRACE_SECS + 60.0
+GRACE_ENV = {"P2PMUX_FAILOVER_GRACE_SECS": str(GRACE_SECS)}
+
+checks: list[tuple[str, bool, str]] = []
+
+
+def check(label: str, passed: bool, detail: str = "") -> None:
+    checks.append((label, passed, detail))
+    print(f"  [{'PASS' if passed else 'FAIL'}] {label}{(' -- ' + detail) if detail else ''}",
+          flush=True)
+
+
+def guard(label: str, action, detail: str = "") -> bool:
+    try:
+        action()
+    except AssertionError as failure:
+        check(label, False, str(failure)[:400])
+        return False
+    check(label, True, detail)
+    return True
+
+
+def chord(peer, lead: bytes, letter: bytes, settle: float = 1.5) -> None:
+    peer.send(lead)
+    time.sleep(0.35)
+    peer.send(letter)
+    time.sleep(settle)
+
+
+def pane_body_cell(screen: str, host: str) -> tuple[int, int]:
+    for row, line in enumerate(screen.split("\n")):
+        index = line.find(f"host: {host}")
+        if index == -1:
+            continue
+        left = line.rfind("┌", 0, index)
+        return (left if left != -1 else 0) + 3, row + 3
+    raise AssertionError(f"no pane hosted by {host!r} on screen:\n{screen}")
+
+
+def panes_on_screen(screen: str) -> int:
+    return len(re.findall(r"Pane #\d+", screen))
+
+
+def main() -> int:
+    if not BINARY.exists():
+        print(f"{BINARY} missing -- run: cargo build --release", file=sys.stderr)
+        return 2
+    try:
+        nyc_host, fra_host = hosts_from_manifest()[:2]
+    except (RemoteError, ValueError) as error:
+        print(error, file=sys.stderr)
+        return 2
+
+    print(f"== scenario V: kill the coordinator on {nyc_host.alias} ==", flush=True)
+    for host in (nyc_host, fra_host):
+        if not host.binary_ready():
+            print(f"{host.alias} has no binary at {host.binary}", file=sys.stderr)
+            return 2
+        host.env.update(GRACE_ENV)
+        host.reset_network()
+        host.reset_home()
+
+    nyc_box = nyc_host.run("hostname").strip()
+    fra_box = fra_host.run("hostname").strip()
+    mac_box = socket.gethostname()
+    print(f"   coordinator {nyc_box} / members {mac_box}, {fra_box}", flush=True)
+
+    try:
+        with Harness("scenario_v_failover") as harness:
+            nyc = spawn_remote(
+                harness,
+                nyc_host,
+                "nyc",
+                ["create", "--name", "nyc", "--session-name", "failover"],
+                cols=COLS,
+                rows=ROWS,
+            )
+            nyc.wait_ready(timeout=60.0)
+            if not guard(
+                "coordinator came up in nyc3",
+                lambda: nyc.wait_for(r"Pane #\d+", timeout=60.0),
+                nyc_box,
+            ):
+                print(nyc.snapshot(), flush=True)
+                return 1
+
+            ticket = nyc_host.cli("ticket").strip().splitlines()[-1].strip()
+
+            # The Mac joins first, so it is the earliest survivor and therefore the one
+            # the succession picks. That is not incidental: the check below asserts *which*
+            # machine takes over, not merely that some machine did.
+            mac = harness.spawn(
+                "mac",
+                ["join", ticket, "--name", "mac"],
+                cols=COLS,
+                rows=ROWS,
+                env=dict(GRACE_ENV),
+            )
+            mac.wait_ready(timeout=60.0)
+            if not guard(
+                "this Mac joined",
+                lambda: mac.wait_for(r"Pane #\d+", timeout=90.0),
+                mac_box,
+            ):
+                print(mac.snapshot(), flush=True)
+                return 1
+
+            fra = spawn_remote(
+                harness,
+                fra_host,
+                "fra",
+                ["join", ticket, "--name", "fra"],
+                cols=COLS,
+                rows=ROWS,
+            )
+            fra.wait_ready(timeout=60.0)
+            if not guard(
+                "fra1 joined",
+                lambda: fra.wait_for(r"Pane #\d+", timeout=90.0),
+                fra_box,
+            ):
+                print(fra.snapshot(), flush=True)
+                return 1
+
+            # Each survivor hosts a pane of its own, so that after the kill there is still
+            # something on screen that belongs to a machine that is still up.
+            for peer, label in ((mac, "mac"), (fra, "fra")):
+                chord(peer, CTRL_P, b"n")
+                guard(
+                    f"{label} hosts a pane of its own",
+                    lambda peer=peer, label=label: peer.wait_for(
+                        f"host: {label}", timeout=60.0
+                    ),
+                )
+            panes_before = panes_on_screen(mac.snapshot())
+
+            # -------------------------------------------------- the coordinator dies
+            print("   killing the coordinator, hard", flush=True)
+            nyc_host.reap()
+            check("the coordinator's node is gone", not nyc_host._p2pmux_pids(), nyc_box)
+
+            guard(
+                "the survivors notice",
+                lambda: mac.wait_for("coordinator unreachable", timeout=60.0),
+            )
+            guard(
+                "a layout edit is refused with a notice, not left hanging",
+                lambda: (
+                    chord(mac, CTRL_P, b"n"),
+                    mac.wait_for("layout changes are paused", timeout=20.0),
+                )[-1],
+            )
+
+            # The claim that matters most: with nobody coordinating anything, one member
+            # can still drive a terminal on another member's machine.
+            guard(
+                "fra can still type into a pane hosted on this Mac",
+                lambda: fra.wait_until(
+                    lambda screen: "host: mac control: free" in screen,
+                    timeout=60.0,
+                    what="the Mac's pane to go free",
+                ),
+            )
+            fra.click(*pane_body_cell(fra.snapshot(), "mac"))
+            fra.run_in_shell(f"echo still-alive-$(hostname)")
+            guard(
+                "and the command runs on this Mac with no coordinator in the session",
+                lambda: fra.wait_for(re.escape(f"still-alive-{mac_box}"), timeout=60.0),
+                mac_box,
+            )
+
+            # -------------------------------------------------- somebody takes over
+            guard(
+                "this Mac promotes itself once grace expires",
+                lambda: mac.wait_until(
+                    lambda screen: "coordinated here" in screen,
+                    timeout=FAILOVER_TIMEOUT,
+                    what="the Mac to take the coordinator role",
+                ),
+                f"{GRACE_SECS}s grace",
+            )
+            guard(
+                "fra reattaches to it without being handed a ticket",
+                lambda: fra.wait_until(
+                    lambda screen: "coordinator unreachable" not in screen,
+                    timeout=FAILOVER_TIMEOUT,
+                    what="fra to find the new coordinator",
+                ),
+            )
+
+            # -------------------------------------------------- the session works again
+            chord(fra, CTRL_P, b"n")
+            guard(
+                "a split committed by the new coordinator lands",
+                lambda: fra.wait_until(
+                    lambda screen: panes_on_screen(screen) > panes_before,
+                    timeout=90.0,
+                    what="a pane the new coordinator committed",
+                ),
+                f"{panes_before} panes before",
+            )
+            guard(
+                "and this Mac draws it too",
+                lambda: mac.wait_until(
+                    lambda screen: panes_on_screen(screen) > panes_before,
+                    timeout=90.0,
+                    what="the new pane on the coordinator's own screen",
+                ),
+            )
+    finally:
+        for host in (nyc_host, fra_host):
+            try:
+                host.reap()
+            except RemoteError as error:
+                print(f"   (cleanup on {host.alias}: {error})", file=sys.stderr)
+
+    failed = [label for label, passed, _ in checks if not passed]
+    print(f"\n== {len(checks) - len(failed)}/{len(checks)} passed ==", flush=True)
+    for label in failed:
+        print(f"   FAILED: {label}", flush=True)
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/e2e/scenario_v_failover.py
+++ b/scripts/e2e/scenario_v_failover.py
@@ -30,8 +30,10 @@ Run:  scripts/e2e/provision_droplets.sh create
 
 from __future__ import annotations
 
+import os
 import re
 import socket
+import subprocess
 import sys
 import time
 from pathlib import Path
@@ -87,6 +89,57 @@ def pane_body_cell(screen: str, host: str) -> tuple[int, int]:
 
 def panes_on_screen(screen: str) -> int:
     return len(re.findall(r"Pane #\d+", screen))
+
+
+def footer(peer) -> str:
+    """The status line, which is where the node reports anything about the session."""
+    lines = [line.rstrip() for line in peer.snapshot().split("\n") if line.strip()]
+    return lines[-1] if lines else ""
+
+
+def local_role(harness) -> str:
+    """What this Mac's own session record says its role is.
+
+    Asserted here rather than on the footer because the footer is a single line that every
+    subsystem shares: the departed coordinator's pane retries forever and its "retrying"
+    message overwrites the takeover notice within a second or two. The record is the thing
+    a takeover is supposed to update anyway -- it is what `p2pmux ls` and
+    `p2pmux ticket <name>` read out of process -- so checking it tests more, not less.
+    """
+    result = subprocess.run(
+        [str(BINARY), "ls"],
+        env={**os.environ, "HOME": str(harness.home)},
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
+def live_nodes(host) -> list[int]:
+    """PIDs of p2pmux processes on `host`, matched by name rather than command line.
+
+    `pgrep -f /usr/local/bin/p2pmux` also matches the ssh command line carrying that
+    path, so the shell running the search is itself a hit -- and `pkill -f` then kills
+    the connection before it finishes, which reads as "the coordinator survived".
+    Matching argv[0] exactly sees the nodes and nothing else.
+    """
+    output = host.run("pgrep -x p2pmux || true", check=False)
+    return [int(line) for line in output.split() if line.isdigit()]
+
+
+def kill_hard(host) -> None:
+    """SIGKILL every p2pmux on `host`, leaving no departure notice behind.
+
+    By PID for the same reason as above, and with `kill -9` because the point is to
+    simulate a machine that stopped rather than a session that ended: a graceful exit
+    would take the coordinator out of the roster on its way past.
+    """
+    for signal in ("-TERM", "-KILL"):
+        pids = live_nodes(host)
+        if not pids:
+            return
+        host.run(f"kill {signal} {' '.join(str(pid) for pid in pids)} || true", check=False)
+        time.sleep(1.0)
 
 
 def main() -> int:
@@ -184,19 +237,38 @@ def main() -> int:
 
             # -------------------------------------------------- the coordinator dies
             print("   killing the coordinator, hard", flush=True)
-            nyc_host.reap()
-            check("the coordinator's node is gone", not nyc_host._p2pmux_pids(), nyc_box)
+            kill_hard(nyc_host)
+            # Worth asserting rather than assuming: a coordinator that is still running is
+            # one the members will simply reattach to, and every check below would then be
+            # measuring an ordinary reconnect while claiming to measure a takeover.
+            check("the coordinator's node is gone", not live_nodes(nyc_host), nyc_box)
 
             guard(
                 "the survivors notice",
                 lambda: mac.wait_for("coordinator unreachable", timeout=60.0),
             )
+            print(f"   mac footer: {footer(mac)}", flush=True)
+            print(f"   fra footer: {footer(fra)}", flush=True)
+
+            # Asserted as an absence plus an explanation, because that is what the user
+            # sees: the pane they asked for does not appear, and the footer says why. The
+            # countdown overwrites any one-shot notice, so match on the countdown.
+            frozen_panes = panes_on_screen(mac.snapshot())
+            chord(mac, CTRL_P, b"n")
+            time.sleep(4.0)
+            check(
+                "a layout edit is refused rather than left hanging",
+                panes_on_screen(mac.snapshot()) == frozen_panes,
+                footer(mac),
+            )
             guard(
-                "a layout edit is refused with a notice, not left hanging",
-                lambda: (
-                    chord(mac, CTRL_P, b"n"),
-                    mac.wait_for("layout changes are paused", timeout=20.0),
-                )[-1],
+                "and the footer says how long the freeze lasts",
+                lambda: mac.wait_until(
+                    lambda screen: re.search(r"taking over in \d+s", screen) is not None,
+                    timeout=20.0,
+                    what="a countdown to the takeover",
+                ),
+                footer(mac),
             )
 
             # The claim that matters most: with nobody coordinating anything, one member
@@ -218,15 +290,19 @@ def main() -> int:
             )
 
             # -------------------------------------------------- somebody takes over
-            guard(
+            deadline = time.monotonic() + FAILOVER_TIMEOUT
+            promoted = ""
+            while time.monotonic() < deadline:
+                promoted = local_role(harness)
+                if "coordinator" in promoted:
+                    break
+                time.sleep(1.0)
+            check(
                 "this Mac promotes itself once grace expires",
-                lambda: mac.wait_until(
-                    lambda screen: "coordinated here" in screen,
-                    timeout=FAILOVER_TIMEOUT,
-                    what="the Mac to take the coordinator role",
-                ),
-                f"{GRACE_SECS}s grace",
+                "coordinator" in promoted,
+                " ".join(promoted.split()) or "no session listed",
             )
+            print(f"   mac footer after grace: {footer(mac)}", flush=True)
             guard(
                 "fra reattaches to it without being handed a ticket",
                 lambda: fra.wait_until(

--- a/src/failover.rs
+++ b/src/failover.rs
@@ -142,6 +142,31 @@ impl Election {
         self.candidates().position(|candidate| candidate == peer)
     }
 
+    /// Where a peer sits in join order, coordinator included.
+    ///
+    /// Unlike [`Self::rank`], which is about succession and so skips the coordinator being
+    /// replaced, this is the raw order -- the thing to compare when two peers both believe
+    /// they hold the role.
+    pub fn order_of(&self, peer: &[u8]) -> Option<usize> {
+        self.members.iter().position(|member| member == peer)
+    }
+
+    /// Whether `claimant` has a better claim than this member does to the same epoch.
+    ///
+    /// The stagger makes two members promoting at once unlikely, not impossible: a partition
+    /// that heals can leave two coordinators on the same epoch, and neither would accept the
+    /// other under [`Self::verdict_on`], which requires the epoch to move forward. Join order
+    /// settles it, and settles it the same way on both machines, so exactly one steps down.
+    pub fn concedes_to(&self, claimant: &[u8], epoch: u64) -> bool {
+        if epoch != self.epoch {
+            return false;
+        }
+        match (self.order_of(claimant), self.order_of(&self.me)) {
+            (Some(theirs), Some(mine)) => theirs < mine,
+            _ => false,
+        }
+    }
+
     /// How long this member waits, from the coordinator going quiet, before acting.
     ///
     /// `None` when it is not a candidate at all, which means it always waits.
@@ -334,6 +359,29 @@ mod tests {
     #[test]
     fn a_stranger_cannot_claim_the_role() {
         assert_eq!(election(3).verdict_on(&peer(9), 1), Verdict::NotAMember);
+    }
+
+    #[test]
+    fn two_coordinators_on_one_epoch_are_settled_by_join_order() {
+        // A partition that heals can leave two members both believing they took over at
+        // epoch 1, and neither would accept the other -- `verdict_on` needs the epoch to
+        // move forward. Both compute this from the same member list, so exactly one of them
+        // concedes and the session converges without a round of messages about it.
+        let earlier = Election::new(vec![peer(1), peer(2), peer(3)], peer(2), 1, peer(2));
+        let later = Election::new(vec![peer(1), peer(2), peer(3)], peer(3), 1, peer(3));
+
+        assert!(later.concedes_to(&peer(2), 1));
+        assert!(!earlier.concedes_to(&peer(3), 1));
+    }
+
+    #[test]
+    fn conceding_is_only_ever_about_the_epoch_in_force() {
+        // A claim from a past or future epoch is `verdict_on`'s business. Answering it here
+        // as well would give a stale claimant two chances to be believed.
+        let held = Election::new(vec![peer(1), peer(2)], peer(2), 1, peer(2));
+
+        assert!(!held.concedes_to(&peer(1), 0));
+        assert!(!held.concedes_to(&peer(1), 2));
     }
 
     #[test]

--- a/src/failover.rs
+++ b/src/failover.rs
@@ -42,6 +42,24 @@ pub const DEFAULT_GRACE: Duration = Duration::from_secs(300);
 /// session anything in the rare case where the earliest survivor is gone too.
 pub const PROMOTION_STAGGER: Duration = Duration::from_secs(3);
 
+/// Override for [`DEFAULT_GRACE`], in whole seconds.
+///
+/// Exists for the end-to-end runs. A cross-machine test of a takeover has to actually wait
+/// out the window, and five real minutes per scenario is the difference between a check that
+/// gets run and one that gets skipped. Out of range or unparseable values are ignored rather
+/// than clamped, so a typo cannot quietly shorten a real session's grace to nothing.
+pub const GRACE_ENV: &str = "P2PMUX_FAILOVER_GRACE_SECS";
+
+/// The grace this process should use: the environment's, if it named a sane one.
+pub fn configured_grace() -> Duration {
+    std::env::var(GRACE_ENV)
+        .ok()
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .filter(|seconds| (1..=3600).contains(seconds))
+        .map(Duration::from_secs)
+        .unwrap_or(DEFAULT_GRACE)
+}
+
 /// What this member should do about the coordinator right now.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Role {
@@ -263,6 +281,20 @@ mod tests {
             second_takeover.role_after(Some(DEFAULT_GRACE), DEFAULT_GRACE),
             Role::Promote { epoch: 2 }
         );
+    }
+
+    #[test]
+    fn a_nonsense_grace_override_leaves_the_real_one_alone() {
+        // Reads the process environment, so it asserts the fallback rather than setting the
+        // variable -- a test that mutated it would change what every other test in this
+        // binary sees. The parse and range rules are the point: a typo must not be able to
+        // shorten a real session's grace to nothing.
+        assert_eq!(
+            std::env::var(GRACE_ENV).ok().as_deref(),
+            None,
+            "this test only means anything with the override unset"
+        );
+        assert_eq!(configured_grace(), DEFAULT_GRACE);
     }
 
     #[test]

--- a/src/failover.rs
+++ b/src/failover.rs
@@ -1,0 +1,315 @@
+//! Who serializes a session once its coordinator stops answering.
+//!
+//! The coordinator is the only member that orders layout changes, admits joiners, and seals
+//! the ledger. Losing it does not stop the session -- panes run on their own hosts and their
+//! control leases are settled there -- but it does freeze everything structural until
+//! somebody takes the role over. This module is the part that decides who.
+//!
+//! Two properties shape the whole design:
+//!
+//! **Nobody hands the role over.** A departed coordinator is, by definition, not available
+//! to nominate a successor or to sign anything attesting to one. So the decision has to be
+//! reachable independently by every member from state they already hold, and it has to come
+//! out the same. That state is the last committed layout: its member list is in join order,
+//! which gives every member the same ranking without a message being exchanged.
+//!
+//! **A claim proves nothing.** Because the decision is derivable, a member never has to
+//! believe a peer that says it is in charge now -- it checks the claim against the answer it
+//! computed itself. That is what makes a takeover safe without the old coordinator's
+//! cooperation, and it is why [`Election::verdict_on`] exists separately from
+//! [`Election::role_after`]: one is what this member would do, the other is what it will
+//! accept from somebody else.
+//!
+//! Everything here is pure. No clock is read, no peer is contacted; elapsed time arrives as
+//! an argument so the whole policy is testable in a few microseconds.
+
+use std::time::Duration;
+
+/// How long a session waits for a missing coordinator before replacing it.
+///
+/// The MVP's number. Long enough that closing a laptop lid, changing networks, or a relay
+/// hiccup does not cost the session its coordinator, short enough that a room whose
+/// coordinator has genuinely left is not stuck watching frozen structure for an afternoon.
+pub const DEFAULT_GRACE: Duration = Duration::from_secs(300);
+
+/// Extra wait per position down the join order before a member promotes itself.
+///
+/// Members do not have a shared view of who else is still reachable -- a member hosting no
+/// panes may hold no connections to its peers at all -- so the ranking is turned into time
+/// instead of into a vote. The earliest survivor acts first; everyone behind it is still
+/// waiting when its takeover arrives, and follows that instead of starting its own. Sized
+/// well above the round trip a takeover needs to propagate, and it only ever costs the
+/// session anything in the rare case where the earliest survivor is gone too.
+pub const PROMOTION_STAGGER: Duration = Duration::from_secs(3);
+
+/// What this member should do about the coordinator right now.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Role {
+    /// The coordinator is answering. Nothing to decide.
+    Following,
+    /// The coordinator is missing, and it is not this member's turn to act.
+    ///
+    /// Either the grace window is still open, or it has closed and somebody ranked earlier
+    /// is expected to take over first. Both are the same instruction: keep the session
+    /// running, keep structural edits frozen, wait.
+    Waiting,
+    /// This member should take the role over, opening the epoch named here.
+    Promote { epoch: u64 },
+}
+
+/// Whether to believe a peer that says it is the coordinator now.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Verdict {
+    /// The claim matches what this member would have decided. Rotate to it.
+    Accept,
+    /// An epoch this member has already left behind, or is already in.
+    ///
+    /// The ordinary cause is a coordinator that dropped, was replaced, and has come back
+    /// without knowing it -- not an attack.
+    Stale { current: u64, claimed: u64 },
+    /// The claimant is not in the last committed member list.
+    NotAMember,
+    /// The claimant is the coordinator that just left, trying to reclaim the role.
+    ///
+    /// It rejoins as an ordinary member instead. Auto-reclaim would make a flapping network
+    /// hand the session back and forth.
+    Deposed,
+}
+
+/// One member's view of the succession, built from the last committed layout.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Election {
+    members: Vec<Vec<u8>>,
+    coordinator: Vec<u8>,
+    epoch: u64,
+    me: Vec<u8>,
+}
+
+impl Election {
+    /// `members` must be in join order, which is the order the committed layout stores them
+    /// in. `coordinator` is whoever currently holds the role, and `epoch` how many times it
+    /// has changed hands.
+    pub fn new(members: Vec<Vec<u8>>, coordinator: Vec<u8>, epoch: u64, me: Vec<u8>) -> Self {
+        Self {
+            members,
+            coordinator,
+            epoch,
+            me,
+        }
+    }
+
+    /// The epoch currently in force.
+    pub fn epoch(&self) -> u64 {
+        self.epoch
+    }
+
+    /// The coordinator currently in force.
+    pub fn coordinator(&self) -> &[u8] {
+        &self.coordinator
+    }
+
+    /// Who should take over, in the order they should try.
+    ///
+    /// The departed coordinator is not a candidate for its own succession, which is what
+    /// stops a coordinator that flaps from being handed the role straight back.
+    pub fn candidates(&self) -> impl Iterator<Item = &[u8]> {
+        self.members
+            .iter()
+            .filter(|peer| *peer != &self.coordinator)
+            .map(Vec::as_slice)
+    }
+
+    /// How far down the succession this member sits, or `None` if it is not a candidate.
+    pub fn rank(&self, peer: &[u8]) -> Option<usize> {
+        self.candidates().position(|candidate| candidate == peer)
+    }
+
+    /// How long this member waits, from the coordinator going quiet, before acting.
+    ///
+    /// `None` when it is not a candidate at all, which means it always waits.
+    pub fn delay_for(&self, peer: &[u8], grace: Duration) -> Option<Duration> {
+        let rank = self.rank(peer)?;
+        Some(grace + PROMOTION_STAGGER.saturating_mul(u32::try_from(rank).unwrap_or(u32::MAX)))
+    }
+
+    /// What to do, given how long the coordinator has been unreachable.
+    ///
+    /// `None` means it is answering.
+    pub fn role_after(&self, unreachable_for: Option<Duration>, grace: Duration) -> Role {
+        let Some(elapsed) = unreachable_for else {
+            return Role::Following;
+        };
+        let Some(delay) = self.delay_for(&self.me, grace) else {
+            return Role::Waiting;
+        };
+        if elapsed < delay {
+            return Role::Waiting;
+        }
+        Role::Promote {
+            epoch: self.epoch.saturating_add(1),
+        }
+    }
+
+    /// Whether to accept `claimant` as the coordinator for `epoch`.
+    ///
+    /// Deliberately not a check that the claimant is the *best* candidate. A member cannot
+    /// tell the difference between "the top-ranked survivor is gone as well" and "somebody
+    /// jumped the queue", and refusing the second would strand the session in the first --
+    /// which is the failure this whole module exists to prevent. The stagger is what keeps
+    /// the queue orderly; membership, non-reclaim and a forward epoch are what keep it safe.
+    pub fn verdict_on(&self, claimant: &[u8], epoch: u64) -> Verdict {
+        if epoch <= self.epoch {
+            return Verdict::Stale {
+                current: self.epoch,
+                claimed: epoch,
+            };
+        }
+        if claimant == self.coordinator {
+            return Verdict::Deposed;
+        }
+        if !self.members.iter().any(|member| member == claimant) {
+            return Verdict::NotAMember;
+        }
+        Verdict::Accept
+    }
+
+    /// Move to a new coordinator, after [`Self::verdict_on`] agreed to it.
+    pub fn rotated(&self, coordinator: Vec<u8>, epoch: u64) -> Self {
+        Self {
+            members: self.members.clone(),
+            coordinator,
+            epoch,
+            me: self.me.clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn peer(id: u8) -> Vec<u8> {
+        vec![id; 32]
+    }
+
+    /// Three members in join order, the first of them coordinating, seen by member `me`.
+    fn election(me: u8) -> Election {
+        Election::new(vec![peer(1), peer(2), peer(3)], peer(1), 0, peer(me))
+    }
+
+    #[test]
+    fn a_coordinator_that_is_answering_settles_nothing() {
+        assert_eq!(election(2).role_after(None, DEFAULT_GRACE), Role::Following);
+    }
+
+    #[test]
+    fn nobody_moves_while_the_grace_window_is_open() {
+        // The whole point of grace: a coordinator that closed its laptop for four minutes
+        // comes back to the session it left, not to one that replaced it.
+        let earliest = election(2);
+        assert_eq!(
+            earliest.role_after(Some(DEFAULT_GRACE - Duration::from_secs(1)), DEFAULT_GRACE),
+            Role::Waiting
+        );
+    }
+
+    #[test]
+    fn the_earliest_survivor_goes_first_and_the_next_one_waits_behind_it() {
+        // Same input, same grace, different answers -- which is what keeps two members from
+        // promoting themselves at the same instant without exchanging a single message.
+        let at_grace = Some(DEFAULT_GRACE);
+        assert_eq!(
+            election(2).role_after(at_grace, DEFAULT_GRACE),
+            Role::Promote { epoch: 1 }
+        );
+        assert_eq!(
+            election(3).role_after(at_grace, DEFAULT_GRACE),
+            Role::Waiting
+        );
+    }
+
+    #[test]
+    fn a_lower_ranked_member_takes_over_when_the_one_ahead_never_does() {
+        // The stagger is a queue, not a veto. If member 2 is gone too, member 3's turn
+        // arrives on its own.
+        assert_eq!(
+            election(3).role_after(Some(DEFAULT_GRACE + PROMOTION_STAGGER), DEFAULT_GRACE),
+            Role::Promote { epoch: 1 }
+        );
+    }
+
+    #[test]
+    fn the_coordinator_does_not_succeed_itself() {
+        // Its own view of the election has to agree with everyone else's, or a coordinator
+        // whose connections dropped would promote itself and fork the session.
+        let itself = election(1);
+        assert_eq!(itself.rank(&peer(1)), None);
+        assert_eq!(
+            itself.role_after(Some(DEFAULT_GRACE * 10), DEFAULT_GRACE),
+            Role::Waiting
+        );
+    }
+
+    #[test]
+    fn the_epoch_counts_up_from_wherever_the_session_already_was() {
+        // Already one takeover in, with member 2 coordinating. Member 1 -- the coordinator
+        // that was replaced last time, back as an ordinary member -- is now first in the
+        // succession again, because rank is join order and nothing about being deposed
+        // removes it from that list.
+        let second_takeover = Election::new(vec![peer(1), peer(2), peer(3)], peer(2), 1, peer(1));
+
+        assert_eq!(second_takeover.rank(&peer(1)), Some(0));
+        assert_eq!(
+            second_takeover.role_after(Some(DEFAULT_GRACE), DEFAULT_GRACE),
+            Role::Promote { epoch: 2 }
+        );
+    }
+
+    #[test]
+    fn a_claim_from_a_member_at_the_next_epoch_is_believed() {
+        assert_eq!(election(3).verdict_on(&peer(2), 1), Verdict::Accept);
+    }
+
+    #[test]
+    fn a_claim_at_an_epoch_already_in_force_is_stale() {
+        // Where a second claimant lands after one takeover has already been accepted, and
+        // where a replayed takeover message lands.
+        let after = election(3).rotated(peer(2), 1);
+
+        assert_eq!(
+            after.verdict_on(&peer(3), 1),
+            Verdict::Stale {
+                current: 1,
+                claimed: 1
+            }
+        );
+        assert_eq!(
+            after.verdict_on(&peer(3), 0),
+            Verdict::Stale {
+                current: 1,
+                claimed: 0
+            }
+        );
+    }
+
+    #[test]
+    fn the_coordinator_that_left_cannot_claim_its_way_back_in() {
+        // A returning coordinator rejoins as an ordinary member. Letting it reclaim the role
+        // would make a flapping network trade the session back and forth.
+        assert_eq!(election(3).verdict_on(&peer(1), 1), Verdict::Deposed);
+    }
+
+    #[test]
+    fn a_stranger_cannot_claim_the_role() {
+        assert_eq!(election(3).verdict_on(&peer(9), 1), Verdict::NotAMember);
+    }
+
+    #[test]
+    fn a_member_that_jumped_the_queue_is_still_accepted() {
+        // Member 3 claiming before member 2 means member 2 is most likely gone as well.
+        // Refusing would leave the session with no coordinator at all, which is worse than
+        // the ordering being imperfect -- and every member reaches the same conclusion, so
+        // they do not split.
+        assert_eq!(election(2).verdict_on(&peer(3), 1), Verdict::Accept);
+    }
+}

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -253,6 +253,55 @@ impl SessionState {
         })
     }
 
+    /// Rebuild authority over a session that already exists, from its last committed layout.
+    ///
+    /// Every other constructor here fabricates a session: one member, one tab, one pane. A
+    /// member promoted after its coordinator left needs the opposite -- the tabs, panes and
+    /// join order the room is already looking at, with itself now the one allowed to change
+    /// them. It does not get to invent any of that, which is why the snapshot goes through
+    /// the same validation an untrusted one would.
+    ///
+    /// The id counters resume past what the snapshot already uses, so a pane created after
+    /// the takeover cannot collide with one created before it. Reservations do not resume:
+    /// they live on the control streams a takeover tears down, and the requester is told its
+    /// pane never landed rather than being left holding a provisional PTY forever.
+    ///
+    /// The departed coordinator stays in the member list. Its panes are dead, and every
+    /// member already draws a pane whose host is gone as unavailable, so evicting it here
+    /// would trade a placeholder for a layout that silently rearranged itself under people
+    /// mid-sentence -- and in a two-person session where only the coordinator hosted
+    /// anything, for no layout at all. Eviction is a decision for whoever calls
+    /// [`Self::remove_member`], once the grace window has actually expired.
+    pub fn restore(snapshot: LayoutSnapshot) -> Result<Self, LayoutError> {
+        Self::validate_snapshot(&snapshot)?;
+        let next_pane_id = snapshot
+            .panes
+            .keys()
+            .copied()
+            .max()
+            .unwrap_or(0)
+            .checked_add(1)
+            .ok_or(LayoutError::RevisionExhausted)?;
+        let next_tab_id = snapshot
+            .tabs
+            .iter()
+            .map(|tab| tab.tab_id)
+            .max()
+            .unwrap_or(0)
+            .checked_add(1)
+            .ok_or(LayoutError::RevisionExhausted)?;
+        Ok(Self {
+            revision: snapshot.revision,
+            members: snapshot.members,
+            tabs: snapshot.tabs,
+            panes: snapshot.panes,
+            next_tab_id,
+            next_pane_id,
+            next_reservation_id: 1,
+            pending_reservation: None,
+        })
+    }
+
     pub fn revision(&self) -> u64 {
         self.revision
     }

--- a/src/ledger.rs
+++ b/src/ledger.rs
@@ -44,6 +44,12 @@ pub enum LedgerError {
     BadCoordinatorSignature,
     /// The named author did not sign the request the entry attributes to them.
     BadAuthorSignature,
+    /// Sealed under a coordinator epoch this member has not accepted.
+    ///
+    /// Distinct from [`Self::BadCoordinatorSignature`] on purpose: a deposed coordinator
+    /// that reconnects and keeps writing is a normal thing to survive, not an attack, and
+    /// the two need different responses.
+    WrongEpoch { current: u64, found: u64 },
 }
 
 impl std::fmt::Display for LedgerError {
@@ -63,6 +69,12 @@ impl std::fmt::Display for LedgerError {
             Self::BadAuthorSignature => {
                 formatter.write_str("ledger entry's author did not sign the change it claims")
             }
+            Self::WrongEpoch { current, found } => {
+                write!(
+                    formatter,
+                    "ledger entry from coordinator epoch {found} arrived under epoch {current}"
+                )
+            }
         }
     }
 }
@@ -75,6 +87,7 @@ pub struct LedgerWriter {
     secret: SecretKey,
     next_seq: u64,
     prev_hash: [u8; LEDGER_HASH_BYTES],
+    epoch: u64,
 }
 
 impl LedgerWriter {
@@ -84,7 +97,35 @@ impl LedgerWriter {
             secret,
             next_seq: 1,
             prev_hash: GENESIS_PREV_HASH,
+            epoch: 0,
         }
+    }
+
+    /// Continue an existing chain under a new coordinator.
+    ///
+    /// The successor picks up at the head it last verified rather than starting over at
+    /// `seq` 1, so the entries it seals extend the history members already hold instead of
+    /// forking a second one beside it. `epoch` must be past the epoch being replaced; the
+    /// caller gets that from its own promotion decision, never from a peer's claim.
+    pub fn resume(
+        session_id: Vec<u8>,
+        secret: SecretKey,
+        next_seq: u64,
+        prev_hash: [u8; LEDGER_HASH_BYTES],
+        epoch: u64,
+    ) -> Self {
+        Self {
+            session_id,
+            secret,
+            next_seq: next_seq.max(1),
+            prev_hash,
+            epoch,
+        }
+    }
+
+    /// The epoch every entry this writer seals is stamped with.
+    pub fn epoch(&self) -> u64 {
+        self.epoch
     }
 
     /// The session these entries belong to, which the coordinator also needs in order to
@@ -119,6 +160,7 @@ impl LedgerWriter {
             payload,
             author_signature,
             coordinator_signature: Vec::new(),
+            coordinator_epoch: self.epoch,
         };
         let hash = entry_hash(&self.session_id, &entry);
         entry.coordinator_signature = self.secret.sign(&hash).to_bytes().to_vec();
@@ -187,16 +229,67 @@ pub struct LedgerVerifier {
     coordinator: PublicKey,
     expected_seq: Option<u64>,
     prev_hash: Option<[u8; LEDGER_HASH_BYTES]>,
+    epoch: u64,
 }
 
 impl LedgerVerifier {
     pub fn new(session_id: Vec<u8>, coordinator: PublicKey) -> Self {
+        Self::at_epoch(session_id, coordinator, 0)
+    }
+
+    /// A verifier for a member that joined after a takeover, so its first entry is already
+    /// past epoch `0` and the welcome is where it learned that.
+    pub fn at_epoch(session_id: Vec<u8>, coordinator: PublicKey, epoch: u64) -> Self {
         Self {
             session_id,
             coordinator,
             expected_seq: None,
             prev_hash: None,
+            epoch,
         }
+    }
+
+    /// The epoch whose entries this verifier currently accepts.
+    pub fn epoch(&self) -> u64 {
+        self.epoch
+    }
+
+    /// Trust a new coordinator from `epoch` onwards.
+    ///
+    /// Nothing in the entry stream can call this: the caller must have decided for itself
+    /// that this peer is the rightful successor, which is the whole reason a takeover is
+    /// safe without the departed coordinator's cooperation. Passing a claim straight from
+    /// the wire into here would hand the session to whoever asked loudest.
+    ///
+    /// Position is cleared, not carried. The successor resumes from *its* head, which may
+    /// sit ahead of a member that was lagging when the old coordinator dropped, so the
+    /// member re-anchors on the first entry of the new epoch exactly as a mid-session
+    /// joiner anchors on the first entry it is sent.
+    pub fn rotate(&mut self, coordinator: PublicKey, epoch: u64) -> Result<(), LedgerError> {
+        if epoch <= self.epoch {
+            return Err(LedgerError::WrongEpoch {
+                current: self.epoch,
+                found: epoch,
+            });
+        }
+        self.coordinator = coordinator;
+        self.epoch = epoch;
+        self.expected_seq = None;
+        self.prev_hash = None;
+        Ok(())
+    }
+
+    /// Where a successor should pick the chain up, if this member is the one promoted.
+    ///
+    /// A member that has not yet seen an entry answers the genesis position, the same place
+    /// [`LedgerWriter::new`] starts. That is not a fork in practice: every member clears its
+    /// position in [`Self::rotate`], so they all re-anchor on whatever the new coordinator
+    /// seals first.
+    pub fn head(&self) -> (u64, [u8; LEDGER_HASH_BYTES]) {
+        (
+            self.expected_seq.unwrap_or(1),
+            self.prev_hash.unwrap_or(GENESIS_PREV_HASH),
+        )
     }
 
     /// Check one entry and, if it holds up, advance to it.
@@ -225,6 +318,16 @@ impl LedgerVerifier {
         }
         let kind =
             LedgerEntryKind::try_from(entry.kind).map_err(|_| LedgerError::Malformed("kind"))?;
+        // Ahead of the signature check on purpose. An entry from an epoch this member has
+        // not accepted is signed by a key it is not holding, so the signature would fail
+        // either way -- but "the wrong coordinator wrote this" is a diagnosis, and
+        // "somebody forged this" is an alarm, and they should not arrive as the same error.
+        if entry.coordinator_epoch != self.epoch {
+            return Err(LedgerError::WrongEpoch {
+                current: self.epoch,
+                found: entry.coordinator_epoch,
+            });
+        }
         if let Some(expected) = self.expected_seq
             && entry.seq != expected
         {
@@ -294,6 +397,7 @@ pub fn entry_hash(session_id: &[u8], entry: &LedgerEntry) -> [u8; LEDGER_HASH_BY
     hasher.update(&entry.kind.to_le_bytes());
     absorb(&mut hasher, &entry.payload);
     absorb(&mut hasher, &entry.author_signature);
+    hasher.update(&entry.coordinator_epoch.to_le_bytes());
     *hasher.finalize().as_bytes()
 }
 
@@ -351,6 +455,95 @@ mod tests {
             assert_eq!(entry.seq, u64::from(step) + 1);
             assert_eq!(verifier.accept(&entry), Ok(()));
         }
+    }
+
+    #[test]
+    fn a_successor_carries_on_the_chain_the_departed_coordinator_left() {
+        // The point of failover: the history does not restart. A member that was following
+        // the old coordinator keeps the same ledger, one epoch further on.
+        let mut old = writer(1);
+        let mut member = verifier(1);
+        let last = append(&mut old, b"before");
+        assert_eq!(member.accept(&last), Ok(()));
+
+        let (next_seq, prev_hash) = member.head();
+        let mut new = LedgerWriter::resume(b"session".to_vec(), key(2), next_seq, prev_hash, 1);
+        member
+            .rotate(key(2).public(), 1)
+            .expect("a member that decided on this successor accepts its key");
+        let first = new.append(
+            key(2).public().as_bytes().to_vec(),
+            LedgerEntryKind::CoordinatorChange,
+            b"takeover".to_vec(),
+            Vec::new(),
+        );
+
+        assert_eq!(first.seq, last.seq + 1);
+        assert_eq!(first.prev_hash, entry_hash(b"session", &last).to_vec());
+        assert_eq!(member.accept(&first), Ok(()));
+    }
+
+    #[test]
+    fn the_deposed_coordinator_writing_on_is_a_stale_epoch_not_a_forgery() {
+        // A coordinator that comes back from a network drop does not know it was replaced,
+        // and its next entry is perfectly well signed -- by the wrong key. Reporting that as
+        // a bad signature would put a returning laptop and an attacker in the same bucket.
+        let mut old = writer(1);
+        let mut member = verifier(1);
+        assert_eq!(member.accept(&append(&mut old, b"before")), Ok(()));
+        member.rotate(key(2).public(), 1).expect("promotion");
+
+        assert_eq!(
+            member.accept(&append(&mut old, b"after")),
+            Err(LedgerError::WrongEpoch {
+                current: 1,
+                found: 0
+            })
+        );
+    }
+
+    #[test]
+    fn a_takeover_cannot_reuse_or_rewind_an_epoch() {
+        // Two members promoting themselves at once must not both land on epoch 1, and a
+        // replayed takeover must not walk the session back to a coordinator it has left.
+        let mut member = verifier(1);
+        member.rotate(key(2).public(), 1).expect("first takeover");
+
+        assert_eq!(
+            member.rotate(key(3).public(), 1),
+            Err(LedgerError::WrongEpoch {
+                current: 1,
+                found: 1
+            })
+        );
+        assert_eq!(
+            member.rotate(key(3).public(), 0),
+            Err(LedgerError::WrongEpoch {
+                current: 1,
+                found: 0
+            })
+        );
+        assert_eq!(member.epoch(), 1);
+    }
+
+    #[test]
+    fn the_epoch_is_covered_by_the_signature() {
+        // Otherwise a stale entry could be relabelled into the current epoch in flight,
+        // which is the one edit that would make the check above meaningless.
+        let mut entry = LedgerEntry {
+            seq: 1,
+            prev_hash: GENESIS_PREV_HASH.to_vec(),
+            author_peer_id: b"peer".to_vec(),
+            kind: LedgerEntryKind::LayoutChange as i32,
+            payload: b"payload".to_vec(),
+            author_signature: Vec::new(),
+            coordinator_signature: Vec::new(),
+            coordinator_epoch: 0,
+        };
+        let at_zero = entry_hash(b"session", &entry);
+        entry.coordinator_epoch = 1;
+
+        assert_ne!(at_zero, entry_hash(b"session", &entry));
     }
 
     #[test]
@@ -536,6 +729,7 @@ mod tests {
             payload,
             author_signature: Vec::new(),
             coordinator_signature: Vec::new(),
+            coordinator_epoch: 0,
         };
 
         assert_ne!(intent, entry_hash(b"session", &entry));
@@ -553,6 +747,7 @@ mod tests {
             payload: b"c".to_vec(),
             author_signature: Vec::new(),
             coordinator_signature: Vec::new(),
+            coordinator_epoch: 0,
         };
         let right = LedgerEntry {
             author_peer_id: b"a".to_vec(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod agent_setup;
 pub mod cli;
 pub mod client;
 pub mod config;
+pub mod failover;
 pub mod hosted_rendezvous;
 pub mod kitty_keyboard;
 pub mod layout;

--- a/src/node.rs
+++ b/src/node.rs
@@ -243,7 +243,7 @@ pub async fn run_background(bootstrap: NodeBootstrap) -> Result<(), Box<dyn Erro
     let listener = UnixListener::bind(&descriptor.socket_path)?;
     listener.set_nonblocking(true)?;
     store.write(&descriptor)?;
-    let result = run_socket_loop(&mut node, listener, &descriptor);
+    let result = run_socket_loop(&mut node, listener, &mut descriptor, &store);
     // `SharedLayoutRuntime` owns a Tokio handle for its asynchronous pane/control cleanup.
     // The node itself runs on this runtime, so perform that blocking teardown outside its worker.
     tokio::task::block_in_place(|| node.shutdown());
@@ -294,7 +294,8 @@ fn configure_accepted(stream: UnixStream) -> Option<UnixStream> {
 fn run_socket_loop(
     node: &mut SharedLayoutNode,
     listener: UnixListener,
-    descriptor: &SessionDescriptor,
+    descriptor: &mut SessionDescriptor,
+    store: &SessionStore,
 ) -> io::Result<()> {
     let gate = AttachmentGate::default();
     let mut client: Option<AttachedClient> = None;
@@ -425,6 +426,22 @@ fn run_socket_loop(
                 .drain()
                 .map_err(|error| io::Error::other(error.to_string()))?;
             drain_elapsed = drain_started.elapsed();
+        }
+        // A takeover or a step-down changes what this machine is advertising about itself.
+        // `p2pmux ls` and `p2pmux ticket <name>` read the record out of process, so until it
+        // is rewritten they hand out a ticket for an endpoint that stopped answering.
+        if let Some(role) = node.take_role_persist() {
+            descriptor.role = if role.coordinating {
+                SessionRole::Coordinator
+            } else {
+                SessionRole::Member
+            };
+            descriptor.ticket = role.ticket;
+            descriptor.join_code = role.join_code;
+            if let Err(error) = store.write(descriptor) {
+                eprintln!("p2pmux node: failed to record the new session role: {error}");
+            }
+            did_work = true;
         }
         did_work |= changed;
         let mut detached = false;
@@ -920,9 +937,12 @@ fn snapshot_message(
         .collect::<Vec<_>>();
     let message = NodeMessage::Snapshot {
         room_name: descriptor.name.clone(),
-        role: match descriptor.role {
-            SessionRole::Coordinator => "coordinator",
-            SessionRole::Member => "member",
+        // Read live rather than from the record this node started with: the role can change
+        // under a running session, and the attached client draws it every frame.
+        role: if node.is_coordinating() {
+            "coordinator"
+        } else {
+            "member"
         }
         .into(),
         summary: SessionSummary {
@@ -1414,6 +1434,16 @@ impl SharedLayoutNode {
         self.runtime
             .apply_agent_status(pane_id, kind, status, cwd, message)
     }
+    /// Whether this node currently serializes the session, for the attached client's header.
+    pub fn is_coordinating(&self) -> bool {
+        self.runtime.is_coordinating()
+    }
+
+    /// A role change the durable session record still has to be told about, once.
+    pub fn take_role_persist(&mut self) -> Option<crate::tui::RolePersist> {
+        self.runtime.take_role_persist()
+    }
+
     pub fn shutdown(self) {
         self.runtime.shutdown_node();
     }

--- a/src/node.rs
+++ b/src/node.rs
@@ -130,7 +130,7 @@ pub async fn run_background(bootstrap: NodeBootstrap) -> Result<(), Box<dyn Erro
     // Before the first pane spawns: every PTY this node opens inherits the
     // socket path from here, and pane 1 is created a few lines below.
     crate::pty_host::set_agent_socket_path(descriptor.socket_path.clone());
-    let (mut node, dispatcher_task, published_code) = match bootstrap.kind {
+    let (mut node, published_code) = match bootstrap.kind {
         NodeBootstrapKind::Create {
             display_name,
             cols,
@@ -182,11 +182,11 @@ pub async fn run_background(bootstrap: NodeBootstrap) -> Result<(), Box<dyn Erro
                 host, panes, layout, initial, ticket, code, handle,
             )?;
             runtime.set_session_id(session_id);
-            (
-                SharedLayoutNode::new(runtime),
-                dispatcher_task,
-                published_code,
-            )
+            // The runtime owns the accept loop from here: losing every member is one of the
+            // shapes a coordinator's own failover takes, and stepping down means this
+            // endpoint has to stop answering joins and start behaving like a member.
+            runtime.set_accept_task(dispatcher_task);
+            (SharedLayoutNode::new(runtime), published_code)
         }
         NodeBootstrapKind::Join {
             ticket,
@@ -225,14 +225,17 @@ pub async fn run_background(bootstrap: NodeBootstrap) -> Result<(), Box<dyn Erro
             panes.replace_roster_from_layout(&state)?;
             let acceptor = panes.clone();
             let dispatcher_task = tokio::spawn(async move { acceptor.accept_loop().await });
-            let runtime = crate::tui::SharedLayoutRuntime::member_from_state(
+            let mut runtime = crate::tui::SharedLayoutRuntime::member_from_state(
                 member,
                 panes,
                 ticket.session_id().to_vec(),
                 state,
                 tokio::runtime::Handle::current(),
             )?;
-            (SharedLayoutNode::new(runtime), dispatcher_task, None)
+            // Handed over for the same reason as on the coordinator, in the other direction:
+            // a member that gets promoted has to start answering joins on this endpoint.
+            runtime.set_accept_task(dispatcher_task);
+            (SharedLayoutNode::new(runtime), None)
         }
     };
     let store = SessionStore::for_current_user()?;
@@ -244,8 +247,6 @@ pub async fn run_background(bootstrap: NodeBootstrap) -> Result<(), Box<dyn Erro
     // `SharedLayoutRuntime` owns a Tokio handle for its asynchronous pane/control cleanup.
     // The node itself runs on this runtime, so perform that blocking teardown outside its worker.
     tokio::task::block_in_place(|| node.shutdown());
-    dispatcher_task.abort();
-    let _ = dispatcher_task.await;
     if let Some(published) = published_code {
         published.retire().await;
     }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -3,7 +3,7 @@
 use prost::Message;
 use std::{collections::HashSet, fmt};
 
-pub const PROTOCOL_VERSION: u32 = 9;
+pub const PROTOCOL_VERSION: u32 = 10;
 pub const MAX_FRAME_BYTES: usize = 1_048_576;
 pub const MAX_ENVELOPE_BYTES: usize = 1_048_560;
 pub const MAX_PEER_ID_BYTES: usize = 64;
@@ -200,6 +200,13 @@ pub struct Welcome {
     pub coordinator_peer_id: Vec<u8>,
     #[prost(string, tag = "4")]
     pub session_name: String,
+    /// How many times this session has changed coordinator, `0` for the one that created it.
+    ///
+    /// A member joining mid-session has no ledger history to read the current epoch out of,
+    /// so the welcome states it. Everything after that arrives as a
+    /// [`LedgerEntryKind::CoordinatorChange`] entry.
+    #[prost(uint64, tag = "5")]
+    pub coordinator_epoch: u64,
 }
 
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -559,6 +566,14 @@ pub struct LedgerEntry {
     /// The coordinator's signature over this entry, which is what fixes its position.
     #[prost(bytes = "vec", tag = "7")]
     pub coordinator_signature: Vec<u8>,
+    /// Which coordinator sealed this, counted from `0` for the one that created the session.
+    ///
+    /// Covered by the signed hash, so it cannot be edited in flight. Without it, an entry
+    /// from a coordinator the receiver has not accepted fails as a bad signature, which is
+    /// indistinguishable from tampering; with it, the receiver can say *stale epoch* and
+    /// keep the two apart.
+    #[prost(uint64, tag = "8")]
+    pub coordinator_epoch: u64,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, ::prost::Enumeration)]
@@ -570,6 +585,31 @@ pub enum LedgerEntryKind {
     PaneReady = 2,
     /// Somebody joining, leaving, or moving to a new address.
     Membership = 3,
+    /// A new coordinator taking over the session, which every later entry is signed by.
+    CoordinatorChange = 4,
+}
+
+/// The payload of a [`LedgerEntryKind::CoordinatorChange`] entry.
+///
+/// Authored by the successor on its own account: the coordinator it replaces is, by
+/// definition, not there to ask. That is why nothing here is trusted on its face — a member
+/// accepts the entry only once it has independently reached the same conclusion about who
+/// should take over (see `crate::failover`), and this record is what it checks that
+/// conclusion against.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CoordinatorChangeRecord {
+    /// The endpoint public key now sealing this session's ledger.
+    #[prost(bytes = "vec", tag = "1")]
+    pub coordinator_peer_id: Vec<u8>,
+    /// Where to reach it, so a member can re-establish its control stream.
+    #[prost(bytes = "vec", tag = "2")]
+    pub endpoint_addr: Vec<u8>,
+    /// The epoch this takeover opens, one past the epoch it replaces.
+    #[prost(uint64, tag = "3")]
+    pub epoch: u64,
+    /// The coordinator whose departure caused this, for members reporting what happened.
+    #[prost(bytes = "vec", tag = "4")]
+    pub replaced_peer_id: Vec<u8>,
 }
 
 /// The payload of a [`LedgerEntryKind::Membership`] entry.

--- a/src/session.rs
+++ b/src/session.rs
@@ -3628,9 +3628,15 @@ pub async fn join_layout_with_display_name(
         })
     }
     .await;
+    // The connection is this function's to clean up. The transport is not, and used to be
+    // closed here as well: harmless while the only caller bound one immediately beforehand
+    // and gave up if the join failed, catastrophic once a running node reuses its own to
+    // look for a coordinator. A single failed dial took the whole endpoint down with it --
+    // every pane subscription, and any chance of this node going on to serve the session
+    // itself -- and the only trace was panes reporting "Endpoint is closed" while the
+    // takeover silently never happened.
     if result.is_err() {
         connection.close(0u8.into(), b"");
-        transport.close().await;
     }
     result
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -149,6 +149,8 @@ pub enum CoordinatorError {
     EndpointIdentityMismatch,
     InvalidEndpointAddress,
     EndpointSerialization(serde_json::Error),
+    /// A takeover by a peer the layout being taken over does not list as a member.
+    NotAMember,
 }
 
 impl fmt::Display for CoordinatorError {
@@ -163,6 +165,9 @@ impl fmt::Display for CoordinatorError {
             }
             Self::EndpointSerialization(error) => {
                 write!(formatter, "endpoint address serialization failed: {error}")
+            }
+            Self::NotAMember => {
+                formatter.write_str("cannot take over a session this peer is not a member of")
             }
         }
     }
@@ -290,6 +295,54 @@ impl LayoutCoordinator {
             reservation_timeout,
             locked: false,
             roster: MemberRoster::default(),
+        })
+    }
+
+    /// Take authority over a session that already exists, from its last committed layout.
+    ///
+    /// The counterpart to the constructors above, which all begin a session. This one
+    /// inherits one: the tabs, panes and join order every member is already looking at, and
+    /// a ledger resumed at the head this member last verified rather than restarted.
+    ///
+    /// Everyone in that member list is pre-admitted. They were admitted by the coordinator
+    /// that left, and a takeover is not the moment to make a room full of people knock
+    /// again -- especially in a locked session, where the lock exists to keep strangers out
+    /// rather than to expel the people already inside.
+    ///
+    /// The session lock itself is not inherited. It is the departed coordinator's live
+    /// setting, not a fact about the layout, so it is not in the snapshot to read; a
+    /// successor that guessed wrong would either leak a locked session open or wall a
+    /// deliberately open one shut. Starting unlocked is the recoverable half of that, and
+    /// the new coordinator can lock it again in one keystroke.
+    pub fn restore(
+        coordinator_peer_id: Vec<u8>,
+        snapshot: LayoutSnapshot,
+        ledger: LedgerWriter,
+        reservation_timeout: Duration,
+    ) -> Result<Self, CoordinatorError> {
+        let state = SessionState::restore(snapshot)?;
+        if !state
+            .members()
+            .iter()
+            .any(|member| member.peer_id == coordinator_peer_id)
+        {
+            return Err(CoordinatorError::NotAMember);
+        }
+        let mut roster = MemberRoster::default();
+        for member in state.members() {
+            roster.admit(member.peer_id.clone());
+        }
+        Ok(Self {
+            state,
+            coordinator_peer_id,
+            ledger,
+            reservations: BTreeMap::new(),
+            agent_rosters: BTreeMap::new(),
+            presence: BTreeMap::new(),
+            presence_epoch: 0,
+            reservation_timeout,
+            locked: false,
+            roster,
         })
     }
 
@@ -1064,7 +1117,8 @@ fn layout_error(error: CoordinatorError) -> LayoutError {
         CoordinatorError::Layout(error) => error,
         CoordinatorError::EndpointIdentityMismatch
         | CoordinatorError::InvalidEndpointAddress
-        | CoordinatorError::EndpointSerialization(_) => LayoutError::InvalidSnapshot,
+        | CoordinatorError::EndpointSerialization(_)
+        | CoordinatorError::NotAMember => LayoutError::InvalidSnapshot,
     }
 }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -541,12 +541,20 @@ impl LayoutCoordinator {
         display_name: String,
     ) -> Result<MembershipChange, CoordinatorError> {
         let endpoint_addr = serialized_endpoint(&peer_id, endpoint_addr)?;
-        if self
+        if let Some(existing) = self
             .state
             .members()
             .iter()
-            .any(|member| member.peer_id == peer_id)
+            .find(|member| member.peer_id == peer_id)
         {
+            // Only touch the layout if the address actually moved. A member whose network is
+            // flapping comes back through here every couple of seconds, and rewriting an
+            // identical address would advance the revision every time -- a burst of layout
+            // commits caused by nothing, at exactly the moment the session is least able to
+            // absorb one.
+            if existing.endpoint_addr == endpoint_addr {
+                return self.membership_change(peer_id, MembershipEvent::Joined, None);
+            }
             let invalidated = self.state.update_member_endpoint(
                 self.state.revision(),
                 &peer_id,

--- a/src/session.rs
+++ b/src/session.rs
@@ -1788,6 +1788,7 @@ pub struct HostSession {
     ticket: JoinTicket,
     address_ready: bool,
     session_name: String,
+    coordinator_epoch: u64,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -1798,6 +1799,9 @@ pub struct JoinReceipt {
     pub endpoint_addr: EndpointAddr,
     pub display_name: String,
     pub session_name: String,
+    /// How many takeovers this session has been through, so a joiner knows which
+    /// coordinator's signatures to expect without having to read the history it missed.
+    pub coordinator_epoch: u64,
 }
 
 #[derive(Debug)]
@@ -1899,6 +1903,7 @@ impl HostSession {
             ticket,
             address_ready,
             session_name,
+            coordinator_epoch: 0,
         })
     }
 
@@ -1916,11 +1921,40 @@ impl HostSession {
             ticket,
             address_ready: true,
             session_name,
+            coordinator_epoch: 0,
+        })
+    }
+
+    /// The host end of a session that already existed, taken over by this endpoint.
+    ///
+    /// The session id is carried across rather than minted, because every live pane
+    /// subscription is keyed on it: a successor that invented a new one would be a new
+    /// session that happened to have the same people in it. What changes is the address the
+    /// ticket points at, which is this endpoint now, and the epoch that says so.
+    pub fn resume_with_session_name(
+        transport: Transport,
+        session_id: Vec<u8>,
+        session_name: String,
+        coordinator_epoch: u64,
+    ) -> Result<Self, SessionError> {
+        let ticket = JoinTicket::from_parts(session_id, transport.endpoint_addr())
+            .map_err(SessionError::Ticket)?;
+        Ok(Self {
+            transport,
+            ticket,
+            address_ready: true,
+            session_name,
+            coordinator_epoch,
         })
     }
 
     pub fn ticket(&self) -> &JoinTicket {
         &self.ticket
+    }
+
+    /// How many takeovers this session has been through, stamped into every welcome.
+    pub fn coordinator_epoch(&self) -> u64 {
+        self.coordinator_epoch
     }
 
     pub fn address_ready(&self) -> bool {
@@ -2072,6 +2106,7 @@ impl HostSession {
             endpoint_addr,
             display_name: join.display_name,
             session_name: self.session_name.clone(),
+            coordinator_epoch: self.coordinator_epoch,
         };
         self.transport
             .write_frame(
@@ -2084,6 +2119,7 @@ impl HostSession {
                         admitted_peer_id: receipt.admitted_peer_id.clone(),
                         coordinator_peer_id: receipt.coordinator_peer_id.clone(),
                         session_name: receipt.session_name.clone(),
+                        coordinator_epoch: receipt.coordinator_epoch,
                     })),
                 },
             )
@@ -2391,6 +2427,8 @@ impl ControlFrameSink for crate::transport::FrameWriter {
 pub struct SharedLayoutMember {
     pub peer_id: Vec<u8>,
     pub coordinator_peer_id: Vec<u8>,
+    /// The epoch this member is following, which is what a promotion has to move past.
+    pub coordinator_epoch: u64,
     pub session_name: String,
     pub events: mpsc::Receiver<LayoutControlEvent>,
     signer: IntentSigner,
@@ -3324,7 +3362,14 @@ pub async fn join_layout_with_display_name(
         // Anchored on the endpoint key the ticket named and QUIC proved on this very
         // connection, rather than on the coordinator id the Welcome claimed: a peer that
         // could lie about the latter is exactly the one this verifier exists to catch.
-        let verifier = LedgerVerifier::new(ticket.session_id().to_vec(), ticket.endpoint_addr().id);
+        // The epoch comes from the welcome rather than starting at zero: a member joining a
+        // session that has already changed hands has no way to read the takeovers it missed,
+        // and entries sealed under the current epoch would otherwise all look wrong to it.
+        let verifier = LedgerVerifier::at_epoch(
+            ticket.session_id().to_vec(),
+            ticket.endpoint_addr().id,
+            receipt.coordinator_epoch,
+        );
         let tasks = vec![
             tokio::spawn(layout_member_reader_task(
                 reader,
@@ -3341,6 +3386,7 @@ pub async fn join_layout_with_display_name(
         Ok(SharedLayoutMember {
             peer_id,
             coordinator_peer_id,
+            coordinator_epoch: receipt.coordinator_epoch,
             session_name,
             events,
             signer: IntentSigner::new(ticket.session_id().to_vec(), transport.secret_key()),
@@ -4174,6 +4220,7 @@ async fn join_handshake_with_display_name(
         endpoint_addr: ticket.endpoint_addr().clone(),
         display_name: String::new(),
         session_name: welcome.session_name,
+        coordinator_epoch: welcome.coordinator_epoch,
     })
 }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -355,6 +355,20 @@ impl LayoutCoordinator {
         self.state.members().len() >= MAX_MEMBERS
     }
 
+    /// Whether this peer would take a new seat, or is simply coming back to the one it has.
+    ///
+    /// A full session must still let its own members reconnect. Otherwise the cap turns into
+    /// a trap: eight people, one dropped stream, and the peer that owns half the panes can
+    /// never get back in -- and after a takeover, where every survivor rejoins, nobody could.
+    pub fn is_full_for(&self, peer_id: &[u8]) -> bool {
+        self.is_full()
+            && !self
+                .state
+                .members()
+                .iter()
+                .any(|member| member.peer_id == peer_id)
+    }
+
     /// Whether the host has closed the session to newcomers.
     pub fn is_locked(&self) -> bool {
         self.locked
@@ -510,6 +524,16 @@ impl LayoutCoordinator {
         self.admit_with_display_name(peer_id, endpoint_addr, String::new())
     }
 
+    /// Admit a peer, or readmit one the layout already lists.
+    ///
+    /// Rejoining is ordinary, not exceptional. A member whose control stream dropped comes
+    /// back through this door, and after a takeover every survivor does -- the successor
+    /// inherited a member list with all of them already in it, and refusing them would leave
+    /// a coordinator that no member could attach to.
+    ///
+    /// The readmission is an endpoint refresh rather than a fresh join, because that is what
+    /// actually happened and because a rejoin is exactly when an address is likely to have
+    /// changed: the usual reason a stream dropped is that the network underneath it moved.
     pub fn admit_with_display_name(
         &mut self,
         peer_id: Vec<u8>,
@@ -517,6 +541,19 @@ impl LayoutCoordinator {
         display_name: String,
     ) -> Result<MembershipChange, CoordinatorError> {
         let endpoint_addr = serialized_endpoint(&peer_id, endpoint_addr)?;
+        if self
+            .state
+            .members()
+            .iter()
+            .any(|member| member.peer_id == peer_id)
+        {
+            let invalidated = self.state.update_member_endpoint(
+                self.state.revision(),
+                &peer_id,
+                endpoint_addr,
+            )?;
+            return self.membership_change(peer_id, MembershipEvent::EndpointChanged, invalidated);
+        }
         let invalidated = self.state.add_member_with_display_name(
             self.state.revision(),
             peer_id.clone(),
@@ -3085,7 +3122,7 @@ impl SharedLayoutHost {
                 .coordinator
                 .lock()
                 .map_err(|_| SessionError::PeerTask)?
-                .is_full()
+                .is_full_for(connection.remote_id().as_bytes())
             {
                 self.host
                     .refuse_join(join_writer, LayoutRejectReason::Limit)

--- a/src/session.rs
+++ b/src/session.rs
@@ -31,14 +31,14 @@ use crate::{
     lease::LeaseState,
     ledger::{IntentSigner, LedgerVerifier, LedgerWriter, verify_intent},
     protocol::{
-        AgentRoster, ControlLease, CreatePane, CreateTab, DeletePane, DeleteTab, Delta, Envelope,
-        Input, Join, LayoutCommit, LayoutNode, LayoutReject, LayoutRejectReason, LayoutRequest,
-        LayoutSplit, LayoutState, LedgerEntryKind, MarkPaneExited, MemberDescriptor,
-        MembershipEvent, MembershipRecord, NewPanePosition as ProtocolNewPanePosition,
-        PROTOCOL_VERSION, PaneDescriptor, PaneFailed, PaneReady, PaneReservation, PaneSubscribe,
-        Presence, PresenceRoster, ReleaseControl, RenamePane, RenameTab, SessionSnapshot,
-        SetPaneLock, SetSplitRatio, Snapshot, SplitAxis, TabDescriptor, TakeControl,
-        UpdatePaneGrids, Welcome, envelope,
+        AgentRoster, ControlLease, CoordinatorChangeRecord, CreatePane, CreateTab, DeletePane,
+        DeleteTab, Delta, Envelope, Input, Join, LayoutCommit, LayoutNode, LayoutReject,
+        LayoutRejectReason, LayoutRequest, LayoutSplit, LayoutState, LedgerEntryKind,
+        MarkPaneExited, MemberDescriptor, MembershipEvent, MembershipRecord,
+        NewPanePosition as ProtocolNewPanePosition, PROTOCOL_VERSION, PaneDescriptor, PaneFailed,
+        PaneReady, PaneReservation, PaneSubscribe, Presence, PresenceRoster, ReleaseControl,
+        RenamePane, RenameTab, SessionSnapshot, SetPaneLock, SetSplitRatio, Snapshot, SplitAxis,
+        TabDescriptor, TakeControl, UpdatePaneGrids, Welcome, envelope,
     },
     screen::ScreenFrame,
     ticket::{JoinTicket, TicketError},
@@ -1018,6 +1018,26 @@ impl LayoutCoordinator {
         .encode_to_vec();
         let author = self.coordinator_peer_id.clone();
         self.layout_commit(author, LedgerEntryKind::Membership, payload, Vec::new())
+    }
+
+    /// Seal this takeover into the ledger.
+    ///
+    /// The layout does not change -- the room is looking at exactly what it was looking at a
+    /// moment ago -- so the entry is the entire point. It is what makes the handover part of
+    /// the record instead of something that happened to the session off the books, and it is
+    /// what a member that reconnects later reads to find out the session changed hands while
+    /// it was away.
+    pub fn seal_coordinator_change(
+        &mut self,
+        record: &CoordinatorChangeRecord,
+    ) -> Result<LayoutCommit, CoordinatorError> {
+        let author = self.coordinator_peer_id.clone();
+        self.layout_commit(
+            author,
+            LedgerEntryKind::CoordinatorChange,
+            record.encode_to_vec(),
+            Vec::new(),
+        )
     }
 
     fn protocol_layout_state(&self) -> Result<LayoutState, CoordinatorError> {
@@ -2483,6 +2503,8 @@ pub struct SharedLayoutMember {
     pub coordinator_peer_id: Vec<u8>,
     /// The epoch this member is following, which is what a promotion has to move past.
     pub coordinator_epoch: u64,
+    /// Shared with the reader task, so a promoted member can read the chain head it verified.
+    verifier: Arc<Mutex<LedgerVerifier>>,
     pub session_name: String,
     pub events: mpsc::Receiver<LayoutControlEvent>,
     signer: IntentSigner,
@@ -2502,6 +2524,19 @@ impl SharedLayoutMember {
     /// The endpoint that owns this member's locally hosted panes and outbound subscriptions.
     pub fn transport(&self) -> Transport {
         self.transport.clone()
+    }
+
+    /// Where in the ledger this member had got to, for a successor resuming the chain.
+    ///
+    /// A member that dropped early holds an earlier head than one that kept up. That is
+    /// fine: whichever of them is promoted, everyone re-anchors on the first entry the new
+    /// epoch produces, so the chain stays checkable from that point on without needing the
+    /// room to have agreed on where it was when the coordinator vanished.
+    pub fn ledger_head(&self) -> (u64, [u8; crate::protocol::LEDGER_HASH_BYTES]) {
+        self.verifier
+            .lock()
+            .map(|verifier| verifier.head())
+            .unwrap_or((1, crate::ledger::GENESIS_PREV_HASH))
     }
 
     pub fn try_request(&self, request: LayoutRequest) -> Result<(), LayoutControlQueueError> {
@@ -2640,8 +2675,109 @@ impl SharedLayoutHost {
         })
     }
 
+    /// Take over a session that already exists, keeping the pane service already serving it.
+    ///
+    /// The pane server is passed in rather than built, and that is the whole point: the
+    /// promoted member is already hosting PTYs and already serving subscriptions to them. A
+    /// fresh one would be an empty registry, and every pane this machine runs would vanish
+    /// from the session at the instant it took charge of it.
+    ///
+    /// The ledger resumes at `ledger_head` under `epoch`, so the entries this coordinator
+    /// seals extend the history the room already holds instead of forking one beside it.
+    pub fn take_over(
+        host: HostSession,
+        pane_server: PaneServer,
+        snapshot: LayoutSnapshot,
+        ledger_head: (u64, [u8; crate::protocol::LEDGER_HASH_BYTES]),
+        reservation_timeout: Duration,
+    ) -> Result<Self, SessionError> {
+        let coordinator_peer_id = host.ticket().endpoint_addr().id.as_bytes().to_vec();
+        let session_id = host.ticket().session_id().to_vec();
+        let (next_seq, prev_hash) = ledger_head;
+        let ledger = LedgerWriter::resume(
+            session_id.clone(),
+            host.transport.secret_key(),
+            next_seq,
+            prev_hash,
+            host.coordinator_epoch(),
+        );
+        let coordinator =
+            LayoutCoordinator::restore(coordinator_peer_id, snapshot, ledger, reservation_timeout)?;
+        let signer = IntentSigner::new(session_id, host.transport.secret_key());
+        Ok(Self {
+            host,
+            pane_server,
+            coordinator: Arc::new(Mutex::new(coordinator)),
+            peers: Arc::new(Mutex::new(BTreeMap::new())),
+            reservation_timeout,
+            signer,
+        })
+    }
+
+    /// Announce this takeover into the ledger, so it is part of the record like any change.
+    ///
+    /// Authored on the successor's own account: the coordinator it replaces is not there to
+    /// author anything, which is the situation this whole path exists for. What makes the
+    /// entry believable is not its contents but that every member reached the same
+    /// conclusion independently before accepting the key that signs it.
+    pub fn announce_takeover(
+        &self,
+        replaced_peer_id: Vec<u8>,
+    ) -> Result<LayoutCommit, SessionError> {
+        let record = CoordinatorChangeRecord {
+            coordinator_peer_id: self.host.ticket().endpoint_addr().id.as_bytes().to_vec(),
+            endpoint_addr: serde_json::to_vec(self.host.ticket().endpoint_addr())
+                .map_err(|_| SessionError::InvalidPostWelcome)?,
+            epoch: self.host.coordinator_epoch(),
+            replaced_peer_id,
+        };
+        let mut coordinator = self
+            .coordinator
+            .lock()
+            .map_err(|_| SessionError::PeerTask)?;
+        let commit = coordinator.seal_coordinator_change(&record)?;
+        broadcast_envelope(
+            &self.peers,
+            coordinator_envelope(
+                self.host.ticket().endpoint_addr().id.as_bytes(),
+                envelope::Body::LayoutCommit(commit.clone()),
+            ),
+        );
+        Ok(commit)
+    }
+
     pub fn ticket(&self) -> &JoinTicket {
         self.host.ticket()
+    }
+
+    /// How many takeovers this session has been through, this one included.
+    pub fn coordinator_epoch(&self) -> u64 {
+        self.host.coordinator_epoch()
+    }
+
+    /// How many members currently hold a control stream to this coordinator.
+    ///
+    /// Zero in a session that has other members in it is the coordinator's own version of
+    /// losing the coordinator: from here there is no way to tell "everyone left" from "my
+    /// network dropped", and the second one means the room is off electing a successor.
+    pub fn connected_peers(&self) -> usize {
+        self.peers.lock().map(|peers| peers.len()).unwrap_or(0)
+    }
+
+    /// Drop every member's control stream, on the way to giving the role up.
+    ///
+    /// Called by a coordinator that was isolated long enough for the room to elect somebody
+    /// else. Any peer still attached here is following a coordinator that no longer is one,
+    /// and leaving those streams open would let it keep sealing entries onto a ledger the
+    /// session has already moved past.
+    pub fn disconnect_peers(&self) {
+        let peers = match self.peers.lock() {
+            Ok(mut peers) => std::mem::take(&mut *peers),
+            Err(_) => return,
+        };
+        for (_, peer) in peers {
+            peer.shutdown();
+        }
     }
 
     pub fn address_ready(&self) -> bool {
@@ -3419,17 +3555,20 @@ pub async fn join_layout_with_display_name(
         // The epoch comes from the welcome rather than starting at zero: a member joining a
         // session that has already changed hands has no way to read the takeovers it missed,
         // and entries sealed under the current epoch would otherwise all look wrong to it.
-        let verifier = LedgerVerifier::at_epoch(
+        // Shared rather than owned by the reader task: a member that ends up promoted has to
+        // resume the ledger from the head it actually verified, and the reader is the only
+        // thing that knows where that is.
+        let verifier = Arc::new(Mutex::new(LedgerVerifier::at_epoch(
             ticket.session_id().to_vec(),
             ticket.endpoint_addr().id,
             receipt.coordinator_epoch,
-        );
+        )));
         let tasks = vec![
             tokio::spawn(layout_member_reader_task(
                 reader,
                 events_tx,
                 coordinator_peer_id.clone(),
-                verifier,
+                Arc::clone(&verifier),
             )),
             tokio::spawn(layout_member_writer_task(
                 writer,
@@ -3441,6 +3580,7 @@ pub async fn join_layout_with_display_name(
             peer_id,
             coordinator_peer_id,
             coordinator_epoch: receipt.coordinator_epoch,
+            verifier,
             session_name,
             events,
             signer: IntentSigner::new(ticket.session_id().to_vec(), transport.secret_key()),
@@ -3631,7 +3771,7 @@ async fn layout_member_reader_task(
     mut reader: crate::transport::FrameReader,
     events_tx: mpsc::Sender<LayoutControlEvent>,
     coordinator_peer_id: Vec<u8>,
-    mut verifier: LedgerVerifier,
+    verifier: Arc<Mutex<LedgerVerifier>>,
 ) {
     while let Ok(Some(envelope)) = reader.read_next().await {
         if envelope.sender_peer_id != coordinator_peer_id {
@@ -3653,7 +3793,11 @@ async fn layout_member_reader_task(
                 let Some(entry) = commit.entry.as_ref() else {
                     break;
                 };
-                if verifier.accept(entry).is_err() {
+                let accepted = verifier
+                    .lock()
+                    .map(|mut verifier| verifier.accept(entry).is_ok())
+                    .unwrap_or(false);
+                if !accepted {
                     break;
                 }
                 LayoutControlEvent::Commit(commit)

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -48,7 +48,7 @@ pub use input::mouse::PaneMouseProtocol;
 pub use multi_pane::MultiPaneTui;
 pub use pane::local::SharedLocalPane;
 pub use render::panes::{render_multi_pane, render_multi_pane_with_copy_feedback};
-pub use runtime::SharedLayoutRuntime;
+pub use runtime::{RolePersist, SharedLayoutRuntime};
 pub(crate) use selection::copy_selection_to_clipboard;
 pub(crate) use share::share_copy_result;
 pub(crate) use snapshot::{

--- a/src/tui/runtime/failover.rs
+++ b/src/tui/runtime/failover.rs
@@ -134,6 +134,7 @@ impl SharedLayoutRuntime {
     /// One pass of the failover state machine. Called from the drain loop.
     pub(in crate::tui) fn tick_failover(&mut self) -> Result<bool, Box<dyn Error>> {
         let mut changed = self.drain_rejoins()?;
+        changed |= self.drain_published_codes();
         self.note_isolation();
         let Some(lost_at) = self.coordinator_lost_at else {
             return Ok(changed);
@@ -193,8 +194,14 @@ impl SharedLayoutRuntime {
         // The invite has to be reissued: the old one names an endpoint nobody is listening
         // on. The short code is republished separately, so until that lands the share panel
         // offers the ticket alone rather than a code that resolves to a dead address.
-        self.invite.ticket = Some(ticket);
+        self.invite.ticket = Some(ticket.clone());
         self.invite.code = None;
+        self.publish_new_code(ticket.clone());
+        self.pending_role_persist = Some(super::RolePersist {
+            coordinating: true,
+            ticket: Some(ticket),
+            join_code: None,
+        });
         self.swap_accept_loop(true);
         if let SharedControl::Host(host) = &self.control
             && let Err(error) = host.announce_takeover(replaced)
@@ -220,7 +227,63 @@ impl SharedLayoutRuntime {
         }
         self.invite.ticket = None;
         self.invite.code = None;
+        self.retire_published_code();
+        self.pending_role_persist = Some(super::RolePersist {
+            coordinating: false,
+            ticket: None,
+            join_code: None,
+        });
         self.swap_accept_loop(false);
+    }
+
+    /// Put a fresh short code in front of the new ticket.
+    ///
+    /// The code a session was created with is sealed under a secret only its creator holds,
+    /// so a successor cannot republish the same one -- it mints another. That is a real cost:
+    /// an invite already pasted into a chat stops working. It is the recoverable half of the
+    /// choice, though, and the alternative is handing every member the power to redirect the
+    /// session's invite, in a product whose whole claim is that nobody holds anyone else's
+    /// keys.
+    ///
+    /// A rendezvous outage degrades the invite rather than the takeover: the ticket still
+    /// works, and the share panel says there is no code instead of showing a dead one.
+    fn publish_new_code(&mut self, ticket: String) {
+        self.retire_published_code();
+        let sender = self.code_tx.clone();
+        self.runtime.spawn(async move {
+            if let Ok(published) = crate::hosted_rendezvous::PublishedCode::publish(ticket).await {
+                let _ = sender.send(published);
+            }
+        });
+    }
+
+    fn retire_published_code(&mut self) {
+        if let Some(published) = self.published_code.take() {
+            self.runtime.spawn(async move { published.retire().await });
+        }
+    }
+
+    /// Adopt a code whose publish finished, if this node is still the one coordinating.
+    fn drain_published_codes(&mut self) -> bool {
+        let mut changed = false;
+        while let Ok(published) = self.code_rx.try_recv() {
+            if !matches!(self.control, SharedControl::Host(_)) {
+                // Stepped back down while the request was in flight. Publishing a code for a
+                // ticket nobody will answer is worse than having none.
+                self.runtime.spawn(async move { published.retire().await });
+                continue;
+            }
+            let code = published.code().printable();
+            self.invite.code = Some(code.clone());
+            self.pending_role_persist = Some(super::RolePersist {
+                coordinating: true,
+                ticket: self.invite.ticket.clone(),
+                join_code: Some(code),
+            });
+            self.published_code = Some(published);
+            changed = true;
+        }
+        changed
     }
 
     /// Point this endpoint's accept loop at the right service for the role it now holds.

--- a/src/tui/runtime/failover.rs
+++ b/src/tui/runtime/failover.rs
@@ -380,6 +380,9 @@ impl SharedLayoutRuntime {
                 Some(election) => {
                     (rejoin.peer_id == election.coordinator() && epoch == election.epoch())
                         || matches!(election.verdict_on(&rejoin.peer_id, epoch), Verdict::Accept)
+                        // Two coordinators on one epoch, which a healed partition can
+                        // produce. Join order settles it identically on both machines.
+                        || election.concedes_to(&rejoin.peer_id, epoch)
                 }
             };
             if !acceptable {

--- a/src/tui/runtime/failover.rs
+++ b/src/tui/runtime/failover.rs
@@ -39,6 +39,12 @@ use super::SharedLayoutRuntime;
 /// hammering it.
 const REJOIN_RETRY: std::time::Duration = std::time::Duration::from_secs(2);
 
+/// How long one dial may take before the next candidate gets a turn.
+///
+/// Generous enough for a relayed handshake between continents, short enough that a peer
+/// which is simply gone does not hold the queue.
+const ATTACH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
 /// The outcome of one attempt to attach to a coordinator, delivered back to the loop.
 pub(in crate::tui) struct Rejoin {
     pub(in crate::tui) peer_id: Vec<u8>,
@@ -150,6 +156,19 @@ impl SharedLayoutRuntime {
                 // changed networks, and a member that reattaches inside the grace window
                 // never learns there was one.
                 changed |= self.attempt_rejoin(&election);
+                // Say how long the freeze lasts. "Structure is frozen" with no end in sight
+                // reads as a broken session; "frozen for another two minutes" reads as a
+                // session waiting for somebody's laptop to come back, which is what it is.
+                if let Some(delay) = election.delay_for(&self.control.peer_id(), self.grace) {
+                    let remaining = delay.saturating_sub(elapsed).as_secs();
+                    let notice = format!(
+                        "coordinator unreachable; taking over in {remaining}s if it stays away"
+                    );
+                    if self.status != notice {
+                        self.status = notice;
+                        changed = true;
+                    }
+                }
             }
             Role::Promote { epoch } => {
                 self.promote(&election, epoch)?;
@@ -446,12 +465,19 @@ async fn attach(
     ticket: JoinTicket,
     display_name: String,
 ) -> Result<RejoinSuccess, SessionError> {
-    let mut member = join_layout_with_display_name(transport, ticket, display_name).await?;
-    match member.events.recv().await {
-        Some(crate::session::LayoutControlEvent::Snapshot(snapshot)) => {
-            let state = snapshot.state.ok_or(SessionError::InvalidPostWelcome)?;
-            Ok(RejoinSuccess { member, state })
+    // Bounded, because the peer being dialled is usually one that has stopped answering.
+    // Without this a single dial into a hole would hold the one in-flight slot forever and
+    // the node would never try anybody else.
+    tokio::time::timeout(ATTACH_TIMEOUT, async {
+        let mut member = join_layout_with_display_name(transport, ticket, display_name).await?;
+        match member.events.recv().await {
+            Some(crate::session::LayoutControlEvent::Snapshot(snapshot)) => {
+                let state = snapshot.state.ok_or(SessionError::InvalidPostWelcome)?;
+                Ok(RejoinSuccess { member, state })
+            }
+            _ => Err(SessionError::InvalidPostWelcome),
         }
-        _ => Err(SessionError::InvalidPostWelcome),
-    }
+    })
+    .await
+    .unwrap_or(Err(SessionError::TimedOut("rejoining a coordinator")))
 }

--- a/src/tui/runtime/failover.rs
+++ b/src/tui/runtime/failover.rs
@@ -1,0 +1,391 @@
+//! Surviving the loss of the coordinator, and taking the role over when it does not come back.
+//!
+//! Losing the coordinator has never ended a session here: panes run on the machines that
+//! host them, their control leases are settled there, and screen data travels peer to peer.
+//! What stops is everything the coordinator alone serializes -- layout edits, admission,
+//! presence -- and until now that stopped permanently.
+//!
+//! This is the part that unfreezes it. Three situations, one mechanism:
+//!
+//! - **A member whose coordinator went quiet** waits out the grace window, then its share of
+//!   the stagger, then takes the role over ([`crate::failover`] decides whose turn it is).
+//! - **A member behind it in the queue** waits, then dials the successor and follows it.
+//! - **A coordinator that lost the room** -- the same event seen from the other side, since a
+//!   coordinator whose network dropped cannot tell that from everyone else leaving -- waits
+//!   the same window and then rejoins as an ordinary member.
+//!
+//! The last one is why demotion exists at all. Without it a coordinator that flapped would
+//! come back believing it still ran a session that had already moved on, and two coordinators
+//! would be sealing entries onto the same ledger.
+
+use std::{error::Error, time::Instant};
+
+use iroh::EndpointAddr;
+
+use crate::{
+    failover::{Election, Role, Verdict},
+    layout::Member,
+    session::{SessionError, SharedLayoutHost, SharedLayoutMember, join_layout_with_display_name},
+    ticket::JoinTicket,
+    tui::pane::control::SharedControl,
+};
+
+use super::SharedLayoutRuntime;
+
+/// How long to leave between attempts to reach a coordinator that is not answering.
+///
+/// A dial that fails costs a round trip against a peer that is probably gone, and the
+/// interesting deadlines here are measured in minutes, so there is nothing to gain by
+/// hammering it.
+const REJOIN_RETRY: std::time::Duration = std::time::Duration::from_secs(2);
+
+/// The outcome of one attempt to attach to a coordinator, delivered back to the loop.
+pub(in crate::tui) struct Rejoin {
+    pub(in crate::tui) peer_id: Vec<u8>,
+    pub(in crate::tui) result: Result<Box<RejoinSuccess>, String>,
+}
+
+pub(in crate::tui) struct RejoinSuccess {
+    pub(in crate::tui) member: SharedLayoutMember,
+    pub(in crate::tui) state: crate::protocol::LayoutState,
+}
+
+impl SharedLayoutRuntime {
+    /// The coordinator's control stream ended. Start the clock.
+    ///
+    /// Deliberately not treated as fatal, and deliberately not reported as an error: from
+    /// here the session is still usable for everything that does not need the coordinator,
+    /// and saying so is the difference between "your session broke" and "structure is frozen
+    /// for a few minutes".
+    pub(in crate::tui) fn note_coordinator_lost(&mut self) {
+        if self.coordinator_lost_at.is_none() {
+            self.coordinator_lost_at = Some(Instant::now());
+        }
+        self.status = String::from(match self.control {
+            SharedControl::Host(_) => "no members reachable; structure frozen while reconnecting",
+            SharedControl::Member(_) => {
+                "coordinator unreachable; panes still live, structure frozen"
+            }
+        });
+    }
+
+    /// Whether layout edits should be refused right now.
+    ///
+    /// A request sent while the coordinator is missing would go into a channel with nothing
+    /// on the other end, and the member would sit forever waiting for a commit that cannot
+    /// arrive. Refusing it up front is what turns that into a footer line.
+    pub(in crate::tui) fn structural_edits_frozen(&self) -> bool {
+        self.coordinator_lost_at.is_some()
+    }
+
+    /// A coordinator's half of the same signal a member gets as a dropped control stream.
+    ///
+    /// There is no event for this. A member is told its coordinator went away because the
+    /// stream it was reading ends; a coordinator is told nothing at all, because the thing
+    /// that would tell it is the peers that just vanished. So it has to notice, and what it
+    /// notices is that a session with other people in it has nobody attached to it.
+    ///
+    /// The reverse matters just as much: one peer reattaching clears the clock. A coordinator
+    /// whose relay blipped for ten seconds must not spend the next five minutes preparing to
+    /// hand over a session it never actually lost.
+    fn note_isolation(&mut self) {
+        let SharedControl::Host(host) = &self.control else {
+            return;
+        };
+        let alone = self.tui.snapshot().members.len() > 1 && host.connected_peers() == 0;
+        match (alone, self.coordinator_lost_at) {
+            (true, None) => self.note_coordinator_lost(),
+            (false, Some(_)) => {
+                self.coordinator_lost_at = None;
+                self.rejoin_deadline = None;
+                self.status.clear();
+            }
+            _ => {}
+        }
+    }
+
+    /// This member's view of the succession, or `None` when there is nothing to decide.
+    fn election(&self) -> Option<Election> {
+        let snapshot = self.tui.snapshot();
+        let members = snapshot
+            .members
+            .iter()
+            .map(|member| member.peer_id.clone())
+            .collect::<Vec<_>>();
+        if members.len() < 2 {
+            // A session of one has nobody to promote and nobody to follow. Whatever happened
+            // to its network, waiting is the only move.
+            return None;
+        }
+        let (coordinator, epoch) = match &self.control {
+            SharedControl::Host(host) => (self.control.peer_id(), host.coordinator_epoch()),
+            SharedControl::Member(member) => {
+                (member.coordinator_peer_id.clone(), member.coordinator_epoch)
+            }
+        };
+        Some(Election::new(
+            members,
+            coordinator,
+            epoch,
+            self.control.peer_id(),
+        ))
+    }
+
+    /// One pass of the failover state machine. Called from the drain loop.
+    pub(in crate::tui) fn tick_failover(&mut self) -> Result<bool, Box<dyn Error>> {
+        let mut changed = self.drain_rejoins()?;
+        self.note_isolation();
+        let Some(lost_at) = self.coordinator_lost_at else {
+            return Ok(changed);
+        };
+        let Some(election) = self.election() else {
+            return Ok(changed);
+        };
+        let elapsed = Instant::now().duration_since(lost_at);
+        match election.role_after(Some(elapsed), self.grace) {
+            Role::Following => {}
+            Role::Waiting => {
+                // Dial while waiting rather than after it. The coordinator may simply have
+                // changed networks, and a member that reattaches inside the grace window
+                // never learns there was one.
+                changed |= self.attempt_rejoin(&election);
+            }
+            Role::Promote { epoch } => {
+                self.promote(&election, epoch)?;
+                changed = true;
+            }
+        }
+        Ok(changed)
+    }
+
+    /// Take the coordinator role over.
+    ///
+    /// Everything the session is made of stays where it is. The PTYs this machine hosts keep
+    /// running, the subscriptions other members hold onto them keep streaming, and the pane
+    /// service that serves those subscriptions is handed to the new coordinator rather than
+    /// rebuilt -- rebuilding it would empty the registry and drop every pane this machine
+    /// runs out of the session at the exact moment it took charge of it.
+    fn promote(&mut self, election: &Election, epoch: u64) -> Result<(), Box<dyn Error>> {
+        let SharedControl::Member(member) = &self.control else {
+            return Ok(());
+        };
+        let ledger_head = member.ledger_head();
+        let session_name = member.session_name.clone();
+        let replaced = election.coordinator().to_vec();
+        let host = crate::session::HostSession::resume_with_session_name(
+            self.transport.clone(),
+            self.session_id.clone(),
+            session_name,
+            epoch,
+        )?;
+        let ticket = host.ticket().to_string();
+        let layout_host = SharedLayoutHost::take_over(
+            host,
+            self.panes.clone(),
+            self.tui.snapshot().clone(),
+            ledger_head,
+            crate::session::DEFAULT_RESERVATION_TIMEOUT,
+        )?;
+        let previous = std::mem::replace(&mut self.control, SharedControl::Host(layout_host));
+        if let SharedControl::Member(member) = previous {
+            member.disconnect_control();
+        }
+        // The invite has to be reissued: the old one names an endpoint nobody is listening
+        // on. The short code is republished separately, so until that lands the share panel
+        // offers the ticket alone rather than a code that resolves to a dead address.
+        self.invite.ticket = Some(ticket);
+        self.invite.code = None;
+        self.swap_accept_loop(true);
+        if let SharedControl::Host(host) = &self.control
+            && let Err(error) = host.announce_takeover(replaced)
+        {
+            self.status = format!("took over the session, but could not record it: {error}");
+        } else {
+            self.status = String::from("coordinator left; this session is now coordinated here");
+        }
+        self.coordinator_lost_at = None;
+        self.rejoin_deadline = None;
+        Ok(())
+    }
+
+    /// Step down to an ordinary member of a session somebody else now coordinates.
+    ///
+    /// Reached by a coordinator that was isolated long enough for the room to replace it. It
+    /// keeps its panes -- they are the same processes on the same machine, and the layout it
+    /// is rejoining still lists them -- and gives up only the authority it no longer has.
+    fn demote(&mut self, member: SharedLayoutMember) {
+        let previous = std::mem::replace(&mut self.control, SharedControl::Member(member));
+        if let SharedControl::Host(host) = previous {
+            host.disconnect_peers();
+        }
+        self.invite.ticket = None;
+        self.invite.code = None;
+        self.swap_accept_loop(false);
+    }
+
+    /// Point this endpoint's accept loop at the right service for the role it now holds.
+    ///
+    /// A coordinator has to answer joins as well as pane subscriptions; a member answers only
+    /// subscriptions. Both loops call `accept_incoming` on the same endpoint, so this is a
+    /// swap and not an addition -- two of them running would race for every connection.
+    fn swap_accept_loop(&mut self, coordinating: bool) {
+        if let Some(task) = self.accept_task.take() {
+            task.abort();
+        }
+        let panes = self.panes.clone();
+        let task = match (&self.control, coordinating) {
+            (SharedControl::Host(host), true) => match host.incoming_dispatcher(panes) {
+                Ok(dispatcher) => self
+                    .runtime
+                    .spawn(async move { dispatcher.accept_loop().await }),
+                Err(error) => {
+                    self.status = format!("could not start serving joins: {error}");
+                    return;
+                }
+            },
+            _ => self.runtime.spawn(async move { panes.accept_loop().await }),
+        };
+        self.accept_task = Some(task);
+    }
+
+    /// Try to attach to whoever is coordinating now, if a previous attempt is not still open.
+    ///
+    /// Candidates are tried in succession order, one per round, so a member that is itself
+    /// about to be promoted does not spend its wait blocked on a peer that is gone.
+    fn attempt_rejoin(&mut self, election: &Election) -> bool {
+        if self.rejoin_in_flight {
+            return false;
+        }
+        let now = Instant::now();
+        if self.rejoin_deadline.is_some_and(|deadline| now < deadline) {
+            return false;
+        }
+        self.rejoin_deadline = Some(now + REJOIN_RETRY);
+        let me = self.control.peer_id();
+        // The coordinator first: the ordinary case is that it is simply still there and this
+        // member's connection to it is what broke.
+        let targets = std::iter::once(election.coordinator().to_vec())
+            .chain(election.candidates().map(<[u8]>::to_vec))
+            .filter(|peer| *peer != me)
+            .collect::<Vec<_>>();
+        let index = self.rejoin_cursor % targets.len().max(1);
+        self.rejoin_cursor = self.rejoin_cursor.wrapping_add(1);
+        let Some(target) = targets.get(index).cloned() else {
+            return false;
+        };
+        let Some(endpoint) = self.member_endpoint(&target) else {
+            return false;
+        };
+        let Ok(ticket) = JoinTicket::from_parts(self.session_id.clone(), endpoint) else {
+            return false;
+        };
+        let display_name = self.local_display_name();
+        let transport = self.transport.clone();
+        let sender = self.rejoin_tx.clone();
+        self.rejoin_in_flight = true;
+        self.runtime.spawn(async move {
+            let result = attach(transport, ticket, display_name).await;
+            let _ = sender.send(Rejoin {
+                peer_id: target,
+                result: result.map(Box::new).map_err(|error| error.to_string()),
+            });
+        });
+        true
+    }
+
+    /// Apply whatever the last attempt produced.
+    fn drain_rejoins(&mut self) -> Result<bool, Box<dyn Error>> {
+        let mut changed = false;
+        while let Ok(rejoin) = self.rejoin_rx.try_recv() {
+            self.rejoin_in_flight = false;
+            changed = true;
+            let success = match rejoin.result {
+                Ok(success) => success,
+                Err(error) => {
+                    self.status = format!("coordinator unreachable: {error}");
+                    continue;
+                }
+            };
+            let epoch = success.member.coordinator_epoch;
+            // A connection is not an argument. The peer answered, which says it is alive and
+            // holds the session secret -- it does not say the room agreed it is in charge,
+            // and that is the question being asked here.
+            let acceptable = match self.election() {
+                None => true,
+                // Reattaching to the same coordinator at the same epoch is the ordinary
+                // case, and nothing has changed hands, so there is no claim to weigh.
+                Some(election) => {
+                    (rejoin.peer_id == election.coordinator() && epoch == election.epoch())
+                        || matches!(election.verdict_on(&rejoin.peer_id, epoch), Verdict::Accept)
+                }
+            };
+            if !acceptable {
+                self.status = String::from("refused a coordinator this session did not elect");
+                success.member.disconnect_control();
+                continue;
+            }
+            let RejoinSuccess { member, state } = *success;
+            self.panes.replace_roster_from_layout(&state)?;
+            if matches!(self.control, SharedControl::Host(_)) {
+                self.demote(member);
+            } else {
+                let previous = std::mem::replace(&mut self.control, SharedControl::Member(member));
+                if let SharedControl::Member(previous) = previous {
+                    previous.disconnect_control();
+                }
+            }
+            self.coordinator_lost_at = None;
+            self.rejoin_deadline = None;
+            // Presence and agent rosters are relayed by the coordinator and cached there, so
+            // a new one starts out knowing nothing about anybody. Clearing what this member
+            // believes it has already published is what makes it publish again.
+            self.seen_presence_epoch = 0;
+            self.last_local_presence = None;
+            self.last_local_agent_entries.clear();
+            self.apply_layout_state(&state)?;
+            self.status = String::from("reattached to the session's coordinator");
+        }
+        Ok(changed)
+    }
+
+    /// This member's own display name, as the session records it.
+    fn local_display_name(&self) -> String {
+        let me = self.control.peer_id();
+        self.tui
+            .snapshot()
+            .members
+            .iter()
+            .find(|member| member.peer_id == me)
+            .map(|member| member.display_name.clone())
+            .unwrap_or_default()
+    }
+
+    fn member_endpoint(&self, peer_id: &[u8]) -> Option<EndpointAddr> {
+        self.tui
+            .snapshot()
+            .members
+            .iter()
+            .find(|member: &&Member| member.peer_id == peer_id)
+            .and_then(|member| serde_json::from_slice(&member.endpoint_addr).ok())
+    }
+}
+
+/// Dial a coordinator and wait for the layout it answers with.
+///
+/// The first snapshot is part of attaching, not something that arrives later: without it
+/// there is nothing to draw, nothing to check the succession against, and no roster to admit
+/// pane subscriptions with.
+async fn attach(
+    transport: crate::transport::Transport,
+    ticket: JoinTicket,
+    display_name: String,
+) -> Result<RejoinSuccess, SessionError> {
+    let mut member = join_layout_with_display_name(transport, ticket, display_name).await?;
+    match member.events.recv().await {
+        Some(crate::session::LayoutControlEvent::Snapshot(snapshot)) => {
+            let state = snapshot.state.ok_or(SessionError::InvalidPostWelcome)?;
+            Ok(RejoinSuccess { member, state })
+        }
+        _ => Err(SessionError::InvalidPostWelcome),
+    }
+}

--- a/src/tui/runtime/layout.rs
+++ b/src/tui/runtime/layout.rs
@@ -48,9 +48,7 @@ impl SharedLayoutRuntime {
             }
             LayoutControlEvent::Reservation(reservation) => self.accept_reservation(reservation)?,
             LayoutControlEvent::Reject(reject) => self.reject_request(reject.request_id),
-            LayoutControlEvent::Disconnected => {
-                self.status = String::from("layout coordinator disconnected")
-            }
+            LayoutControlEvent::Disconnected => self.note_coordinator_lost(),
         }
         Ok(())
     }
@@ -271,6 +269,22 @@ impl SharedLayoutRuntime {
     }
 
     pub(in crate::tui) fn handle_intent(&mut self, intent: UiIntent) -> Result<(), Box<dyn Error>> {
+        // Refused here rather than sent and forgotten. Only the coordinator commits any of
+        // these, so with it missing the request would go into a channel with nothing on the
+        // other end -- and a split, worse, would spawn a local PTY first and leave it
+        // orphaned when the commit that was meant to adopt it never came. Moving focus and
+        // switching tabs are this member's own business and stay available.
+        if self.structural_edits_frozen()
+            && !matches!(
+                intent,
+                UiIntent::FocusPane { .. } | UiIntent::SwitchTab { .. }
+            )
+        {
+            self.footer_notice = Some(String::from(
+                "coordinator unreachable; layout changes are paused",
+            ));
+            return Ok(());
+        }
         match intent {
             UiIntent::CreatePane {
                 target_pane_id,

--- a/src/tui/runtime/layout.rs
+++ b/src/tui/runtime/layout.rs
@@ -280,9 +280,13 @@ impl SharedLayoutRuntime {
                 UiIntent::FocusPane { .. } | UiIntent::SwitchTab { .. }
             )
         {
-            self.footer_notice = Some(String::from(
-                "coordinator unreachable; layout changes are paused",
-            ));
+            let notice = String::from("coordinator unreachable; layout changes are paused");
+            self.footer_notice = Some(notice.clone());
+            // Also as status, which is the only one of the two that survives the trip to an
+            // attached client: the node is headless and forwards `status`, so a refusal that
+            // lived in `footer_notice` alone would be invisible to everybody not running the
+            // old foreground path -- which is to say, to everybody.
+            self.status = notice;
             return Ok(());
         }
         match intent {

--- a/src/tui/runtime/mod.rs
+++ b/src/tui/runtime/mod.rs
@@ -3,12 +3,18 @@
 //!
 //! The inherent impl is split by concern across this module's files.
 
+mod failover;
 mod forward;
 mod layout;
 mod node;
 mod run;
 
-use std::{collections::BTreeMap, error::Error, io, time::Instant};
+use std::{
+    collections::BTreeMap,
+    error::Error,
+    io,
+    time::{Duration, Instant},
+};
 
 use iroh::EndpointAddr;
 
@@ -72,6 +78,22 @@ pub struct SharedLayoutRuntime {
     /// coordinator advances it: a member is handed rosters by the broadcast instead.
     pub(in crate::tui) seen_agent_generations: BTreeMap<Vec<u8>, u64>,
     pub(in crate::tui) presence: Vec<Presence>,
+    /// When the coordinator stopped answering, and `None` while it is answering.
+    ///
+    /// A coordinator sets this too, for the mirror-image case: one whose network dropped
+    /// cannot tell that from every member leaving at once, and both are the same state --
+    /// this node is alone and the session may have moved on without it.
+    pub(in crate::tui) coordinator_lost_at: Option<Instant>,
+    pub(in crate::tui) grace: Duration,
+    /// The endpoint's accept loop, which serves joins on a coordinator and pane
+    /// subscriptions on a member. Held here because a promotion has to swap it.
+    pub(in crate::tui) accept_task:
+        Option<tokio::task::JoinHandle<Result<(), crate::session::SessionError>>>,
+    pub(in crate::tui) rejoin_tx: tokio::sync::mpsc::UnboundedSender<failover::Rejoin>,
+    pub(in crate::tui) rejoin_rx: tokio::sync::mpsc::UnboundedReceiver<failover::Rejoin>,
+    pub(in crate::tui) rejoin_in_flight: bool,
+    pub(in crate::tui) rejoin_deadline: Option<Instant>,
+    pub(in crate::tui) rejoin_cursor: usize,
 }
 impl SharedLayoutRuntime {
     pub fn host(
@@ -146,6 +168,7 @@ impl SharedLayoutRuntime {
         runtime: tokio::runtime::Handle,
     ) -> Result<Self, Box<dyn Error>> {
         let (subscription_tx, subscription_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (rejoin_tx, rejoin_rx) = tokio::sync::mpsc::unbounded_channel();
         let mut local = BTreeMap::new();
         if let Some(initial) = initial {
             local.insert(initial.pane_id, initial);
@@ -189,6 +212,14 @@ impl SharedLayoutRuntime {
             seen_presence_epoch: 0,
             seen_agent_generations: BTreeMap::new(),
             presence: Vec::new(),
+            coordinator_lost_at: None,
+            grace: crate::failover::DEFAULT_GRACE,
+            accept_task: None,
+            rejoin_tx,
+            rejoin_rx,
+            rejoin_in_flight: false,
+            rejoin_deadline: None,
+            rejoin_cursor: 0,
         };
         value.refresh_local_views();
         Ok(value)
@@ -196,6 +227,25 @@ impl SharedLayoutRuntime {
 
     pub fn set_session_id(&mut self, session_id: Vec<u8>) {
         self.session_id = session_id;
+    }
+
+    /// Hand over the endpoint's accept loop, which a promotion has to be able to replace.
+    ///
+    /// Owned here rather than by the caller that spawned it because the runtime is where the
+    /// role changes: a member serving only pane subscriptions becomes a coordinator that must
+    /// also answer joins, and the two loops cannot both be reading the same endpoint.
+    pub fn set_accept_task(
+        &mut self,
+        task: tokio::task::JoinHandle<Result<(), crate::session::SessionError>>,
+    ) {
+        if let Some(previous) = self.accept_task.replace(task) {
+            previous.abort();
+        }
+    }
+
+    /// Shorten the wait before a missing coordinator is replaced. For tests.
+    pub fn set_failover_grace(&mut self, grace: Duration) {
+        self.grace = grace;
     }
 
     pub fn local_focus(&self) -> (u64, u64) {
@@ -265,6 +315,9 @@ impl SharedLayoutRuntime {
     }
 
     pub(in crate::tui) fn shutdown(mut self) {
+        if let Some(task) = self.accept_task.take() {
+            task.abort();
+        }
         self.agent_sampler.shutdown();
         for (_, mut pane) in std::mem::take(&mut self.local) {
             let _ = self.panes.remove_local_pane(pane.pane_id);

--- a/src/tui/runtime/mod.rs
+++ b/src/tui/runtime/mod.rs
@@ -94,6 +94,29 @@ pub struct SharedLayoutRuntime {
     pub(in crate::tui) rejoin_in_flight: bool,
     pub(in crate::tui) rejoin_deadline: Option<Instant>,
     pub(in crate::tui) rejoin_cursor: usize,
+    /// A short code this runtime published for itself, after taking the role over.
+    ///
+    /// The one a session starts with belongs to whoever created it; this is the replacement,
+    /// and holding it here is what lets it be retired when this node stops.
+    pub(in crate::tui) published_code: Option<crate::hosted_rendezvous::PublishedCode>,
+    pub(in crate::tui) code_tx:
+        tokio::sync::mpsc::UnboundedSender<crate::hosted_rendezvous::PublishedCode>,
+    pub(in crate::tui) code_rx:
+        tokio::sync::mpsc::UnboundedReceiver<crate::hosted_rendezvous::PublishedCode>,
+    /// A role change the durable session record has not caught up with yet.
+    ///
+    /// `p2pmux ls` and `p2pmux ticket <name>` read that record out of process, so a takeover
+    /// that never reached it leaves the machine advertising a ticket for an endpoint that
+    /// stopped answering and a role that is no longer true.
+    pub(in crate::tui) pending_role_persist: Option<RolePersist>,
+}
+
+/// What the durable session record has to be updated to after a role change.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RolePersist {
+    pub coordinating: bool,
+    pub ticket: Option<String>,
+    pub join_code: Option<String>,
 }
 impl SharedLayoutRuntime {
     pub fn host(
@@ -169,6 +192,7 @@ impl SharedLayoutRuntime {
     ) -> Result<Self, Box<dyn Error>> {
         let (subscription_tx, subscription_rx) = tokio::sync::mpsc::unbounded_channel();
         let (rejoin_tx, rejoin_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (code_tx, code_rx) = tokio::sync::mpsc::unbounded_channel();
         let mut local = BTreeMap::new();
         if let Some(initial) = initial {
             local.insert(initial.pane_id, initial);
@@ -220,6 +244,10 @@ impl SharedLayoutRuntime {
             rejoin_in_flight: false,
             rejoin_deadline: None,
             rejoin_cursor: 0,
+            published_code: None,
+            code_tx,
+            code_rx,
+            pending_role_persist: None,
         };
         value.refresh_local_views();
         Ok(value)
@@ -246,6 +274,19 @@ impl SharedLayoutRuntime {
     /// Shorten the wait before a missing coordinator is replaced. For tests.
     pub fn set_failover_grace(&mut self, grace: Duration) {
         self.grace = grace;
+    }
+
+    /// Whether this node currently serializes the session.
+    ///
+    /// Read rather than remembered: after a takeover or a step-down the role on the record
+    /// this node started with is stale, and the attached client draws it every frame.
+    pub fn is_coordinating(&self) -> bool {
+        matches!(self.control, SharedControl::Host(_))
+    }
+
+    /// A role change the durable session record still has to be told about, once.
+    pub fn take_role_persist(&mut self) -> Option<RolePersist> {
+        self.pending_role_persist.take()
     }
 
     pub fn local_focus(&self) -> (u64, u64) {
@@ -317,6 +358,9 @@ impl SharedLayoutRuntime {
     pub(in crate::tui) fn shutdown(mut self) {
         if let Some(task) = self.accept_task.take() {
             task.abort();
+        }
+        if let Some(published) = self.published_code.take() {
+            self.runtime.block_on(published.retire());
         }
         self.agent_sampler.shutdown();
         for (_, mut pane) in std::mem::take(&mut self.local) {

--- a/src/tui/runtime/mod.rs
+++ b/src/tui/runtime/mod.rs
@@ -237,7 +237,7 @@ impl SharedLayoutRuntime {
             seen_agent_generations: BTreeMap::new(),
             presence: Vec::new(),
             coordinator_lost_at: None,
-            grace: crate::failover::DEFAULT_GRACE,
+            grace: crate::failover::configured_grace(),
             accept_task: None,
             rejoin_tx,
             rejoin_rx,

--- a/src/tui/runtime/run.rs
+++ b/src/tui/runtime/run.rs
@@ -481,6 +481,7 @@ impl SharedLayoutRuntime {
             }
             changed = true;
         }
+        changed |= self.tick_failover()?;
         changed |= self.refresh_local_views();
         changed |= self.refresh_agent_rows();
         Ok(changed)

--- a/tests/failover.rs
+++ b/tests/failover.rs
@@ -1,0 +1,273 @@
+//! A session outliving the coordinator that started it, over real endpoints.
+//!
+//! The unit tests elsewhere cover the two halves in isolation: `failover` decides whose turn
+//! it is, `ledger` decides whose signature to believe. What they cannot show is the thing
+//! that actually has to work -- that a member can pick the role up and the room can find it
+//! again -- because that involves minting a ticket on an existing session id, resuming a
+//! chain mid-flight, and a second member dialling an address it was never handed. So these
+//! run over loopback endpoints and dial for real.
+
+use std::{net::Ipv4Addr, time::Duration};
+
+use iroh::{Endpoint, RelayMode, endpoint::presets};
+use p2pmux::{
+    ledger::LedgerVerifier,
+    protocol::{LedgerEntryKind, PROTOCOL_VERSION},
+    session::{
+        DEFAULT_RESERVATION_TIMEOUT, HostSession, LayoutControlEvent, SharedLayoutHost,
+        SharedLayoutMember, join_layout_with_display_name, layout_snapshot_from_state,
+    },
+    ticket::JoinTicket,
+    transport::{ALPN, Transport},
+};
+use prost::Message;
+use tokio::time::timeout;
+
+const TEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+async fn loopback_transport() -> Transport {
+    let endpoint = Endpoint::builder(presets::Minimal)
+        .relay_mode(RelayMode::Disabled)
+        .clear_ip_transports()
+        .bind_addr((Ipv4Addr::LOCALHOST, 0))
+        .expect("localhost address should be valid")
+        .alpns(vec![ALPN.to_vec()])
+        .bind()
+        .await
+        .expect("loopback endpoint should bind");
+    Transport::from_endpoint(endpoint)
+}
+
+/// A coordinator with its accept loop running, as a live session would have.
+async fn coordinator(transport: Transport) -> (SharedLayoutHost, tokio::task::JoinHandle<()>) {
+    let host = SharedLayoutHost::with_display_name(
+        HostSession::from_transport_with_session_name(transport, String::from("lisbon"))
+            .expect("host session"),
+        String::from("coordinator"),
+        24,
+        80,
+    )
+    .expect("shared layout host");
+    let panes = host.pane_server();
+    let dispatcher = host
+        .incoming_dispatcher(panes)
+        .expect("dispatcher should accept this host's own pane server");
+    let task = tokio::spawn(async move {
+        let _ = dispatcher.accept_loop().await;
+    });
+    (host, task)
+}
+
+/// Join a coordinator and take delivery of the layout it answers with.
+async fn join(
+    transport: Transport,
+    ticket: &JoinTicket,
+    display_name: &str,
+) -> (SharedLayoutMember, p2pmux::protocol::LayoutState) {
+    let mut member = timeout(
+        TEST_TIMEOUT,
+        join_layout_with_display_name(transport, ticket.clone(), display_name.to_owned()),
+    )
+    .await
+    .expect("join should not time out")
+    .expect("join should be admitted");
+    let state = match timeout(TEST_TIMEOUT, member.events.recv())
+        .await
+        .expect("first control event should not time out")
+    {
+        Some(LayoutControlEvent::Snapshot(snapshot)) => {
+            snapshot.state.expect("welcome carries a layout")
+        }
+        other => panic!("expected an opening snapshot, got {other:?}"),
+    };
+    (member, state)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_promoted_member_serves_the_same_session_the_coordinator_left_behind() {
+    let coordinator_transport = loopback_transport().await;
+    let (host, host_task) = coordinator(coordinator_transport.clone()).await;
+    let ticket = host.ticket().clone();
+    let session_id = ticket.session_id().to_vec();
+
+    let first_transport = loopback_transport().await;
+    let (first, state) = join(first_transport.clone(), &ticket, "first").await;
+    let second_transport = loopback_transport().await;
+    let (second, _) = join(second_transport.clone(), &ticket, "second").await;
+    // The second join moves the layout on, so promote from what the coordinator holds rather
+    // than from the older copy the first member happened to be sent.
+    let state = host
+        .session_snapshot()
+        .expect("coordinator layout")
+        .state
+        .unwrap_or(state);
+    let before = layout_snapshot_from_state(&state).expect("committed layout");
+    assert_eq!(before.members.len(), 3);
+    assert_eq!(first.coordinator_epoch, 0, "nothing has changed hands yet");
+
+    // The coordinator goes away without saying anything, which is the case that matters:
+    // a clean exit would have removed it from the roster on its way out.
+    host_task.abort();
+    coordinator_transport.close().await;
+    second.disconnect_control();
+
+    let head = first.ledger_head();
+    let promoted = SharedLayoutHost::take_over(
+        HostSession::resume_with_session_name(
+            first_transport.clone(),
+            session_id.clone(),
+            first.session_name.clone(),
+            first.coordinator_epoch + 1,
+        )
+        .expect("a member can mint a ticket on the session id it already holds"),
+        first
+            .pane_server(session_id.clone())
+            .expect("the member's own pane service"),
+        before.clone(),
+        head,
+        DEFAULT_RESERVATION_TIMEOUT,
+    )
+    .expect("a member in the layout can take it over");
+    let panes = promoted.pane_server();
+    let dispatcher = promoted
+        .incoming_dispatcher(panes)
+        .expect("dispatcher for the promoted host");
+    let promoted_task = tokio::spawn(async move {
+        let _ = dispatcher.accept_loop().await;
+    });
+
+    // Nothing handed this ticket out. It is built from the session id every member already
+    // holds plus the successor's address out of the layout, which is the whole reason a
+    // takeover needs no new protocol.
+    let rejoin_ticket = JoinTicket::from_parts(
+        session_id.clone(),
+        promoted.ticket().endpoint_addr().clone(),
+    )
+    .expect("a ticket for the new coordinator");
+    assert_ne!(
+        rejoin_ticket.endpoint_addr().id,
+        ticket.endpoint_addr().id,
+        "the rebuilt ticket must name the successor, not the coordinator that left"
+    );
+    assert_eq!(rejoin_ticket.session_id(), ticket.session_id());
+
+    let (returning, after) = join(second_transport.clone(), &rejoin_ticket, "second").await;
+
+    assert_eq!(
+        returning.coordinator_epoch, 1,
+        "the welcome states which coordinator this member is now following"
+    );
+    let after = layout_snapshot_from_state(&after).expect("layout from the successor");
+    assert_eq!(
+        after
+            .members
+            .iter()
+            .map(|member| member.peer_id.clone())
+            .collect::<Vec<_>>(),
+        before
+            .members
+            .iter()
+            .map(|member| member.peer_id.clone())
+            .collect::<Vec<_>>(),
+        "the room is looking at the same session, in the same join order"
+    );
+    assert_eq!(after.panes.len(), before.panes.len());
+    assert!(
+        after.revision >= before.revision,
+        "a takeover must not rewind the layout"
+    );
+
+    promoted_task.abort();
+    returning.disconnect_control();
+    first_transport.close().await;
+    second_transport.close().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn the_successor_carries_on_the_ledger_rather_than_starting_a_second_one() {
+    let coordinator_transport = loopback_transport().await;
+    let (host, host_task) = coordinator(coordinator_transport.clone()).await;
+    let ticket = host.ticket().clone();
+    let session_id = ticket.session_id().to_vec();
+
+    let first_transport = loopback_transport().await;
+    let (first, _) = join(first_transport.clone(), &ticket, "first").await;
+    let state = host
+        .session_snapshot()
+        .expect("coordinator layout")
+        .state
+        .expect("layout state");
+    let before = layout_snapshot_from_state(&state).expect("committed layout");
+
+    host_task.abort();
+    coordinator_transport.close().await;
+
+    let (next_seq, prev_hash) = first.ledger_head();
+    let promoted = SharedLayoutHost::take_over(
+        HostSession::resume_with_session_name(
+            first_transport.clone(),
+            session_id.clone(),
+            String::from("lisbon"),
+            1,
+        )
+        .expect("host session"),
+        first
+            .pane_server(session_id.clone())
+            .expect("pane service")
+            .clone(),
+        before,
+        (next_seq, prev_hash),
+        DEFAULT_RESERVATION_TIMEOUT,
+    )
+    .expect("takeover");
+
+    let commit = promoted
+        .announce_takeover(ticket.endpoint_addr().id.as_bytes().to_vec())
+        .expect("a takeover is recorded like any other change");
+    let entry = commit.entry.expect("a commit carries its entry");
+
+    assert_eq!(
+        entry.seq, next_seq,
+        "the successor picks up where this member had got to, not at 1"
+    );
+    assert_eq!(entry.prev_hash, prev_hash.to_vec());
+    assert_eq!(entry.coordinator_epoch, 1);
+    assert_eq!(entry.kind, LedgerEntryKind::CoordinatorChange as i32);
+
+    let record = p2pmux::protocol::CoordinatorChangeRecord::decode(entry.payload.as_slice())
+        .expect("the payload is a coordinator-change record");
+    assert_eq!(
+        record.replaced_peer_id,
+        ticket.endpoint_addr().id.as_bytes().to_vec()
+    );
+    assert_eq!(record.epoch, 1);
+
+    // A member that made the same decision independently, and so rotated onto this key,
+    // accepts what it seals. That is the only thing that makes the entry believable: the
+    // coordinator it replaces never signed anything approving of it.
+    let mut rotated = LedgerVerifier::new(session_id.clone(), ticket.endpoint_addr().id);
+    rotated
+        .rotate(promoted.ticket().endpoint_addr().id, 1)
+        .expect("the member decided on this successor");
+    assert_eq!(rotated.accept(&entry), Ok(()));
+
+    // One that did not rotate refuses it, and says why: wrong coordinator, not a forgery.
+    let mut following_the_old_one = LedgerVerifier::new(session_id, ticket.endpoint_addr().id);
+    assert_eq!(
+        following_the_old_one.accept(&entry),
+        Err(p2pmux::ledger::LedgerError::WrongEpoch {
+            current: 0,
+            found: 1
+        })
+    );
+
+    first_transport.close().await;
+}
+
+#[test]
+fn the_wire_version_gates_peers_that_cannot_read_an_epoch() {
+    // A v9 peer parses the new welcome and the new entries, and silently reads every epoch
+    // as 0 -- which is exactly the confusion the epoch exists to prevent. The version bump
+    // is what keeps it out.
+    assert_eq!(PROTOCOL_VERSION, 10);
+}

--- a/tests/layout.rs
+++ b/tests/layout.rs
@@ -38,6 +38,95 @@ fn removing_a_member_atomically_prunes_its_panes_and_empty_tabs() {
     SessionState::validate_snapshot(&snapshot).expect("departure leaves a valid snapshot");
 }
 
+#[test]
+fn a_restored_state_is_the_one_the_room_was_already_looking_at() {
+    // What a promoted member inherits. Not a fresh session that happens to have the same
+    // people in it -- the same tabs, panes and join order, at the same revision.
+    let mut original = state();
+    original
+        .add_member(original.revision(), HOST_B.to_vec(), ADDR_B.to_vec())
+        .expect("member B joins");
+    original
+        .create_tab(HOST_B, original.revision(), 24, 80)
+        .expect("B creates a tab");
+    let before = snapshot(&original);
+
+    let restored = SessionState::restore(before.clone()).expect("a committed layout restores");
+
+    assert_eq!(snapshot(&restored), before);
+    assert_eq!(restored.revision(), original.revision());
+    assert_eq!(
+        restored
+            .members()
+            .iter()
+            .map(|member| member.peer_id.clone())
+            .collect::<Vec<_>>(),
+        vec![HOST_A.to_vec(), HOST_B.to_vec()],
+        "join order is the succession order, so it has to survive verbatim"
+    );
+}
+
+#[test]
+fn a_restored_state_issues_ids_past_the_ones_already_in_use() {
+    // Resuming the counters from zero would hand a new pane the id of one somebody is
+    // currently typing into.
+    let mut original = state();
+    original
+        .add_member(original.revision(), HOST_B.to_vec(), ADDR_B.to_vec())
+        .expect("member B joins");
+    original
+        .create_tab(HOST_B, original.revision(), 24, 80)
+        .expect("B creates a tab");
+    let highest_pane = *snapshot(&original).panes.keys().max().expect("panes exist");
+
+    let mut restored = SessionState::restore(snapshot(&original)).expect("restores");
+    let reservation = restored
+        .reserve_tab(HOST_A, restored.revision(), 24, 80)
+        .expect("the new coordinator can still create");
+
+    assert!(
+        reservation.pane_id > highest_pane,
+        "a pane created after the takeover must not collide with one created before it"
+    );
+}
+
+#[test]
+fn a_restored_state_keeps_the_departed_coordinator_and_its_panes() {
+    // The design calls for unavailable placeholders, not a layout that rearranges itself
+    // under people. It also has to hold in the two-person case, where evicting the
+    // coordinator's panes would leave the survivor looking at nothing at all.
+    let mut original = state();
+    original
+        .add_member(original.revision(), HOST_B.to_vec(), ADDR_B.to_vec())
+        .expect("member B joins");
+    let before = snapshot(&original);
+    assert!(
+        before
+            .panes
+            .values()
+            .all(|pane| pane.host_peer_id == HOST_A),
+        "only the coordinator hosts anything, which is the case that would break"
+    );
+
+    let restored = SessionState::restore(before).expect("restores");
+
+    assert_eq!(restored.members().len(), 2);
+    assert_eq!(restored.panes().count(), 1);
+}
+
+#[test]
+fn a_layout_that_would_be_refused_from_a_peer_is_refused_from_a_successor_too() {
+    // A takeover is not a way to smuggle in a layout the validator would reject: the
+    // successor is a member like any other and does not get to invent state.
+    let mut malformed = snapshot(&state());
+    malformed.revision = 0;
+
+    assert_eq!(
+        SessionState::restore(malformed),
+        Err(LayoutError::InvalidSnapshot)
+    );
+}
+
 fn tab(snapshot: &LayoutSnapshot, tab_id: u64) -> &p2pmux::layout::Tab {
     snapshot
         .tabs

--- a/tests/module_surface.rs
+++ b/tests/module_surface.rs
@@ -1,5 +1,6 @@
 use p2pmux::{
     cli::Cli,
+    failover::Election,
     protocol::{Envelope, PROTOCOL_VERSION},
     pty_host::PtyHost,
     session::HostSession,
@@ -17,5 +18,8 @@ fn exposes_the_scaffold_module_boundaries() {
     let _: Option<JoinTicket> = None;
     let _: Option<HostSession> = None;
     let _: Option<Envelope> = None;
-    assert_eq!(PROTOCOL_VERSION, 9);
+    let _: Option<Election> = None;
+    // Bumped by the coordinator epoch, which every welcome and every ledger entry now
+    // carries: a peer on 9 cannot tell which coordinator sealed what it is being sent.
+    assert_eq!(PROTOCOL_VERSION, 10);
 }

--- a/tests/protocol.rs
+++ b/tests/protocol.rs
@@ -54,8 +54,11 @@ fn envelope(body: envelope::Body) -> Envelope {
 }
 
 #[test]
-fn protocol_version_is_v9() {
-    assert_eq!(PROTOCOL_VERSION, 9);
+fn protocol_version_is_v10() {
+    // v10 added the coordinator epoch to the welcome and to every ledger entry. A v9 peer
+    // cannot tell which coordinator sealed what it is being handed, so it must not be let in
+    // rather than be left guessing.
+    assert_eq!(PROTOCOL_VERSION, 10);
 }
 
 #[test]

--- a/tests/protocol.rs
+++ b/tests/protocol.rs
@@ -32,6 +32,7 @@ fn ledger_entry() -> LedgerEntry {
         payload: b"payload".to_vec(),
         author_signature: Vec::new(),
         coordinator_signature: vec![7; LEDGER_SIGNATURE_BYTES],
+        coordinator_epoch: 0,
     }
 }
 
@@ -64,6 +65,7 @@ fn welcome_session_name_round_trips_and_defaults_empty() {
         admitted_peer_id: b"peer-a".to_vec(),
         coordinator_peer_id: b"peer-host".to_vec(),
         session_name: "lisbon".to_owned(),
+        coordinator_epoch: 0,
     }));
     assert_eq!(decode_frame(&encode_frame(&named).unwrap()).unwrap(), named);
 
@@ -72,6 +74,7 @@ fn welcome_session_name_round_trips_and_defaults_empty() {
         admitted_peer_id: b"peer-a".to_vec(),
         coordinator_peer_id: b"peer-host".to_vec(),
         session_name: String::new(),
+        coordinator_epoch: 0,
     }));
     let decoded = decode_frame(&encode_frame(&legacy).unwrap()).unwrap();
     let Some(envelope::Body::Welcome(welcome)) = decoded.body else {
@@ -232,6 +235,7 @@ fn envelope_exposes_each_v1_body() {
             admitted_peer_id: b"peer-a".to_vec(),
             coordinator_peer_id: b"peer-host".to_vec(),
             session_name: String::new(),
+            coordinator_epoch: 0,
         })),
         envelope(envelope::Body::Input(Input {
             pane_id: b"pane-a".to_vec(),
@@ -360,6 +364,7 @@ fn sample_envelopes() -> Vec<Envelope> {
             admitted_peer_id: b"peer-a".to_vec(),
             coordinator_peer_id: b"peer-host".to_vec(),
             session_name: String::new(),
+            coordinator_epoch: 0,
         })),
         envelope(envelope::Body::Input(Input {
             pane_id: b"pane-a".to_vec(),


### PR DESCRIPTION
Keeps a session alive when the coordinator's machine dies, and hands the role to a survivor.

**Verified across three machines:** coordinator on a nyc3 droplet, members on this Mac and a fra1 droplet, coordinator killed with `SIGKILL`. 15/15 checks — panes kept working with nobody coordinating, the Mac took the role over on its own, fra1 found it without being handed anything, and a split committed by the new coordinator landed on both.

## Why

A lost coordinator never ended a session — panes run on their own hosts and settle their own control leases, so they keep rendering and keep taking input. What it did was freeze everything the coordinator serializes (layout edits, joins, presence) *permanently*, with no way back: `LedgerVerifier` is anchored on the coordinator key from the join ticket, so no successor's signature could ever be accepted.

## The three decisions that shaped it

**Nobody hands the role over.** A departed coordinator can't nominate a successor or sign anything attesting to one. So the decision has to be reachable independently by every member and come out the same. The committed layout already holds members in join order; that ranking becomes *staggered time* rather than a vote, because members have no shared view of who is still reachable — one hosting no panes may hold no peer connections at all.

**A claim proves nothing.** Every ledger entry now carries the coordinator epoch that sealed it, covered by the signed hash. A verifier rotates onto a new key only when its own election already agreed. A peer answering the door proves it's alive and holds the session secret, not that the room elected it.

**Rejoining needs no new protocol.** Ticket v3 carries 32 random bytes every member already holds, so a survivor rebuilds a ticket from that plus the successor's address out of the layout and joins through the existing path.

## Two bugs this surfaced

- `join_layout_with_display_name` closed the whole **transport** on failure, not just the connection. Harmless when the caller bound one immediately beforehand; catastrophic once a running node reuses its own — one failed dial took down every pane subscription and any chance of promotion. Only reproduces on real machines, where dials to a dead peer fail repeatedly.
- Rejoining hit `AlreadyMember`, because `add_member` refuses a peer it already has. Pre-existing — any dropped control stream hit it — but a takeover makes it universal, since every survivor rejoins into a member list that already lists them.

## Costs, stated plainly

- **The invite does not survive.** The join code is sealed under a secret only the session's creator holds. The successor mints a new ticket and code; an invite already pasted into a chat stops working. Replicating that secret to every member would let any of them redirect the session's invite.
- **Wire version 10.** A v9 peer reads every epoch as `0`, which is the exact confusion the epoch prevents, so it is kept out rather than left guessing.
- **The departed coordinator's panes stay** as unavailable placeholders rather than being evicted. Removing them would rearrange the layout under people, and in a two-person session where only the coordinator hosted anything it would leave no layout at all.
- A promoted node starts the session **unlocked** — the lock is the old coordinator's live setting, not a fact about the layout.

## Testing

`tests/failover.rs` (3 tests, real loopback endpoints), 14 unit tests in `src/failover.rs`, 4 in `src/ledger.rs`, 4 in `tests/layout.rs`, and `scripts/e2e/scenario_v_failover.py` for the cross-machine run. Grace is overridable via `P2PMUX_FAILOVER_GRACE_SECS` (range-checked, so a typo can't shorten a real session's window).

Docs updated: `MVP_DESIGN.md` and `SPIKE_PLAN.md` now record failover as built, including where it departs from the original spec and why.