### PR TITLE
fix(inbox): land on the agent's tab whole, not zoomed over it

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -309,11 +309,16 @@ Each row is a status dot, the machine the agent is on, the agent, its state, wha
 was doing, and how long it has been in that state. Rows sort blocked → done → running → idle: a
 row that needs you never appears below one that does not, and that is the point of the screen.
 
+Opening a row puts you on the tab that agent lives on, focused on its pane, with the rest of that
+tab drawn around it. The focused pane's border says which one you landed in, so there is nothing
+to hunt for, and the panes it shares the tab with stay where you left them. Use `Ctrl+P` then `z`
+if you want the agent alone on screen.
+
 | Key | Does |
 |-----|------|
 | `Ctrl+O` | The inbox, from anywhere including inside a live terminal |
 | `Ctrl+A` | The same, kept for the muscle memory the old agents overlay built |
-| `Enter` | Open the selected agent's terminal, full screen |
+| `Enter` | Go to the selected agent's tab and focus its pane |
 | `n` | New terminal on this machine |
 | `m` | Expand the machine list |
 | `↑` `↓` | Move the selection |

--- a/src/tui/home.rs
+++ b/src/tui/home.rs
@@ -288,7 +288,7 @@ impl MultiPaneTui {
         vec![UiIntent::FocusPane { pane_id }]
     }
 
-    /// The pane drawn alone, when Home handed the user into one.
+    /// The pane drawn alone, when the user asked for one with `Ctrl+P` `z`.
     ///
     /// Cleared whenever the pane stops existing or focus moves elsewhere, so a
     /// stale zoom can never hide the rest of a tab.
@@ -304,11 +304,11 @@ impl MultiPaneTui {
 
     /// Give the focused pane the whole content area, or give it back.
     ///
-    /// The same local view state Home already uses to hand you into an agent,
-    /// reachable on purpose rather than only as a side effect of arriving from
-    /// the inbox. Nothing about the layout changes: the pane keeps the grid the
-    /// session gave it and simply stops sharing the screen with its siblings,
-    /// so no other member sees anything happen.
+    /// The only way into a zoom now that the inbox stopped arriving in one, so
+    /// a pane is alone on screen because the user asked for that and not as a
+    /// side effect of how they got there. Nothing about the layout changes: the
+    /// pane keeps the grid the session gave it and simply stops sharing the
+    /// screen with its siblings, so no other member sees anything happen.
     ///
     /// A tab with one pane is already zoomed, so the key does nothing there
     /// rather than lighting a badge that describes no change.
@@ -775,23 +775,37 @@ mod tests {
         );
     }
 
-    /// A zoom the user asked for on one tab must not follow them into the tab
-    /// the inbox hands them next.
+    /// A zoom the user asked for earlier must not still be up on the pane the
+    /// inbox hands them next.
+    ///
+    /// The leftover has to be on *that* pane to say anything: `zoomed_pane()`
+    /// reports a zoom only while it is also the focused pane, so a zoom parked
+    /// on some other pane reads as `None` whether or not anything cleared it.
+    ///
+    /// Set here directly because every real door into Home — `Ctrl+O`,
+    /// `Ctrl+A`, stepping left off the first tab, the inbox badge — clears the
+    /// zoom on the way in. The guarantee is pinned on the path that lands the
+    /// user rather than on four callers each remembering.
     #[test]
     fn enter_stands_down_a_zoom_left_over_from_an_earlier_visit() {
         let mut tui = home_tui(&[
             ("laptop", "claude", AgentRosterState::Working),
             ("desktop", "claude", AgentRosterState::Pending),
         ]);
-        tui.select_pane(1, 1, "test");
-        tui.zoomed_pane = Some(1);
-        assert_eq!(tui.zoomed_pane(), Some(1));
+        // The pending agent sorts to the top row, so it is the one Enter opens.
+        tui.select_pane(2, 2, "test");
+        tui.zoomed_pane = Some(2);
+        assert_eq!(tui.zoomed_pane(), Some(2));
 
         tui.set_home_open(true, "test");
         tui.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE), AREA);
 
-        assert_eq!(tui.focused_pane(), 2);
-        assert_eq!(tui.zoomed_pane(), None);
+        assert_eq!(tui.focused_pane(), 2, "the row the inbox opened");
+        assert_eq!(
+            tui.zoomed_pane(),
+            None,
+            "the leftover zoom is stood down, not carried into the tab"
+        );
     }
 
     #[test]

