### PR TITLE
fix: stop mouse reports being typed into the pane they were not meant for

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -641,7 +641,10 @@ pub fn run_on(
                             if let Some(perf_id) = perf_id {
                                 crate::perf::log(&format!("P2PMUX_PERF id={perf_id} client_input"));
                             }
-                            write_message(&mut stream, &ClientMessage::Input { bytes, perf_id })?;
+                            write_message(
+                                &mut stream,
+                                &pane_input(tui.focused_pane(), bytes, perf_id),
+                            )?;
                             history.remove(&tui.focused_pane());
                             pending_scroll.remove(&tui.focused_pane());
                             desired_scroll.remove(&tui.focused_pane());
@@ -659,10 +662,7 @@ pub fn run_on(
                     }
                     write_message(
                         &mut stream,
-                        &ClientMessage::Input {
-                            bytes: text.into_bytes(),
-                            perf_id,
-                        },
+                        &pane_input(tui.focused_pane(), text.into_bytes(), perf_id),
                     )?;
                     history.remove(&tui.focused_pane());
                     pending_scroll.remove(&tui.focused_pane());
@@ -698,7 +698,10 @@ pub fn run_on(
                         .and_then(|handling| handling.forward_bytes);
                     if let Some(bytes) = forwarded {
                         let perf_id = next_perf_id_if_enabled(&mut next_perf_id);
-                        write_message(&mut stream, &ClientMessage::Input { bytes, perf_id })?;
+                        write_message(
+                            &mut stream,
+                            &pane_input(tui.focused_pane(), bytes, perf_id),
+                        )?;
                     } else {
                         let pane_id =
                             tui.pane_at_or_focused_for_mouse(mouse.column, mouse.row, area);
@@ -743,6 +746,9 @@ pub fn run_on(
                         }
                     }
                 } else {
+                    // Read before the click, which is allowed to move focus: the
+                    // report was encoded against the pane that had focus then.
+                    let addressed = tui.focused_pane();
                     let handling = tui.handle_mouse(
                         mouse,
                         area,
@@ -754,7 +760,7 @@ pub fn run_on(
                     }
                     if let Some(bytes) = handling.forward_bytes {
                         let perf_id = next_perf_id_if_enabled(&mut next_perf_id);
-                        write_message(&mut stream, &ClientMessage::Input { bytes, perf_id })?;
+                        write_message(&mut stream, &pane_input(addressed, bytes, perf_id))?;
                     }
                     send_intents(&mut stream, tui, handling.intents, &mut pending_focus)?;
                     if handling.copy_selection_requested {
@@ -818,6 +824,20 @@ fn refresh_tui_timers(
         dirty = true;
     }
     dirty
+}
+
+/// Bytes addressed to the pane they were encoded for.
+///
+/// Every byte this client sends was shaped by one pane's state -- its keyboard
+/// mode, its xterm mouse mode -- so it names that pane rather than letting the
+/// node re-decide from its own focus, which lags this one by a round trip after
+/// every pane the session creates.
+fn pane_input(pane_id: u64, bytes: Vec<u8>, perf_id: Option<u64>) -> ClientMessage {
+    ClientMessage::Input {
+        bytes,
+        pane_id: Some(pane_id),
+        perf_id,
+    }
 }
 
 /// The mouse reporting the focused pane's child has turned on, if any.

--- a/src/client.rs
+++ b/src/client.rs
@@ -1689,6 +1689,24 @@ mod tests {
     }
 
     #[test]
+    fn an_echoed_focus_lets_the_pane_created_next_take_focus() {
+        let mut tui = None;
+        // The click landed on the pane the node had already focused, so the echo
+        // that releases this hold is one the node only sends because it answers
+        // every focus request rather than only the ones that moved it.
+        let mut pending_focus = Some((1, 2));
+        apply_focus_snapshot(&mut tui, layout(&[1, 2]), 1, 2, &mut pending_focus);
+        assert_eq!(pending_focus, None);
+
+        let mut created = layout(&[1, 2, 3]);
+        created.revision = 2;
+        apply_focus_snapshot(&mut tui, created, 1, 3, &mut pending_focus);
+
+        let tui = tui.unwrap();
+        assert_eq!((tui.current_tab(), tui.focused_pane()), (1, 3));
+    }
+
+    #[test]
     fn snapshot_focus_replaces_pending_focus_when_layout_removes_it() {
         let mut tui = None;
         let mut pending_focus = Some((1, 2));

--- a/src/local_ipc.rs
+++ b/src/local_ipc.rs
@@ -27,6 +27,19 @@ pub enum ClientMessage {
     },
     Input {
         bytes: Vec<u8>,
+        /// The pane the client encoded these bytes for.
+        ///
+        /// Input is only meaningful next to the pane it was aimed at: a key is
+        /// encoded against that pane's keyboard mode and a mouse report against
+        /// its xterm mouse mode, and a report the addressed child asked for is
+        /// line noise typed into any other one. Routing by the node's own focus
+        /// instead loses exactly that during the round trip that follows a new
+        /// pane, when the two ends briefly disagree about where focus is.
+        ///
+        /// Omitted by clients older than this field; those still route to
+        /// whatever the node has focused.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pane_id: Option<u64>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         perf_id: Option<u64>,
     },

--- a/src/node.rs
+++ b/src/node.rs
@@ -500,13 +500,17 @@ fn run_socket_loop(
         let mut full_snapshot = false;
         if !shutdown && let Some(client) = client.as_mut() {
             match read_message(&mut client.reader) {
-                Ok(Some(ClientMessage::Input { bytes, perf_id })) => {
-                    let focused_pane = node.local_focus().1;
-                    node.input(bytes)
+                Ok(Some(ClientMessage::Input {
+                    bytes,
+                    pane_id,
+                    perf_id,
+                })) => {
+                    let target = node
+                        .input(pane_id, bytes)
                         .map_err(|error| io::Error::other(error.to_string()))?;
-                    client
-                        .publish
-                        .arm_target_urgency(focused_pane, Instant::now());
+                    if let Some(target) = target {
+                        client.publish.arm_target_urgency(target, Instant::now());
+                    }
                     client.publish.perf_id = perf_id;
                     if let Some(perf_id) = perf_id {
                         crate::perf::log(&format!("P2PMUX_PERF id={perf_id} node_input"));
@@ -1444,8 +1448,14 @@ impl SharedLayoutNode {
         self.runtime.drain_node()
     }
 
-    pub fn input(&mut self, bytes: Vec<u8>) -> Result<(), Box<dyn Error>> {
-        self.runtime.node_input(bytes)
+    /// Deliver a client's bytes to the pane it named, or to this node's focus
+    /// when the client named none. Returns the pane they reached, if any.
+    pub fn input(
+        &mut self,
+        pane_id: Option<u64>,
+        bytes: Vec<u8>,
+    ) -> Result<Option<u64>, Box<dyn Error>> {
+        self.runtime.node_input(pane_id, bytes)
     }
     pub fn local_peer_id(&self) -> Vec<u8> {
         self.runtime.local_peer_id()
@@ -1631,6 +1641,7 @@ mod tests {
         let (mut writer, stream) = UnixStream::pair().unwrap();
         let mut frames = serde_json::to_vec(&ClientMessage::Input {
             bytes: b"first".to_vec(),
+            pane_id: Some(1),
             perf_id: None,
         })
         .unwrap();
@@ -1976,7 +1987,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn local_focus_reads_runtime_state_without_drain() {
+    async fn focus_reads_runtime_state_and_input_lands_on_the_pane_the_client_named() {
         let host = SharedLayoutHost::new(HostSession::create().await.unwrap(), 2, 8).unwrap();
         let panes = host.pane_server();
         let host_peer_id = host.ticket().endpoint_addr().id.as_bytes().to_vec();
@@ -2032,6 +2043,18 @@ mod tests {
         node.focus(1, 2).unwrap();
 
         assert_eq!(node.local_focus(), (1, 2));
+
+        // Input goes where the client aimed it, not where this node happens to
+        // be looking -- the two disagree for one round trip after every new
+        // pane, and that is exactly when a mouse report encoded for one pane
+        // would otherwise be typed into another.
+        assert_eq!(
+            node.input(Some(1), b"\x1b[<35;1;1M".to_vec()).unwrap(),
+            Some(1)
+        );
+        // A client too old to name a pane still gets the node's focus.
+        assert_eq!(node.input(None, b"x".to_vec()).unwrap(), Some(2));
+
         tokio::task::block_in_place(|| node.shutdown());
     }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -598,6 +598,14 @@ fn run_socket_loop(
                 Ok(Some(ClientMessage::Focus { tab_id, pane_id })) => {
                     node.focus(tab_id, pane_id)
                         .map_err(|error| io::Error::other(error.to_string()))?;
+                    // Answer the request even when it asked for the focus this node
+                    // already had. The client holds its own optimistic focus until it
+                    // sees the node say the same thing back, and focus is otherwise
+                    // published only when it changes -- so a request that changed
+                    // nothing would never be answered, and that client would pin
+                    // itself to that pane and refuse every later focus, including the
+                    // one that follows a freshly created pane.
+                    client.publish.reannounce_focus();
                     changed = true;
                 }
                 Ok(Some(ClientMessage::Detach {
@@ -1076,6 +1084,17 @@ impl AttachmentPublishState {
         self.target_urgency = Some((pane_id, now + TARGET_SCREEN_URGENCY_TTL));
     }
 
+    /// Whether this client still has to be told where the focus is.
+    fn focus_due(&self, focus: (u64, u64)) -> bool {
+        self.focus != Some(focus)
+    }
+
+    /// Forget what this client was last told about focus, so the next publish
+    /// says it again even though nothing moved.
+    fn reannounce_focus(&mut self) {
+        self.focus = None;
+    }
+
     fn reset_for_snapshot(&mut self) {
         self.layout = None;
         self.leases = None;
@@ -1211,7 +1230,7 @@ fn queue_updates(
         publish.presence = Some(presence);
         published = true;
     }
-    if publish.focus != Some(focus) {
+    if publish.focus_due(focus) {
         if !queue_update(
             writer,
             publish,
@@ -1684,6 +1703,22 @@ mod tests {
         assert!(periodic_drain_due(Some(now), now + PERIODIC_DRAIN_INTERVAL));
         // Draining faster than the client can be sent frames is wasted parse/diff work.
         assert!(PERIODIC_DRAIN_INTERVAL >= TARGET_SCREEN_PUBLISH_INTERVAL);
+    }
+
+    #[test]
+    fn a_focus_request_is_answered_even_when_it_asks_for_the_focus_we_have() {
+        let mut publish = AttachmentPublishState {
+            focus: Some((1, 2)),
+            ..Default::default()
+        };
+        // Nothing moved, so ordinarily there is nothing to say.
+        assert!(!publish.focus_due((1, 2)));
+        // A client that asked for this pane is holding its own optimistic focus
+        // until it hears the node agree. Left unanswered it holds it forever and
+        // rejects every later focus, so the answer goes out even though the focus
+        // did not change.
+        publish.reannounce_focus();
+        assert!(publish.focus_due((1, 2)));
     }
 
     #[test]

--- a/src/session.rs
+++ b/src/session.rs
@@ -15,7 +15,9 @@ use std::{
 
 use iroh::{
     EndpointAddr, EndpointId,
-    endpoint::{ConnectingError, Connection, Incoming, SendStream},
+    endpoint::{
+        ConnectingError, Connection, ConnectionError, Incoming, SendStream, VarInt, WriteError,
+    },
 };
 use prost::Message as _;
 use tokio::{
@@ -3422,11 +3424,37 @@ fn expected_service_error(error: &SessionError) -> bool {
     )
 }
 
+/// Whether a serve loop ended because the subscriber hung up, rather than
+/// because something went wrong.
+///
+/// A guest that detaches closes its connection, and which call notices depends
+/// on what the host was doing at that instant. Reading the guest's next frame
+/// fails, which is the common case -- but a host in the middle of pushing a
+/// screen sees the close on the stream it was opening or writing instead. Same
+/// event, three shapes; only the first was recognised, so a clean detach could
+/// surface to the operator as a pane-connection error and redden a test that
+/// asserts a served subscription ended cleanly.
+///
+/// Every close this protocol sends carries code 0, so a peer that closed with
+/// any other code is saying something and is still worth reporting.
 fn is_normal_peer_disconnect(result: &Result<(), SessionError>) -> bool {
-    matches!(
-        result,
-        Err(SessionError::Transport(TransportError::StreamRead(_)))
-    )
+    match result {
+        Err(SessionError::Transport(TransportError::StreamRead(_))) => true,
+        Err(SessionError::Transport(TransportError::Stream(error))) => is_graceful_close(error),
+        Err(SessionError::Transport(TransportError::Write(WriteError::ConnectionLost(error)))) => {
+            is_graceful_close(error)
+        }
+        _ => false,
+    }
+}
+
+fn is_graceful_close(error: &ConnectionError) -> bool {
+    match error {
+        // Our own shutdown, racing a subscription that was still being served.
+        ConnectionError::LocallyClosed => true,
+        ConnectionError::ApplicationClosed(close) => close.error_code == VarInt::from_u32(0),
+        _ => false,
+    }
 }
 
 fn layout_queue_error<T>(error: mpsc::error::TrySendError<T>) -> LayoutControlQueueError {
@@ -4593,6 +4621,44 @@ mod control_queue_tests {
     use super::*;
     use crate::protocol::{AgentRosterEntry, AgentRosterState};
     use tokio::sync::oneshot;
+
+    #[test]
+    fn a_subscriber_hanging_up_mid_serve_is_not_a_service_error() {
+        use iroh::endpoint::ApplicationClose;
+
+        let hung_up = || {
+            ConnectionError::ApplicationClosed(ApplicationClose {
+                error_code: VarInt::from_u32(0),
+                reason: Default::default(),
+            })
+        };
+        let transport = |error| Err(SessionError::Transport(error));
+
+        // Noticed while reading the guest's next frame, while opening the stream
+        // for the next screen, or while writing one: one detach, three shapes.
+        assert!(is_normal_peer_disconnect(&transport(
+            TransportError::Stream(hung_up())
+        )));
+        assert!(is_normal_peer_disconnect(&transport(
+            TransportError::Write(WriteError::ConnectionLost(hung_up()))
+        )));
+        assert!(is_normal_peer_disconnect(&transport(
+            TransportError::Stream(ConnectionError::LocallyClosed)
+        )));
+
+        // A peer that closed with a code is saying something, and a connection
+        // that timed out did not hang up at all.
+        assert!(!is_normal_peer_disconnect(&transport(
+            TransportError::Stream(ConnectionError::ApplicationClosed(ApplicationClose {
+                error_code: VarInt::from_u32(7),
+                reason: Default::default(),
+            }))
+        )));
+        assert!(!is_normal_peer_disconnect(&transport(
+            TransportError::Stream(ConnectionError::TimedOut)
+        )));
+        assert!(!is_normal_peer_disconnect(&Ok(())));
+    }
 
     struct FailingWriter;
 

--- a/src/tui/multi_pane/mod.rs
+++ b/src/tui/multi_pane/mod.rs
@@ -550,6 +550,13 @@ impl MultiPaneTui {
     ) -> bool {
         let old_tab = self.current_tab;
         let old_pane = self.focused_pane;
+        if old_pane != pane_id {
+            // A press was forwarded to the pane that held focus, and the child
+            // there is waiting for its release. Focus moving out from under the
+            // gesture -- a peer's layout change, a pane created elsewhere --
+            // ends it: the release belongs to that child, not to the next one.
+            self.mouse_forwarding = false;
+        }
         self.current_tab = tab_id;
         self.focused_pane = pane_id;
         let unread_cleared = self.unread_agent_panes.remove(&pane_id);

--- a/src/tui/multi_pane/mouse.rs
+++ b/src/tui/multi_pane/mouse.rs
@@ -447,6 +447,28 @@ mod tests {
     }
 
     #[test]
+    fn focus_moving_mid_gesture_ends_the_forwarding_instead_of_releasing_elsewhere() {
+        let mut tui = MultiPaneTui::new(split_layout()).expect("layout");
+        let area = Rect::new(0, 0, 80, 24);
+        let protocol = reporting_child();
+
+        tui.handle_mouse(
+            left_mouse(MouseEventKind::Down(MouseButton::Left), 2, 3),
+            area,
+            protocol,
+        );
+        // The node moved focus while the button was still down.
+        tui.set_focus(1, 2).expect("the split has a second pane");
+        let up = tui.handle_mouse(
+            left_mouse(MouseEventKind::Up(MouseButton::Left), 4, 3),
+            area,
+            protocol,
+        );
+
+        assert_eq!(up.forward_bytes, None);
+    }
+
+    #[test]
     fn a_forwarded_press_keeps_the_drag_and_release_away_from_selection() {
         let mut tui = MultiPaneTui::new(split_layout()).expect("layout");
         let area = Rect::new(0, 0, 80, 24);

--- a/src/tui/runtime/node.rs
+++ b/src/tui/runtime/node.rs
@@ -36,10 +36,21 @@ impl SharedLayoutRuntime {
         self.drain()
     }
 
-    pub fn node_input(&mut self, bytes: Vec<u8>) -> Result<(), Box<dyn Error>> {
-        let pane_id = self.tui.focused_pane();
+    /// Deliver a client's bytes to the pane it addressed them to, and report
+    /// which pane that turned out to be.
+    ///
+    /// `pane_id` is `None` for a client too old to name one; that one still gets
+    /// this node's focus, which is what every client used to get. The pane comes
+    /// back so the caller can prioritise that pane's next screen without asking
+    /// focus a second question and getting a different answer.
+    pub fn node_input(
+        &mut self,
+        pane_id: Option<PaneId>,
+        bytes: Vec<u8>,
+    ) -> Result<Option<PaneId>, Box<dyn Error>> {
+        let pane_id = pane_id.unwrap_or_else(|| self.tui.focused_pane());
         if !self.input_allowed(pane_id) {
-            return Ok(());
+            return Ok(None);
         }
         if let Some(pane) = self.local.get_mut(&pane_id) {
             pane.input(bytes.clone())?;
@@ -48,7 +59,7 @@ impl SharedLayoutRuntime {
             pane.input(bytes);
         }
         self.tui.reset_scrollback(pane_id);
-        Ok(())
+        Ok(Some(pane_id))
     }
 
     pub fn release_all_local_control(&mut self) -> Result<(), Box<dyn Error>> {

--- a/tests/detach_resume_node.rs
+++ b/tests/detach_resume_node.rs
@@ -174,6 +174,9 @@ fn run_detach_resume_round_trip(
         &mut stream,
         &ClientMessage::Input {
             bytes: b"printf p2pmux-detach-roundtrip\\r".to_vec(),
+            // Addressed to the pane the client is looking at, the way the real
+            // client sends it, rather than left for the node to guess.
+            pane_id: Some(1),
             perf_id: None,
         },
     );

--- a/tests/local_ipc.rs
+++ b/tests/local_ipc.rs
@@ -43,6 +43,35 @@ fn agent_status_is_tagged_and_tolerates_a_producer_that_omits_cwd() {
 }
 
 #[test]
+fn input_names_the_pane_it_was_encoded_for_and_tolerates_a_client_that_cannot() {
+    let message = ClientMessage::Input {
+        bytes: b"\x1b[<35;12;5M".to_vec(),
+        pane_id: Some(7),
+        perf_id: None,
+    };
+    let value = serde_json::to_value(&message).unwrap();
+    assert_eq!(value["type"], "input");
+    assert_eq!(value["pane_id"], 7);
+    assert_eq!(
+        serde_json::from_value::<ClientMessage>(value).unwrap(),
+        message
+    );
+
+    // A client from before the field routes the way every client used to: to
+    // whatever the node has focused.
+    let unaddressed: ClientMessage =
+        serde_json::from_str(r#"{"type":"input","bytes":[120]}"#).expect("pane_id is optional");
+    assert_eq!(
+        unaddressed,
+        ClientMessage::Input {
+            bytes: b"x".to_vec(),
+            pane_id: None,
+            perf_id: None,
+        }
+    );
+}
+
+#[test]
 fn protocol_messages_are_tagged_and_attachment_is_generation_safe() {
     let message = NodeMessage::Snapshot {
         room_name: "lisbon".into(),


### PR DESCRIPTION
Creating a pane or a tab sometimes printed a burst of junk at a shell prompt — `35;32;46M35;32;45M35;32;41M…` — and sometimes left focus on the wrong pane.

## What that text is

The tail of an SGR mouse report, `\x1b[<35;32;46M`. Button code 35 is `32` (motion) + `3` (no button): a pointer move, at column 32, row 46. The rows walking 46 → 1 are one upward sweep of the mouse. A shell's line editor swallows the `ESC [ <` as an unmatched key sequence and inserts what is left as literal text.

## Why it lands in the wrong pane

Two processes decided where input goes, and pane creation is exactly when they disagreed.

- The **client** encoded it: `focused_pane_mouse_protocol` reads the mouse mode latched by *the client's* focused pane. With an agent or an editor there, that mode is `AnyMotion`, so crossterm's `Moved` events — `EnableMouseCapture` turns on `?1003h`, so there is one per cell of pointer travel — became reports.
- The **node** delivered it: `ClientMessage::Input` carried no pane id, so `node.input(bytes)` applied it to *the node's* focused pane.

Creating a pane moves the node's focus the moment the PTY spawns; the client only learns where focus went a round trip later, and that spawn also does a cwd lookup. Move the mouse in that window and reports encoded for the pane you came from are typed into the new shell. Keystrokes took the same wrong turn, silently.

Focus had a second, stickier bug. A client holds its optimistic focus until the node echoes it, but focus was published only when it *changed* — so a click on the pane the node had already focused (what you land on right after a new pane) was never answered. That client then vetoed every later focus and pinned itself to that pane for the rest of the session.

## The commits

1. **`fix(node)`** — answer a focus request even when it asks for the focus the node already has. Unsticks the veto.
2. **`fix(ipc)`** — the client names the pane it encoded for; the node delivers there. `pane_id` is optional on the wire, so an older client still routes to the node's focus exactly as before. The routed pane also drives the screen-urgency hint, instead of asking focus a second question and getting a different answer.
3. **`fix(mouse)`** — a gesture forwarded to a child ends when focus leaves the pane, instead of releasing a button on a child that never saw it pressed.
4. **`test(client)`** — the client half of 1: after the echo, the focus that follows a created pane is accepted.

## Deliberately not done

Dropping `?1003h` from `EnableMouseCapture` and enabling all-motion only while a child wants it would end the motion firehose at the source. It also ends hover: `pane_border_hovered` is painted from `Moved` events, so the pane under the pointer would stop highlighting. Not worth the trade, and with input addressed by pane the stray reports are gone anyway.

## Performance

No new work on the input path — one optional `u64` on a message that was already JSON per keystroke, and one fewer `local_focus()` call per input in the node loop. Redraw and publish cadence are untouched.

## Tests

`cargo fmt`, `cargo clippy --all-targets --all-features -D warnings`, and `cargo test --all-features` all run clean locally, except the known load-only flake `session_store::tests::a_node_too_busy_to_answer_keeps_its_record`, which passes in isolation and touches nothing here.

New coverage: wire compatibility for an unaddressed `Input`, routing to a named pane vs. the node's focus, the focus re-announcement, the client accepting a created pane's focus, and the released gesture. `tests/detach_resume_node.rs` now sends its input addressed, so the end-to-end path is exercised too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QqTAZjJFig8W1CnsusG7Mz