### PR TITLE
A session no longer ends without a word, or because something else on the machine ran

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -142,6 +142,20 @@ Two consequences worth knowing before you need them:
 `P2PMUX_FAILOVER_GRACE_SECS` overrides the five-minute window for a session, which is mostly of
 interest to the end-to-end tests.
 
+### When the session itself ends
+
+A session that stops while you are in it drops you back to your shell with `p2pmux node ended`,
+followed by whatever the node had to say for itself. The node has no terminal of its own, so it
+keeps a log beside its socket — `/tmp/p2pmux-$(id -u)/<id>.log` on macOS, `$XDG_RUNTIME_DIR`
+otherwise — and that is where a longer story is. A session you end yourself takes the log with
+it; one that ended on its own leaves it for you.
+
+Nothing else on the machine can end a session for you. `p2pmux ls`, `attach`, `ticket` and
+`--resume` all read the socket directory, which every p2pmux this user runs shares whatever
+`HOME` started it, and a session that is busy enough to refuse a connection used to look dead to
+them. Liveness is settled with the process table now, so a test harness or a script running in a
+sandbox `HOME` cannot delete a running session's record or unlink its socket.
+
 ## Control
 
 Only one peer controls a pane while they are actively typing. After about thirty seconds without

--- a/src/agent_detect.rs
+++ b/src/agent_detect.rs
@@ -324,6 +324,39 @@ pub fn node_process_is_alive(pid: u32) -> bool {
     refreshed(&mut system, pid).is_some_and(|process| is_node_process(&snapshot_of(process)))
 }
 
+/// The socket every p2pmux node on this machine is listening on.
+///
+/// Read from the command lines rather than from any session store, because the
+/// store is the one thing that does not answer this question: the socket
+/// directory is shared by every p2pmux this user runs, whatever `HOME` each was
+/// started with, while the records are not. A test harness, a probe script, or
+/// anything else running in a sandbox `HOME` therefore finds sockets it has no
+/// record of -- and used to delete the live ones among them.
+///
+/// A node is launched as `p2pmux __node --bootstrap <id>.bootstrap`, beside the
+/// `<id>.sock` it binds, so its command line names the socket it owns for as
+/// long as it lives.
+pub fn node_socket_paths() -> HashSet<PathBuf> {
+    let mut sampler = SysinfoSampler::default();
+    node_sockets_in(&sample_global_snapshot(&mut sampler))
+}
+
+fn node_sockets_in(processes: &[ProcessSnapshot]) -> HashSet<PathBuf> {
+    processes
+        .iter()
+        .filter(|process| is_node_process(process))
+        .filter_map(|process| socket_of_node(&process.cmdline))
+        .collect()
+}
+
+fn socket_of_node(cmdline: &[String]) -> Option<PathBuf> {
+    let bootstrap = cmdline
+        .iter()
+        .skip_while(|argument| *argument != "--bootstrap")
+        .nth(1)?;
+    Some(PathBuf::from(bootstrap).with_extension("sock"))
+}
+
 /// One process from a sampler snapshot.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ProcessSnapshot {
@@ -1153,6 +1186,43 @@ mod tests {
         );
         // Nobody has looked a name up yet, which is the caller's job.
         assert!(loose.iter().all(|agent| agent.session.is_empty()));
+    }
+
+    /// A node names the socket it owns on its command line, which is the only
+    /// place to read it from when the record belongs to another `HOME`.
+    #[test]
+    fn every_running_nodes_socket_is_found_whatever_home_recorded_it() {
+        let mut node = process(10, Some(1), "p2pmux", Some(10));
+        node.cmdline = vec![
+            String::from("/opt/homebrew/bin/p2pmux"),
+            String::from("__node"),
+            String::from("--bootstrap"),
+            String::from("/tmp/p2pmux-503/abc.bootstrap"),
+        ];
+        // Not a node: the client in front of the user, and this repository's
+        // own tooling with `__node` on its command line.
+        let mut client = process(20, Some(1), "p2pmux", Some(20));
+        client.cmdline = vec![String::from("p2pmux"), String::from("attach")];
+        let mut grep = process(30, Some(1), "rg", Some(30));
+        grep.cmdline = vec![String::from("rg"), String::from("--bootstrap")];
+
+        let sockets = node_sockets_in(&[node, client, grep]);
+
+        assert_eq!(
+            sockets,
+            HashSet::from([PathBuf::from("/tmp/p2pmux-503/abc.sock")])
+        );
+    }
+
+    /// A node with no `--bootstrap` at all is not a socket to protect, and must
+    /// not be read as one -- `nth(1)` off the end of a command line is `None`.
+    #[test]
+    fn a_node_without_a_bootstrap_argument_names_no_socket() {
+        assert_eq!(socket_of_node(&[String::from("p2pmux")]), None);
+        assert_eq!(
+            socket_of_node(&[String::from("p2pmux"), String::from("--bootstrap")]),
+            None
+        );
     }
 
     /// What the session store asks before deleting a session's only record.

--- a/src/agent_detect.rs
+++ b/src/agent_detect.rs
@@ -304,6 +304,26 @@ fn is_node_process(process: &ProcessSnapshot) -> bool {
             .any(|argument| argument == NODE_SUBCOMMAND)
 }
 
+/// Whether `pid` is a p2pmux node that is still running.
+///
+/// Asked of the operating system rather than of the node's socket, because a
+/// socket cannot tell the two apart: it answers "connection refused" both when
+/// its listener has gone and when the listener is merely not accepting fast
+/// enough to keep its backlog under the limit. `SessionStore::list_live` needs
+/// the difference before it deletes anything.
+///
+/// The command line is checked, not just the pid's existence, because pids are
+/// reused -- fast, on a machine building software -- and treating whatever now
+/// holds a dead node's pid as that node would keep a stale record forever.
+pub fn node_process_is_alive(pid: u32) -> bool {
+    if pid == 0 {
+        return false;
+    }
+    let pid = Pid::from_u32(pid);
+    let mut system = System::new();
+    refreshed(&mut system, pid).is_some_and(|process| is_node_process(&snapshot_of(process)))
+}
+
 /// One process from a sampler snapshot.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ProcessSnapshot {