--- a/src/tui/home.rs
+++ b/src/tui/home.rs
@@ -250,12 +250,18 @@ impl MultiPaneTui {
         self.ensure_home_selection_visible();
     }
 
-    /// Enter: leave Home and land in the selected agent's terminal, alone on
-    /// screen.
+    /// Enter: leave Home and land in the selected agent's terminal, on the tab
+    /// it lives on, with the rest of that tab still around it.
     ///
-    /// Full screen rather than the pane grid, because Home is what you open and
-    /// the terminal is what you land in — arriving in a four-way split means
-    /// hunting for the agent you just selected by name.
+    /// It used to arrive zoomed, on the argument that a four-way split means
+    /// hunting for the agent you just selected by name. It does not: the
+    /// focused pane carries its own border color, so the pane you landed in is
+    /// the one thing on the tab that cannot be missed. What the zoom cost was
+    /// the context. The siblings vanished, and because a zoom only holds while
+    /// it is the focused pane, the next focus change stood it down and the rest
+    /// of the tab appeared a beat later unasked — which reads as a glitch, not
+    /// as a choice. `Ctrl+P` then `z` is still there for anyone who wants the
+    /// pane alone on screen, now as something the user asks for.
     pub(in crate::tui) fn open_home_selection(&mut self) -> Vec<UiIntent> {
         let Some(pane_id) = self.home_selected else {
             return Vec::new();
@@ -274,7 +280,10 @@ impl MultiPaneTui {
         };
         let tab_id = tab.tab_id;
         self.select_pane(tab_id, pane_id, "home_enter");
-        self.zoomed_pane = Some(pane_id);
+        // A zoom left over from an earlier visit is stood down rather than
+        // carried into the tab the inbox just chose: arriving with a sibling
+        // hidden is the thing this path stopped doing.
+        self.clear_zoom();
         self.set_home_open(false, "enter");
         vec![UiIntent::FocusPane { pane_id }]
     }
@@ -548,8 +557,12 @@ mod tests {
 
     use super::{home_layout, machine_lines, machine_rows};
     use crate::{
+        layout::{Axis, Node, Tab},
         protocol::AgentRosterState,
-        tui::{KeyHandling, MultiPaneTui, UiIntent, test_support::home_tui},
+        tui::{
+            KeyHandling, MultiPaneTui, UiIntent,
+            test_support::{agent_row, home_tui, layout},
+        },
     };
 
     const AREA: Rect = Rect {
@@ -722,14 +735,63 @@ mod tests {
         assert_eq!(tui.focused_pane(), 1);
         assert_eq!(
             tui.zoomed_pane(),
-            Some(1),
-            "Enter lands in the terminal full screen, not in the pane grid"
+            None,
+            "Enter lands in the agent's pane on its tab, not zoomed over it"
         );
+    }
+
+    /// The fixture the other Home tests use gives every agent a tab to itself,
+    /// so only a tab with a sibling can say whether the sibling is drawn.
+    #[test]
+    fn enter_draws_the_rest_of_the_agents_tab_around_it() {
+        let mut tui = MultiPaneTui::new(layout(
+            vec![Tab {
+                tab_id: 7,
+                root: Node::Split {
+                    axis: Axis::LeftRight,
+                    first_share_bps: crate::layout::DEFAULT_FIRST_SHARE_BPS,
+                    first: Box::new(Node::Leaf { pane_id: 1 }),
+                    second: Box::new(Node::Leaf { pane_id: 2 }),
+                },
+                title: None,
+            }],
+            &[(1, 2, 8), (2, 2, 8)],
+        ))
+        .expect("valid layout");
+        tui.set_agent_rows(vec![agent_row(2, 1, 2)]);
+        tui.repair_home_selection();
+        tui.set_home_open(true, "test");
+
+        assert_eq!(
+            tui.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE), AREA),
+            KeyHandling::Consumed(vec![UiIntent::FocusPane { pane_id: 2 }])
+        );
+        assert_eq!(tui.current_tab(), 7, "Enter goes to the agent's tab");
+        assert_eq!(tui.focused_pane(), 2, "and focuses the agent's pane");
         assert_eq!(
             tui.geometry(AREA).panes.len(),
-            1,
-            "nothing else on that tab is drawn while the agent is zoomed"
+            2,
+            "the pane it shares that tab with is still drawn"
         );
+    }
+
+    /// A zoom the user asked for on one tab must not follow them into the tab
+    /// the inbox hands them next.
+    #[test]
+    fn enter_stands_down_a_zoom_left_over_from_an_earlier_visit() {
+        let mut tui = home_tui(&[
+            ("laptop", "claude", AgentRosterState::Working),
+            ("desktop", "claude", AgentRosterState::Pending),
+        ]);
+        tui.select_pane(1, 1, "test");
+        tui.zoomed_pane = Some(1);
+        assert_eq!(tui.zoomed_pane(), Some(1));
+
+        tui.set_home_open(true, "test");
+        tui.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE), AREA);
+
+        assert_eq!(tui.focused_pane(), 2);
+        assert_eq!(tui.zoomed_pane(), None);
     }
 
     #[test]

