### PR TITLE
Make the inbox a screen for a fleet, not a list of processes

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -291,41 +291,89 @@ are Claude Code (`claude`), Codex (`codex`), Cursor Agent (including its `agent`
 ```
 p2pmux (paris) │ inbox 2 │ Tab #1 · Tab #2
 
- Agents · 2 need you
-
- ● desktop   claude   needs you   wants to run: rm -rf node_modules     2m
- ● droplet   codex    needs you   permission: write to /etc/hosts      12m
- ✓ laptop    codex    done        6 files changed, tests pass          31m
- ○ laptop    claude   running     editing the auth handler              4m
- ○ droplet   claude   running     running tests                        18m
- ○ desktop   cursor   running     state unknown — no hooks              7m
-
- laptop ✓   desktop ✓   droplet ✓   oldbox asleep
-
- enter open · n new terminal · m machines · q quit
+ Agents · 2 need you                                    │ MACHINES · 3
+                                                        │
+›● desktop    claude                  needs you    2m14s│ ● laptop
+   wants to run: rm -rf node_modules                    │   this machine · 2 agents
+   work/api · tab 1 · pane 2                            │
+                                                        │ ● droplet
+ ✗ laptop     codex                   error       1m02s │   1 agent
+   cargo test --all exited 101                          │
+   Desktop/p2pmux · tab 2 · pane 1                      │ ○ oldbox
+                                                        │   asleep
+ ✓ laptop     opencode                done        31m04s│
+   6 files changed, tests pass                          │
+   scratch/demo · tab 3 · pane 1                        │ ─────────────────────────
+                                                        │ a  add a machine
+ enter open · a add machine · n new terminal · q quit
 ```
 
-Each row is a status dot, the machine the agent is on, the agent, its state, what it last said it
-was doing, and how long it has been in that state. Rows sort blocked → done → running → idle: a
-row that needs you never appears below one that does not, and that is the point of the screen.
+Each agent gets a card: a status dot, the machine it is on, the agent, its state and how long it
+has been in that state; then its own words at whatever length it said them; then the repository it
+is in and the tab and pane `Enter` will put you on. Cards sort blocked → done → running → idle: an
+agent that needs you never appears below one that does not, and that is the point of the screen.
+
+The list is paged rather than scrolled, at most eight agents to a page, and the count beside the
+title is of the whole list — so a page you cannot see is never hiding something that needs you.
+A terminal too short for cards drops the location line, and then falls back to one line per agent.
 
 | Key | Does |
 |-----|------|
 | `Ctrl+O` | The inbox, from anywhere including inside a live terminal |
 | `Ctrl+A` | The same, kept for the muscle memory the old agents overlay built |
-| `Enter` | Open the selected agent's terminal, full screen |
+| `Enter` | Open the selected agent's terminal |
+| `a` | Add a machine to your fleet |
 | `n` | New terminal on this machine |
-| `m` | Expand the machine list |
 | `↑` `↓` | Move the selection |
+| `h` `l` | Turn the page, when there is more than one |
 | `q` | Quit |
 
 `Esc` is deliberately **not** the way back. Claude Code interrupts on it and vim needs it
 constantly, so swallowing it would break the terminal you just opened. Inside a pane every
 unmodified key belongs to the program running there.
 
-Left-clicking a row opens it. The mouse wheel scrolls the list. To retain readline's
+Left-clicking a card opens it. The mouse wheel turns the page. To retain readline's
 beginning-of-line shortcut, press `Ctrl+A` twice within 200ms to forward one Ctrl+A to the focused
 PTY instead.
+
+### The machines rail
+
+Every machine you have paired with is listed down the right-hand side for as long as the inbox is
+up: whether it is answering, whether it accepts work from your machines, and how many agents it is
+running. A machine that is paired but not in the session is one you own that is not answering, and
+it says `asleep` rather than disappearing.
+
+The rail takes width the agents were not using. A terminal too narrow for it puts the same table
+under the agents instead, and one too narrow for that falls back to a line of names and ticks —
+which still answers "is my fleet up", which is what earns it the space.
+
+`a` adds one, without leaving the screen:
+
+```
+╭─ Add a machine ────────────────────────────────────────────╮
+│                                                            │
+│  On the machine you want to add, run:                      │
+│                                                            │
+│  p2pmux pair 4KP7Q-M2XRW                                   │
+│                                                            │
+│  Not installed there yet? First run:                       │
+│  curl -fsSL https://p2pmux.com/install.sh | sh             │
+│                                                            │
+│  ⠹ waiting for it to join…                                 │
+│  Anyone who runs it gets a full shell here.                │
+│                                                            │
+│ <c> COPY   <Esc> CLOSE                                     │
+╰────────────────────────────────────────────────────────────╯
+```
+
+The panel stays up and reports the machine arriving, so the half of pairing that used to mean
+running something else somewhere else happens on the screen you started from. It is the same
+invite `Ctrl+S` hands out, so it carries the same warning: anyone who runs that line gets a full
+shell on this machine. Only the machine hosting the session can offer one; a member is told so.
+
+It records the session's ticket in `pairing.toml`, which is what makes bare `p2pmux` rejoin on
+both machines afterwards. It does not answer the accepts-work question — that is asked once, by
+`p2pmux pair`, and its answer is default-deny.
 
 The `inbox` badge in the tab bar carries the count of agents blocked on a human, in amber, so it
 stays visible while you are deep inside a terminal. It never shows a zero: absence is quieter and

--- a/src/client.rs
+++ b/src/client.rs
@@ -623,8 +623,14 @@ pub fn run_on(
                                 share_code.as_deref(),
                             ));
                         }
+                        if tui.take_pair_offer()
+                            && let Some(ticket) = share_ticket.as_deref()
+                            && let Err(error) = crate::pairing::offer(ticket)
+                        {
+                            share_notice = Some(format!("could not record the pairing: {error}"));
+                        }
                         // The notice belongs to one visit to the modal, not to the session.
