### PR TITLE
fix(cli): bare `p2pmux` always ends in a session, and says what it is waiting on

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ halves are true at once, and [the trust model](#trust) says exactly what that me
 ```sh
 curl -fsSL https://p2pmux.com/install.sh | sh
 
-p2pmux create                # you host; Ctrl+S shows the line to send
+p2pmux                       # you host; Ctrl+S shows the line to send
 p2pmux join 4KP7Q-M2XRW      # them, on their own machine
 ```
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -19,7 +19,7 @@ live-session picker, `p2pmux attach <name>` to attach directly, `p2pmux rename <
 rename a session, and `p2pmux kill <name>` to shut it down gracefully. Killing a coordinator asks
 for confirmation; use `--yes` for non-interactive scripts.
 
-`p2pmux ls` prints the live sessions on this machine — the names every one of those commands takes:
+`p2pmux list` prints the live sessions on this machine — the names every one of those commands takes:
 
 ```text
 NAME       ROLE         CODE         UP
@@ -93,7 +93,7 @@ It is also available from a shell, printed to stdout alone so `p2pmux code | pbc
 
 ```text
 p2pmux code              # the one session hosted on this machine
-p2pmux code <name>       # when several are; the name is the one p2pmux ls shows
+p2pmux code <name>       # when several are; the name is the one p2pmux list shows
 ```
 
 ### The ticket behind the code
@@ -150,7 +150,7 @@ keeps a log beside its socket — `/tmp/p2pmux-$(id -u)/<id>.log` on macOS, `$XD
 otherwise — and that is where a longer story is. A session you end yourself takes the log with
 it; one that ended on its own leaves it for you.
 
-Nothing else on the machine can end a session for you. `p2pmux ls`, `attach`, `ticket` and
+Nothing else on the machine can end a session for you. `p2pmux list`, `attach`, `ticket` and
 `--resume` all read the socket directory, which every p2pmux this user runs shares whatever
 `HOME` started it, and a session that is busy enough to refuse a connection used to look dead to
 them. Liveness is settled with the process table now, so a test harness or a script running in a

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -5,9 +5,15 @@ Everything the README does not need to say on first read. Start with
 
 ## Sessions
 
-`p2pmux` with no arguments needs none of what follows. It attaches the newest live session here,
-or rejoins the one your pairing recorded, or starts a fresh one — and lands you on the inbox
-either way. The commands below are for naming a specific session out loud.
+`p2pmux` with no arguments needs none of what follows: it puts this terminal in a session, always.
+On a machine you have paired it rejoins the session your pairing recorded, so every machine you
+own converges on one; on a machine with no fleet it starts a session and drops you straight into
+the shell. A session someone is already sitting in is passed over rather than fought over, so a
+second window on the same machine gets its own terminal instead of an error. The commands below
+are for naming a specific session out loud.
+
+`p2pmux attach` is the way back to a session already running here — with a name, or with none at
+all for the one started most recently.
 
 `create` and `join` start a session-scoped background node, then attach the local TUI client.
 Ctrl+Q asks which leaving you meant: `d` detaches that client without stopping shells, Iroh, or
@@ -15,7 +21,7 @@ hosted panes, and `k` ends the session on this machine — its panes die with it
 nobody is left hosting a pane in is over. Enter is `d` and Esc backs out, so a reflex press never
 destroys work. Detaching prints the exact `--resume`, `attach`, and `kill` commands needed to
 return. Use `p2pmux --resume` for the
-live-session picker, `p2pmux attach <name>` to attach directly, `p2pmux rename <old> <new>` to
+live-session picker, `p2pmux attach [name]` to attach directly, `p2pmux rename <old> <new>` to
 rename a session, and `p2pmux kill <name>` to shut it down gracefully. Killing a coordinator asks
 for confirmation; use `--yes` for non-interactive scripts.
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1122,7 +1122,7 @@ fn print_enrolment_token() -> Result<(), Box<dyn Error>> {
     let Some(ticket) = pairing.ticket.clone() else {
         return Err(CliError(
             "this machine is not in a fleet yet — run `p2pmux pair` on it once, \
-             or start a session with `p2pmux create`, and try again",
+             or start a session with `p2pmux`, and try again",
         )
         .into());
     };
@@ -1456,7 +1456,7 @@ fn resume_picker(always_picker: bool) -> Result<(), Box<dyn Error>> {
         if always_picker {
             return Err(CliError("no live p2pmux sessions").into());
         }
-        return Err(CliError("no live session; run p2pmux create").into());
+        return Err(CliError("no live session here; `p2pmux` starts one").into());
     }
     let selected = pick_session(&sessions)?;
     crate::client::run(&selected)
@@ -1823,7 +1823,7 @@ fn sole_hosted_session(
         .collect();
     match hosted.len() {
         0 => Err(CliError(
-            "no session was created on this machine; run p2pmux create first",
+            "no session was created on this machine; `p2pmux` starts one",
         )),
         1 => Ok(hosted.remove(0)),
         _ => Err(CliError(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1344,6 +1344,21 @@ async fn open_home() -> Result<(), Box<dyn Error>> {
         {
             return result;
         }
+        // Said before the dial, not after it. Reaching a machine that is not
+        // answering costs iroh about thirty seconds, and this command spent
+        // every one of them printing nothing at all: a bare `p2pmux` on a laptop
+        // whose paired desktop is asleep looked exactly like a command that had
+        // hung. Thirty seconds of "waiting for my other machine" is a wait; the
+        // same thirty seconds in silence is what "p2pmux does nothing" was.
+        {
+            let mut stderr = io::stderr().lock();
+            writeln!(
+                stderr,
+                "rejoining the session this machine is paired with; this can take \
+                 up to half a minute if the other machine is asleep…"
+            )?;
+            stderr.flush()?;
+        }
         match rejoin_paired_session(ticket).await {
             Ok(descriptor) => {
                 return crate::client::run_on(&descriptor, crate::client::StartScreen::Home);
@@ -1852,6 +1867,42 @@ mod tests {
             .0;
         assert!(create_arm.contains("launch_background_node("));
         assert!(create_arm.contains("crate::client::run(&descriptor)"));
+    }
+
+    /// Bare `p2pmux` says it is dialling *before* it dials.
+    ///
+    /// Reaching a paired machine that is asleep costs iroh about thirty
+    /// seconds. Printing afterwards — which is all this did — meant those
+    /// thirty seconds were blank, and a blank terminal is indistinguishable
+    /// from a hung command. Measured on a droplet whose peer was unreachable,
+    /// the first byte arrived at t=31.6s.
+    ///
+    /// Pinned by order rather than by behaviour because the alternative is a
+    /// test that waits out a real dial to a machine that is deliberately not
+    /// answering, and a half-minute of CI per run is a worse trade than this.
+    #[test]
+    fn bare_p2pmux_announces_the_rejoin_before_it_waits_on_one() {
+        let source = include_str!("cli.rs");
+        let body = source
+            .split_once("async fn open_home()")
+            .expect("open_home")
+            .1
+            .split_once("\nasync fn ")
+            .map_or_else(
+                || source.split_once("async fn open_home()").unwrap().1,
+                |split| split.0,
+            );
+
+        let announcement = body
+            .find("rejoining the session this machine is paired with")
+            .expect("open_home should say it is rejoining");
+        let dial = body
+            .find("rejoin_paired_session(ticket)")
+            .expect("open_home should rejoin");
+        assert!(
+            announcement < dial,
+            "the notice must be printed before the dial it explains, not after it"
+        );
     }
 
     /// The node has no terminal, so whatever it writes to stderr is the only

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -85,16 +85,21 @@ enum Command {
         name: String,
     },
     /// List the live sessions on this machine.
-    Ls,
+    ///
+    /// `ls` is kept as an alias: it is what every release so far has answered
+    /// to, and it is written down in scripts and muscle memory this rename has
+    /// no business breaking.
+    #[command(alias = "ls")]
+    List,
     /// Print the full reusable join ticket for a session hosted on this machine.
     Ticket {
-        /// The memorable session name, as listed by `p2pmux ls`. Omit it when one session
+        /// The memorable session name, as listed by `p2pmux list`. Omit it when one session
         /// is hosted here.
         session: Option<String>,
     },
     /// Print the short join code for a session hosted on this machine.
     Code {
-        /// The memorable session name, as listed by `p2pmux ls`. Omit it when one session
+        /// The memorable session name, as listed by `p2pmux list`. Omit it when one session
         /// is hosted here.
         session: Option<String>,
     },
@@ -319,7 +324,7 @@ pub fn run_without_runtime(cli: &Cli) -> Option<Result<(), Box<dyn Error>>> {
             ),
         }),
         // Reading the finder records is a directory scan; it needs no runtime either.
-        Some(Command::Ls) => Some(print_sessions()),
+        Some(Command::List) => Some(print_sessions()),
         // Editing a settings file and reporting on it are both plain filesystem
         // work, and a user running them wants an answer, not a thread pool.
         Some(Command::Setup { agent }) => Some(match agent {
@@ -341,7 +346,7 @@ pub fn run_without_runtime(cli: &Cli) -> Option<Result<(), Box<dyn Error>>> {
 
 /// The live sessions on this machine, as `ticket`, `code`, `attach`, `kill` and `rename` name them.
 ///
-/// Those five commands all take a session name and every one of them documented `p2pmux ls` as
+/// Those five commands all take a session name and every one of them documented `p2pmux list` as
 /// where to read it, so this is the command that makes the rest addressable. It prints nothing
 /// but a header when there are none, rather than failing: "no sessions" is a legitimate answer
 /// to a listing, unlike to `p2pmux code`.
@@ -430,7 +435,7 @@ pub async fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
         // Already handled by the `run_without_runtime` call above; reaching
         // here would mean the two dispatches disagreed.
         Some(Command::Notify { .. })
-        | Some(Command::Ls)
+        | Some(Command::List)
         | Some(Command::Setup { .. })
         | Some(Command::Doctor) => Ok(()),
         Some(Command::Local) => crate::tui::run_local(),
@@ -1750,7 +1755,7 @@ fn sole_hosted_session(
         )),
         1 => Ok(hosted.remove(0)),
         _ => Err(CliError(
-            "several sessions are hosted on this machine; pass the session name, as listed by p2pmux ls",
+            "several sessions are hosted on this machine; pass the session name, as listed by p2pmux list",
         )),
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -103,8 +103,16 @@ enum Command {
         /// is hosted here.
         session: Option<String>,
     },
-    /// Attach a live local session by memorable name.
-    Attach { name: String },
+    /// Go back to a session already running on this machine.
+    ///
+    /// Bare `p2pmux` starts somewhere new; this is how you return to somewhere
+    /// old. With no name it takes the session started most recently here, which
+    /// is what "put me back" means when only one is running.
+    Attach {
+        /// The memorable session name, as listed by `p2pmux list`. Omit it to
+        /// take the most recently started one.
+        name: Option<String>,
+    },
     /// Gracefully stop a live local session.
     Kill {
         name: String,
@@ -684,7 +692,15 @@ pub async fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
         }
         Some(Command::Ticket { session }) => print_join_ticket(session),
         Some(Command::Code { session }) => print_join_code(session),
-        Some(Command::Attach { name }) => crate::client::run(&find_live(&name)?),
+        Some(Command::Attach { name }) => crate::client::run(&match name {
+            Some(name) => find_live(&name)?,
+            None => {
+                newest_live(&crate::session_store::SessionStore::for_current_user()?.list_live()?)
+                    .ok_or(CliError(
+                    "no session is running on this machine; `p2pmux` starts one",
+                ))?
+            }
+        }),
         Some(Command::Kill { name, yes }) => {
             let descriptor = find_live(&name)?;
             if descriptor.role == crate::session_store::SessionRole::Coordinator && !yes {
@@ -1292,27 +1308,42 @@ fn machine_rows() -> Result<Vec<crate::tui::MachineRow>, Box<dyn Error>> {
     Ok(rows)
 }
 
-/// What bare `p2pmux` does: open the inbox.
+/// What bare `p2pmux` does: put this terminal in a session, always.
 ///
-/// Not a session picker. The question the command answers is "which of my
-/// agents needs me", and making someone choose a session first is asking them
-/// to answer a question they did not have in order to be shown the one they
-/// did. `--resume` still reaches the picker for anyone who wants it.
+/// The command has to answer for a machine in a fleet and a machine on its own,
+/// and those two want opposite things from the same six keystrokes:
 ///
-/// Three cases, in order, and all of them end on Home:
+/// * **Paired** — rejoin the session the pairing recorded. Every machine you own
+///   converging on one session is the whole point of pairing once, and the line
+///   `p2pmux pair` prints promises exactly this. Creating a fresh session here
+///   instead would leave each machine hosting its own and the fleet never
+///   meeting.
+/// * **On its own** — create a session. Someone with no fleet who types the
+///   shortest command wants a terminal, and this is the command that gives them
+///   one.
 ///
-/// 1. A session is already live here — attach it.
-/// 2. This machine is paired — rejoin the session the pairing recorded, with
-///    no code typed. That is the whole point of pairing once.
-/// 3. Nothing yet — start a solo session, so a first run has a real terminal
-///    behind `n` rather than an empty screen and an error.
+/// What it may never do is end without a session. It used to attach the newest
+/// live one first, whoever was in it — and a node serves one terminal at a time,
+/// so the second window on a machine that already had p2pmux open got
+/// `Error: already attached` and nothing else. That is the state of every
+/// machine actually using this, which is why bare `p2pmux` read as broken. An
+/// occupied session is now a session to pass over, not a failure to report.
+///
+/// `--resume` still reaches the picker, and `p2pmux attach` still goes back to a
+/// session already running here.
 async fn open_home() -> Result<(), Box<dyn Error>> {
     let store = crate::session_store::SessionStore::for_current_user()?;
-    if let Some(descriptor) = newest_live(&store.list_live()?) {
-        return crate::client::run_on(&descriptor, crate::client::StartScreen::Home);
-    }
     let pairing = crate::pairing::load_or_empty();
     if let Some(ticket) = pairing.ticket.as_deref() {
+        // A node here is already in the fleet's session: use it rather than
+        // standing up a second one alongside it. Only while it is free — an
+        // occupied one falls through to a node of this terminal's own, which
+        // lands in the same shared session anyway.
+        if let Some(descriptor) = newest_live(&joined_to(&store.list_live()?, ticket))
+            && let Some(result) = attach_unless_busy(&descriptor, crate::client::StartScreen::Home)
+        {
+            return result;
+        }
         match rejoin_paired_session(ticket).await {
             Ok(descriptor) => {
                 return crate::client::run_on(&descriptor, crate::client::StartScreen::Home);
@@ -1328,7 +1359,48 @@ async fn open_home() -> Result<(), Box<dyn Error>> {
         }
     }
     let descriptor = start_solo_session()?;
-    crate::client::run_on(&descriptor, crate::client::StartScreen::Home)
+    // The session screen, not the inbox. A session created a moment ago has one
+    // pane and no agents in it, so Home would open on an empty list — the blank
+    // screen a first run is least able to interpret. Rejoining a fleet session
+    // is the opposite case and keeps the inbox.
+    crate::client::run_on(&descriptor, crate::client::StartScreen::Session)
+}
+
+/// Attach `descriptor`, unless another terminal is already in it.
+///
+/// `None` means only that: the session is taken, and the caller should look
+/// elsewhere. Every other failure comes back as `Some(Err(..))` and stays the
+/// caller's problem to report — swallowing those would hide a broken session
+/// behind a brand-new one and make the fault impossible to see.
+fn attach_unless_busy(
+    descriptor: &crate::session_store::SessionDescriptor,
+    start: crate::client::StartScreen,
+) -> Option<Result<(), Box<dyn Error>>> {
+    match crate::client::run_on(descriptor, start) {
+        Err(error) if crate::client::is_already_attached(&*error) => None,
+        result => Some(result),
+    }
+}
+
+/// The live sessions here that are the one the pairing recorded.
+///
+/// Matched by ticket rather than taken as "the newest", because a machine in a
+/// fleet also starts sessions of its own: attaching one of those for a bare
+/// `p2pmux` would put the user somewhere their other machines are not, which is
+/// the one place this command must never leave them. The coordinator that
+/// minted the pairing ticket holds it as `ticket`; every machine that joined
+/// holds the same string as `joined_ticket`.
+fn joined_to(
+    live: &[crate::session_store::SessionDescriptor],
+    ticket: &str,
+) -> Vec<crate::session_store::SessionDescriptor> {
+    live.iter()
+        .filter(|descriptor| {
+            descriptor.joined_ticket.as_deref() == Some(ticket)
+                || descriptor.ticket.as_deref() == Some(ticket)
+        })
+        .cloned()
+        .collect()
 }
 
 /// The most recently created live session, which is the one a bare command

--- a/src/client.rs
+++ b/src/client.rs
@@ -218,15 +218,49 @@ fn scroll_pane_toward(
 
 /// Which screen an attaching client lands on.
 ///
-/// Bare `p2pmux` opens the inbox: the question it answers is "which of my
-/// agents needs me", and answering it should not require picking a session
-/// first. Every other entry point named a session out loud — `create`, `join`,
-/// `attach` — so it lands in the terminal the user asked for.
+/// The inbox is for arriving somewhere that was already running: the question
+/// it answers is "which of my agents needs me", and a session with other
+/// machines in it has an answer worth reading before anything else. Bare
+/// `p2pmux` opens on it when it rejoins a fleet session for that reason.
+///
+/// Everything that *starts* a session lands in the terminal instead — `create`,
+/// `join`, `attach`, and bare `p2pmux` on a machine with no fleet. A session one
+/// second old has a single pane and no agents, so its inbox is an empty list,
+/// and opening on an empty list is indistinguishable from opening on nothing.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub enum StartScreen {
     #[default]
     Session,
     Home,
+}
+
+/// A node turning this client away at the door, carrying its reason verbatim.
+///
+/// Typed rather than folded into `io::Error` so a caller can tell the one
+/// refusal it can recover from — the session already has a terminal in it —
+/// from every other way attaching fails. Matching on the message text would
+/// have worked until somebody reworded it.
+#[derive(Debug)]
+pub struct AttachRejected(String);
+
+impl std::fmt::Display for AttachRejected {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for AttachRejected {}
+
+/// Whether this is a node refusing a second client, rather than a session that
+/// is genuinely broken.
+///
+/// A node serves one terminal at a time, so this is the ordinary state of every
+/// session a user already has open — not a fault, and not something to end a
+/// command over.
+pub fn is_already_attached(error: &(dyn std::error::Error + 'static)) -> bool {
+    error
+        .downcast_ref::<AttachRejected>()
+        .is_some_and(|rejected| rejected.0 == crate::local_ipc::ALREADY_ATTACHED)
 }
 
 pub fn run(descriptor: &SessionDescriptor) -> Result<(), Box<dyn std::error::Error>> {
@@ -258,7 +292,7 @@ pub fn run_on(
     )?;
     let generation = match read_message(&mut reader)? {
         Some(NodeMessage::AttachAccepted { generation }) => generation,
-        Some(NodeMessage::AttachRejected { reason }) => return Err(io::Error::other(reason).into()),
+        Some(NodeMessage::AttachRejected { reason }) => return Err(AttachRejected(reason).into()),
         _ => return Err(io::Error::other("node did not accept attachment").into()),
     };
     let (wake_tx, wakes) = mpsc::channel();
@@ -1506,6 +1540,29 @@ mod tests {
     };
 
     use super::*;
+
+    /// The one refusal a caller recovers from, told apart from every other.
+    ///
+    /// Bare `p2pmux` passes over a session that already has a terminal in it and
+    /// opens another; it must not do that for a session that is genuinely
+    /// broken, because then the fault disappears behind a working session and
+    /// nobody ever sees it.
+    #[test]
+    fn only_a_busy_session_reads_as_already_attached() {
+        let busy: Box<dyn std::error::Error> =
+            AttachRejected(crate::local_ipc::ALREADY_ATTACHED.into()).into();
+        assert!(is_already_attached(&*busy));
+
+        // A rejection with any other reason is the node saying something else.
+        let other: Box<dyn std::error::Error> =
+            AttachRejected("session is shutting down".into()).into();
+        assert!(!is_already_attached(&*other));
+
+        // And a plain I/O failure — a socket that has gone away, say — is not a
+        // rejection at all.
+        let broken: Box<dyn std::error::Error> = io::Error::other("connection reset").into();
+        assert!(!is_already_attached(&*broken));
+    }
 
     fn layout(pane_ids: &[u64]) -> LayoutSnapshot {
         let root = pane_ids

--- a/src/local_ipc.rs
+++ b/src/local_ipc.rs
@@ -327,6 +327,15 @@ pub struct SessionSummary {
     pub coordinator_name: String,
 }
 
+/// Why [`AttachmentGate::attach`] refused, and what the node sends back as the
+/// rejection reason.
+///
+/// Named rather than written out at each end because a caller decides what to do
+/// next by reading it: bare `p2pmux` treats this one refusal as "that session is
+/// taken, open another" rather than as an error, and a typo here would turn that
+/// recovery back into the dead end it replaced.
+pub const ALREADY_ATTACHED: &str = "already attached";
+
 /// Single-client gate. A generation makes delayed disconnects harmless after a reattach.
 #[derive(Clone, Default)]
 pub struct AttachmentGate(Arc<Mutex<AttachmentState>>);
@@ -340,7 +349,7 @@ impl AttachmentGate {
     pub fn attach(&self) -> Result<u64, &'static str> {
         let mut state = self.0.lock().expect("attachment gate poisoned");
         if state.attached {
-            return Err("already attached");
+            return Err(ALREADY_ATTACHED);
         }
         state.generation = state.generation.saturating_add(1).max(1);
         state.attached = true;

--- a/src/node.rs
+++ b/src/node.rs
@@ -416,7 +416,7 @@ fn run_socket_loop(
                                 let _ = write_message(
                                     reader.get_mut(),
                                     &NodeMessage::AttachRejected {
-                                        reason: "already attached".into(),
+                                        reason: crate::local_ipc::ALREADY_ATTACHED.into(),
                                     },
                                 );
                                 continue;

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -106,6 +106,41 @@ fn help_lists_the_local_terminal_command() {
     assert!(stdout.contains("full reusable join ticket"));
 }
 
+/// The listing is spelled `list`, and `ls` still reaches it.
+///
+/// Renaming the command a user types every day is only worth doing if the old
+/// spelling keeps working: `ls` is in scripts, in shell history and in three
+/// releases' worth of documentation, and a rename that breaks those buys a
+/// nicer name at the price of every one of them.
+#[test]
+fn list_and_its_ls_alias_print_the_same_sessions() {
+    let session = FakeSession::hosted("lisbon");
+
+    let long = run_with_home(session.home(), &["list"]);
+    let short = run_with_home(session.home(), &["ls"]);
+
+    assert!(long.status.success());
+    assert!(short.status.success());
+    let listed = String::from_utf8(long.stdout).expect("stdout should be UTF-8");
+    assert!(listed.contains("lisbon"), "{listed}");
+    assert!(listed.contains("coordinator"), "{listed}");
+    assert_eq!(
+        listed,
+        String::from_utf8(short.stdout).expect("stdout should be UTF-8")
+    );
+}
+
+/// `list` is the one the help text teaches, so the rename reaches the place a
+/// user goes to find out what the commands are.
+#[test]
+fn help_names_the_listing_command_list() {
+    let output = run(&["--help"]);
+
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be UTF-8");
+    assert!(stdout.contains("list"), "{stdout}");
+    assert!(stdout.contains("List the live sessions"), "{stdout}");
+}
+
 #[test]
 fn ticket_prints_a_pasteable_ticket_that_join_would_accept() {
     let session = FakeSession::hosted("lisbon");

--- a/tests/detach_resume_node.rs
+++ b/tests/detach_resume_node.rs
@@ -169,13 +169,19 @@ fn run_detach_resume_round_trip(
     );
 
     // A second live client is refused while the first holds the attachment gate.
+    //
+    // The reason is asserted word for word, not just the variant: bare `p2pmux`
+    // reads it to decide that this session is merely taken and it should open
+    // another, and a reword here would silently turn that recovery back into
+    // the `Error: already attached` dead end it exists to prevent.
     let mut refused = UnixStream::connect(socket_path).unwrap();
     send(&mut refused, &ClientMessage::Hello { cols: 80, rows: 24 });
     let mut refused_reader = BufReader::new(refused.try_clone().unwrap());
-    assert!(matches!(
-        receive(&mut refused_reader, "second client rejection"),
-        NodeMessage::AttachRejected { .. }
-    ));
+    let rejection = receive(&mut refused_reader, "second client rejection");
+    let NodeMessage::AttachRejected { reason } = &rejection else {
+        panic!("expected the second client to be refused, got {rejection:?}");
+    };
+    assert_eq!(reason, p2pmux::local_ipc::ALREADY_ATTACHED);
 
     send(
         &mut stream,


### PR DESCRIPTION
## What was broken

"Bare `p2pmux` does nothing" turned out to be **two** faults, and which one you
hit depends on whether a session is already live on the machine.

**1. A session is live here → an instant error.** Bare `p2pmux` attached the
newest live session before doing anything else. A node serves one terminal at a
time, so the second window on a machine that already had p2pmux open got:

```
$ p2pmux
Error: already attached
```

and no session — the ordinary state of every machine actually using this.

**2. No session, but this machine is paired → 30 seconds of silence.** The
rejoin dial costs iroh about half a minute when the paired machine is asleep,
and the only thing that path printed was the failure, *after* the wait. Measured
on a droplet whose peer was unreachable, the first byte reached the terminal at
**t=31.6s**. A blank terminal for half a minute is indistinguishable from a hung
command.

## What it does now

An occupied session is something to pass over, not a failure to report, and the
wait is announced before it happens rather than after. What the command does
depends on whether this machine is in a fleet:

| | bare `p2pmux` |
|---|---|
| **paired** | rejoins the session the pairing recorded, so every machine you own converges on one |
| **on its own** | creates a session, and lands in the terminal |

The paired branch is deliberate: `p2pmux pair` prints *"from now on, bare
`p2pmux` rejoins with no code"*, and several machines sharing one session is the
point of the product. Always creating would leave each machine hosting its own.

The unpaired branch now opens on the **session** screen rather than the inbox. A
session one second old has one pane and no agents, so its inbox is an empty list
— and the control run below shows the old build's first terminal never gave you
a shell at all for exactly that reason.

Telling the recoverable refusal from every other one needs the reason typed, not
matched as a string: `AttachRejected` carries it, `client::is_already_attached`
reads it, and node and client share one `ALREADY_ATTACHED` constant. Every other
attach failure still ends the command — a broken session hidden behind a working
one is a fault nobody ever sees.

## Also here

* **`p2pmux list`**, with `ls` kept as an alias. Every other command is spelled
  out (`machines`, `attach`, `rename`, `unpair`); the listing was the one
  abbreviation, and the one people type most. `ls` stays because it is in
  scripts, shell history and three releases of docs.
* **`p2pmux attach` takes the name optionally.** Bare `p2pmux` no longer goes
  back to a running session, so something had to.
* README and USAGE updated, plus the three error messages pointing at
  `p2pmux create`.

## Testing

`cargo test` (508 unit + all integration), `clippy -D warnings` and `fmt --check`
green on macOS locally; CI covers macOS and Ubuntu.

None of that can see either bug — both need two terminals against a real node, or
a real unreachable peer — so this ran on **two DigitalOcean droplets**, nyc3 and
fra1, over the public internet.

### A/B against pre-change `main`, same droplet, same sequence

| | pre-change `main` | this branch |
|---|---|---|
| 1st terminal | 2460 bytes, **shell never ran the marker** (opened on the empty inbox) | 3610 bytes, **marker evaluated** |
| 2nd terminal | **25 bytes, EOF, `already attached`** | 3544 bytes, **no error, marker evaluated**, 2nd session created |

The marker is `echo FIRST_$((6*7))` — the PTY echoes the literal `$((6*7))`, so
only a shell that actually ran it produces `FIRST_42`. A plain `echo FOO` check
would have passed on its own echo and proved nothing.

### The silent wait, before and after

```
before:  t= 31.6s  could not rejoin the paired session: could not reach the session host…
after:   t=  1.6s  rejoining the session this machine is paired with; this can take
                   up to half a minute if the other machine is asleep…
         t= 31.6s  could not rejoin the paired session: …
```

### Full scenario run

```
T1  bare `p2pmux` on a machine that has never run it        4/4 PASS
T2  a second terminal, while the first is still attached    3/3 PASS
T3  `list`, its `ls` alias, and no-argument `attach`        3/3 PASS
T4  two machines, one session                               6/6 PASS
```

T4 is the one that matters for the fleet goal — bare `p2pmux` on the paired
droplet joined the *other* droplet's session as a `member` rather than starting
its own, and its fleet lists both machines.

The droplets were destroyed after the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