--- a/src/tui/multi_pane/mod.rs
+++ b/src/tui/multi_pane/mod.rs
@@ -373,10 +373,10 @@ impl MultiPaneTui {
                 .saturating_sub(tab_bar.height + tab_bar_gap + footer_height),
         );
         let mut panes = BTreeMap::new();
-        // A pane opened from Home gets the whole content area to itself. This is
-        // a local view choice and never reaches the layout, so the pane keeps
-        // the fixed grid the shared layout gave it and simply stops sharing the
-        // screen with its siblings.
+        // A zoomed pane gets the whole content area to itself. This is a local
+        // view choice and never reaches the layout, so the pane keeps the fixed
+        // grid the shared layout gave it and simply stops sharing the screen
+        // with its siblings.
         if let Some(pane_id) = self.zoomed_pane() {
             panes.insert(pane_id, content);
         } else if let Some(tab) = self.current_tab_layout() {


### PR DESCRIPTION
## What

Enter on an inbox row (and a click on one) used to set `zoomed_pane`, so the pane the row named arrived alone on screen with the rest of its tab undrawn. Now it switches to the agent's tab, focuses its pane, and draws the tab it found.

## Why

The zoom was deliberate — the comment on `open_home_selection` argued that arriving in a four-way split means hunting for the agent you just selected by name. That argument no longer holds: the focused pane carries its own border color, so the pane you landed in is the one thing on the tab that cannot be missed.

What the zoom cost was worse than what it bought. `zoomed_pane()` only reports a zoom while it is *also* the focused pane, so the next focus change stood it down and the siblings appeared a beat later without being asked for. Arriving into a pane and watching the tab assemble itself around it reads as a glitch, not as a choice.

`Ctrl+P` then `z` still zooms. It is now something the user asks for rather than something the inbox does on their behalf, and `enter_pane_from_home` clears a leftover zoom rather than carrying it into the tab the inbox just chose.

## Tests

- `arrows_move_the_selection_and_enter_lands_in_that_agents_terminal` — inverted; now asserts no zoom.
- `enter_draws_the_rest_of_the_agents_tab_around_it` — **new**. The shared `home_tui` fixture gives every agent a tab to itself, so its old "nothing else on that tab is drawn" assertion was vacuous; this one builds a two-pane split and checks the sibling is still in the geometry.
- `enter_stands_down_a_zoom_left_over_from_an_earlier_visit` — **new**.

## Review pass (`a7e710c`)

`enter_stands_down_a_zoom_left_over_from_an_earlier_visit` did not test what it was named for. It parked the zoom on pane 1 and had Enter open pane 2, but `zoomed_pane()` reports a zoom only while it is *also* the focused pane — so it read `None` whether or not `enter_pane_from_home` cleared anything. Deleting the `clear_zoom()` call the test exists to guard left the whole suite green. The leftover now sits on the pane the inbox actually opens, which is the only case where the raw field survives the getter's filter; deleting `clear_zoom()` fails it.

Three comments still described Home as the thing that zooms, and are retired: the doc comments on `zoomed_pane()` and `toggle_zoom()`, and the geometry comment on the branch that hands a zoomed pane the content area.

## Note

Built in a worktree off `d395ff5`. `origin/main` has since picked up the node-side zoom work that note referred to (`53d09ca`, `9f14fa0`) plus `6e4535a`; merged in at `354a4e8`, no conflicts. Together they make `Ctrl+P` `z` — the only way to zoom after this PR — reflow the PTY on both the attached and the detached path.

Gates on the merged branch: `cargo fmt --all -- --check` clean, `cargo clippy --all-targets --all-features -- -D warnings` clean, `cargo check --all-targets --all-features` clean, `cargo test --all-features` 389 lib + all integration suites passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UDs9NqTaJD4NAqWMd89h9b