@@ -344,30 +364,35 @@ impl ProcessSampler for SysinfoSampler {
                 .with_cmd(UpdateKind::Always)
                 .with_cwd(UpdateKind::Always),
         );
-        self.system
-            .processes()
-            .values()
-            .map(|process| ProcessSnapshot {
-                pid: process.pid().as_u32(),
-                parent_pid: process.parent().map(|pid| pid.as_u32()),
-                exe_basename: process
-                    .exe()
-                    .and_then(|path| path.file_name())
-                    .unwrap_or(process.name())
-                    .to_string_lossy()
-                    .into_owned(),
-                name: process.name().to_string_lossy().into_owned(),
-                cmdline: process
-                    .cmd()
-                    .iter()
-                    .map(|argument| argument.to_string_lossy().into_owned())
-                    .collect(),
-                start_time: Some(process.start_time()),
-                cwd: process
-                    .cwd()
-                    .map(|path| path.to_string_lossy().into_owned()),
-            })
-            .collect()
+        self.system.processes().values().map(snapshot_of).collect()
+    }
+}
+
+/// One `sysinfo` process in this module's own terms.
+///
+/// `cwd` is whatever the refresh that produced `process` asked for: a caller
+/// that did not ask gets `None`, which is the same thing a process that will
+/// not say gets.
+fn snapshot_of(process: &sysinfo::Process) -> ProcessSnapshot {
+    ProcessSnapshot {
+        pid: process.pid().as_u32(),
+        parent_pid: process.parent().map(|pid| pid.as_u32()),
+        exe_basename: process
+            .exe()
+            .and_then(|path| path.file_name())
+            .unwrap_or(process.name())
+            .to_string_lossy()
+            .into_owned(),
+        name: process.name().to_string_lossy().into_owned(),
+        cmdline: process
+            .cmd()
+            .iter()
+            .map(|argument| argument.to_string_lossy().into_owned())
+            .collect(),
+        start_time: Some(process.start_time()),
+        cwd: process
+            .cwd()
+            .map(|path| path.to_string_lossy().into_owned()),
     }
 }
 
@@ -1128,6 +1153,16 @@ mod tests {
         );
         // Nobody has looked a name up yet, which is the caller's job.
         assert!(loose.iter().all(|agent| agent.session.is_empty()));