-                        if !tui.share_open() {
+                        if !tui.share_open() && !tui.add_machine_open() {
                             share_notice = None;
                         }
                         dirty = true;

--- a/src/pairing.rs
+++ b/src/pairing.rs
@@ -167,6 +167,26 @@ pub fn save(pairing: &Pairing) -> Result<(), PairingError> {
     save_to(&pairing_path()?, pairing)
 }
 
+/// Record the session that machines paired from here will rejoin.
+///
+/// The one write that turns handing out a code into a pairing: without a
+/// ticket, bare `p2pmux` has nothing to rejoin and [`remember_peers`] declines
+/// to record the machines that turn up, so the fleet forgets a machine the
+/// moment it goes to sleep.
+///
+/// It deliberately leaves `accepts_work` alone. That question is asked once,
+/// its answer is default-deny, and a path that never asks it must not answer
+/// it — least of all in the permissive direction.
+pub fn offer(ticket: &str) -> Result<(), PairingError> {
+    let path = pairing_path()?;
+    let mut pairing = load_from(&path)?;
+    if pairing.ticket.as_deref() == Some(ticket) {
+        return Ok(());
+    }
+    pairing.ticket = Some(ticket.to_owned());
+    save_to(&path, &pairing)
+}
+
 /// Record the machines currently in the session, if this machine is paired.
 ///
 /// Called by the node when the member list changes. It is a no-op on a session

--- a/src/pairing.rs
+++ b/src/pairing.rs
@@ -221,7 +221,7 @@ pub fn remember_peers(names: &[String]) -> Result<(), PairingError> {
 
 /// Best-effort read for the paths where a failure must not stop the UI.
 ///
-/// The inbox draws a machine strip from this. A pairing file that cannot be
+/// The inbox draws its machines rail from this. A pairing file that cannot be
 /// read is worth a missing strip, never a client that refuses to start.
 pub fn load_or_empty() -> Pairing {
     load().unwrap_or_default()

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -57,12 +57,12 @@ pub(crate) use share::share_copy_result;
 pub(crate) use snapshot::{
     LocalScrollbackWindow, NodeLeaseSnapshots, NodeScreenSnapshot, NodeScreenSnapshots,
 };
+pub(in crate::tui) use state::{
+    AddMachinePrompt, Invite, ModalState, PaneTextSelection, RenamePrompt, RenameTarget, ScreenCell,
+};
 pub use state::{
     AgentOverlayRow, ChordMode, KeyHandling, MouseHandling, PairedMachine, PaneGeometry,
     PaneViewState, QuitAction, ShareCopy, ShareView, UiIntent,
-};
-pub(in crate::tui) use state::{
-    Invite, ModalState, PaneTextSelection, RenamePrompt, RenameTarget, ScreenCell,
 };
 pub(crate) use terminal::clear_before_first_frame;
 pub(in crate::tui) use terminal::{TerminalGuard, enable_keyboard_enhancement};

--- a/src/tui/home.rs
+++ b/src/tui/home.rs
@@ -615,7 +615,7 @@ pub(in crate::tui) fn machine_rows(tui: &MultiPaneTui) -> Vec<MachineRow> {
     rows
 }
 
-/// One line of the machine strip, and one row of `p2pmux machines`.
+/// One machine on the inbox, and one row of `p2pmux machines`.
 ///
 /// Public because the CLI builds these too: the `m` key on Home and the command
 /// print the same rows through the same formatter, so the two can never drift

--- a/src/tui/home.rs
+++ b/src/tui/home.rs
@@ -65,7 +65,6 @@ impl MultiPaneTui {
             // owner.
             self.modal = ModalState::None;
             self.exit_chord_mode();
-            self.machines_expanded = false;
             // Arriving puts the cursor back on the top row, which is the one
             // that most wants a human. That is the whole reason for the sort
             // order, and a cursor left where a previous visit happened to end
@@ -319,10 +318,6 @@ impl MultiPaneTui {
         true
     }
 
-    pub(in crate::tui) fn toggle_machines_expanded(&mut self) {
-        self.machines_expanded = !self.machines_expanded;
-    }
-
     /// Which peer this client is, so the machine list can mark the row for the
     /// machine the user is sitting at. Only the node knows it.
     pub fn set_local_peer_id(&mut self, peer_id: Vec<u8>) {
@@ -383,10 +378,6 @@ impl MultiPaneTui {
                     grid_cols,
                 }])
             }
-            KeyCode::Char('m') if key.modifiers.is_empty() => {
-                self.toggle_machines_expanded();
-                KeyHandling::Consumed(vec![])
-            }
             // The same question Ctrl+Q asks, asked the same way. Home is the
             // one screen where a bare `q` is free, but it should not be the one
             // screen where leaving skips the prompt.
@@ -422,10 +413,42 @@ pub(in crate::tui) struct HomeLayout {
     pub(in crate::tui) rows: Rect,
     /// The `p2pmux setup` nudge. Zero-height unless every row is unreported.
     pub(in crate::tui) hint: Rect,
-    /// The one-line machine strip, or the expanded list under `m`.
-    /// Zero-height only before the member list has arrived.
+    /// Where the machines go. Zero-height only before the member list has
+    /// arrived, and shaped by [`HomeLayout::machine_panel`].
     pub(in crate::tui) machines: Rect,
+    pub(in crate::tui) machine_panel: MachinePanel,
 }
+
+/// How the fleet is drawn, which is a question of how much room there is.
+///
+/// The screen's spare space is horizontal as much as vertical — the column that
+/// says what an agent is doing is rarely more than half used — so the widest
+/// tier spends that width on machines rather than leaving it blank.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(in crate::tui) enum MachinePanel {
+    /// A column down the right-hand side, with a line each for what a machine
+    /// is and what it is running.
+    Rail,
+    /// The same facts as a table under the agents, when the terminal is too
+    /// narrow to give a column away.
+    Table,
+    /// Names and ticks on one line, when there is not even room for a table.
+    /// It still answers "is my fleet up", which is what earns it the space.
+    Strip,
+    /// Nothing known yet. The member list has not arrived.
+    Empty,
+}
+
+/// How wide the rail is, including the rule it hangs off.
+pub(in crate::tui) const MACHINE_RAIL_WIDTH: u16 = 26;
+/// The narrowest terminal that gets a rail.
+///
+/// Below this the agents would be paying for the fleet: a card whose sentence
+/// column is under 40 columns truncates what the agent said, which is the one
+/// thing on the screen worth reading in full.
+const MACHINE_RAIL_MIN_WIDTH: u16 = 88;
+/// The shortest terminal that gets a rail: a heading, a blank, and one machine.
+const MACHINE_RAIL_MIN_HEIGHT: u16 = 6;
 
 /// Every machine this client knows about, session members first.
 ///
@@ -486,59 +509,96 @@ pub struct MachineRow {
     pub this_machine: bool,
 }
 
-/// How many lines the machine block wants.
-///
-/// One machine still gets a strip. Hiding it until a second machine appeared
-/// made a fleet of one look like a fleet of none — the screen said "no
-/// machines" about the machine it was being read on. A strip with one name in
-/// it says the fleet is up and has room for more, which is the truth.
-pub(in crate::tui) fn machine_lines(tui: &MultiPaneTui) -> u16 {
-    let machines = machine_rows(tui).len();
-    if machines == 0 {
-        return 0;
-    }
-    if tui.machines_expanded {
-        // A blank spacer, a heading, and one line each.
-        u16::try_from(machines)
-            .unwrap_or(u16::MAX)
-            .saturating_add(2)
-    } else {
-        2
-    }
+/// How many lines the table under the agents wants: a blank spacer, a heading,
+/// and one line per machine.
+fn machine_table_lines(machines: usize) -> u16 {
+    u16::try_from(machines)
+        .unwrap_or(u16::MAX)
+        .saturating_add(2)
 }
 
 pub(in crate::tui) fn home_layout(area: Rect, tui: &MultiPaneTui) -> HomeLayout {
-    // Header, then rows, then the machine block pinned to the bottom. The key
-    // bar is not here: it takes over the window footer, so that four keys stay
-    // visible in the same place they are on every other screen. A terminal too
-    // short to hold everything loses agent rows before the machine strip — the
-    // strip is one line and answers "is my fleet even up", which a list of
-    // agents cannot.
-    let header_height = 2u16.min(area.height);
-    let mut left = area.height.saturating_sub(header_height);
-    // The strip outranks agent rows when space runs out, but it never takes the
-    // last one: a list with nothing left in it stops being a list, and Home
-    // would be a screen about machines with the agents it exists for cut off.
-    // All or nothing — half a strip is a blank line where a fleet should be.
-    let wanted = machine_lines(tui);
-    let machines_height = if wanted <= left.saturating_sub(1) {
-        wanted
+    // Header, then rows, then the machines — down the right on a terminal with
+    // width to spare, and pinned to the bottom otherwise. The key bar is not
+    // here: it takes over the window footer, so that four keys stay visible in
+    // the same place they are on every other screen.
+    let machines = machine_rows(tui).len();
+    if machines == 0 {
+        let (header, rows, hint) = stacked(area, tui, 0);
+        return HomeLayout {
+            header,
+            rows,
+            hint,
+            machines: Rect::new(area.x, hint.bottom(), area.width, 0),
+            machine_panel: MachinePanel::Empty,
+        };
+    }
+    if area.width >= MACHINE_RAIL_MIN_WIDTH && area.height >= MACHINE_RAIL_MIN_HEIGHT {
+        // The rail is full height rather than sized to the fleet: it is a column
+        // of the screen, and a short one would leave a ragged hole beside the
+        // agents. A fleet too tall for it says so on its last line.
+        let rail = Rect::new(
+            area.right().saturating_sub(MACHINE_RAIL_WIDTH),
+            area.y,
+            MACHINE_RAIL_WIDTH,
+            area.height,
+        );
+        let (header, rows, hint) = stacked(
+            Rect::new(
+                area.x,
+                area.y,
+                area.width.saturating_sub(MACHINE_RAIL_WIDTH),
+                area.height,
+            ),
+            tui,
+            0,
+        );
+        return HomeLayout {
+            header,
+            rows,
+            hint,
+            machines: rail,
+            machine_panel: MachinePanel::Rail,
+        };
+    }
+    // Under the agents, then. The machines outrank agent rows when space runs
+    // out, but never take the last one: a list with nothing left in it stops
+    // being a list, and Home would be a screen about machines with the agents
+    // it exists for cut off. All or nothing — half a block is a blank line
+    // where a fleet should be.
+    let left = area.height.saturating_sub(2u16.min(area.height));
+    let table = machine_table_lines(machines);
+    let (panel, height) = if table <= left.saturating_sub(1) {
+        (MachinePanel::Table, table)
+    } else if left.saturating_sub(1) >= 2 {
+        (MachinePanel::Strip, 2)
     } else {
-        0
+        (MachinePanel::Empty, 0)
     };
-    left = left.saturating_sub(machines_height);
+    let (header, rows, hint) = stacked(area, tui, height);
+    HomeLayout {
+        header,
+        rows,
+        hint,
+        machines: Rect::new(area.x, hint.bottom(), area.width, height),
+        machine_panel: panel,
+    }
+}
+
+/// The header, the agent rows and the hint, stacked into whatever width and
+/// height are left once the machines have taken their share.
+fn stacked(area: Rect, tui: &MultiPaneTui, machines_height: u16) -> (Rect, Rect, Rect) {
+    let header_height = 2u16.min(area.height);
+    let left = area
+        .height
+        .saturating_sub(header_height)
+        .saturating_sub(machines_height);
     let hint_height = u16::from(tui.home_all_unwired()).min(left);
     let rows_height = left.saturating_sub(hint_height);
     let header = Rect::new(area.x, area.y, area.width, header_height);
     let rows = Rect::new(area.x, header.bottom(), area.width, rows_height);
     let hint = Rect::new(area.x, rows.bottom(), area.width, hint_height);
-    let machines = Rect::new(area.x, hint.bottom(), area.width, machines_height);
-    HomeLayout {
-        header,
-        rows,
-        hint,
-        machines,
-    }
+    (header, rows, hint)
 }
 
 #[cfg(test)]
@@ -546,7 +606,7 @@ mod tests {
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
     use ratatui::layout::Rect;
 
-    use super::{home_layout, machine_lines, machine_rows};
+    use super::{MACHINE_RAIL_WIDTH, MachinePanel, home_layout, machine_rows};
     use crate::{
         protocol::AgentRosterState,
         tui::{KeyHandling, MultiPaneTui, UiIntent, test_support::home_tui},
@@ -650,33 +710,76 @@ mod tests {
     }
 
     #[test]
-    fn the_machine_strip_lists_this_machine_with_nothing_paired() {
-        // A fleet of one is still a fleet. Hiding the strip made the screen
+    fn the_machine_list_holds_this_machine_with_nothing_paired() {
+        // A fleet of one is still a fleet. Hiding the list made the screen
         // say "no machines" about the machine it was being read on.
         let tui = home_tui(&[("laptop", "claude", AgentRosterState::Working)]);
 
         let machines = machine_rows(&tui);
         assert_eq!(machines.len(), 1);
         assert!(machines[0].this_machine);
-        assert_eq!(machine_lines(&tui), 2);
-        assert_eq!(home_layout(AREA, &tui).machines.height, 2);
+
+        let layout = home_layout(AREA, &tui);
+        assert_eq!(layout.machine_panel, MachinePanel::Rail);
+        assert_eq!(layout.machines.height, AREA.height);
     }
 
-    /// The strip outranks agent rows, but not the last one.
+    /// The rail is a column of the screen, so what it costs is width, and the
+    /// agents keep every line they had.
     #[test]
-    fn a_home_too_short_for_both_keeps_a_row_rather_than_the_whole_strip() {
+    fn the_rail_takes_width_from_the_agents_and_never_a_row() {
         let tui = home_tui(&[("laptop", "claude", AgentRosterState::Working)]);
 
-        // Two lines of header, three left: the strip fits with a row to spare.
-        let roomy = home_layout(Rect::new(0, 0, 40, 5), &tui);
-        assert_eq!(roomy.machines.height, 2);
-        assert_eq!(roomy.rows.height, 1);
+        let layout = home_layout(AREA, &tui);
+        assert_eq!(layout.rows.width, AREA.width - MACHINE_RAIL_WIDTH);
+        assert_eq!(layout.machines.x, AREA.width - MACHINE_RAIL_WIDTH);
+        assert_eq!(
+            layout.rows.height,
+            AREA.height - 2,
+            "the header is the only thing above the agents"
+        );
+    }
+
+    /// Narrow terminals get the same facts under the agents instead, and the
+    /// machines outrank agent rows there — but never take the last one.
+    #[test]
+    fn a_terminal_too_narrow_for_a_rail_puts_the_machines_underneath() {
+        let tui = home_tui(&[("laptop", "claude", AgentRosterState::Working)]);
+
+        // A spacer, a heading and one machine, with rows to spare.
+        let roomy = home_layout(Rect::new(0, 0, 40, 10), &tui);
+        assert_eq!(roomy.machine_panel, MachinePanel::Table);
+        assert_eq!(roomy.machines.height, 3);
+        assert_eq!(roomy.rows.height, 5);
+
+        // No room for the table: the strip still answers "is my fleet up".
+        let tight = home_layout(Rect::new(0, 0, 40, 5), &tui);
+        assert_eq!(tight.machine_panel, MachinePanel::Strip);
+        assert_eq!(tight.machines.height, 2);
+        assert_eq!(tight.rows.height, 1);
 
         // One line fewer and the strip would take every row there is, so it
         // stands down whole — half a strip is a blank line where a fleet goes.
         let cramped = home_layout(Rect::new(0, 0, 40, 4), &tui);
+        assert_eq!(cramped.machine_panel, MachinePanel::Empty);
         assert_eq!(cramped.machines.height, 0);
         assert_eq!(cramped.rows.height, 2);
+    }
+
+    /// A terminal too short for a rail falls back rather than drawing a
+    /// two-line column beside a two-line list.
+    #[test]
+    fn a_wide_but_short_terminal_falls_back_from_the_rail() {
+        let tui = home_tui(&[("laptop", "claude", AgentRosterState::Working)]);
+
+        assert_eq!(
+            home_layout(Rect::new(0, 0, 120, 5), &tui).machine_panel,
+            MachinePanel::Strip
+        );
+        assert_eq!(
+            home_layout(Rect::new(0, 0, 120, 6), &tui).machine_panel,
+            MachinePanel::Rail
+        );
     }
 
     #[test]
@@ -695,7 +798,6 @@ mod tests {
             .expect("the paired machine is listed");
         assert!(!oldbox.reachable);
         assert_eq!(oldbox.accepts_work, Some(true));
-        assert_eq!(machine_lines(&tui), 2);
     }
 
     #[test]
@@ -777,19 +879,21 @@ mod tests {
         );
     }
 
+    /// `m` used to expand the strip into the table. The rail is the table, so
+    /// there is nothing left for the key to do and it no longer claims one.
     #[test]
-    fn m_expands_the_machines_list_in_place() {
+    fn every_machine_is_listed_without_a_key_to_expand_them() {
         let mut tui = home_tui(&[("laptop", "claude", AgentRosterState::Working)]);
         tui.paired_machines = vec![crate::tui::PairedMachine {
             name: String::from("droplet"),
             accepts_work: None,
         }];
         tui.set_home_open(true, "test");
-        assert_eq!(machine_lines(&tui), 2);
 
+        assert_eq!(machine_rows(&tui).len(), 2);
+        let before = home_layout(AREA, &tui);
         tui.handle_key(KeyEvent::new(KeyCode::Char('m'), KeyModifiers::NONE), AREA);
-        assert!(tui.machines_expanded);
-        assert_eq!(machine_lines(&tui), 4, "a spacer, a heading, and two rows");
+        assert_eq!(home_layout(AREA, &tui), before);
     }
 
     #[test]

--- a/src/tui/home.rs
+++ b/src/tui/home.rs
@@ -74,7 +74,7 @@ impl MultiPaneTui {
             // where the user put it, and a row changing state under it must
             // never drag it somewhere else.
             self.home_selected = None;
-            self.home_scroll_line = 0;
+            self.home_page = 0;
             self.repair_home_selection();
         }
         ui_debug_log(
@@ -135,34 +135,64 @@ impl MultiPaneTui {
         {
             self.home_selected = rows.first().copied();
         }
-        self.clamp_home_scroll();
+        self.clamp_home_page();
         self.ensure_home_selection_visible();
     }
 
-    pub(in crate::tui) fn set_home_viewport(&mut self, lines: u16) {
-        self.home_viewport_lines = lines;
-        self.clamp_home_scroll();
+    pub(in crate::tui) fn set_home_viewport(&mut self, page_size: usize) {
+        self.home_page_size = page_size.max(1);
+        self.clamp_home_page();
     }
 
-    /// Tell Home how many rows fit, from the whole terminal rather than from a
-    /// line count the caller had to work out for itself.
+    /// Tell Home how many agents fit on a page, from the whole terminal rather
+    /// than from a count the caller had to work out for itself.
     pub fn set_home_viewport_for(&mut self, area: Rect) {
         let rows = home_layout(self.geometry(area).content, self).rows.height;
-        self.set_home_viewport(rows);
+        self.set_home_viewport(home_page_size(rows));
     }
 
     /// Wheel over the inbox. Returns whether anything moved, so a scroll at the
     /// end of the list never costs a repaint.
+    ///
+    /// A page at a time rather than an agent at a time: the list is paged, and
+    /// a wheel that slid one card off the top would leave a page nobody chose,
+    /// with the first agent half in view.
     pub fn scroll_home(&mut self, area: Rect, up: bool) -> bool {
         self.set_home_viewport_for(area);
-        let previous = self.home_scroll_line;
+        let previous = self.home_page;
         if up {
-            self.home_scroll_line = self.home_scroll_line.saturating_sub(1);
+            self.home_page = self.home_page.saturating_sub(1);
         } else {
-            self.home_scroll_line = self.home_scroll_line.saturating_add(1);
+            self.home_page = self.home_page.saturating_add(1);
         }
-        self.clamp_home_scroll();
-        self.home_scroll_line != previous
+        self.clamp_home_page();
+        if self.home_page != previous {
+            // The cursor follows the page. Leaving it behind on a page that is
+            // no longer drawn means Enter opens an agent that is not on screen.
+            self.home_selected = self
+                .home_rows()
+                .get(self.home_page.saturating_mul(self.home_page_size.max(1)))
+                .map(|row| row.pane_id);
+            return true;
+        }
+        false
+    }
+
+    /// How many pages the list has. Never zero: an empty inbox is one page.
+    pub(in crate::tui) fn home_page_count(&self) -> usize {
+        self.agent_rows
+            .len()
+            .div_ceil(self.home_page_size.max(1))
+            .max(1)
+    }
+
+    pub(in crate::tui) fn home_page(&self) -> usize {
+        self.home_page
+    }
+
+    /// The index of the first agent on the page being drawn.
+    pub(in crate::tui) fn home_page_start(&self) -> usize {
+        self.home_page.saturating_mul(self.home_page_size.max(1))
     }
 
     /// A click on an inbox row selects it and opens it, in one gesture.
@@ -184,32 +214,30 @@ impl MultiPaneTui {
     }
 
     pub(in crate::tui) fn home_row_at(&self, column: u16, row: u16, area: Rect) -> Option<PaneId> {
-        let rows = home_layout(self.geometry(area).content, self).rows;
-        if !crate::tui::geometry::rect_contains(rows, column, row) {
+        let layout = home_layout(self.geometry(area).content, self);
+        if !crate::tui::geometry::rect_contains(layout.rows, column, row) {
             return None;
         }
-        let line = usize::from(row.saturating_sub(rows.y)).saturating_add(self.home_scroll_line);
-        self.home_rows().get(line).map(|row| row.pane_id)
+        let line = usize::from(row.saturating_sub(layout.rows.y));
+        let card = home_card(layout.rows.height).lines();
+        // A click on a card's blank spacer belongs to the card above it, which
+        // is the one the pointer looks like it is on.
+        self.home_rows()
+            .get(self.home_page_start().saturating_add(line / card))
+            .map(|row| row.pane_id)
     }
 
-    pub(in crate::tui) fn home_max_scroll(&self) -> usize {
-        self.agent_rows
-            .len()
-            .saturating_sub(usize::from(self.home_viewport_lines.max(1)))
+    pub(in crate::tui) fn clamp_home_page(&mut self) {
+        self.home_page = self.home_page.min(self.home_page_count().saturating_sub(1));
     }
 
-    pub(in crate::tui) fn clamp_home_scroll(&mut self) {
-        if self.home_viewport_lines == 0 {
-            self.home_scroll_line = 0;
-            return;
-        }
-        self.home_scroll_line = self.home_scroll_line.min(self.home_max_scroll());
-    }
-
+    /// Puts the page the cursor is on on screen.
+    ///
+    /// The selection is what the page follows, never the other way round: the
+    /// sort order decides which agent most wants a human, and a page that
+    /// stayed put while the cursor walked off it would be a screen showing
+    /// agents nobody chose.
     pub(in crate::tui) fn ensure_home_selection_visible(&mut self) {
-        if self.home_viewport_lines == 0 {
-            return;
-        }
         let Some(index) = self.home_selected.and_then(|pane_id| {
             self.home_rows()
                 .iter()
@@ -217,13 +245,8 @@ impl MultiPaneTui {
         }) else {
             return;
         };
-        let viewport = usize::from(self.home_viewport_lines.max(1));
-        if index < self.home_scroll_line {
-            self.home_scroll_line = index;
-        } else if index >= self.home_scroll_line.saturating_add(viewport) {
-            self.home_scroll_line = index.saturating_add(1).saturating_sub(viewport);
-        }
-        self.clamp_home_scroll();
+        self.home_page = index / self.home_page_size.max(1);
+        self.clamp_home_page();
     }
 
     pub(in crate::tui) fn move_home_selection(&mut self, forward: bool) {
@@ -352,7 +375,7 @@ impl MultiPaneTui {
         area: Rect,
     ) -> crate::tui::KeyHandling {
         use crate::tui::KeyHandling;
-        self.set_home_viewport(home_layout(self.geometry(area).content, self).rows.height);
+        self.set_home_viewport_for(area);
         match key.code {
             KeyCode::Up | KeyCode::Char('k') if key.modifiers.is_empty() => {
                 self.move_home_selection(false);
@@ -446,8 +469,66 @@ pub(in crate::tui) enum MachinePanel {
     Empty,
 }
 
+/// How much of the screen one agent gets.
+///
+/// A line each was the right answer when the screen was a list of processes.
+/// It is the wrong one for a fleet: nobody runs thirty agents, so the list
+/// occupied a fifth of a terminal and left the rest blank, and a row that had
+/// to fit in one line could show what an agent said *or* which repository it
+/// said it in, never both.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(in crate::tui) enum HomeCard {
+    /// Who and where, what it said, and where Enter will land you.
+    Full,
+    /// Who and where, and what it said. The location line is the first thing
+    /// worth dropping: it is the only one you can get by pressing Enter.
+    Compact,
+    /// One line, as it was. What a terminal too short for anything else gets.
+    Row,
+}
+
+impl HomeCard {
+    /// Lines on screen per agent, including the blank that separates two cards.
+    pub(in crate::tui) fn lines(self) -> usize {
+        match self {
+            Self::Full => 4,
+            Self::Compact => 3,
+            Self::Row => 1,
+        }
+    }
+}
+
+/// The richest card the agent list has room for.
+///
+/// Chosen from the height alone, never from how many agents there are: a screen
+/// that changed shape when a fifth agent appeared would be a screen you have to
+/// re-read every time the fleet moves.
+pub(in crate::tui) fn home_card(rows_height: u16) -> HomeCard {
+    // Three cards' worth, so a tier is only taken when it can show a list
+    // rather than a single agent and a gap.
+    if rows_height >= 12 {
+        HomeCard::Full
+    } else if rows_height >= 9 {
+        HomeCard::Compact
+    } else {
+        HomeCard::Row
+    }
+}
+
+/// The most agents one page shows.
+///
+/// Not a space limit — a tall terminal fits more. It is the number of things a
+/// screen can be glanced at rather than read, and the inbox is sorted so that
+/// what is on page one is what most wants a human.
+pub(in crate::tui) const HOME_PAGE_MAX: usize = 8;
+
+/// How many agents fit on a page of a list this tall.
+pub(in crate::tui) fn home_page_size(rows_height: u16) -> usize {
+    (usize::from(rows_height) / home_card(rows_height).lines()).clamp(1, HOME_PAGE_MAX)
+}
+
 /// How wide the rail is, including the rule it hangs off.
-pub(in crate::tui) const MACHINE_RAIL_WIDTH: u16 = 26;
+pub(in crate::tui) const MACHINE_RAIL_WIDTH: u16 = 28;
 /// The narrowest terminal that gets a rail.
 ///
 /// Below this the agents would be paying for the fleet: a card whose sentence

--- a/src/tui/home.rs
+++ b/src/tui/home.rs
@@ -378,6 +378,13 @@ impl MultiPaneTui {
                     grid_cols,
                 }])
             }
+            KeyCode::Char('a') if key.modifiers.is_empty() => {
+                // Adding a machine used to mean leaving the screen the fleet is
+                // on: `p2pmux pair` in a terminal, then finding out whether it
+                // worked by running something else. Both halves belong here.
+                self.open_add_machine();
+                KeyHandling::Consumed(vec![])
+            }
             // The same question Ctrl+Q asks, asked the same way. Home is the
             // one screen where a bare `q` is free, but it should not be the one
             // screen where leaving skips the prompt.

--- a/src/tui/home.rs
+++ b/src/tui/home.rs
@@ -1200,6 +1200,35 @@ mod tests {
         assert_eq!(tui.home_page(), 0);
     }
 
+    /// A card is one target, not three. Clicking the line an agent's words are
+    /// on has to open that agent — and clicking the gap under it belongs to the
+    /// card above, which is the one the pointer looks like it is on.
+    #[test]
+    fn every_line_of_a_card_opens_the_agent_it_belongs_to() {
+        let (tui, _) = paged_tui(3);
+        let rows = tui
+            .home_rows()
+            .into_iter()
+            .map(|row| row.pane_id)
+            .collect::<Vec<_>>();
+        let list = home_layout(tui.geometry(AREA).content, &tui).rows;
+        assert_eq!(home_card(list.height), HomeCard::Full);
+
+        for line in 0..HomeCard::Full.lines() as u16 {
+            assert_eq!(
+                tui.home_row_at(2, list.y + line, AREA),
+                Some(rows[0]),
+                "line {line} of the first card belongs to it"
+            );
+        }
+        assert_eq!(
+            tui.home_row_at(2, list.y + HomeCard::Full.lines() as u16, AREA),
+            Some(rows[1])
+        );
+        // The rail is not the list, and a click on it opens nothing.
+        assert_eq!(tui.home_row_at(AREA.width - 2, list.y, AREA), None);
+    }
+
     /// One page means no paging: the keys do nothing rather than redrawing the
     /// same agents under a page number that never changes.
     #[test]

--- a/src/tui/home.rs
+++ b/src/tui/home.rs
@@ -178,6 +178,28 @@ impl MultiPaneTui {
         false
     }
 
+    /// `h` and `l`, and the page keys: a whole page at a time, cursor and all.
+    ///
+    /// The cursor lands on the first agent of the page it arrives at, which is
+    /// the most urgent one there — the same rule that decides what the cursor
+    /// sits on when the inbox opens.
+    pub(in crate::tui) fn turn_home_page(&mut self, forward: bool) -> bool {
+        let pages = self.home_page_count();
+        if pages < 2 {
+            return false;
+        }
+        self.home_page = if forward {
+            (self.home_page + 1) % pages
+        } else {
+            (self.home_page + pages - 1) % pages
+        };
+        self.home_selected = self
+            .home_rows()
+            .get(self.home_page_start())
+            .map(|row| row.pane_id);
+        true
+    }
+
     /// How many pages the list has. Never zero: an empty inbox is one page.
     pub(in crate::tui) fn home_page_count(&self) -> usize {
         self.agent_rows
@@ -383,6 +405,17 @@ impl MultiPaneTui {
             }
             KeyCode::Down | KeyCode::Char('j') if key.modifiers.is_empty() => {
                 self.move_home_selection(true);
+                KeyHandling::Consumed(vec![])
+            }
+            // Pages step sideways, so the sideways keys move them. Not `←` and
+            // `→`: `→` already steps off Home onto the tabs, and the second way
+            // in should not become the way to page a list.
+            KeyCode::Char('l') | KeyCode::PageDown if key.modifiers.is_empty() => {
+                self.turn_home_page(true);
+                KeyHandling::Consumed(vec![])
+            }
+            KeyCode::Char('h') | KeyCode::PageUp if key.modifiers.is_empty() => {
+                self.turn_home_page(false);
                 KeyHandling::Consumed(vec![])
             }
             KeyCode::Enter if key.modifiers.is_empty() => {
@@ -694,7 +727,10 @@ mod tests {
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
     use ratatui::layout::Rect;
 
-    use super::{MACHINE_RAIL_WIDTH, MachinePanel, home_layout, machine_rows};
+    use super::{
+        HOME_PAGE_MAX, HomeCard, MACHINE_RAIL_WIDTH, MachinePanel, home_card, home_layout,
+        home_page_size, machine_rows,
+    };
     use crate::{
         protocol::AgentRosterState,
         tui::{KeyHandling, MultiPaneTui, UiIntent, test_support::home_tui},
@@ -982,6 +1018,110 @@ mod tests {
         let before = home_layout(AREA, &tui);
         tui.handle_key(KeyEvent::new(KeyCode::Char('m'), KeyModifiers::NONE), AREA);
         assert_eq!(home_layout(AREA, &tui), before);
+    }
+
+    /// Eight is the ceiling however tall the terminal is, and one is the floor
+    /// however short: a page with nothing on it is not a page.
+    #[test]
+    fn a_page_holds_what_fits_and_never_more_than_eight() {
+        assert_eq!(home_card(200), HomeCard::Full);
+        assert_eq!(home_page_size(200), HOME_PAGE_MAX);
+        // Twenty lines of `Full` cards is five agents, not eight.
+        assert_eq!(home_page_size(20), 5);
+        // Short enough for rows, where a line each is all an agent gets.
+        assert_eq!(home_page_size(8), 8);
+        assert_eq!(home_page_size(3), 3);
+        assert_eq!(home_page_size(0), 1);
+    }
+
+    /// An inbox with `count` agents on it, opened and measured against [`AREA`],
+    /// alongside the page size that terminal works out to.
+    fn paged_tui(count: usize) -> (MultiPaneTui, usize) {
+        let rows = (0..count)
+            .map(|index| {
+                (
+                    if index % 2 == 0 { "laptop" } else { "droplet" },
+                    "claude",
+                    AgentRosterState::Working,
+                )
+            })
+            .collect::<Vec<_>>();
+        let mut tui = home_tui(&rows);
+        tui.set_home_open(true, "test");
+        tui.set_home_viewport_for(AREA);
+        let page_size = tui.home_page_size;
+        (tui, page_size)
+    }
+
+    /// A list longer than a page is paged, not scrolled, and `h`/`l` move a
+    /// whole page with the cursor rather than leaving it behind.
+    #[test]
+    fn h_and_l_turn_the_page_and_take_the_cursor_with_them() {
+        let (mut tui, page_size) = paged_tui(8);
+        assert_eq!(tui.home_page_count(), 2);
+        assert_eq!(tui.home_page(), 0);
+
+        let first = tui.home_selected.expect("a cursor on arrival");
+        tui.handle_key(KeyEvent::new(KeyCode::Char('l'), KeyModifiers::NONE), AREA);
+        assert_eq!(tui.home_page(), 1);
+        assert_eq!(
+            tui.home_selected,
+            tui.home_rows().get(page_size).map(|row| row.pane_id),
+            "the cursor lands on the first agent of the page it arrives at"
+        );
+
+        // Two pages, so `l` wraps back rather than stopping at the end.
+        tui.handle_key(KeyEvent::new(KeyCode::Char('l'), KeyModifiers::NONE), AREA);
+        assert_eq!(tui.home_page(), 0);
+        assert_eq!(tui.home_selected, Some(first));
+
+        tui.handle_key(KeyEvent::new(KeyCode::PageUp, KeyModifiers::NONE), AREA);
+        assert_eq!(tui.home_page(), 1);
+    }
+
+    /// The page follows the cursor. Walking off the bottom of one page has to
+    /// bring the next one into view, or `j` stops at the end of page one.
+    #[test]
+    fn walking_the_cursor_off_a_page_brings_the_next_one_into_view() {
+        let (mut tui, page_size) = paged_tui(8);
+
+        for _ in 0..page_size {
+            tui.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE), AREA);
+        }
+        assert_eq!(tui.home_page(), 1);
+        assert_eq!(
+            tui.home_selected,
+            tui.home_rows().get(page_size).map(|row| row.pane_id)
+        );
+
+        // And back up over the same edge.
+        tui.handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE), AREA);
+        assert_eq!(tui.home_page(), 0);
+    }
+
+    /// A page must not survive the agents that were on it going away.
+    #[test]
+    fn a_page_that_empties_falls_back_to_one_that_has_something_on_it() {
+        let (mut tui, page_size) = paged_tui(8);
+        tui.handle_key(KeyEvent::new(KeyCode::Char('l'), KeyModifiers::NONE), AREA);
+        assert_eq!(tui.home_page(), 1);
+
+        let rows = tui.agent_rows[..page_size].to_vec();
+        tui.set_agent_rows(rows);
+        tui.repair_home_selection();
+        assert_eq!(tui.home_page_count(), 1);
+        assert_eq!(tui.home_page(), 0);
+    }
+
+    /// One page means no paging: the keys do nothing rather than redrawing the
+    /// same agents under a page number that never changes.
+    #[test]
+    fn a_list_that_fits_on_one_page_has_no_pages_to_turn() {
+        let (mut tui, _) = paged_tui(3);
+
+        assert_eq!(tui.home_page_count(), 1);
+        assert!(!tui.turn_home_page(true));
+        assert_eq!(tui.home_page(), 0);
     }
 
     #[test]

--- a/src/tui/multi_pane/keys.rs
+++ b/src/tui/multi_pane/keys.rs
@@ -80,6 +80,11 @@ impl MultiPaneTui {
         if matches!(self.modal, ModalState::ConfirmDeleteTab { .. }) {
             return self.handle_confirm_delete_tab_key(key);
         }
+        // Above Ctrl+O, so the key that opens the inbox does not walk out from
+        // under a panel that is waiting on another machine to answer.
+        if self.add_machine_open() {
+            return self.handle_add_machine_key(key);
+        }
         // Home, from anywhere — including from inside a live pane, which is the
         // only reason it is claimed this early. `Ctrl+O` is free in shells and
         // transmits in every terminal. `Esc` deliberately is not the way back:

--- a/src/tui/multi_pane/mod.rs
+++ b/src/tui/multi_pane/mod.rs
@@ -71,8 +71,11 @@ pub struct MultiPaneTui {
     /// Local to this client and never replicated: see [`crate::tui::home`].
     pub(in crate::tui) home_open: bool,
     pub(in crate::tui) home_selected: Option<PaneId>,
-    pub(in crate::tui) home_scroll_line: usize,
-    pub(in crate::tui) home_viewport_lines: u16,
+    /// Which page of the agent list is drawn. Derived from the selection
+    /// everywhere except the wheel, which moves both.
+    pub(in crate::tui) home_page: usize,
+    /// How many agents that page holds, from the last layout that was measured.
+    pub(in crate::tui) home_page_size: usize,
     /// The pane Home handed the user into, drawn alone in the content area.
     ///
     /// A local view choice, so it never reaches the layout: the pane keeps the
@@ -139,8 +142,8 @@ impl MultiPaneTui {
             pending_home_toggle: None,
             home_open: false,
             home_selected: None,
-            home_scroll_line: 0,
-            home_viewport_lines: 0,
+            home_page: 0,
+            home_page_size: crate::tui::home::HOME_PAGE_MAX,
             zoomed_pane: None,
             paired_machines: Vec::new(),
             local_peer_id: None,

--- a/src/tui/multi_pane/mod.rs
+++ b/src/tui/multi_pane/mod.rs
@@ -94,6 +94,9 @@ pub struct MultiPaneTui {
     /// A share-modal copy request. Invite material lives in the node's rendezvous record
     /// rather than in the layout, so the attached client resolves and copies it.
     pub(in crate::tui) pending_share_copy: Option<ShareCopy>,
+    /// Whether the add-machine panel has asked the client to record the
+    /// session's ticket in the pairing file. The TUI owns no filesystem.
+    pub(in crate::tui) pending_pair_offer: bool,
     /// Whether the coordinator is refusing new peers. Mirrored from the node rather than
     /// derived, because only the coordinator knows it and any peer may be drawing it.
     pub(in crate::tui) session_locked: bool,
@@ -146,6 +149,7 @@ impl MultiPaneTui {
             session_locked: false,
             mouse_forwarding: false,
             pending_share_copy: None,
+            pending_pair_offer: false,
         })
     }
 
@@ -182,6 +186,7 @@ impl MultiPaneTui {
                 | ModalState::ConfirmDeleteTab { .. }
                 | ModalState::Share
                 | ModalState::Quit
+                | ModalState::AddMachine(_)
         )
     }
 

--- a/src/tui/multi_pane/mod.rs
+++ b/src/tui/multi_pane/mod.rs
@@ -73,8 +73,6 @@ pub struct MultiPaneTui {
     pub(in crate::tui) home_selected: Option<PaneId>,
     pub(in crate::tui) home_scroll_line: usize,
     pub(in crate::tui) home_viewport_lines: u16,
-    /// Whether `m` has expanded the machine strip into the full list.
-    pub(in crate::tui) machines_expanded: bool,
     /// The pane Home handed the user into, drawn alone in the content area.
     ///
     /// A local view choice, so it never reaches the layout: the pane keeps the
@@ -140,7 +138,6 @@ impl MultiPaneTui {
             home_selected: None,
             home_scroll_line: 0,
             home_viewport_lines: 0,
-            machines_expanded: false,
             zoomed_pane: None,
             paired_machines: Vec::new(),
             local_peer_id: None,

--- a/src/tui/multi_pane/modal.rs
+++ b/src/tui/multi_pane/modal.rs
@@ -6,8 +6,8 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use crate::{
     layout::{TabId, normalize_title},
     tui::{
-        KeyHandling, ModalState, MultiPaneTui, QuitAction, RenamePrompt, RenameTarget, ShareCopy,
-        UiIntent,
+        AddMachinePrompt, KeyHandling, ModalState, MultiPaneTui, QuitAction, RenamePrompt,
+        RenameTarget, ShareCopy, UiIntent,
     },
 };
 
@@ -93,6 +93,65 @@ impl MultiPaneTui {
                 self.pending_share_copy = Some(ShareCopy::Ticket);
             }
             KeyCode::Esc if key.modifiers.is_empty() => {
+                self.modal = ModalState::None;
+            }
+            _ => {}
+        }
+        KeyHandling::Consumed(vec![])
+    }
+
+    /// `a` on the inbox: put up the line the other machine has to run.
+    ///
+    /// The machines already here are remembered so the panel can say which one
+    /// arrived, and the client is asked to record the session's ticket — that
+    /// write is what makes bare `p2pmux` rejoin on both machines afterwards,
+    /// and what lets the node remember the newcomer once it appears.
+    pub(in crate::tui) fn open_add_machine(&mut self) {
+        self.modal = ModalState::AddMachine(AddMachinePrompt {
+            known: crate::tui::home::machine_rows(self)
+                .into_iter()
+                .map(|machine| machine.name)
+                .collect(),
+        });
+        self.pending_pair_offer = true;
+        self.exit_chord_mode();
+    }
+
+    pub fn add_machine_open(&self) -> bool {
+        matches!(self.modal, ModalState::AddMachine(_))
+    }
+
+    /// The machine that has joined since the panel went up, if one has.
+    ///
+    /// Read from the member list rather than from the pairing file: a machine
+    /// that has joined is in the session, and that is the fact the user is
+    /// waiting on. The pairing record catches up a moment later, out of process.
+    pub(in crate::tui) fn add_machine_joined(&self) -> Option<String> {
+        let ModalState::AddMachine(prompt) = &self.modal else {
+            return None;
+        };
+        crate::tui::home::machine_rows(self)
+            .into_iter()
+            .map(|machine| machine.name)
+            .find(|name| !prompt.known.contains(name))
+    }
+
+    /// Takes the request to record the session's ticket in the pairing file.
+    ///
+    /// The TUI never touches the filesystem — the attaching process owns it,
+    /// exactly as it owns the clipboard for [`Self::take_share_copy_request`].
+    pub fn take_pair_offer(&mut self) -> bool {
+        std::mem::take(&mut self.pending_pair_offer)
+    }
+
+    /// `c` copies the line, `Esc` closes. Nothing else: the panel is waiting on
+    /// another machine, and there is no third thing to do while it does.
+    pub(in crate::tui) fn handle_add_machine_key(&mut self, key: KeyEvent) -> KeyHandling {
+        match key.code {
+            KeyCode::Enter | KeyCode::Char('c') if key.modifiers.is_empty() => {
+                self.pending_share_copy = Some(ShareCopy::Pair);
+            }
+            KeyCode::Esc | KeyCode::Char('a') if key.modifiers.is_empty() => {
                 self.modal = ModalState::None;
             }
             _ => {}
@@ -595,6 +654,87 @@ mod tests {
 
         let _ = tui.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE), area);
         assert!(!tui.share_open());
+    }
+
+    /// Adding a machine is two halves — the line to run there, and finding out
+    /// whether it worked — and the panel holds both. The second half is the one
+    /// that used to mean going somewhere else.
+    #[test]
+    pub(in crate::tui) fn the_add_machine_panel_shows_the_line_then_reports_the_join() {
+        let area = Rect::new(0, 0, 100, 24);
+        let mut tui = crate::tui::test_support::home_tui(&[(
+            "laptop",
+            "claude",
+            crate::protocol::AgentRosterState::Working,
+        )]);
+        tui.snapshot.members[0].display_name = String::from("laptop");
+        tui.set_home_open(true, "test");
+
+        assert_eq!(
+            tui.handle_key(KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE), area),
+            KeyHandling::Consumed(vec![])
+        );
+        assert!(tui.add_machine_open());
+        assert!(
+            tui.take_pair_offer(),
+            "the session's ticket has to be recorded, or nothing that joins is remembered"
+        );
+        assert!(!tui.take_pair_offer(), "a claimed request is claimed once");
+        assert_eq!(tui.add_machine_joined(), None);
+
+        // `c` copies the pair line rather than the join line: the same code,
+        // but what the machine at the other end does with it is not the same.
+        let _ = tui.handle_key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::NONE), area);
+        assert_eq!(tui.take_share_copy_request(), Some(ShareCopy::Pair));
+
+        // The machine turns up in the member list, which is the fact the user
+        // is waiting on — the pairing file catches up out of process.
+        tui.snapshot.members.push(crate::layout::Member {
+            peer_id: b"droplet".to_vec(),
+            endpoint_addr: b"endpoint-droplet".to_vec(),
+            display_name: String::from("droplet"),
+        });
+        assert_eq!(tui.add_machine_joined().as_deref(), Some("droplet"));
+
+        let _ = tui.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE), area);
+        assert!(!tui.add_machine_open());
+    }
+
+    /// The panel is waiting on another machine. A key that walked out from
+    /// under it would leave a dialog owning the keyboard with nothing on
+    /// screen, so it holds every key but the one that ends the session.
+    #[test]
+    pub(in crate::tui) fn the_add_machine_panel_holds_the_keyboard_until_it_is_dismissed() {
+        let area = Rect::new(0, 0, 100, 24);
+        let mut tui = crate::tui::test_support::home_tui(&[]);
+        tui.set_home_open(true, "test");
+        let _ = tui.handle_key(KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE), area);
+
+        for key in [KeyCode::Char('n'), KeyCode::Char('q'), KeyCode::Down] {
+            assert_eq!(
+                tui.handle_key(KeyEvent::new(key, KeyModifiers::NONE), area),
+                KeyHandling::Consumed(vec![]),
+                "{key:?} must not reach Home while the panel is up"
+            );
+            assert!(tui.add_machine_open());
+        }
+        assert_eq!(
+            tui.handle_key(
+                KeyEvent::new(KeyCode::Char('o'), KeyModifiers::CONTROL),
+                area
+            ),
+            KeyHandling::Consumed(vec![])
+        );
+        assert!(tui.home_open(), "and never closes the screen underneath it");
+
+        // Ctrl+Q outranks every panel, here as everywhere else.
+        assert_eq!(
+            tui.handle_key(
+                KeyEvent::new(KeyCode::Char('q'), KeyModifiers::CONTROL),
+                area
+            ),
+            KeyHandling::Quit(QuitAction::Detach)
+        );
     }
 
     #[test]

--- a/src/tui/render/footer.rs
+++ b/src/tui/render/footer.rs
@@ -180,6 +180,15 @@ pub(in crate::tui) const SHARE_HELP_GUEST: &[FooterSegment] = &[
     FooterSegment::Key("Esc"),
     FooterSegment::Text("> CLOSE"),
 ];
+/// The add-machine panel offers one invite and one thing to do with it, so
+/// there is no second key to name.
+pub(in crate::tui) const ADD_MACHINE_HELP: &[FooterSegment] = &[
+    FooterSegment::Text("<"),
+    FooterSegment::Key("c"),
+    FooterSegment::Text("> COPY   <"),
+    FooterSegment::Key("Esc"),
+    FooterSegment::Text("> CLOSE"),
+];
 /// The help segments for a chord mode, narrowed to the widest tier `width` can hold.
 ///
 /// Pane mode has tiers because its bar is the longest one here and adding a key

--- a/src/tui/render/home.rs
+++ b/src/tui/render/home.rs
@@ -63,6 +63,20 @@ const HOME_KEYS: &[FooterSegment] = &[
     FooterSegment::Key("q"),
     FooterSegment::Text(" quit"),
 ];
+/// The same bar with the paging keys, shown only while there is a second page
+/// for them to reach — by the same rule that took `m` off the bar.
+const HOME_KEYS_PAGED: &[FooterSegment] = &[
+    FooterSegment::Key("enter"),
+    FooterSegment::Text(" open   "),
+    FooterSegment::Key("h l"),
+    FooterSegment::Text(" page   "),
+    FooterSegment::Key("a"),
+    FooterSegment::Text(" add machine   "),
+    FooterSegment::Key("n"),
+    FooterSegment::Text(" new terminal   "),
+    FooterSegment::Key("q"),
+    FooterSegment::Text(" quit"),
+];
 
 /// Column widths. The machine and agent columns are fixed so the eye can read
 /// down them; everything the row has left over goes to what the agent is doing,
@@ -177,7 +191,7 @@ fn render_home_in(
     }
 
     if keys.width > 0 && keys.height > 0 {
-        render_home_keys(frame.buffer_mut(), theme, keys);
+        render_home_keys(frame.buffer_mut(), theme, keys, tui.home_page_count() > 1);
     }
 }
 
@@ -820,7 +834,7 @@ pub fn machine_line(machine: &MachineRow) -> String {
     )
 }
 
-fn render_home_keys(buffer: &mut Buffer, theme: &UiTheme, keys: Rect) {
+fn render_home_keys(buffer: &mut Buffer, theme: &UiTheme, keys: Rect, paged: bool) {
     if keys.height == 0 {
         return;
     }
@@ -837,7 +851,7 @@ fn render_home_keys(buffer: &mut Buffer, theme: &UiTheme, keys: Rect) {
         keys.x.saturating_add(1),
         keys.y,
         keys.right(),
-        HOME_KEYS,
+        if paged { HOME_KEYS_PAGED } else { HOME_KEYS },
     );
 }
 

--- a/src/tui/render/home.rs
+++ b/src/tui/render/home.rs
@@ -23,7 +23,7 @@ use crate::{
         AgentOverlayRow, MultiPaneTui,
         home::{
             HomeCard, HomeLayout, MACHINE_RAIL_WIDTH, MachinePanel, MachineRow, home_card,
-            home_layout, machine_rows,
+            home_layout, home_page_size, machine_rows,
         },
         render::footer::{FooterSegment, render_footer_segments},
         text::{sanitize_single_line, text_width, truncate_leading, truncate_trailing},
@@ -162,7 +162,11 @@ fn render_home_in(
             let lines = rows
                 .into_iter()
                 .skip(tui.home_page_start())
-                .take(usize::from(layout.rows.height) / card.lines())
+                // A page, not everything the height happens to fit: past eight
+                // agents the two stop being the same number, and drawing more
+                // than a page holds puts agents on screen that `h` and `l` then
+                // step over, under a marker claiming a page they are not on.
+                .take(home_page_size(layout.rows.height))
                 .flat_map(|row| {
                     format_home_card(
                         row,
@@ -942,10 +946,36 @@ mod tests {
         protocol::AgentRosterState,
         tui::{
             MultiPaneTui,
-            home::{HomeCard, MachineRow},
+            home::{HOME_PAGE_MAX, HomeCard, MachineRow},
             test_support::agent_row,
         },
     };
+
+    /// A page has to be what the screen *draws*, not only what `h` and `l` step
+    /// by. A tall terminal has room for more agents than a page holds, and
+    /// filling it drew agents that paging then stepped straight over, under a
+    /// marker naming a page they were not on.
+    #[test]
+    fn a_tall_terminal_draws_one_page_rather_than_everything_that_fits() {
+        use ratatui::layout::Rect;
+
+        let agents = (0..9)
+            .map(|_| ("laptop", "claude", AgentRosterState::Working))
+            .collect::<Vec<_>>();
+        let mut tui = crate::tui::test_support::home_tui(&agents);
+        tui.set_home_open(true, "test");
+        tui.set_home_viewport_for(Rect::new(0, 0, 120, 60));
+
+        assert_eq!(tui.home_page_count(), 2, "nine agents is more than a page");
+        let drawn = screen(&tui, 120, 60)
+            .iter()
+            .filter(|line| line.contains("claude"))
+            .count();
+        assert_eq!(
+            drawn, HOME_PAGE_MAX,
+            "a page holds eight however tall the terminal is"
+        );
+    }
 
     fn rendered(state: AgentRosterState, message: &str) -> String {
         let mut row = agent_row(1, 1, 1);

--- a/src/tui/render/home.rs
+++ b/src/tui/render/home.rs
@@ -21,7 +21,9 @@ use crate::{
     protocol::AgentRosterState,
     tui::{
         AgentOverlayRow, MultiPaneTui,
-        home::{HomeLayout, MachineRow, home_layout, machine_rows},
+        home::{
+            HomeLayout, MACHINE_RAIL_WIDTH, MachinePanel, MachineRow, home_layout, machine_rows,
+        },
         render::footer::{FooterSegment, render_footer_segments},
         text::{sanitize_single_line, text_width, truncate_leading, truncate_trailing},
     },
@@ -47,13 +49,14 @@ pub(in crate::tui) const HOME_EMPTY_NO_HOOKS: &str =
 /// long as it is true.
 pub(in crate::tui) const HOME_ROW_NO_HOOKS: &str = "state unknown — no hooks";
 
+/// `m machines` is gone from here: it expanded the strip into a table, and the
+/// rail is that table, permanently. A key that changes nothing is worse on a
+/// key bar than a key that is missing from one.
 const HOME_KEYS: &[FooterSegment] = &[
     FooterSegment::Key("enter"),
     FooterSegment::Text(" open   "),
     FooterSegment::Key("n"),
     FooterSegment::Text(" new terminal   "),
-    FooterSegment::Key("m"),
-    FooterSegment::Text(" machines   "),
     FooterSegment::Key("q"),
     FooterSegment::Text(" quit"),
 ];
@@ -67,6 +70,10 @@ const STATE_WIDTH: u16 = 12;
 /// Wide enough for `9h59m59s`, which is every clock anyone watches. A longer
 /// one pushes into the description column rather than losing a digit.
 const ELAPSED_WIDTH: u16 = 8;
+/// What a rail line has left for words once the rule and its space are drawn.
+const RAIL_TEXT_WIDTH: usize = MACHINE_RAIL_WIDTH as usize - 2;
+/// A spacer, the name, and what the machine is doing.
+const RAIL_LINES_PER_MACHINE: usize = 3;
 
 pub(in crate::tui) fn render_home(frame: &mut Frame<'_>, tui: &MultiPaneTui, now_unix_ms: u64) {
     let geometry = tui.geometry(frame.area());
@@ -144,7 +151,13 @@ fn render_home_in(
     }
 
     if layout.machines.height > 0 {
-        frame.render_widget(Paragraph::new(machine_block(tui, theme)), layout.machines);
+        let lines = match layout.machine_panel {
+            MachinePanel::Rail => machine_rail(tui, theme, layout.machines.height),
+            MachinePanel::Table => machine_table(tui, theme),
+            MachinePanel::Strip => machine_strip(tui, theme),
+            MachinePanel::Empty => Vec::new(),
+        };
+        frame.render_widget(Paragraph::new(lines), layout.machines);
     }
 
     if keys.width > 0 && keys.height > 0 {
@@ -378,36 +391,119 @@ fn home_kind_label(kind: &str) -> &'static str {
     }
 }
 
-/// The machine strip: fleet health in one line, without a second screen.
-pub(in crate::tui) fn machine_block(tui: &MultiPaneTui, theme: &UiTheme) -> Vec<Line<'static>> {
+/// The fleet down the right-hand side: every machine, two lines each.
+///
+/// A column rather than a footer because the space it spends was never being
+/// used — the sentence an agent gets is rarely half the width of the screen —
+/// and because a fleet you can see the whole time is the difference between
+/// machines being part of the product and being a command you remember to run.
+fn machine_rail(tui: &MultiPaneTui, theme: &UiTheme, height: u16) -> Vec<Line<'static>> {
     let machines = machine_rows(tui);
-    // Empty only before the member list has arrived — the machine this is
-    // running on is a machine, and once it is known it is always in the strip.
-    if machines.is_empty() {
-        return Vec::new();
+    let mut lines = vec![
+        rail_line(Vec::new(), theme),
+        rail_line(
+            vec![Span::styled(
+                format!("MACHINES · {}", machines.len()),
+                Style::default()
+                    .fg(theme.agent_overlay_muted)
+                    .add_modifier(Modifier::BOLD),
+            )],
+            theme,
+        ),
+    ];
+    // A spacer and two lines each. A fleet too tall for the rail gives up its
+    // last two lines to a count of what did not fit, because a rail that simply
+    // stopped would be a fleet with machines silently missing from it.
+    let height = usize::from(height);
+    let body = height.saturating_sub(lines.len());
+    let mut shown = body / RAIL_LINES_PER_MACHINE;
+    if shown < machines.len() {
+        shown = body.saturating_sub(2) / RAIL_LINES_PER_MACHINE;
     }
-    if !tui.machines_expanded {
-        let mut spans = vec![Span::raw(" ")];
-        for machine in &machines {
-            spans.push(Span::styled(
-                sanitize_single_line(&machine.name),
-                Style::default().fg(theme.agent_overlay_foreground),
-            ));
-            spans.push(Span::styled(
-                if machine.reachable {
-                    " ✓   ".to_owned()
-                } else {
-                    " asleep   ".to_owned()
-                },
-                Style::default().fg(if machine.reachable {
-                    theme.agent_overlay_muted
-                } else {
-                    theme.agent_overlay_secondary
-                }),
-            ));
-        }
-        return vec![Line::raw(""), Line::from(spans)];
+    for machine in machines.iter().take(shown) {
+        lines.push(rail_line(Vec::new(), theme));
+        lines.push(rail_line(
+            vec![
+                Span::styled(
+                    if machine.reachable { "● " } else { "○ " },
+                    Style::default().fg(if machine.reachable {
+                        theme.agent_overlay_chrome
+                    } else {
+                        theme.agent_overlay_secondary
+                    }),
+                ),
+                Span::styled(
+                    truncate_trailing(&sanitize_single_line(&machine.name), RAIL_TEXT_WIDTH - 2),
+                    Style::default().fg(theme.agent_overlay_foreground),
+                ),
+            ],
+            theme,
+        ));
+        lines.push(rail_line(
+            vec![Span::styled(
+                format!(
+                    "  {}",
+                    truncate_trailing(&machine_detail(machine), RAIL_TEXT_WIDTH - 2)
+                ),
+                Style::default().fg(theme.agent_overlay_muted),
+            )],
+            theme,
+        ));
     }
+    if shown < machines.len() {
+        let rest = machines.len() - shown;
+        lines.push(rail_line(Vec::new(), theme));
+        lines.push(rail_line(
+            vec![Span::styled(
+                format!("+{rest} more"),
+                Style::default().fg(theme.agent_overlay_secondary),
+            )],
+            theme,
+        ));
+    }
+    lines
+}
+
+/// What a machine is, under its name: whether it is this one, whether it is
+/// answering, and what it is running.
+///
+/// `accepts work` appears only when that machine actually said so. The answer
+/// is given during its own pairing and has no way back here, so printing
+/// anything for a machine that never said would be inventing consent.
+fn machine_detail(machine: &MachineRow) -> String {
+    let mut parts: Vec<String> = Vec::new();
+    if machine.this_machine {
+        parts.push(String::from("this machine"));
+    } else if !machine.reachable {
+        parts.push(String::from("asleep"));
+    }
+    if machine.accepts_work == Some(true) {
+        parts.push(String::from("accepts work"));
+    }
+    match machine.agents {
+        0 => {}
+        1 => parts.push(String::from("1 agent")),
+        count => parts.push(format!("{count} agents")),
+    }
+    if parts.is_empty() {
+        parts.push(String::from("ready"));
+    }
+    parts.join(" · ")
+}
+
+/// One rail line, hung off the rule that separates it from the agents.
+fn rail_line(mut spans: Vec<Span<'static>>, theme: &UiTheme) -> Line<'static> {
+    let mut line = vec![Span::styled(
+        "│ ",
+        Style::default().fg(theme.agent_overlay_secondary),
+    )];
+    line.append(&mut spans);
+    Line::from(line)
+}
+
+/// The same facts as a table under the agents, for a terminal too narrow to
+/// give a column away.
+fn machine_table(tui: &MultiPaneTui, theme: &UiTheme) -> Vec<Line<'static>> {
     let mut lines = vec![
         Line::raw(""),
         Line::styled(
@@ -420,13 +516,37 @@ pub(in crate::tui) fn machine_block(tui: &MultiPaneTui, theme: &UiTheme) -> Vec<
                 .add_modifier(Modifier::BOLD),
         ),
     ];
-    for machine in &machines {
+    for machine in &machine_rows(tui) {
         lines.push(Line::styled(
             format!(" {}", machine_line(machine)),
             Style::default().fg(theme.agent_overlay_foreground),
         ));
     }
     lines
+}
+
+/// Fleet health in one line, for a terminal with room for nothing else.
+fn machine_strip(tui: &MultiPaneTui, theme: &UiTheme) -> Vec<Line<'static>> {
+    let mut spans = vec![Span::raw(" ")];
+    for machine in &machine_rows(tui) {
+        spans.push(Span::styled(
+            sanitize_single_line(&machine.name),
+            Style::default().fg(theme.agent_overlay_foreground),
+        ));
+        spans.push(Span::styled(
+            if machine.reachable {
+                " ✓   ".to_owned()
+            } else {
+                " asleep   ".to_owned()
+            },
+            Style::default().fg(if machine.reachable {
+                theme.agent_overlay_muted
+            } else {
+                theme.agent_overlay_secondary
+            }),
+        ));
+    }
+    vec![Line::raw(""), Line::from(spans)]
 }
 
 /// One machine, formatted identically on Home and in `p2pmux machines`, so the
@@ -509,13 +629,13 @@ mod tests {
 
     use super::{
         ELAPSED_WIDTH, HOME_EMPTY_NO_AGENTS, HOME_EMPTY_NO_HOOKS, HOME_ROW_NO_HOOKS,
-        format_home_row, header_line, home_elapsed, machine_line,
+        format_home_row, header_line, home_elapsed, machine_detail, machine_line,
     };
     use crate::{
         agent_detect::{AgentKind, AgentState, DetectedAgent, PaneAgentTracker},
         config::UiTheme,
         protocol::AgentRosterState,
-        tui::{home::MachineRow, test_support::agent_row},
+        tui::{MultiPaneTui, home::MachineRow, test_support::agent_row},
     };
 
     fn rendered(state: AgentRosterState, message: &str) -> String {
@@ -525,6 +645,24 @@ mod tests {
         row.kind = String::from("claude");
         row.message = message.to_owned();
         format_home_row(&row, false, 100, 0, 0, &UiTheme::default()).to_string()
+    }
+
+    /// Home drawn into a terminal of the given size, one string per screen row.
+    pub(in crate::tui) fn screen(tui: &MultiPaneTui, width: u16, height: u16) -> Vec<String> {
+        use ratatui::{Terminal, backend::TestBackend};
+
+        let mut terminal = Terminal::new(TestBackend::new(width, height)).expect("terminal");
+        terminal
+            .draw(|frame| super::render_home(frame, tui, 0))
+            .expect("render");
+        let buffer = terminal.backend().buffer().clone();
+        (0..height)
+            .map(|row| {
+                (0..width)
+                    .map(|column| buffer[(column, row)].symbol())
+                    .collect::<String>()
+            })
+            .collect()
     }
 
     /// The rule, checked at the boundary where it is consumed rather than only
@@ -684,5 +822,109 @@ mod tests {
         };
 
         assert!(machine_line(&asleep).contains("asleep"));
+    }
+
+    /// The line under a machine's name says what it is and what it is running.
+    /// A machine that is up and idle still says something — a blank line under
+    /// a name reads as a machine the screen knows nothing about.
+    #[test]
+    fn the_line_under_a_machine_names_what_it_is_and_what_it_runs() {
+        let base = MachineRow {
+            name: String::from("droplet"),
+            reachable: true,
+            accepts_work: None,
+            agents: 0,
+            this_machine: false,
+        };
+
+        assert_eq!(machine_detail(&base), "ready");
+        assert_eq!(
+            machine_detail(&MachineRow {
+                agents: 1,
+                ..base.clone()
+            }),
+            "1 agent"
+        );
+        assert_eq!(
+            machine_detail(&MachineRow {
+                this_machine: true,
+                agents: 3,
+                ..base.clone()
+            }),
+            "this machine · 3 agents"
+        );
+        assert_eq!(
+            machine_detail(&MachineRow {
+                reachable: false,
+                ..base.clone()
+            }),
+            "asleep"
+        );
+        // Never said is never printed: the answer is given during that
+        // machine's own pairing and has no way back here, so anything else
+        // would be inventing consent nobody gave.
+        assert_eq!(
+            machine_detail(&MachineRow {
+                accepts_work: None,
+                agents: 2,
+                ..base.clone()
+            }),
+            "2 agents"
+        );
+        assert_eq!(
+            machine_detail(&MachineRow {
+                accepts_work: Some(true),
+                agents: 2,
+                ..base
+            }),
+            "accepts work · 2 agents"
+        );
+    }
+
+    /// The fleet stays on screen the whole time the inbox is up, in width the
+    /// agents were never using.
+    #[test]
+    fn the_rail_draws_every_machine_beside_the_agents() {
+        let mut tui =
+            crate::tui::test_support::home_tui(&[("laptop", "claude", AgentRosterState::Working)]);
+        tui.snapshot.members[0].display_name = String::from("laptop");
+        tui.paired_machines = vec![crate::tui::PairedMachine {
+            name: String::from("oldbox"),
+            accepts_work: None,
+        }];
+        tui.set_home_open(true, "test");
+
+        let drawn = screen(&tui, 120, 30).join("\n");
+        assert!(drawn.contains("MACHINES · 2"), "{drawn}");
+        assert!(drawn.contains("● laptop"), "{drawn}");
+        assert!(drawn.contains("this machine · 1 agent"), "{drawn}");
+        assert!(drawn.contains("○ oldbox"), "{drawn}");
+        assert!(drawn.contains("asleep"), "{drawn}");
+        assert!(
+            drawn.contains('│'),
+            "the rail hangs off a rule rather than floating: {drawn}"
+        );
+    }
+
+    /// A rail with more machines than lines says how many it left out. One that
+    /// simply stopped would be a fleet with machines silently missing from it.
+    #[test]
+    fn a_rail_too_short_for_the_fleet_counts_what_it_cut() {
+        let mut tui =
+            crate::tui::test_support::home_tui(&[("laptop", "claude", AgentRosterState::Working)]);
+        tui.paired_machines = (1..=6)
+            .map(|index| crate::tui::PairedMachine {
+                name: format!("box{index}"),
+                accepts_work: None,
+            })
+            .collect();
+        tui.set_home_open(true, "test");
+
+        let drawn = screen(&tui, 120, 14).join("\n");
+        assert!(drawn.contains("MACHINES · 7"), "{drawn}");
+        assert!(
+            drawn.contains(" more"),
+            "the machines that did not fit are counted, not dropped: {drawn}"
+        );
     }
 }

--- a/src/tui/render/home.rs
+++ b/src/tui/render/home.rs
@@ -22,7 +22,8 @@ use crate::{
     tui::{
         AgentOverlayRow, MultiPaneTui,
         home::{
-            HomeLayout, MACHINE_RAIL_WIDTH, MachinePanel, MachineRow, home_layout, machine_rows,
+            HomeCard, HomeLayout, MACHINE_RAIL_WIDTH, MachinePanel, MachineRow, home_card,
+            home_layout, machine_rows,
         },
         render::footer::{FooterSegment, render_footer_segments},
         text::{sanitize_single_line, text_width, truncate_leading, truncate_trailing},
@@ -78,6 +79,9 @@ const RAIL_TEXT_WIDTH: usize = MACHINE_RAIL_WIDTH as usize - 2;
 const RAIL_LINES_PER_MACHINE: usize = 3;
 /// The rule and the key under it, which the fleet never grows into.
 const RAIL_FOOTER_LINES: usize = 2;
+/// Where a card's second and third lines start: under the dot, not under the
+/// marker, so the block of text hangs off the state glyph that introduces it.
+const CARD_INDENT: u16 = 3;
 
 pub(in crate::tui) fn render_home(frame: &mut Frame<'_>, tui: &MultiPaneTui, now_unix_ms: u64) {
     let geometry = tui.geometry(frame.area());
@@ -102,7 +106,13 @@ fn render_home_in(
         frame.render_widget(
             Paragraph::new(vec![
                 Line::raw(""),
-                header_line(tui.home_needs_you_count(), theme),
+                header_line(
+                    tui.home_needs_you_count(),
+                    tui.home_page(),
+                    tui.home_page_count(),
+                    layout.header.width,
+                    theme,
+                ),
             ]),
             layout.header,
         );
@@ -123,13 +133,15 @@ fn render_home_in(
             );
         } else {
             let animation_phase = animation_phase(now_unix_ms);
+            let card = home_card(layout.rows.height);
             let lines = rows
                 .into_iter()
-                .skip(tui.home_scroll_line)
-                .take(usize::from(layout.rows.height))
-                .map(|row| {
-                    format_home_row(
+                .skip(tui.home_page_start())
+                .take(usize::from(layout.rows.height) / card.lines())
+                .flat_map(|row| {
+                    format_home_card(
                         row,
+                        card,
                         tui.home_selected == Some(row.pane_id),
                         layout.rows.width,
                         now_unix_ms,
@@ -171,7 +183,18 @@ fn render_home_in(
 
 /// `Agents · 2 need you` — the whole value of the screen in one number, and the
 /// exact sentence a notification will one day carry.
-pub(in crate::tui) fn header_line(needs_you: usize, theme: &UiTheme) -> Line<'static> {
+///
+/// The page marker sits at the other end, and only when there is more than one
+/// page. It never has to be read to know whether something is waiting: the
+/// count beside the title covers the whole list, not the page on screen, and
+/// the sort order puts what most wants a human on page one.
+pub(in crate::tui) fn header_line(
+    needs_you: usize,
+    page: usize,
+    pages: usize,
+    width: u16,
+    theme: &UiTheme,
+) -> Line<'static> {
     let mut spans = vec![Span::styled(
         " Agents",
         Style::default()
@@ -193,16 +216,199 @@ pub(in crate::tui) fn header_line(needs_you: usize, theme: &UiTheme) -> Line<'st
                 .add_modifier(Modifier::BOLD),
         ));
     }
+    if pages > 1 {
+        let marker = format!("page {} of {pages} ", page.saturating_add(1), pages = pages);
+        let used = spans.iter().fold(0_u16, |total, span| {
+            total.saturating_add(text_width(&span.content))
+        });
+        let gap = width
+            .saturating_sub(used)
+            .saturating_sub(text_width(&marker));
+        if gap > 0 {
+            spans.push(Span::raw(" ".repeat(usize::from(gap))));
+            spans.push(Span::styled(
+                marker,
+                Style::default().fg(theme.agent_overlay_muted),
+            ));
+        }
+    }
     Line::from(spans)
+}
+
+/// One agent, as many lines as the terminal has room for.
+///
+/// The `Full` card is the one worth reading:
+///
+/// ```text
+/// › ● droplet    claude                     needs you        2m14s
+///     permission: write to /etc/hosts
+///     ~/work/p2pmux · tab 2 · pane 1
+/// ```
+///
+/// The second line is what the agent said, at whatever length it said it, and
+/// the third is the two facts a one-line row had to choose between showing —
+/// which repository it is in, and where Enter is about to put you. It is never
+/// a model-written summary: a richer sentence that can lie about what an agent
+/// did defeats the entire point of not reading the terminal yourself.
+pub(in crate::tui) fn format_home_card(
+    row: &AgentOverlayRow,
+    card: HomeCard,
+    selected: bool,
+    width: u16,
+    now_unix_ms: u64,
+    animation_phase: usize,
+    theme: &UiTheme,
+) -> Vec<Line<'static>> {
+    if card == HomeCard::Row {
+        return vec![format_home_row(
+            row,
+            selected,
+            width,
+            now_unix_ms,
+            animation_phase,
+            theme,
+        )];
+    }
+    let background = if selected {
+        Style::default().bg(theme.agent_overlay_selected_background)
+    } else {
+        Style::default()
+    };
+    let (said, said_style) = home_description(row, theme);
+    let mut lines = vec![
+        card_headline(row, selected, width, now_unix_ms, animation_phase, theme),
+        card_line(&said, said_style, width, background),
+    ];
+    if card == HomeCard::Full {
+        // The cwd only when the line above did not already have to be it: the
+        // fallback for an agent that has said nothing is its directory, and
+        // printing that twice would waste the line the card exists for.
+        let location = home_location(row, said == short_cwd(&row.cwd));
+        lines.push(card_line(
+            &location,
+            Style::default().fg(theme.agent_overlay_secondary),
+            width,
+            background,
+        ));
+    }
+    // The blank between two cards, tinted with the selection so the band reads
+    // as one agent rather than as three lines that happen to be adjacent.
+    lines.push(card_line("", Style::default(), width, background));
+    lines
+}
+
+/// `~/work/p2pmux · tab 2 · pane 1` — where the agent is, and where Enter goes.
+fn home_location(row: &AgentOverlayRow, cwd_already_shown: bool) -> String {
+    let where_it_runs = format!("tab {} · pane {}", row.tab_ordinal, row.pane_ordinal);
+    if cwd_already_shown || row.cwd.is_empty() {
+        return where_it_runs;
+    }
+    format!("{} · {where_it_runs}", short_cwd(&row.cwd))
+}
+
+/// A card's second or third line: indented under the dot, and padded so the
+/// selection band covers the whole width.
+fn card_line(text: &str, style: Style, width: u16, background: Style) -> Line<'static> {
+    let room = usize::from(width.saturating_sub(CARD_INDENT));
+    let text = truncate_trailing(&sanitize_single_line(text), room);
+    Line::from(vec![
+        Span::styled(" ".repeat(usize::from(CARD_INDENT)), background),
+        Span::styled(format!("{text:<room$}"), style.patch(background)),
+    ])
+    .style(background)
+}
+
+/// The first line of a card: who, where, what state, and for how long.
+fn card_headline(
+    row: &AgentOverlayRow,
+    selected: bool,
+    width: u16,
+    now_unix_ms: u64,
+    animation_phase: usize,
+    theme: &UiTheme,
+) -> Line<'static> {
+    let (dot, state_word) = home_state_label(row.state, animation_phase);
+    let state_color = home_state_color(row.state, theme);
+    let background = if selected {
+        Style::default().bg(theme.agent_overlay_selected_background)
+    } else {
+        Style::default()
+    };
+    let mut state_style = Style::default().fg(state_color);
+    if row.state.needs_you() {
+        state_style = state_style.add_modifier(Modifier::BOLD);
+    }
+
+    let mut spans = vec![
+        Span::styled(
+            if selected { "›" } else { " " },
+            Style::default()
+                .fg(theme.agent_overlay_chrome)
+                .patch(background),
+        ),
+        Span::styled(dot, Style::default().fg(state_color).patch(background)),
+        Span::styled(" ", background),
+        Span::styled(
+            pad(&sanitize_single_line(&row.host), MACHINE_WIDTH),
+            Style::default()
+                .fg(theme.agent_overlay_foreground)
+                .patch(background),
+        ),
+        Span::styled(" ", background),
+        Span::styled(
+            pad(home_kind_label(&row.kind), AGENT_WIDTH),
+            Style::default()
+                .fg(theme.agent_overlay_foreground)
+                .add_modifier(Modifier::BOLD)
+                .patch(background),
+        ),
+    ];
+    // State and elapsed are pushed to the right-hand edge, where they line up
+    // down the page and leave the middle to the name. Both drop off a terminal
+    // too narrow to hold them rather than pushing the name off the front.
+    let used = text_width("  ")
+        .saturating_add(text_width(dot))
+        .saturating_add(MACHINE_WIDTH)
+        .saturating_add(AGENT_WIDTH)
+        .saturating_add(1);
+    let tail = STATE_WIDTH.saturating_add(ELAPSED_WIDTH).saturating_add(1);
+    if width > used.saturating_add(tail) {
+        spans.push(Span::styled(
+            " ".repeat(usize::from(width.saturating_sub(used).saturating_sub(tail))),
+            background,
+        ));
+        spans.push(Span::styled(
+            pad(state_word, STATE_WIDTH),
+            state_style.patch(background),
+        ));
+        spans.push(Span::styled(
+            format!(
+                "{:>width$}",
+                home_elapsed(row, now_unix_ms),
+                width = usize::from(ELAPSED_WIDTH)
+            ),
+            Style::default()
+                .fg(theme.agent_overlay_muted)
+                .patch(background),
+        ));
+    }
+    let drawn = spans.iter().fold(0_u16, |total, span| {
+        total.saturating_add(text_width(&span.content))
+    });
+    spans.push(Span::styled(
+        " ".repeat(usize::from(width.saturating_sub(drawn))),
+        background,
+    ));
+    Line::from(spans).style(background)
 }
 
 /// One agent, one line:
 /// `‹dot› ‹machine› ‹agent› ‹state› ‹what it is doing› ‹elapsed›`.
 ///
-/// Machine is a column rather than a panel because you care about a machine
-/// almost exclusively through an agent that happens to be on it. Elapsed is
-/// right-aligned and last because it is the first thing worth cutting when the
-/// terminal is narrow.
+/// What a terminal too short for a card falls back to. Machine is a column
+/// rather than a panel because you care about a machine almost exclusively
+/// through an agent that happens to be on it. Elapsed is right-aligned and last
+/// because it is the first thing worth cutting when the terminal is narrow.
 pub(in crate::tui) fn format_home_row(
     row: &AgentOverlayRow,
     selected: bool,
@@ -663,13 +869,17 @@ mod tests {
 
     use super::{
         ELAPSED_WIDTH, HOME_EMPTY_NO_AGENTS, HOME_EMPTY_NO_HOOKS, HOME_ROW_NO_HOOKS,
-        format_home_row, header_line, home_elapsed, machine_detail, machine_line,
+        format_home_row, header_line, home_card, home_elapsed, machine_detail, machine_line,
     };
     use crate::{
         agent_detect::{AgentKind, AgentState, DetectedAgent, PaneAgentTracker},
         config::UiTheme,
         protocol::AgentRosterState,
-        tui::{MultiPaneTui, home::MachineRow, test_support::agent_row},
+        tui::{
+            MultiPaneTui,
+            home::{HomeCard, MachineRow},
+            test_support::agent_row,
+        },
     };
 
     fn rendered(state: AgentRosterState, message: &str) -> String {
@@ -795,15 +1005,28 @@ mod tests {
     #[test]
     fn the_header_says_the_count_in_words_a_notification_could_reuse() {
         let theme = UiTheme::default();
-        assert_eq!(header_line(0, &theme).to_string().trim(), "Agents");
-        assert_eq!(
-            header_line(1, &theme).to_string().trim(),
-            "Agents · 1 needs you"
+        let header = |needs_you| header_line(needs_you, 0, 1, 80, &theme).to_string();
+
+        assert_eq!(header(0).trim(), "Agents");
+        assert_eq!(header(1).trim(), "Agents · 1 needs you");
+        assert_eq!(header(2).trim(), "Agents · 2 need you");
+    }
+
+    /// The page marker appears only when there is a second page, and never
+    /// where it could be read as part of the count: the count is of the whole
+    /// list, so a page you cannot see can never be hiding something urgent.
+    #[test]
+    fn the_header_marks_the_page_only_when_there_is_more_than_one() {
+        let theme = UiTheme::default();
+
+        assert!(
+            !header_line(2, 0, 1, 80, &theme)
+                .to_string()
+                .contains("page")
         );
-        assert_eq!(
-            header_line(2, &theme).to_string().trim(),
-            "Agents · 2 need you"
-        );
+        let paged = header_line(2, 1, 3, 80, &theme).to_string();
+        assert!(paged.starts_with(" Agents · 2 need you"), "{paged:?}");
+        assert!(paged.trim_end().ends_with("page 2 of 3"), "{paged:?}");
     }
 
     #[test]
@@ -913,6 +1136,55 @@ mod tests {
             }),
             "accepts work · 2 agents"
         );
+    }
+
+    /// The card shows what a one-line row had to choose between: what the agent
+    /// said, *and* which repository it said it in.
+    #[test]
+    fn a_card_shows_the_words_and_the_place_a_row_could_only_pick_between() {
+        let mut tui =
+            crate::tui::test_support::home_tui(&[("droplet", "claude", AgentRosterState::Pending)]);
+        tui.agent_rows[0].message = String::from("permission: write to /etc/hosts");
+        tui.agent_rows[0].cwd = String::from("/Users/sam/work/p2pmux");
+        tui.set_home_open(true, "test");
+
+        let drawn = screen(&tui, 120, 30).join("\n");
+        assert!(drawn.contains("permission: write to /etc/hosts"), "{drawn}");
+        assert!(drawn.contains("work/p2pmux · tab 1 · pane 1"), "{drawn}");
+        assert!(drawn.contains("needs you"), "{drawn}");
+    }
+
+    /// An agent that has said nothing falls back to its directory, and the card
+    /// must not then print the directory twice.
+    #[test]
+    fn a_card_with_nothing_said_does_not_print_the_directory_twice() {
+        let mut tui =
+            crate::tui::test_support::home_tui(&[("droplet", "claude", AgentRosterState::Working)]);
+        tui.agent_rows[0].cwd = String::from("/Users/sam/work/p2pmux");
+        tui.set_home_open(true, "test");
+
+        let drawn = screen(&tui, 120, 30).join("\n");
+        assert_eq!(
+            drawn.matches("work/p2pmux").count(),
+            1,
+            "the fallback line already is the directory: {drawn}"
+        );
+        assert!(drawn.contains("tab 1 · pane 1"), "{drawn}");
+    }
+
+    /// A terminal too short for cards keeps the one-line rows rather than
+    /// showing one agent and a gap.
+    #[test]
+    fn a_short_terminal_falls_back_to_one_line_a_row() {
+        let tui = crate::tui::test_support::home_tui(&[
+            ("droplet", "claude", AgentRosterState::Pending),
+            ("laptop", "codex", AgentRosterState::Working),
+        ]);
+
+        assert_eq!(home_card(20), HomeCard::Full);
+        assert_eq!(home_card(11), HomeCard::Compact);
+        assert_eq!(home_card(8), HomeCard::Row);
+        let _ = tui;
     }
 
     /// The fleet stays on screen the whole time the inbox is up, in width the

--- a/src/tui/render/home.rs
+++ b/src/tui/render/home.rs
@@ -55,6 +55,8 @@ pub(in crate::tui) const HOME_ROW_NO_HOOKS: &str = "state unknown — no hooks";
 const HOME_KEYS: &[FooterSegment] = &[
     FooterSegment::Key("enter"),
     FooterSegment::Text(" open   "),
+    FooterSegment::Key("a"),
+    FooterSegment::Text(" add machine   "),
     FooterSegment::Key("n"),
     FooterSegment::Text(" new terminal   "),
     FooterSegment::Key("q"),
@@ -74,6 +76,8 @@ const ELAPSED_WIDTH: u16 = 8;
 const RAIL_TEXT_WIDTH: usize = MACHINE_RAIL_WIDTH as usize - 2;
 /// A spacer, the name, and what the machine is doing.
 const RAIL_LINES_PER_MACHINE: usize = 3;
+/// The rule and the key under it, which the fleet never grows into.
+const RAIL_FOOTER_LINES: usize = 2;
 
 pub(in crate::tui) fn render_home(frame: &mut Frame<'_>, tui: &MultiPaneTui, now_unix_ms: u64) {
     let geometry = tui.geometry(frame.area());
@@ -411,11 +415,14 @@ fn machine_rail(tui: &MultiPaneTui, theme: &UiTheme, height: u16) -> Vec<Line<'s
             theme,
         ),
     ];
-    // A spacer and two lines each. A fleet too tall for the rail gives up its
-    // last two lines to a count of what did not fit, because a rail that simply
-    // stopped would be a fleet with machines silently missing from it.
+    // A spacer and two lines each, inside whatever the heading and the key at
+    // the foot leave behind. A fleet too tall for that gives up two more lines
+    // to a count of what did not fit, because a rail that simply stopped would
+    // be a fleet with machines silently missing from it.
     let height = usize::from(height);
-    let body = height.saturating_sub(lines.len());
+    let body = height
+        .saturating_sub(lines.len())
+        .saturating_sub(RAIL_FOOTER_LINES);
     let mut shown = body / RAIL_LINES_PER_MACHINE;
     if shown < machines.len() {
         shown = body.saturating_sub(2) / RAIL_LINES_PER_MACHINE;
@@ -461,6 +468,33 @@ fn machine_rail(tui: &MultiPaneTui, theme: &UiTheme, height: u16) -> Vec<Line<'s
             theme,
         ));
     }
+    // The way to add another one, at the foot of the list of the ones you have,
+    // which is where somebody looking at a fleet of one will be looking.
+    while lines.len() + RAIL_FOOTER_LINES < height {
+        lines.push(rail_line(Vec::new(), theme));
+    }
+    lines.push(rail_line(
+        vec![Span::styled(
+            "─".repeat(RAIL_TEXT_WIDTH.saturating_sub(1)),
+            Style::default().fg(theme.agent_overlay_secondary),
+        )],
+        theme,
+    ));
+    lines.push(rail_line(
+        vec![
+            Span::styled(
+                "a",
+                Style::default()
+                    .fg(theme.agent_overlay_chrome)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                "  add a machine",
+                Style::default().fg(theme.agent_overlay_foreground),
+            ),
+        ],
+        theme,
+    ));
     lines
 }
 
@@ -904,6 +938,9 @@ mod tests {
             drawn.contains('│'),
             "the rail hangs off a rule rather than floating: {drawn}"
         );
+        // At the foot of the machines you have, which is where somebody looking
+        // for how to add another one is already looking.
+        assert!(drawn.contains("add a machine"), "{drawn}");
     }
 
     /// A rail with more machines than lines says how many it left out. One that

--- a/src/tui/render/home.rs
+++ b/src/tui/render/home.rs
@@ -1,4 +1,4 @@
-//! Drawing Home: the header count, one line per agent, the machine strip, and
+//! Drawing Home: the header count, a card per agent, the machines rail, and
 //! the key bar.
 //!
 //! What is deliberately *not* here is as load-bearing as what is: no output

--- a/src/tui/render/home.rs
+++ b/src/tui/render/home.rs
@@ -36,6 +36,23 @@ use crate::{
 /// and that the screen will change on its own once you do it.
 pub(in crate::tui) const HOME_EMPTY_NO_AGENTS: &str =
     "Start an agent in any terminal and it appears here.";
+/// The first run, at length, in the space the cards freed.
+///
+/// The screen is emptiest exactly when its reader is newest, so that is when
+/// there is room to answer the question one grey line could not: what do I do
+/// to make something appear here. The steps are in the order they have to
+/// happen — the hooks first, because an inbox that cannot say `needs you` is a
+/// list of processes, and running an agent before wiring them teaches that.
+const HOME_EMPTY_STEPS: &[(&str, &str)] = &[
+    (
+        "Run `p2pmux setup` once, so your agents can say what they need.",
+        "",
+    ),
+    (
+        "Start claude, codex or opencode in any terminal — on this machine",
+        "or on any machine in the list — and it appears here on its own.",
+    ),
+];
 /// The nudge shown when agents are running but nothing is reporting on them.
 ///
 /// This is the state a default install lands in — the hooks are opt-in — and it
@@ -136,13 +153,7 @@ fn render_home_in(
         let rows = tui.home_rows();
         if rows.is_empty() {
             frame.render_widget(
-                Paragraph::new(vec![
-                    Line::raw(""),
-                    Line::styled(
-                        format!(" {HOME_EMPTY_NO_AGENTS}"),
-                        Style::default().fg(theme.agent_overlay_muted),
-                    ),
-                ]),
+                Paragraph::new(home_empty_state(layout.rows.height, theme)),
                 layout.rows,
             );
         } else {
@@ -193,6 +204,46 @@ fn render_home_in(
     if keys.width > 0 && keys.height > 0 {
         render_home_keys(frame.buffer_mut(), theme, keys, tui.home_page_count() > 1);
     }
+}
+
+/// The screen a first run lands on: what is here (nothing), and what to do
+/// about it.
+///
+/// The numbered form only where there is room for it. A terminal too short
+/// falls back to the one line, which says the same thing in the space it has.
+fn home_empty_state(height: u16, theme: &UiTheme) -> Vec<Line<'static>> {
+    let muted = Style::default().fg(theme.agent_overlay_muted);
+    // A blank, the heading, a blank, and two lines per step.
+    let wanted = 3 + HOME_EMPTY_STEPS.len() * 3;
+    if usize::from(height) < wanted {
+        return vec![
+            Line::raw(""),
+            Line::styled(format!(" {HOME_EMPTY_NO_AGENTS}"), muted),
+        ];
+    }
+    let mut lines = vec![
+        Line::raw(""),
+        Line::styled(
+            String::from(" Nothing running yet."),
+            Style::default()
+                .fg(theme.agent_overlay_foreground)
+                .add_modifier(Modifier::BOLD),
+        ),
+    ];
+    for (index, (first, second)) in HOME_EMPTY_STEPS.iter().enumerate() {
+        lines.push(Line::raw(""));
+        lines.push(Line::from(vec![
+            Span::styled(
+                format!(" {}  ", index + 1),
+                Style::default().fg(theme.agent_overlay_chrome),
+            ),
+            Span::styled((*first).to_owned(), muted),
+        ]));
+        if !second.is_empty() {
+            lines.push(Line::styled(format!("    {second}"), muted));
+        }
+    }
+    lines
 }
 
 /// `Agents · 2 need you` — the whole value of the screen in one number, and the
@@ -1053,6 +1104,36 @@ mod tests {
             HOME_EMPTY_NO_HOOKS,
             "Run `p2pmux setup` to see which agents need you."
         );
+    }
+
+    /// The screen is emptiest exactly when its reader is newest, so that is
+    /// when there is room to say what to do rather than only that nothing is
+    /// here — and the hooks come first, because starting an agent before
+    /// wiring them teaches an inbox that cannot say `needs you`.
+    #[test]
+    fn a_first_run_gets_the_steps_rather_than_one_grey_line() {
+        let mut tui = crate::tui::test_support::home_tui(&[]);
+        tui.set_home_open(true, "test");
+
+        let drawn = screen(&tui, 120, 30).join("\n");
+        assert!(drawn.contains("Nothing running yet."), "{drawn}");
+        let setup = drawn.find("p2pmux setup").expect("the first step");
+        let start = drawn.find("Start claude").expect("the second step");
+        assert!(setup < start, "wiring the hooks comes first: {drawn}");
+        assert!(drawn.contains(" 1  "), "{drawn}");
+        assert!(drawn.contains(" 2  "), "{drawn}");
+    }
+
+    /// A terminal too short for the steps says the same thing in one line
+    /// rather than showing half a checklist.
+    #[test]
+    fn a_short_first_run_keeps_the_one_line_it_has_room_for() {
+        let mut tui = crate::tui::test_support::home_tui(&[]);
+        tui.set_home_open(true, "test");
+
+        let drawn = screen(&tui, 120, 8).join("\n");
+        assert!(drawn.contains(HOME_EMPTY_NO_AGENTS), "{drawn}");
+        assert!(!drawn.contains("Nothing running yet."), "{drawn}");
     }
 
     #[test]

--- a/src/tui/render/modals.rs
+++ b/src/tui/render/modals.rs
@@ -14,9 +14,10 @@ use crate::{
     tui::{
         RenamePrompt, RenameTarget, ShareView,
         render::footer::{
-            SHARE_HELP, SHARE_HELP_GUEST, SHARE_HELP_NO_CODE, render_footer_segments,
+            ADD_MACHINE_HELP, SHARE_HELP, SHARE_HELP_GUEST, SHARE_HELP_NO_CODE,
+            render_footer_segments,
         },
-        share::join_command,
+        share::{join_command, pair_command},
         text::{truncate_trailing, wrap_fixed},
     },
 };
@@ -153,6 +154,155 @@ pub(in crate::tui) fn render_share_modal(
         },
     );
 }
+/// The install line for a machine that has never had p2pmux on it.
+///
+/// The case the CLI flow never covered: `p2pmux pair <code>` is useless advice
+/// on a machine with no p2pmux, and "add a machine" means a new one far more
+/// often than it means one already set up.
+const INSTALL_COMMAND: &str = "curl -fsSL https://p2pmux.com/install.sh | sh";
+
+/// The panel behind `a` on the inbox: the one line to run on the machine being
+/// added, and then the machine arriving.
+///
+/// It stays up after the code is shown because the second half of adding a
+/// machine — finding out whether it worked — used to mean running something
+/// else somewhere else. Here it is the same panel, which is what makes this
+/// feel like adding a machine rather than like reading a manual.
+pub(in crate::tui) fn render_add_machine_modal(
+    frame: &mut Frame<'_>,
+    theme: &UiTheme,
+    share: ShareView<'_>,
+    joined: Option<&str>,
+    animation_phase: usize,
+) {
+    let area = frame.area();
+    let label = Style::default().fg(theme.agent_overlay_muted);
+    let value = Style::default()
+        .fg(theme.agent_overlay_foreground)
+        .add_modifier(Modifier::BOLD);
+
+    let width = area.width.saturating_sub(4).clamp(32, 64).min(area.width);
+    let content_width = usize::from(width.saturating_sub(4)).max(1);
+    let mut lines: Vec<Line> = Vec::new();
+    // The code resolves to the ticket, so it is the invite when there is one
+    // and the ticket stands in when the rendezvous service was unreachable.
+    match share.code.or(share.ticket) {
+        Some(invite) => {
+            lines.push(Line::styled("On the machine you want to add, run:", label));
+            lines.push(Line::raw(""));
+            lines.extend(
+                wrap_fixed(&pair_command(invite), content_width)
+                    .into_iter()
+                    .map(|chunk| Line::styled(chunk, value)),
+            );
+            lines.push(Line::raw(""));
+            lines.push(Line::styled("Not installed there yet? First run:", label));
+            lines.extend(
+                wrap_fixed(INSTALL_COMMAND, content_width)
+                    .into_iter()
+                    .map(|chunk| {
+                        Line::styled(chunk, Style::default().fg(theme.agent_overlay_secondary))
+                    }),
+            );
+            lines.push(Line::raw(""));
+            lines.push(match joined {
+                Some(name) => Line::styled(
+                    format!("✓ {name} joined — it is in your machines now."),
+                    Style::default().fg(theme.copy_feedback_accent),
+                ),
+                None => Line::styled(
+                    format!("{} waiting for it to join…", waiting_glyph(animation_phase)),
+                    label,
+                ),
+            });
+            // The same warning the share panel carries, because this hands over
+            // the same ticket. A friendlier way in must not be a quieter one.
+            lines.push(Line::styled(
+                "Anyone who runs it gets a full shell here.",
+                Style::default().fg(theme.agent_overlay_warm),
+            ));
+        }
+        None => lines.push(Line::styled(
+            "Only the machine hosting this session can add one.",
+            label,
+        )),
+    }
+    if let Some(notice) = share.notice {
+        lines.push(Line::raw(""));
+        lines.push(Line::styled(
+            notice.to_owned(),
+            Style::default().fg(theme.copy_feedback_accent),
+        ));
+    }
+
+    let height = u16::try_from(lines.len().saturating_add(5))
+        .unwrap_or(u16::MAX)
+        .min(area.height);
+    let panel = Rect::new(
+        area.x.saturating_add(area.width.saturating_sub(width) / 2),
+        area.y
+            .saturating_add(area.height.saturating_sub(height) / 2),
+        width,
+        height,
+    );
+    frame.render_widget(Clear, panel);
+    let block = Block::bordered()
+        .title(Line::styled(
+            " Add a machine ",
+            Style::default()
+                .fg(theme.agent_overlay_chrome)
+                .add_modifier(Modifier::BOLD),
+        ))
+        .border_style(Style::default().fg(theme.agent_overlay_chrome));
+    let inner = block.inner(panel);
+    frame.render_widget(block, panel);
+    if inner.width == 0 || inner.height == 0 {
+        return;
+    }
+    frame.render_widget(
+        Paragraph::new(lines),
+        Rect::new(
+            inner.x.saturating_add(1),
+            inner.y.saturating_add(1),
+            inner.width.saturating_sub(2),
+            inner.height.saturating_sub(3).max(1),
+        ),
+    );
+
+    let help = Rect::new(
+        inner.x,
+        inner.y.saturating_add(inner.height.saturating_sub(1)),
+        inner.width,
+        1,
+    );
+    let buffer = frame.buffer_mut();
+    buffer.set_stringn(
+        help.x,
+        help.y,
+        " ".repeat(usize::from(help.width)),
+        usize::from(help.width),
+        Style::default().bg(theme.footer_background),
+    );
+    render_footer_segments(
+        buffer,
+        theme,
+        help.x.saturating_add(1),
+        help.y,
+        help.right(),
+        if share.code.is_some() || share.ticket.is_some() {
+            ADD_MACHINE_HELP
+        } else {
+            SHARE_HELP_GUEST
+        },
+    );
+}
+
+/// The waiting spinner, on the same clock as the inbox's own.
+fn waiting_glyph(animation_phase: usize) -> &'static str {
+    const FRAMES: [&str; 10] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+    FRAMES[animation_phase % FRAMES.len()]
+}
+
 pub(in crate::tui) fn render_rename_prompt(
     frame: &mut Frame<'_>,
     prompt: &RenamePrompt,
@@ -399,5 +549,104 @@ mod tests {
         // Enter already falls back to the ticket here, so offering `t` as well would be the
         // same key twice.
         assert!(!rendered.contains("TICKET, WORKS OFFLINE"));
+    }
+
+    fn add_machine_screen(tui: &MultiPaneTui) -> String {
+        let mut terminal = Terminal::new(TestBackend::new(120, 30)).expect("terminal");
+        terminal
+            .draw(|frame| {
+                render_multi_pane_with_copy_feedback(
+                    frame,
+                    tui,
+                    &BTreeMap::new(),
+                    None,
+                    None,
+                    ShareView {
+                        code: Some("4KP7Q-M2XRW"),
+                        ticket: Some("p2pmux-v3:TICKETVALUE"),
+                        notice: None,
+                    },
+                    None,
+                    None,
+                );
+            })
+            .expect("draw");
+        terminal
+            .backend()
+            .buffer()
+            .content
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>()
+    }
+
+    #[test]
+    fn the_add_machine_panel_gives_a_line_to_run_and_a_way_to_get_p2pmux_there() {
+        let mut tui = crate::tui::test_support::home_tui(&[]);
+        tui.set_home_open(true, "test");
+        tui.open_add_machine();
+
+        let rendered = add_machine_screen(&tui);
+        assert!(rendered.contains("Add a machine"));
+        // `pair`, not `join`: the same code, but a standing arrangement rather
+        // than one visit, and the word is what tells them apart beforehand.
+        assert!(rendered.contains("p2pmux pair 4KP7Q-M2XRW"), "{rendered}");
+        assert!(!rendered.contains("p2pmux join 4KP7Q-M2XRW"));
+        // The case the CLI flow never covered: a machine with no p2pmux on it.
+        assert!(rendered.contains("curl -fsSL https://p2pmux.com/install.sh | sh"));
+        assert!(rendered.contains("waiting for it to join"));
+        // The same ticket the share panel warns about, so the same warning.
+        assert!(rendered.contains("Anyone who runs it gets a full shell here."));
+    }
+
+    #[test]
+    fn the_add_machine_panel_reports_the_machine_that_turned_up() {
+        let mut tui = crate::tui::test_support::home_tui(&[]);
+        tui.set_home_open(true, "test");
+        tui.open_add_machine();
+        tui.snapshot.members.push(crate::layout::Member {
+            peer_id: b"droplet".to_vec(),
+            endpoint_addr: b"endpoint-droplet".to_vec(),
+            display_name: String::from("droplet"),
+        });
+
+        let rendered = add_machine_screen(&tui);
+        assert!(rendered.contains("droplet joined"), "{rendered}");
+        assert!(!rendered.contains("waiting for it to join"));
+    }
+
+    /// Only the coordinator's node holds a ticket, so a guest is told rather
+    /// than offered an invite it cannot make.
+    #[test]
+    fn a_member_with_no_invite_is_told_it_cannot_add_one() {
+        let mut tui = crate::tui::test_support::home_tui(&[]);
+        tui.set_home_open(true, "test");
+        tui.open_add_machine();
+
+        let mut terminal = Terminal::new(TestBackend::new(120, 30)).expect("terminal");
+        terminal
+            .draw(|frame| {
+                render_multi_pane_with_copy_feedback(
+                    frame,
+                    &tui,
+                    &BTreeMap::new(),
+                    None,
+                    None,
+                    ShareView::default(),
+                    None,
+                    None,
+                );
+            })
+            .expect("draw");
+        let rendered = terminal
+            .backend()
+            .buffer()
+            .content
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+
+        assert!(rendered.contains("Only the machine hosting this session can add one."));
+        assert!(!rendered.contains("p2pmux pair"));
     }
 }

--- a/src/tui/render/panes.rs
+++ b/src/tui/render/panes.rs
@@ -25,8 +25,8 @@ use crate::{
             footer::render_contextual_footer,
             home::render_home,
             modals::{
-                render_delete_tab_confirmation, render_quit_prompt, render_rename_prompt,
-                render_share_modal,
+                render_add_machine_modal, render_delete_tab_confirmation, render_quit_prompt,
+                render_rename_prompt, render_share_modal,
             },
             vt::{VtScreen, viewed_screen},
         },
@@ -465,7 +465,17 @@ pub(in crate::tui) fn render_shared_multi_pane(
     // drawing panes behind a screen that covers them is wasted work on every
     // frame.
     if tui.home_open() {
-        render_home(frame, tui, crate::tui::clock::unix_ms_now());
+        let now_unix_ms = crate::tui::clock::unix_ms_now();
+        render_home(frame, tui, now_unix_ms);
+        if tui.add_machine_open() {
+            render_add_machine_modal(
+                frame,
+                theme,
+                share,
+                tui.add_machine_joined().as_deref(),
+                crate::tui::render::home::animation_phase(now_unix_ms),
+            );
+        }
         // Home replaces the session chrome but not the question Ctrl+Q asks:
         // `q` opens the same prompt from here, so it has to be drawn here too.
         if tui.quit_open() {

--- a/src/tui/runtime/run.rs
+++ b/src/tui/runtime/run.rs
@@ -64,8 +64,17 @@ impl SharedLayoutRuntime {
                         self.invite.code.as_deref(),
                     ));
                 }
+                // A foreground session hands out the same invite an attached one
+                // does, so the add-machine panel has to record the ticket here
+                // too. Without it the machine that joins is never remembered.
+                if self.tui.take_pair_offer()
+                    && let Some(ticket) = self.invite.ticket.as_deref()
+                    && let Err(error) = crate::pairing::offer(ticket)
+                {
+                    self.share_notice = Some(format!("could not record the pairing: {error}"));
+                }
                 // The notice belongs to one visit to the modal, not to the session.
-                if !self.tui.share_open() {
+                if !self.tui.share_open() && !self.tui.add_machine_open() {
                     self.share_notice = None;
                 }
                 Ok(false)

--- a/src/tui/share.rs
+++ b/src/tui/share.rs
@@ -12,6 +12,15 @@ pub(in crate::tui) fn join_command(invite: &str) -> String {
     format!("p2pmux join {invite}")
 }
 
+/// The line a machine you own runs to be added to the fleet, permanently.
+///
+/// Deliberately not [`join_command`], which the same code would also satisfy: a
+/// join is one visit and pairing is a standing arrangement, and the word on
+/// screen is the only thing that tells the two apart before the fact.
+pub(in crate::tui) fn pair_command(invite: &str) -> String {
+    format!("p2pmux pair {invite}")
+}
+
 /// Run one share-modal copy and report the result back into the modal.
 ///
 /// A code request with no code falls back to the ticket rather than reporting nothing: the
@@ -28,11 +37,19 @@ pub(crate) fn share_copy_result(
             None => ("ticket command", ticket),
         },
         ShareCopy::Ticket => ("ticket command", ticket),
+        // The panel prefers the short code and falls back to the ticket for the
+        // same reason the share modal does: a rendezvous outage costs the code,
+        // never the invite.
+        ShareCopy::Pair => ("pair command", code.or(ticket)),
     };
     let Some(text) = text else {
         return format!("no {what} to copy");
     };
-    match copy_selection_to_clipboard(&join_command(text)) {
+    let line = match request {
+        ShareCopy::Pair => pair_command(text),
+        ShareCopy::Code | ShareCopy::Ticket => join_command(text),
+    };
+    match copy_selection_to_clipboard(&line) {
         Ok(_) => format!("✓ copied {what}"),
         Err(error) => format!("clipboard copy failed: {error}"),
     }
@@ -51,6 +68,23 @@ mod tests {
         assert_eq!(
             share_copy_result(ShareCopy::Code, None, None),
             "no ticket command to copy"
+        );
+    }
+
+    /// Pairing and joining resolve the same code, so the only thing that says
+    /// which one is happening is the word in the line that gets pasted.
+    #[test]
+    fn a_pair_copy_is_the_pair_line_and_falls_back_to_the_ticket_too() {
+        assert_eq!(pair_command("4KP7Q-M2XRW"), "p2pmux pair 4KP7Q-M2XRW");
+        assert_eq!(
+            share_copy_result(ShareCopy::Pair, None, None),
+            "no pair command to copy"
+        );
+        // A rendezvous outage costs the short code, never the invite, so the
+        // panel still has a line to hand over.
+        assert_ne!(
+            share_copy_result(ShareCopy::Pair, Some("p2pmux-v3:T"), None),
+            "no pair command to copy"
         );
     }
 

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -163,11 +163,15 @@ pub(in crate::tui) struct RenamePrompt {
     pub(in crate::tui) value: String,
     pub(in crate::tui) error: Option<String>,
 }
-/// Which piece of invite material the share modal asked the client to copy.
+/// Which piece of invite material a panel asked the client to copy.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ShareCopy {
     Ticket,
     Code,
+    /// The same invite, as the `p2pmux pair` line the add-machine panel shows.
+    /// Pairing and joining resolve the same code; what differs is what the
+    /// machine at the other end does with it afterwards.
+    Pair,
 }
 /// The host-only invite material the share modal renders.
 ///
@@ -204,6 +208,22 @@ pub(in crate::tui) enum ModalState {
     },
     /// Ctrl+Q, asking which of the two leavings was meant.
     Quit,
+    /// `a` on the inbox: the line to run on the machine being added.
+    AddMachine(AddMachinePrompt),
+}
+/// The add-machine panel, and what it needs to notice the machine arriving.
+///
+/// Adding a machine used to mean leaving the UI: `p2pmux pair` on one machine,
+/// carry the code to the other, and find out whether it worked by running
+/// something else. The panel keeps both halves on the screen the fleet is
+/// already on, and stays up to report the join rather than leaving the user to
+/// go and check.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub(in crate::tui) struct AddMachinePrompt {
+    /// The machines that were already here when the panel went up. Anything
+    /// that appears afterwards is the one being added, which is the whole
+    /// difference between instructions and a report.
+    pub(in crate::tui) known: Vec<String>,
 }
 /// The two ways out, which one keystroke used to conflate.
 ///

--- a/src/tui/test_support.rs
+++ b/src/tui/test_support.rs
@@ -110,7 +110,7 @@ pub(in crate::tui) fn home_tui(
         .map(|pane_id| (pane_id, 2, 8))
         .collect::<Vec<_>>();
     let mut tui = MultiPaneTui::new(layout(tabs, &panes)).expect("valid layout");
-    // A real client always knows its own peer id, and the machine strip reads it
+    // A real client always knows its own peer id, and the machines rail reads it
     // to mark which row is the machine being looked at.
     tui.local_peer_id = Some(b"host".to_vec());
     tui.set_agent_rows(


### PR DESCRIPTION
The inbox was a list of one-line rows and a one-line machine strip. Neither
scaled to what the screen is actually for: nobody runs thirty agents, so the
list occupied a fifth of the terminal and left the rest blank, and adding a
machine meant leaving the screen the fleet is on.

Six commits, each independently green.

## What changed

**Every agent gets a card.** Who and where, then its own words at whatever
length it said them, then the repository and the tab and pane `Enter` will put
you in. A one-line row could show what an agent said *or* which repository it
said it in, never both — which is exactly the pair you need to decide whether
to go and look. The card tier comes from the terminal height alone, so the
screen never changes shape because a fifth agent appeared; short terminals drop
the location line and then fall back to the row this replaces.

**The list is paged**, at most eight agents to a page, turned with `h`/`l` or
PgUp/PgDn. The page follows the cursor, never the other way round, and the
count beside the title is still of the whole list — so a page you cannot see
can never be hiding something that needs you.

**The fleet gets a rail** down the right-hand side: every machine, with a line
each for what it is and what it is running. The spare space on this screen is
horizontal as much as vertical, so the widest tier spends it on machines rather
than leaving it blank. Narrower terminals get the same table underneath; the
one-line strip survives as the last resort. `m` is gone with it — it expanded
the strip into that table, and a key that changes nothing is worse on a key bar
than a key missing from one.

**`a` adds a machine without leaving the screen.** The panel shows
`p2pmux pair <code>` from the invite the node already holds, carries the install
one-liner for a machine that has never had p2pmux on it, and stays up to report
the machine arriving — the half of pairing that used to mean running something
else somewhere else. Same ticket as `Ctrl+S`, so the same warning: a friendlier
way in must not be a quieter one. It records the session's ticket in
`pairing.toml` (what makes bare `p2pmux` rejoin on both machines) and leaves
`accepts_work` alone, because that question is asked once and its answer is
default-deny.

**A first run is a checklist.** The screen is emptiest exactly when its reader
is newest, and it spent that space on one grey line. Two steps now, hooks
first.

## What deliberately did not change

Still no output previews, token counters or charts — each turns a screen you
glance at into a screen you read. Card text is still the agent's own words,
never a summary a model wrote. And the roster still carries no message across
machines: the privacy boundary in `pane/local.rs` is asserted on the encoded
bytes, and the relay path goes through a coordinator that may be somebody
else's machine, so "only my paired machines" is not a distinction the wire can
draw today. Cards make that gap more visible, so line two falls back to the
working directory rather than sitting blank.

## Testing

`cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings` and
`cargo test --all-features` all green locally (25 test binaries, 408 unit
tests). New coverage: the layout tiers, the page arithmetic and its edges, the
card fallbacks, the rail's truncation count, and the add-machine panel's key
handling and three render states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011uoR92gs3ETyEQpJAZ4PoN