+    }
+
+    /// What the session store asks before deleting a session's only record.
+    /// Nothing here is a node: not pid 0, and not this test binary -- which is
+    /// the point, since it is a process in this repository with `__node` in
+    /// reach of its command line.
+    #[test]
+    fn nothing_that_is_not_a_node_is_reported_as_one() {
+        assert!(!node_process_is_alive(0));
+        assert!(!node_process_is_alive(std::process::id()));
     }
 
     /// The client is a `p2pmux` process too, and a `cargo test` in this

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -404,15 +404,26 @@ pub async fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
     match cli.command {
         None => open_home().await,
         Some(Command::Node { bootstrap }) => {
-            // This process has no terminal and its stderr is /dev/null, so a startup
-            // failure would otherwise be invisible and the launcher could only report
-            // that the socket never appeared. Leave the reason where it can find it.
+            // This process has no terminal, so a failure would otherwise be invisible and
+            // the launcher could only report that the socket never appeared. Leave the
+            // reason where it can find it -- and where the client can, long after the
+            // launcher stopped waiting: a node that dies an hour into a session used to
+            // leave nothing at all behind, which made "p2pmux node ended" the whole of
+            // what anybody could know about it.
             let result = match crate::node::read_bootstrap(&bootstrap) {
                 Ok(parsed) => crate::node::run_background(parsed).await,
                 Err(error) => Err(error.into()),
             };
-            if let Err(error) = &result {
-                let _ = std::fs::write(bootstrap.with_extension("error"), error.to_string());
+            match &result {
+                Err(error) => {
+                    let _ = std::fs::write(bootstrap.with_extension("error"), error.to_string());
+                }
+                // Nothing went wrong, so the log is a temporary file nobody will
+                // ever read. A node that panicked runs neither arm and leaves its
+                // log where the client will look.
+                Ok(()) => {
+                    let _ = std::fs::remove_file(bootstrap.with_extension("log"));
+                }
             }
             result
         }
@@ -1476,8 +1487,22 @@ pub(crate) fn launch_background_node(
         .arg("--bootstrap")
         .arg(&bootstrap_path)
         .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null());
+        .stdout(Stdio::null());
+    // Whatever the node has to say about itself, kept for as long as the session
+    // lives and deleted with it. It goes beside the socket rather than into a log
+    // directory because it belongs to this session and to nothing else: the node's
+    // own warnings, and -- the reason this exists -- the panic message of a node
+    // that died under someone who was working in it. `/dev/null` here is what made
+    // a session that ended on its own impossible to explain afterwards.
+    let log_path = descriptor.socket_path.with_extension("log");
+    match std::fs::File::create(&log_path) {
+        Ok(log) => {
+            command.stderr(Stdio::from(log));
+        }
+        Err(_) => {
+            command.stderr(Stdio::null());
+        }
+    }
     #[cfg(unix)]
     {
         use std::os::unix::process::CommandExt;
@@ -1750,5 +1775,31 @@ mod tests {
             .0;
         assert!(create_arm.contains("launch_background_node("));
         assert!(create_arm.contains("crate::client::run(&descriptor)"));
+    }
+
+    /// The node has no terminal, so whatever it writes to stderr is the only
+    /// account of a session that ended by itself. Sending that to `/dev/null`
+    /// is what left `p2pmux node ended` as the whole of what anyone could know.
+    #[test]
+    fn the_background_node_keeps_a_log_rather_than_discarding_its_stderr() {
+        let source = include_str!("cli.rs");
+        let launcher = source
+            .split_once("pub(crate) fn launch_background_node(")
+            .expect("the launcher")
+            .1
+            .split_once("let deadline = Instant::now()")
+            .expect("the readiness wait")
+            .0;
+
+        assert!(launcher.contains("with_extension(\"log\")"));
+        assert!(launcher.contains("Stdio::from(log)"));
+
+        // And a session that ended the way it was asked to takes its log with
+        // it, so this does not leave a file per session behind.
+        let node_arm = source
+            .split_once("Some(Command::Node { bootstrap }) => {")
+            .expect("the node arm")
+            .1;
+        assert!(node_arm.contains("remove_file(bootstrap.with_extension(\"log\"))"));
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -929,7 +929,10 @@ pub fn run_on(
             .and_then(|store| store.remove(&descriptor.id));
         println!("Killed {}", descriptor.name);
     } else if node_ended {
-        println!("p2pmux node ended");
+        match node_exit_reason(descriptor) {
+            Some(reason) => println!("p2pmux node ended: {reason}"),
+            None => println!("p2pmux node ended"),
+        }
     } else {
         println!(
             "Detached. Resume: p2pmux --resume  |  Attach: p2pmux attach {}  |  Kill: p2pmux kill {}",
@@ -937,6 +940,32 @@ pub fn run_on(
         );
     }
     Ok(())
+}
+
+/// What the node said on its way out, if it left anything.
+///
+/// Two places, because a node ends in two ways. One returns an error, which it
+/// writes beside its socket -- the same file `launch_background_node` reads
+/// while it is still waiting for a startup that never came. The other is a
+/// panic, which returns nothing and writes only to stderr; that is why the node
+/// is given a log rather than `/dev/null`, and why the last line of it is worth
+/// reading here.
+///
+/// A session that ends under someone working in it is the case this serves. All
+/// they had was `p2pmux node ended`, which names the event and nothing about it.
+fn node_exit_reason(descriptor: &SessionDescriptor) -> Option<String> {
+    let reported = descriptor.socket_path.with_extension("error");
+    if let Ok(message) = std::fs::read_to_string(&reported) {
+        let message = message.trim().to_owned();
+        if !message.is_empty() {
+            let _ = std::fs::remove_file(&reported);
+            return Some(message);
+        }
+    }
+    let log = descriptor.socket_path.with_extension("log");
+    let text = std::fs::read_to_string(&log).ok()?;
+    let last = text.lines().rev().find(|line| !line.trim().is_empty())?;
+    Some(format!("{}\n  its log: {}", last.trim(), log.display()))
 }
 
 fn refresh_tui_timers(
@@ -1994,6 +2023,50 @@ mod tests {
         assert!(tui.modal_open());
         assert!(!should_forward_paste(&tui, b"host"));
         assert!(!tui.scroll_mouse_pane(10, 2, area, 10, true));
+    }
+
+    /// What somebody dropped back to their shell mid-session gets to read.
+    #[test]
+    fn a_node_that_left_a_reason_is_quoted_rather_than_summarised() {
+        let root = std::path::PathBuf::from(format!("/tmp/p2pmux-why-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).expect("fixture directory");
+        let socket = root.join("n.sock");
+        let descriptor = crate::session_store::SessionDescriptor::new(
+            crate::session_store::generate_id().expect("id"),
+            "lisbon".into(),
+            socket.clone(),
+            42,
+            crate::session_store::SessionRole::Coordinator,
+        );
+
+        // A node that ended on its own says nothing it was not asked to say.
+        assert_eq!(node_exit_reason(&descriptor), None);
+
+        // An error on the way out is reported verbatim, and consumed: it
+        // describes one death, and reading it twice would misattribute it.
+        std::fs::write(root.join("n.error"), "the coordinator refused this build\n")
+            .expect("error file");
+        assert_eq!(
+            node_exit_reason(&descriptor).as_deref(),
+            Some("the coordinator refused this build")
+        );
+        assert_eq!(node_exit_reason(&descriptor), None);
+
+        // A panic returns no error at all, and is only ever in the log.
+        std::fs::write(
+            root.join("n.log"),
+            "p2pmux node: slow drain\nthread 'main' panicked at src/node.rs:1: assertion failed\n",
+        )
+        .expect("log file");
+        let reason = node_exit_reason(&descriptor).expect("the log's last word");
+        assert!(reason.starts_with("thread 'main' panicked"), "{reason}");
+        assert!(
+            reason.contains("n.log"),
+            "the log is worth naming: {reason}"
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
     }
 
     #[test]

--- a/src/node.rs
+++ b/src/node.rs
@@ -412,53 +412,33 @@ fn run_socket_loop(
                             break;
                         }
                         Ok(Some(ClientMessage::Hello { cols, rows })) => {
-                            if let Ok(generation) = gate.attach() {
-                                node.resize(cols, rows)
-                                    .map_err(|error| io::Error::other(error.to_string()))?;
-                                let mut publish = AttachmentPublishState::default();
-                                match write_message(
-                                    reader.get_mut(),
-                                    &NodeMessage::AttachAccepted { generation },
-                                )
-                                .and_then(|()| {
-                                    write_snapshot(
-                                        reader.get_mut(),
-                                        descriptor,
-                                        node,
-                                        &mut publish,
-                                        Duration::ZERO,
-                                    )
-                                }) {
-                                    Ok(()) => {
-                                        reader
-                                            .get_mut()
-                                            .set_read_timeout(Some(Duration::from_millis(1)))?;
-                                        let writer =
-                                            AttachmentWriter::start(reader.get_mut().try_clone()?)?;
-                                        client = Some(AttachedClient {
-                                            reader,
-                                            generation,
-                                            publish,
-                                            writer,
-                                            close_after_ack: false,
-                                            shutdown_after_ack: false,
-                                        });
-                                        did_work = true;
-                                    }
-                                    Err(error) => {
-                                        eprintln!(
-                                            "p2pmux node: failed to write initial local snapshot: {error}"
-                                        );
-                                        let _ = gate.detach(generation);
-                                    }
-                                }
-                            } else {
+                            let Ok(generation) = gate.attach() else {
                                 let _ = write_message(
                                     reader.get_mut(),
                                     &NodeMessage::AttachRejected {
                                         reason: "already attached".into(),
                                     },
                                 );
+                                continue;
+                            };
+                            match attach_client(reader, generation, cols, rows, descriptor, node) {
+                                Ok(attached) => {
+                                    client = Some(attached);
+                                    did_work = true;
+                                }
+                                // Losing one client is not losing the session.
+                                // Everything this can fail on belongs to the
+                                // connection, not to the node: a peer that
+                                // hung up mid-handshake -- for which macOS
+                                // answers EINVAL to `setsockopt` rather than
+                                // anything about the peer -- or a descriptor
+                                // limit reached while duplicating its socket.
+                                // Ending the socket loop over any of them took
+                                // every pane down with it.
+                                Err(error) => {
+                                    eprintln!("p2pmux node: could not attach that client: {error}");
+                                    let _ = gate.detach(generation);
+                                }
                             }
                         }
                         Ok(None) => {}
@@ -482,7 +462,16 @@ fn run_socket_loop(
                 {
                     continue;
                 }
-                Err(error) => return Err(error),
+                // Stop accepting for this pass rather than ending the session.
+                // The realistic causes are a descriptor limit reached by
+                // something else on the machine, which passes; and a listener
+                // that is genuinely broken costs one line per pass and leaves
+                // the panes and the attached client alive, which is strictly
+                // better than taking them down.
+                Err(error) => {
+                    eprintln!("p2pmux node: could not accept a local connection: {error}");
+                    break;
+                }
             }
         }
         let drain_started = Instant::now();
@@ -865,6 +854,48 @@ struct AttachedClient {
     writer: AttachmentWriter,
     close_after_ack: bool,
     shutdown_after_ack: bool,
+}
+
+/// Take a client that said hello onto the single attachment.
+///
+/// Separate from the socket loop so that it can fail without the loop failing:
+/// every step here is about one connection, and the loop has a session's panes
+/// behind it. The connection is dropped on the way out of the error, which is
+/// what tells a client that is still there to stop waiting.
+fn attach_client(
+    mut reader: BufReader<UnixStream>,
+    generation: u64,
+    cols: u16,
+    rows: u16,
+    descriptor: &SessionDescriptor,
+    node: &mut SharedLayoutNode,
+) -> io::Result<AttachedClient> {
+    node.resize(cols, rows)
+        .map_err(|error| io::Error::other(error.to_string()))?;
+    let mut publish = AttachmentPublishState::default();
+    write_message(
+        reader.get_mut(),
+        &NodeMessage::AttachAccepted { generation },
+    )?;
+    write_snapshot(
+        reader.get_mut(),
+        descriptor,
+        node,
+        &mut publish,
+        Duration::ZERO,
+    )?;
+    reader
+        .get_mut()
+        .set_read_timeout(Some(Duration::from_millis(1)))?;
+    let writer = AttachmentWriter::start(reader.get_mut().try_clone()?)?;
+    Ok(AttachedClient {
+        reader,
+        generation,
+        publish,
+        writer,
+        close_after_ack: false,
+        shutdown_after_ack: false,
+    })
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -1695,6 +1726,41 @@ mod tests {
         drop(live);
 
         let _ = fs::remove_dir_all(&directory);
+    }
+
+    /// The other half of the same rule, where the type system cannot state it.
+    ///
+    /// `configure_accepted` returns an `Option` precisely so that one dead
+    /// connection cannot be `?`-propagated into ending the session. The arms
+    /// that run *after* it — the ones that take a client onto the attachment —
+    /// are ordinary fallible calls, and the loop kept its own escape hatch: a
+    /// `?` on the socket options, on the descriptor duplicated for the writer,
+    /// and a `return Err` for anything `accept` answered that was not already
+    /// named. Each of those is about one connection and none of them is worth
+    /// a session, so the accept loop no longer has a way out.
+    #[test]
+    fn nothing_about_one_connection_leaves_the_accept_loop() {
+        let source = include_str!("node.rs");
+        let loop_body = source
+            .split_once("match listener.accept() {")
+            .expect("the accept loop")
+            .1
+            .split_once("let drain_started = Instant::now();")
+            .expect("the end of the accept loop")
+            .0;
+
+        assert!(
+            !loop_body.contains("?;"),
+            "a per-connection failure can end the socket loop again"
+        );
+        assert!(
+            !loop_body.contains("return Err("),
+            "an accept error can end the socket loop again"
+        );
+        assert!(
+            loop_body.contains("attach_client("),
+            "the hello arm should hand off to the fallible helper"
+        );
     }
 
     /// The shape of every agent hook: write one line, exit immediately.

--- a/src/session_store.rs
+++ b/src/session_store.rs
@@ -225,6 +225,12 @@ impl SessionDescriptor {
 pub struct SessionStore {
     sessions_dir: PathBuf,
     socket_dir: PathBuf,
+    /// How this store asks whether a recorded node is still running.
+    ///
+    /// A field rather than a direct call so a test can describe a live node
+    /// without having to start one: the real answer comes from the process
+    /// table, which a test cannot fabricate.
+    node_alive: fn(u32) -> bool,
 }
 
 impl SessionStore {
@@ -252,6 +258,7 @@ impl SessionStore {
         Self {
             sessions_dir,
             socket_dir,
+            node_alive: crate::agent_detect::node_process_is_alive,
         }
     }
 
@@ -354,9 +361,17 @@ impl SessionStore {
         }
     }
 
-    /// Returns only connectable descriptors. A refused connection is the sole condition under
-    /// which a finder record is removed, avoiding accidental deletion of a node that is merely
-    /// starting -- or merely busy.
+    /// Returns the sessions that still have a node. A record is removed only when the socket
+    /// refuses a connection *and* the process that wrote the record is gone, avoiding accidental
+    /// deletion of a node that is merely starting -- or merely busy.
+    ///
+    /// The second half of that test is not belt and braces. A unix socket refuses connections
+    /// once its listener's backlog is full, exactly as it does when the listener has gone: on
+    /// macOS the 129th connection to a live, bound socket is answered `ECONNREFUSED`. A node
+    /// that is not accepting for a moment -- a long drain, a machine under a build -- therefore
+    /// looked dead to every `p2pmux ls`, `attach`, `ticket`, `kill` and `--resume` on the
+    /// machine, each of which would then delete the only record of a running session and unlink
+    /// the socket it was still listening on. The operating system knows the difference.
     ///
     /// A node that accepts the connection but does not answer within [`PROBE_ACK_TIMEOUT`] is
     /// still listed and, above all, still kept: it is alive and loaded, and deleting its record
@@ -383,6 +398,13 @@ impl SessionStore {
             match self.read(id) {
                 Ok(descriptor) => match probe(&descriptor.socket_path) {
                     Liveness::Acked | Liveness::Listening => sessions.push(descriptor),
+                    // Refused, which the process table gets the last word on.
+                    // Still listed when the node is alive: the session exists,
+                    // and the next connection -- once the backlog drains -- will
+                    // reach it.
+                    Liveness::Gone if (self.node_alive)(descriptor.node_pid) => {
+                        sessions.push(descriptor)
+                    }
                     Liveness::Gone => {
                         let _ = fs::remove_file(&descriptor.socket_path);
                         let _ = fs::remove_file(path);
@@ -393,7 +415,11 @@ impl SessionStore {
                 }
             }
         }
-        self.sweep_dead_sockets();
+        let held = sessions
+            .iter()
+            .map(|session| session.socket_path.clone())
+            .collect::<HashSet<_>>();
+        self.sweep_dead_sockets(&held);
         sessions.sort_by_key(|session| session.created_at);
         Ok(sessions)
     }
@@ -407,7 +433,16 @@ impl SessionStore {
     /// Failure to connect is the test, not absence of a descriptor: `run_background` binds
     /// the listener before it writes the record, so a session that is still starting up has
     /// a live socket and no record yet, and must not be swept.
-    fn sweep_dead_sockets(&self) {
+    ///
+    /// `held` names the sockets [`Self::list_live`] just accounted for, whose nodes are known
+    /// to be running. They are skipped rather than re-tested, because the connection this would
+    /// open is refused by a node whose backlog is full -- and unlinking a live session's socket
+    /// leaves it running with no way in.
+    ///
+    /// A socket nobody claims is still given a second chance a moment later. The directory is
+    /// shared by every p2pmux this user runs, so one of these may belong to a node that bound
+    /// its listener a millisecond ago and has not written its record yet.
+    fn sweep_dead_sockets(&self, held: &HashSet<PathBuf>) {
         let Ok(entries) = fs::read_dir(&self.socket_dir) else {
             return;
         };
@@ -416,8 +451,14 @@ impl SessionStore {
             if path.extension().and_then(|value| value.to_str()) != Some("sock") {
                 continue;
             }
+            if held.contains(&path) {
+                continue;
+            }
             if UnixStream::connect(&path).is_err() {
-                let _ = fs::remove_file(&path);
+                std::thread::sleep(SWEEP_RETRY_DELAY);
+                if UnixStream::connect(&path).is_err() {
+                    let _ = fs::remove_file(&path);
+                }
             }
         }
     }
@@ -536,11 +577,14 @@ fn now_secs() -> u64 {
 enum Liveness {
     /// The node answered the probe. Live, beyond doubt.
     Acked,
-    /// The connection was accepted but no ack arrived in time. A unix socket refuses
-    /// connections once its listener is gone, so something is still holding this one --
-    /// it is a busy node, not a dead one.
+    /// The connection was accepted but no ack arrived in time. Something is holding this
+    /// socket open -- it is a busy node, not a dead one.
     Listening,
-    /// Nobody is on the other end: the socket is missing, or connecting was refused.
+    /// The socket is missing, or connecting was refused.
+    ///
+    /// Refused is *not* the same as gone, whatever this name suggests: a listener whose
+    /// backlog is full refuses connections too. Callers settle it with the process table
+    /// rather than treating this as a verdict -- see [`SessionStore::list_live`].
     Gone,
 }
 
@@ -549,6 +593,13 @@ enum Liveness {
 /// Short on purpose: `p2pmux ls` waits this out once per session, and missing it is no
 /// longer expensive now that only [`Liveness::Gone`] deletes anything.
 const PROBE_ACK_TIMEOUT: Duration = Duration::from_millis(250);
+
+/// How long an unclaimed socket is left alone before a second connection decides it.
+///
+/// Only ever paid for a socket about to be deleted, and only for one that no live record
+/// claims. It exists for the node that has bound its listener and not yet written its
+/// record: that gap is microseconds, and this is comfortably longer than it.
+const SWEEP_RETRY_DELAY: Duration = Duration::from_millis(50);
 
 fn probe(path: &Path) -> Liveness {
     let Ok(mut stream) = UnixStream::connect(path) else {
@@ -769,6 +820,73 @@ mod tests {
             unrelated.exists(),
             "non-socket files are not ours to delete"
         );
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    /// The bug this file's `list_live` doc describes, in one test: a node that
+    /// is alive but not accepting -- a full backlog answers `ECONNREFUSED`
+    /// exactly as a dead listener does -- must keep both its record and its
+    /// socket, or every `p2pmux ls` on the machine strands a running session.
+    #[test]
+    fn a_node_that_is_running_survives_a_refused_connection() {
+        let root = PathBuf::from(format!("/tmp/p2pmux-alive-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&root);
+        let mut store = SessionStore::at(root.join("s"), root.join("k"));
+        store.node_alive = |_| true;
+
+        let id = generate_id().unwrap();
+        let socket = store.socket_path(&id).unwrap();
+        store
+            .write(&SessionDescriptor::new(
+                id.clone(),
+                "helsinki".into(),
+                socket.clone(),
+                4321,
+                SessionRole::Coordinator,
+            ))
+            .unwrap();
+        // Nothing is listening on it, which is what a refused connection looks
+        // like from the outside whether the node is gone or merely saturated.
+        fs::write(&socket, b"").unwrap();
+
+        let live = store.list_live().unwrap();
+
+        assert_eq!(
+            live.iter()
+                .map(|session| session.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["helsinki"],
+            "a running node's session must still be listed"
+        );
+        assert!(store.read(&id).is_ok(), "its record must survive");
+        assert!(socket.exists(), "its socket must survive the sweep");
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    /// The other half: once the node really is gone, the record goes with it.
+    #[test]
+    fn a_session_whose_node_is_gone_is_still_forgotten() {
+        let root = PathBuf::from(format!("/tmp/p2pmux-gone-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&root);
+        let mut store = SessionStore::at(root.join("s"), root.join("k"));
+        store.node_alive = |_| false;
+
+        let id = generate_id().unwrap();
+        let socket = store.socket_path(&id).unwrap();
+        store
+            .write(&SessionDescriptor::new(
+                id.clone(),
+                "helsinki".into(),
+                socket.clone(),
+                4321,
+                SessionRole::Coordinator,
+            ))
+            .unwrap();
+        fs::write(&socket, b"").unwrap();
+
+        assert!(store.list_live().unwrap().is_empty());
+        assert!(store.read(&id).is_err(), "the record should be gone");
+        assert!(!socket.exists(), "the socket should have been swept");
         let _ = fs::remove_dir_all(&root);
     }
 

--- a/src/session_store.rs
+++ b/src/session_store.rs
@@ -439,13 +439,19 @@ impl SessionStore {
     /// open is refused by a node whose backlog is full -- and unlinking a live session's socket
     /// leaves it running with no way in.
     ///
-    /// A socket nobody claims is still given a second chance a moment later. The directory is
-    /// shared by every p2pmux this user runs, so one of these may belong to a node that bound
-    /// its listener a millisecond ago and has not written its record yet.
+    /// A socket nobody claims is still given a second chance a moment later, and then asked
+    /// about of the process table. The directory is shared by every p2pmux this user runs,
+    /// whatever `HOME` each was started with -- so a store in a sandbox `HOME`, which is how
+    /// every test harness and probe script isolates itself, finds sockets it has no record of.
+    /// Some of them belong to the sessions somebody is working in. The last word therefore
+    /// belongs to the nodes themselves, which name the socket they own on their command line.
     fn sweep_dead_sockets(&self, held: &HashSet<PathBuf>) {
         let Ok(entries) = fs::read_dir(&self.socket_dir) else {
             return;
         };
+        // Only paid for by a sweep that has found something to delete, which is rare: one
+        // pass of the process table against a directory that is almost always all live.
+        let mut owned_elsewhere: Option<HashSet<PathBuf>> = None;
         for entry in entries.flatten() {
             let path = entry.path();
             if path.extension().and_then(|value| value.to_str()) != Some("sock") {
@@ -454,11 +460,16 @@ impl SessionStore {
             if held.contains(&path) {
                 continue;
             }
-            if UnixStream::connect(&path).is_err() {
-                std::thread::sleep(SWEEP_RETRY_DELAY);
-                if UnixStream::connect(&path).is_err() {
-                    let _ = fs::remove_file(&path);
-                }
+            if UnixStream::connect(&path).is_ok() {
+                continue;
+            }
+            std::thread::sleep(SWEEP_RETRY_DELAY);
+            if UnixStream::connect(&path).is_ok() {
+                continue;
+            }
+            let owned = owned_elsewhere.get_or_insert_with(crate::agent_detect::node_socket_paths);
+            if !owned.contains(&path) {
+                let _ = fs::remove_file(&path);
             }
         }
     }

--- a/tests/node_survives_bad_clients.rs
+++ b/tests/node_survives_bad_clients.rs
@@ -1,0 +1,243 @@
+//! One bad local connection must never end a session.
+//!
+//! The node's socket loop is single-threaded and sits in front of every pane
+//! the session hosts. It also accepts connections from anything on the machine
+//! that can reach the socket: `p2pmux ls`, an agent hook, a test harness, a
+//! client whose terminal was closed mid-handshake. Every one of those used to
+//! be able to end the loop -- and with it the session -- through a `?` on a
+//! per-connection call.
+//!
+//! The node here is given its own `HOME` and its own socket directory, so this
+//! never sees, probes, or sweeps a session the developer is sitting in.
+
+use std::{
+    io::{BufReader, Write},
+    os::unix::net::UnixStream,
+    path::PathBuf,
+    process::{Child, Command, Stdio},
+    time::{Duration, Instant},
+};
+
+use p2pmux::{
+    client,
+    local_ipc::{ClientMessage, NodeMessage},
+    node::{NodeBootstrap, NodeBootstrapKind, write_bootstrap},
+    session_store::{SessionDescriptor, SessionRole, generate_id},
+};
+
+const READY_TIMEOUT: Duration = Duration::from_secs(30);
+const RECEIVE_TIMEOUT: Duration = Duration::from_secs(8);
+/// Comfortably past the 128 a listener's backlog holds, which is the point at
+/// which further connections are refused while the node is still very much
+/// alive.
+const STORM: usize = 400;
+
+struct Fixture {
+    root: PathBuf,
+    socket: PathBuf,
+    node: Child,
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let _ = self.node.kill();
+        let _ = self.node.wait();
+        let _ = std::fs::remove_dir_all(&self.root);
+    }
+}
+
+impl Fixture {
+    /// A node of our own, in a sandbox of our own.
+    ///
+    /// The path stays short because a unix socket address has to: `sockaddr_un`
+    /// is 104 bytes on macOS, and a temp directory under the target directory
+    /// would not fit.
+    fn start() -> Self {
+        let root = PathBuf::from(format!("/tmp/p2pmux-bad-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(root.join("home")).unwrap();
+        let socket = root.join("n.sock");
+        let bootstrap = root.join("n.bootstrap");
+        let descriptor = SessionDescriptor::new(
+            generate_id().unwrap(),
+            "lisbon".into(),
+            socket.clone(),
+            1,
+            SessionRole::Coordinator,
+        );
+        write_bootstrap(
+            &bootstrap,
+            &NodeBootstrap {
+                descriptor,
+                kind: NodeBootstrapKind::Create {
+                    display_name: "Test User".into(),
+                    cols: 80,
+                    rows: 24,
+                },
+            },
+        )
+        .unwrap();
+        let node = Command::new(env!("CARGO_BIN_EXE_p2pmux"))
+            .arg("__node")
+            .arg("--bootstrap")
+            .arg(&bootstrap)
+            .env("HOME", root.join("home"))
+            // A pane of this node would otherwise inherit the pane and socket
+            // of whatever session the developer ran `cargo test` from.
+            .env_remove("P2PMUX_PANE_ID")
+            .env_remove("P2PMUX_SOCK")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .unwrap();
+        let mut fixture = Self { root, socket, node };
+        let deadline = Instant::now() + READY_TIMEOUT;
+        while !fixture.socket.exists() {
+            assert!(
+                fixture.node.try_wait().unwrap().is_none(),
+                "node exited before binding its socket"
+            );
+            assert!(Instant::now() < deadline, "node never bound its socket");
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        fixture
+    }
+
+    fn running(&mut self) -> bool {
+        self.node.try_wait().unwrap().is_none()
+    }
+}
+
+#[test]
+fn a_session_outlives_every_kind_of_bad_local_client() {
+    let mut fixture = Fixture::start();
+
+    // The client the user is sitting in front of.
+    let (mut stream, mut reader, _) = attach(&fixture.socket);
+    receive_until_snapshot(&mut reader);
+
+    // Enough connections to fill the listener's backlog and have the next ones
+    // refused -- what any p2pmux command on the machine does to a busy node.
+    let storm = (0..STORM)
+        .filter_map(|_| UnixStream::connect(&fixture.socket).ok())
+        .collect::<Vec<_>>();
+    assert!(fixture.running(), "a connection storm ended the node");
+    drop(storm);
+    assert!(fixture.running(), "the storm hanging up ended the node");
+
+    // A client that says hello and is gone before the node can configure the
+    // connection. macOS answers EINVAL to `setsockopt` on a socket whose peer
+    // has left, which used to leave the socket loop through a `?`.
+    for _ in 0..100 {
+        if let Ok(mut gone) = UnixStream::connect(&fixture.socket) {
+            let _ = gone.write_all(b"{\"type\":\"hello\",\"cols\":80,\"rows\":24}\n");
+            let _ = gone.flush();
+        }
+    }
+    assert!(fixture.running(), "a client that hung up ended the node");
+
+    // The same, one step later: a client that leaves between the node
+    // accepting its attachment and the node configuring the socket it was
+    // accepted on. That is the window in which every `setsockopt` on the
+    // connection starts answering EINVAL.
+    for _ in 0..100 {
+        if let Ok(mut leaving) = UnixStream::connect(&fixture.socket) {
+            let _ = leaving.set_read_timeout(Some(Duration::from_millis(200)));
+            let _ = leaving.write_all(b"{\"type\":\"hello\",\"cols\":80,\"rows\":24}\n");
+            let _ = leaving.flush();
+            let mut accepted = String::new();
+            let _ = std::io::BufRead::read_line(&mut BufReader::new(&leaving), &mut accepted);
+        }
+    }
+    assert!(
+        fixture.running(),
+        "a client that left mid-handshake ended the node"
+    );
+
+    // Nonsense, a truncated frame, and a connection that says nothing at all.
+    for payload in [&b"not json at all\n"[..], &b"{\"type\":\"hel"[..], &b""[..]] {
+        for _ in 0..20 {
+            if let Ok(mut rude) = UnixStream::connect(&fixture.socket) {
+                let _ = rude.write_all(payload);
+            }
+        }
+    }
+    assert!(fixture.running(), "a malformed frame ended the node");
+
+    // The session is not merely alive but still serving the client that was
+    // attached before any of it started.
+    send(
+        &mut stream,
+        &ClientMessage::Input {
+            bytes: b"printf p2pmux-survived\r".to_vec(),
+            pane_id: Some(1),
+            perf_id: None,
+        },
+    );
+    receive_until_screens(&mut reader);
+    assert!(fixture.running());
+}
+
+fn attach(socket: &std::path::Path) -> (UnixStream, BufReader<UnixStream>, u64) {
+    let mut stream = UnixStream::connect(socket).unwrap();
+    stream
+        .set_read_timeout(Some(Duration::from_secs(2)))
+        .unwrap();
+    send(&mut stream, &ClientMessage::Hello { cols: 80, rows: 24 });
+    let mut reader = BufReader::new(stream.try_clone().unwrap());
+    let generation = match receive(&mut reader) {
+        NodeMessage::AttachAccepted { generation } => generation,
+        message => panic!("unexpected attach response: {message:?}"),
+    };
+    (stream, reader, generation)
+}
+
+fn send(stream: &mut UnixStream, message: &ClientMessage) {
+    let mut frame = serde_json::to_vec(message).unwrap();
+    frame.push(b'\n');
+    stream.write_all(&frame).unwrap();
+    stream.flush().unwrap();
+}
+
+fn receive(reader: &mut BufReader<UnixStream>) -> NodeMessage {
+    let deadline = Instant::now() + RECEIVE_TIMEOUT;
+    loop {
+        match client::read_message(reader) {
+            Ok(Some(message)) => return message,
+            Ok(None) => panic!("the node closed its socket"),
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {}
+            Err(error) if error.kind() == std::io::ErrorKind::TimedOut => {}
+            Err(error) => panic!("reading from the node failed: {error}"),
+        }
+        assert!(Instant::now() < deadline, "the node said nothing in time");
+    }
+}
+
+fn receive_until_snapshot(reader: &mut BufReader<UnixStream>) -> NodeMessage {
+    receive_until(reader, "snapshot", |message| {
+        matches!(message, NodeMessage::Snapshot { .. })
+    })
+}
+
+/// A pane drawing something is the node doing the work a session is for.
+fn receive_until_screens(reader: &mut BufReader<UnixStream>) -> NodeMessage {
+    receive_until(reader, "screen update", |message| {
+        matches!(message, NodeMessage::Screens { .. })
+    })
+}
+
+fn receive_until(
+    reader: &mut BufReader<UnixStream>,
+    wanted: &str,
+    matches: impl Fn(&NodeMessage) -> bool,
+) -> NodeMessage {
+    let deadline = Instant::now() + RECEIVE_TIMEOUT;
+    loop {
+        let message = receive(reader);
+        if matches(&message) {
+            return message;
+        }
+        assert!(Instant::now() < deadline, "no {wanted} arrived");
+    }
+}

--- a/tests/node_survives_bad_clients.rs
+++ b/tests/node_survives_bad_clients.rs
@@ -22,7 +22,7 @@ use p2pmux::{
     client,
     local_ipc::{ClientMessage, NodeMessage},
     node::{NodeBootstrap, NodeBootstrapKind, write_bootstrap},
-    session_store::{SessionDescriptor, SessionRole, generate_id},
+    session_store::{SessionDescriptor, SessionRole, SessionStore, generate_id},
 };
 
 const READY_TIMEOUT: Duration = Duration::from_secs(30);
@@ -52,8 +52,8 @@ impl Fixture {
     /// The path stays short because a unix socket address has to: `sockaddr_un`
     /// is 104 bytes on macOS, and a temp directory under the target directory
     /// would not fit.
-    fn start() -> Self {
-        let root = PathBuf::from(format!("/tmp/p2pmux-bad-{}", std::process::id()));
+    fn start(name: &str) -> Self {
+        let root = PathBuf::from(format!("/tmp/p2pmux-{name}-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&root);
         std::fs::create_dir_all(root.join("home")).unwrap();
         let socket = root.join("n.sock");
@@ -111,7 +111,7 @@ impl Fixture {
 
 #[test]
 fn a_session_outlives_every_kind_of_bad_local_client() {
-    let mut fixture = Fixture::start();
+    let mut fixture = Fixture::start("rude");
 
     // The client the user is sitting in front of.
     let (mut stream, mut reader, _) = attach(&fixture.socket);
@@ -177,6 +177,51 @@ fn a_session_outlives_every_kind_of_bad_local_client() {
     );
     receive_until_screens(&mut reader);
     assert!(fixture.running());
+}
+
+/// The shape that ends sessions on a developer's machine: a p2pmux started with
+/// a sandbox `HOME` -- every e2e scenario, every probe script -- sweeping the
+/// socket directory, which `HOME` does not move. It has no record of the
+/// session somebody is working in, and the socket refuses its connection
+/// because the node's backlog is full, so it used to unlink it and leave a
+/// running node nobody could reach.
+#[test]
+fn a_store_in_another_home_does_not_sweep_a_live_nodes_socket() {
+    let mut fixture = Fixture::start("sweep");
+    let (_stream, mut reader, _) = attach(&fixture.socket);
+    receive_until_snapshot(&mut reader);
+
+    // What the sweep falls back on for a socket that answers nothing and that no
+    // record it can see claims. Nothing else can tell it this socket belongs to a
+    // session somebody is working in: the record is in another `HOME`, and a node
+    // whose backlog is full refuses connections exactly as a dead one does.
+    // Asserted against a node that is genuinely running, since reading a live
+    // process's command line is the half a unit test cannot fake.
+    assert!(
+        p2pmux::agent_detect::node_socket_paths().contains(&fixture.socket),
+        "a running node's socket was not traced back to it"
+    );
+
+    // A store that has never heard of this session, pointed at the directory
+    // every p2pmux on the machine shares.
+    let elsewhere = SessionStore::at(
+        fixture.root.join("other-home"),
+        fixture
+            .socket
+            .parent()
+            .expect("socket directory")
+            .to_owned(),
+    );
+    assert!(
+        elsewhere.list_live().unwrap().is_empty(),
+        "the sandbox store should know of no sessions"
+    );
+
+    assert!(
+        fixture.socket.exists(),
+        "a live node's socket was swept by a store in another HOME"
+    );
+    assert!(fixture.running(), "and its node is still running");
 }
 
 fn attach(socket: &std::path::Path) -> (UnixStream, BufReader<UnixStream>, u64) {


### PR DESCRIPTION
Two p2pmux sessions ended on their own this afternoon, each leaving nothing behind but `p2pmux node ended`. This is why there was nothing to find, and the three ways a session could be ended by something that was not it.

## What was wrong

**A refused connection was read as a dead node.** A unix socket refuses connections once its listener's backlog is full, exactly as it does when the listener has gone — measured on macOS, the 129th connection to a live, bound socket is answered `ECONNREFUSED`. `list_live` treated that single signal as death: it deleted the session's record and unlinked the socket it was still listening on. So a node that was merely not accepting for a moment — a long drain, a machine under a build — was stranded by any `p2pmux ls`, `attach`, `ticket`, `kill` or `--resume` that happened to run.

**A sandbox `HOME` does not isolate any of this.** Records follow `HOME`; sockets do not. `/tmp/p2pmux-{uid}` is where every p2pmux this user runs binds, and that is precisely how every e2e scenario and every ad-hoc probe script isolates itself — so each of them sweeps a directory full of sockets it has no record of, some belonging to the session somebody is working in.

**One bad connection could end the whole node.** `configure_accepted` already returns an `Option` so a peer that hung up before being accepted cannot be `?`-propagated into ending the socket loop, but the arms after it kept the escape hatch: the socket options for an accepted client, the descriptor duplicated for its writer, and anything `accept` answered that was not already named. macOS answers `EINVAL` to `setsockopt` on a socket whose peer has left — verified — and that left the loop through a `?`, taking every pane with it.

**And a node that died said nothing.** No terminal, stderr to `/dev/null`, and the file it writes its error to is read only by `launch_background_node`, which stopped waiting long ago. No crash report either: a Rust panic exits like any other failure.

## What changed

- Liveness is settled with the process table. A record is removed only when connecting is refused *and* the pid that wrote it is no longer a running p2pmux node — the command line is checked too, since pids are reused fast on a machine building software.
- The sweep skips the sockets `list_live` just accounted for, gives an unclaimed one a second chance 50ms later, and then asks which sockets running nodes name on their command lines. A live node's socket is never unlinked, whatever `HOME` recorded it.
- The attachment handshake moves into `attach_client`, which is allowed to fail: losing one client costs that client its connection and nothing else. An unexpected `accept` error stops accepting for that pass instead of ending the session.
- The node keeps a log beside its socket, deleted with a session that ends the way it was asked to and kept by one that did not. The client reads the error file first and falls back to the log's last line, so the message is now `p2pmux node ended: <what happened>`.

## Testing

`cargo test` (496 unit + every integration binary), `cargo clippy --all-targets`, `cargo fmt --check`. New: two integration tests in `tests/node_survives_bad_clients.rs` (a node under a connection storm, clients hanging up at both ends of the handshake, malformed frames; and a store in another `HOME` sweeping a live node's directory), plus unit tests for the store's two liveness verdicts, the node-socket lookup, the accept loop's shape, and `node_exit_reason`.

Checked by hand against the live session on this Mac: a `p2pmux ls` from a second sandbox `HOME` left its record, its socket and its node alone; the log appears when a session starts and is gone after `p2pmux kill`.

Deliberately not done: namespacing the socket directory per `HOME`. It would isolate tests more completely, but it also loses track of sessions already running across an upgrade, and it is not needed for safety now that a live node's socket cannot be swept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X1n4RqmK1d6S5qM6JquFpw