### PR TITLE
fix(cursor): the caret goes where the typing goes

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -286,6 +286,11 @@ width they were written at, so a pane that got narrower clips them rather than l
 Alternate-screen applications have no scrollback to browse at all, and remote-hosted panes return
 an empty scrollback window in this v1 implementation.
 
+A pane being browsed shows no cursor: it is not displaying where its program's cursor is, and a
+caret left blinking on a row of history says otherwise. Typing returns the pane to its live edge
+and the cursor with it, and so does anything that ends the browse session — a resize, or a node
+answering that the rows are gone.
+
 Slow viewers may receive coalesced screen deltas and then a fresh snapshot to recover. Resizing an
 outer terminal reflows locally hosted panes: the host resizes its PTY and VT screen and commits any
 changed host-owned grids. Guests only receive the resulting commit and screen snapshot.

--- a/scripts/e2e/driver.py
+++ b/scripts/e2e/driver.py
@@ -375,6 +375,17 @@ class Peer:
         with self._lock:
             return self._screen.cursor.y, self._screen.cursor.x
 
+    def cursor_hidden(self) -> bool:
+        """Whether the caret is off, which is a claim in its own right.
+
+        p2pmux hides it deliberately -- a pane scrolled into history is not
+        showing where its program's cursor is, and a dialog that has taken the
+        keyboard has taken the caret with it -- so a scenario needs to be able
+        to assert the absence and not only the position.
+        """
+        with self._lock:
+            return bool(self._screen.cursor.hidden)
+
     def raw_text(self) -> str:
         with self._lock:
             return self.raw.decode("utf-8", errors="replace")

--- a/scripts/e2e/scenario_ag_caret_cross.py
+++ b/scripts/e2e/scenario_ag_caret_cross.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Where the caret is, with one of the panes on another machine.
+
+The caret is the only mark on screen that says where typing goes, and three
+rules govern it. Each was broken in a way no unit test could see, because each
+depends on state the client assembles from somewhere else:
+
+  * a pane scrolled into history is not showing where its program's cursor is,
+    so it must not keep the caret. A client keeps no scrollback of its own -- it
+    renders history by swapping in a viewport the node built, whose own offset
+    is always zero -- so a gate that asked the *screen* how far back it was
+    scrolled always answered "at the live edge";
+  * a dialog that takes the keyboard takes the caret with it, or the panel gets
+    the typing while the caret goes on blinking in the pane behind it;
+  * anything that throws those fetched viewports away -- a resize, or a node
+    answering that the history is gone -- drops the pane at its live edge, so
+    its offset has to come back to zero with them. Otherwise the pane reads as
+    scrolled while showing the newest output: no caret, and the next several
+    notches of wheel-down spent walking back through rows that are not there.
+
+Every assertion is made on the Mac, which is the client under test. The droplet
+is here to host a pane: a remote-hosted pane's screen arrives over Iroh, its
+cursor position is the other machine's, and its history is the case the node
+answers "unavailable" for -- which is the third rule's other trigger.
+
+Requires the provisioned lab (`scripts/e2e/provision_droplets.sh create`).
+
+Run: python3 scripts/e2e/scenario_ag_caret_cross.py
+"""
+
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from driver import Harness  # noqa: E402
+from remote import hosts_from_manifest, spawn_remote  # noqa: E402
+
+CTRL_P = b"\x10"
+ESC = b"\x1b"
+
+COLS = 120
+ROWS = 36
+# Clear of every border: the left pane is the Mac's, the right one the droplet's.
+LEFT_COL = 20
+RIGHT_COL = 95
+PANE_ROW = 10
+
+
+def main() -> int:
+    results: list[bool] = []
+
+    def check(name: str, ok: bool, detail: str = "") -> None:
+        results.append(bool(ok))
+        print(f"  [{'PASS' if ok else 'FAIL'}] {name}" + (f" -- {detail}" if detail and not ok else ""))
+
+    def wheel(peer, col: int, up: bool, times: int) -> None:
+        for _ in range(times):
+            (peer.wheel_up if up else peer.wheel_down)(col, PANE_ROW)
+            time.sleep(0.25)
+        time.sleep(1.5)
+
+    remote = hosts_from_manifest()[0]
+    remote.reset_home()
+    print(f"== scenario AG: the caret, with a pane on {remote.alias} ==", flush=True)
+
+    try:
+        with Harness("ag-caret-cross") as harness:
+            host, ticket = harness.create_room("mac", cols=COLS, rows=ROWS)
+            guest = spawn_remote(
+                harness, remote, "droplet", ["join", ticket, "--name", "droplet"],
+                cols=COLS, rows=ROWS,
+            )
+            guest.wait_ready(timeout=60)
+            guest.wait_for(r"Pane #\d+", timeout=60)
+
+            # The droplet splits, so the right-hand pane's PTY lives on Linux.
+            guest.send(CTRL_P)
+            time.sleep(0.5)
+            guest.send(b"n")
+            time.sleep(4.0)
+            # By title, not by number: "Pane #2" appears the moment the layout
+            # arrives, while what this scenario needs is a pane whose PTY is on
+            # the other machine.
+            host.wait_for(r"host: droplet", timeout=60)
+
+            # ------------------------------------------- a pane on the other machine
+            host.click(RIGHT_COL, PANE_ROW)
+            time.sleep(1.5)
+            check(
+                "a focused pane hosted on the droplet carries the caret",
+                not host.cursor_hidden(),
+                f"caret at {host.cursor()}",
+            )
+
+            # ------------------------------------------- a dialog takes it
+            host.send(CTRL_P)
+            time.sleep(0.5)
+            host.send(b"e")
+            time.sleep(1.5)
+            host.send(b"buildbox")
+            time.sleep(2.0)
+            renaming = host.snapshot().splitlines()
+            caret_row, caret_col = host.cursor()
+            field_row = next(
+                (index for index, line in enumerate(renaming) if "buildbox" in line), None
+            )
+            check("the rename panel is up with what was typed in it", field_row is not None,
+                  "\n".join(renaming)[:400])
+            check(
+                "the caret is in the field being typed into, not the pane behind it",
+                field_row is not None and caret_row == field_row,
+                f"caret on row {caret_row}, field on row {field_row}",
+            )
+            check(
+                "and it sits just past the last character typed",
+                field_row is not None and renaming[field_row][:caret_col].endswith("buildbox"),
+                f"row up to the caret reads {renaming[field_row][:caret_col]!r}"
+                if field_row is not None
+                else "no field",
+            )
+            host.send(ESC)
+            time.sleep(1.5)
+            check("closing the panel gives the caret back to the pane",
+                  not host.cursor_hidden())
+
+            # ------------------------------------------- history that is not reachable
+            check("the droplet is still in the session", guest.alive)
+            guest.send(b"for i in $(seq 1 400); do echo remote-line-$i; done\r")
+            host.wait_for("remote-line-400", timeout=60)
+            host.click(RIGHT_COL, PANE_ROW)
+            time.sleep(1.0)
+            wheel(host, RIGHT_COL, up=True, times=6)
+            after_remote_wheel = host.snapshot()
+            # v1: only the node that hosts a pane can serve its scrollback. The
+            # pane therefore stays where it is -- and, having never left the live
+            # edge, keeps its caret.
+            check(
+                "a remote-hosted pane that cannot serve history keeps its caret",
+                not host.cursor_hidden(),
+                f"caret hidden; screen: {after_remote_wheel[-300:]!r}",
+            )
+            check(
+                "and stays at the live edge rather than freezing on a view it never got",
+                "remote-line-400" in after_remote_wheel,
+                after_remote_wheel[-300:],
+            )
+            check("no panic from scrolling a remote pane", "panicked" not in host.raw_text())
+
+            # ------------------------------------------- history that is reachable
+            host.click(LEFT_COL, PANE_ROW)
+            time.sleep(1.0)
+            host.send(b"for i in $(seq 1 400); do echo mac-line-$i; done\r")
+            host.wait_for("mac-line-400", timeout=45)
+            time.sleep(1.0)
+            wheel(host, LEFT_COL, up=True, times=6)
+            scrolled = host.snapshot()
+            check(
+                "the Mac's own pane really does move into history",
+                "mac-line-400" not in scrolled,
+                "the live edge is still on screen",
+            )
+            check(
+                "scrolling into history takes the caret off the pane",
+                host.cursor_hidden(),
+                f"caret still shown at {host.cursor()}",
+            )
+
+            wheel(host, LEFT_COL, up=False, times=10)
+            check("returning to the live edge gives the caret back", not host.cursor_hidden())
+
+            # ------------------------------------------- resized mid-history
+            wheel(host, LEFT_COL, up=True, times=6)
+            check("scrolled back again", host.cursor_hidden())
+            host.resize(COLS - 12, ROWS - 4)
+            time.sleep(3.0)
+            check(
+                "a resize mid-history lands at the live edge, caret and all",
+                not host.cursor_hidden(),
+                f"caret still hidden; screen: {host.snapshot()[-300:]!r}",
+            )
+
+            check("both peers still alive", host.alive and guest.alive)
+            check(
+                "no panic anywhere",
+                "panicked" not in host.raw_text() and "panicked" not in guest.raw_text(),
+            )
+    finally:
+        remote.reap()
+
+    print(f"\n{sum(results)}/{len(results)} checks passed")
+    return 0 if all(results) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/client.rs
+++ b/src/client.rs
@@ -930,9 +930,15 @@ pub fn run_on(
                 viewport = (cols, rows);
                 if !tui.modal_open() {
                     tui.set_home_viewport_for(Rect::new(0, 0, cols, rows));
+                    // The cached viewports were built against the old grid, so
+                    // they go — and with them the only rows a scrolled-back pane
+                    // had to show. What it falls back to is its live screen, so
+                    // the offsets have to come back to the live edge too, or the
+                    // pane reads as scrolled while showing the newest output.
                     history.clear();
                     pending_scroll.clear();
                     desired_scroll.clear();
+                    tui.reset_all_scrollback();
                     write_message(&mut stream, &ClientMessage::Resize { cols, rows })?;
                     node_viewport = (cols, rows);
                 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -119,6 +119,28 @@ fn take_matching_pending(
     pending.remove(&pane_id)
 }
 
+/// Give up on a pane's history and put it back at its live edge.
+///
+/// The node answers "unavailable" for a pane it does not host, for one on the
+/// alternate screen, and for a frozen session it has since evicted — and the
+/// last of those can arrive for a pane that is *already* parked in history.
+/// Everything cached for it goes, so what the pane falls back to is its live
+/// screen; leaving the offset behind would leave it reading as scrolled while
+/// showing the newest output, which costs it its caret and swallows the next
+/// several notches of wheel-down.
+fn abandon_history(
+    tui: Option<&mut MultiPaneTui>,
+    history: &mut BTreeMap<u64, HistoryCache>,
+    desired_scroll: &mut BTreeMap<u64, usize>,
+    pane_id: u64,
+) {
+    desired_scroll.remove(&pane_id);
+    history.remove(&pane_id);
+    if let Some(tui) = tui {
+        tui.set_pane_scrollback_offset(pane_id, 0);
+    }
+}
+
 const PANE_SCROLL_WHEEL_STEP: usize = 3;
 
 /// Rows pulled in per step by a selection dragged past a pane's edge.
@@ -513,14 +535,18 @@ pub fn run_on(
                             continue;
                         };
                         let Some(snapshot) = snapshot else {
-                            // No history to reach, so anything the burst queued behind this
-                            // is unreachable too.
-                            desired_scroll.remove(&pane_id);
-                            // Drop the cached session with it. The answer is also what a
-                            // node gives for a history id it no longer holds, and keeping
-                            // that dead id would put it on every later query -- one
-                            // evicted session and the pane could never be scrolled again.
-                            history.remove(&pane_id);
+                            // No history to reach: anything the burst queued behind this is
+                            // unreachable too, and the cached session goes with it. That
+                            // answer is also what a node gives for a history id it no
+                            // longer holds, and keeping that dead id would put it on every
+                            // later query -- one evicted session and the pane could never
+                            // be scrolled again.
+                            abandon_history(
+                                tui.as_mut(),
+                                &mut history,
+                                &mut desired_scroll,
+                                pane_id,
+                            );
                             footer_notice = unavailable;
                             dirty = true;
                             continue;
@@ -1846,6 +1872,60 @@ mod tests {
                 .unwrap()
                 .contents()
                 .contains("one")
+        );
+    }
+
+    /// The node says "unavailable" for a pane it does not host, for one on the
+    /// alternate screen, and for a frozen session it has since evicted. Only the
+    /// last of those can reach a pane that is already parked in history -- and
+    /// when it does, everything that pane had to show is gone, so it is back at
+    /// its live edge whether or not its offset admits it.
+    #[test]
+    fn losing_a_panes_history_returns_it_to_the_live_edge() {
+        let host = HostScreen::new(2, 8).unwrap();
+        let mut tui = None;
+        let mut screens = BTreeMap::new();
+        let mut history = BTreeMap::new();
+        let mut pending_focus = None;
+        apply_snapshot(
+            &mut tui,
+            crate::config::UiTheme::default(),
+            &mut screens,
+            &mut history,
+            String::from("room"),
+            layout(&[1]),
+            vec![PaneScreenSnapshot {
+                pane_id: 1,
+                state: ScreenUpdate::Snapshot {
+                    sequence: 1,
+                    snapshot: host.current_frame().snapshot.as_ref().to_vec(),
+                    kitty_keyboard_active: false,
+                },
+                history_len: 40,
+                history_end: 40,
+            }],
+            vec![],
+            vec![],
+            1,
+            1,
+            &mut pending_focus,
+        )
+        .unwrap();
+        let view = tui.as_mut().expect("a snapshot builds the view");
+        assert!(view.set_pane_scrollback_offset(1, 12));
+        let mut desired_scroll = BTreeMap::from([(1_u64, 30_usize)]);
+
+        abandon_history(tui.as_mut(), &mut history, &mut desired_scroll, 1);
+
+        assert_eq!(
+            tui.as_ref().expect("view").pane_scrollback_offset(1),
+            0,
+            "the pane is showing live output, so it has to say so"
+        );
+        assert!(!history.contains_key(&1), "the dead session goes with it");
+        assert!(
+            !desired_scroll.contains_key(&1),
+            "and so does whatever the burst had queued behind it"
         );
     }
 

--- a/src/tui/multi_pane/scrollback.rs
+++ b/src/tui/multi_pane/scrollback.rs
@@ -66,6 +66,22 @@ impl MultiPaneTui {
         true
     }
 
+    /// Put every pane back at its live edge.
+    ///
+    /// For the client, which keeps no scrollback and holds only the viewports
+    /// the node built for it: the moment those are thrown away — a resize
+    /// reflows every retained row, so they are — the panes are showing live
+    /// output again, and an offset left behind says otherwise. It hid the caret
+    /// on a pane that was at its live edge, and made the next several notches of
+    /// wheel-down walk back through rows that were no longer on screen.
+    pub(crate) fn reset_all_scrollback(&mut self) -> bool {
+        let mut moved = false;
+        for view in self.pane_views.values_mut() {
+            moved |= std::mem::take(&mut view.scrollback) != 0;
+        }
+        moved
+    }
+
     pub(in crate::tui) fn reset_scrollback(&mut self, pane_id: PaneId) -> bool {
         let Some(view) = self.pane_views.get_mut(&pane_id) else {
             return false;
@@ -126,6 +142,25 @@ mod tests {
         assert!(tui.scroll_pane(pane_id, 4, false));
         assert!(!tui.scroll_pane(pane_id, 4, false));
         assert_eq!(tui.pane_view(pane_id).expect("pane view").scrollback, 0);
+    }
+
+    /// A resize throws away every viewport the node built, so every pane is
+    /// back at its live edge whether or not it was the one being scrolled.
+    #[test]
+    fn dropping_the_fetched_history_returns_every_pane_to_the_live_edge() {
+        let mut tui = MultiPaneTui::new(split_layout()).expect("valid layout");
+        assert!(tui.scroll_pane(1, 40, true));
+        assert!(tui.scroll_pane(3, 40, true));
+        assert!(tui.scroll_pane(3, 40, true));
+
+        assert!(tui.reset_all_scrollback());
+
+        assert_eq!(tui.pane_view(1).expect("pane view").scrollback, 0);
+        assert_eq!(tui.pane_view(3).expect("pane view").scrollback, 0);
+        assert!(
+            !tui.reset_all_scrollback(),
+            "nothing moved, so nothing to redraw"
+        );
     }
 
     #[test]

--- a/src/tui/render/modals.rs
+++ b/src/tui/render/modals.rs
@@ -15,7 +15,7 @@ use crate::{
         RenamePrompt, RenameTarget, ShareView,
         render::footer::{add_machine_help, render_footer_segments, share_help},
         share::{INSTALL_COMMAND, join_command, pair_command},
-        text::{truncate_trailing, wrap_fixed},
+        text::{text_width, truncate_trailing, wrap_fixed},
     },
 };
 
@@ -356,6 +356,10 @@ pub(in crate::tui) fn render_rename_prompt(
     );
     let inner = Block::bordered().inner(panel);
     let field = truncate_trailing(&prompt.value, usize::from(inner.width));
+    let caret = inner
+        .x
+        .saturating_add(text_width(&field))
+        .min(inner.right().saturating_sub(1));
     let mut lines = vec![Line::raw(field)];
     if let Some(error) = &prompt.error {
         lines.push(Line::styled(error.clone(), Style::default().fg(Color::Red)));
@@ -367,6 +371,11 @@ pub(in crate::tui) fn render_rename_prompt(
         Style::default().fg(theme.footer_muted),
     ));
     frame.render_widget(Paragraph::new(lines), inner);
+    // Typing without a caret reads as a field that is not listening. It goes
+    // last because the pane behind this panel has already released it.
+    if inner.width > 0 && inner.height > 0 {
+        frame.set_cursor_position((caret, inner.y));
+    }
 }
 pub(in crate::tui) fn render_delete_tab_confirmation(
     frame: &mut Frame<'_>,
@@ -528,10 +537,144 @@ mod tests {
     use crate::{
         layout::{Node, Tab},
         tui::{
-            ModalState, MultiPaneTui, ShareView, render_multi_pane_with_copy_feedback,
-            test_support::layout,
+            ModalState, MultiPaneTui, PaneViewState, RenamePrompt, RenameTarget, ShareView,
+            render_multi_pane_with_copy_feedback, test_support::layout,
         },
     };
+
+    /// A pane with a caret in it and a dialog over the top of it.
+    fn tui_with_a_live_pane(modal: ModalState) -> MultiPaneTui {
+        let mut tui = MultiPaneTui::new(layout(
+            vec![Tab {
+                tab_id: 1,
+                root: Node::Leaf { pane_id: 1 },
+                title: None,
+            }],
+            &[(1, 2, 9)],
+        ))
+        .expect("layout");
+        tui.set_pane_view(
+            1,
+            PaneViewState {
+                ready: true,
+                controller_peer_id: None,
+                controller_active: false,
+                scrollback: 0,
+            },
+        );
+        tui.modal = modal;
+        tui
+    }
+
+    fn draw(tui: &MultiPaneTui, screen: &vt100::Screen) -> Terminal<TestBackend> {
+        let screens = BTreeMap::from([(1, screen)]);
+        let mut terminal = Terminal::new(TestBackend::new(60, 16)).expect("terminal");
+        terminal
+            .draw(|frame| {
+                render_multi_pane_with_copy_feedback(
+                    frame,
+                    tui,
+                    &screens,
+                    None,
+                    None,
+                    ShareView::default(),
+                    None,
+                    None,
+                );
+            })
+            .expect("draw");
+        terminal
+    }
+
+    /// The caret is the only thing on screen that says where typing goes, and
+    /// while a dialog is up it does not go to the pane. It used to be left
+    /// blinking down there, under a panel that had taken the keyboard.
+    #[test]
+    fn a_dialog_takes_the_caret_off_the_pane_behind_it() {
+        let mut parser = vt100::Parser::new(2, 9, 0);
+        parser.process(b"one\r\ntwo");
+
+        let live = draw(&tui_with_a_live_pane(ModalState::None), parser.screen());
+        assert!(
+            live.backend().cursor_visible(),
+            "with nothing over it the pane keeps its caret"
+        );
+
+        for modal in [
+            ModalState::Share,
+            ModalState::Quit,
+            ModalState::ConfirmDeleteTab {
+                tab_id: 1,
+                pane_count: 1,
+            },
+            ModalState::ConfirmRemoteWork {
+                command: vec!["cargo".into(), "test".into()],
+            },
+        ] {
+            let terminal = draw(&tui_with_a_live_pane(modal.clone()), parser.screen());
+            assert!(
+                !terminal.backend().cursor_visible(),
+                "{modal:?} left the caret in the pane behind it"
+            );
+        }
+    }
+
+    /// The one dialog that does take typing puts the caret where the typing
+    /// lands, at the end of what has been typed so far.
+    #[test]
+    fn the_rename_field_carries_the_caret_at_the_end_of_what_is_typed() {
+        let mut parser = vt100::Parser::new(2, 9, 0);
+        parser.process(b"one\r\ntwo");
+        let tui = tui_with_a_live_pane(ModalState::Rename(RenamePrompt {
+            target: RenameTarget::Pane(1),
+            value: "build".into(),
+            error: None,
+        }));
+
+        let mut terminal = draw(&tui, parser.screen());
+
+        assert!(terminal.backend().cursor_visible());
+        let caret = ratatui::backend::Backend::get_cursor_position(terminal.backend_mut())
+            .expect("caret position");
+        let buffer = terminal.backend().buffer();
+        let field = (0..5)
+            .map(|offset| buffer[(caret.x - 5 + offset, caret.y)].symbol())
+            .collect::<String>();
+        assert_eq!(field, "build", "the caret sits just past the typed name");
+        assert_eq!(
+            buffer[(caret.x, caret.y)].symbol(),
+            " ",
+            "and on the empty cell after it"
+        );
+    }
+
+    /// An empty field still has somewhere to type: the caret goes to the front
+    /// of it, not to wherever the last frame left it.
+    #[test]
+    fn an_empty_rename_field_puts_the_caret_at_its_start() {
+        let mut parser = vt100::Parser::new(2, 9, 0);
+        parser.process(b"one\r\ntwo");
+        let empty = tui_with_a_live_pane(ModalState::Rename(RenamePrompt {
+            target: RenameTarget::Pane(1),
+            value: String::new(),
+            error: None,
+        }));
+        let typed = tui_with_a_live_pane(ModalState::Rename(RenamePrompt {
+            target: RenameTarget::Pane(1),
+            value: "x".into(),
+            error: None,
+        }));
+
+        let mut empty = draw(&empty, parser.screen());
+        let mut typed = draw(&typed, parser.screen());
+
+        let start = ratatui::backend::Backend::get_cursor_position(empty.backend_mut())
+            .expect("caret position");
+        let after = ratatui::backend::Backend::get_cursor_position(typed.backend_mut())
+            .expect("caret position");
+        assert_eq!(after.y, start.y);
+        assert_eq!(after.x, start.x + 1);
+    }
 
     #[test]
     fn share_modal_shows_one_runnable_join_line_and_keeps_the_ticket_off_screen() {

--- a/src/tui/render/panes.rs
+++ b/src/tui/render/panes.rs
@@ -628,9 +628,14 @@ pub(in crate::tui) fn render_shared_multi_pane(
                 viewport,
             );
             let (row, col) = screen.cursor_position();
+            // `scrollback`, not the screen's own offset: a client keeps no
+            // scrollback of its own and renders history by swapping in a
+            // viewport the node built, whose retained-row count -- and so whose
+            // offset -- is always zero. Asking the screen left the caret parked
+            // on a row of history, at a position that belonged to the live edge.
             if focused
                 && view.ready
-                && screen.scrollback() == 0
+                && scrollback == 0
                 && !screen.hide_cursor()
                 && !pane.exited
                 && row < viewport.height
@@ -1354,6 +1359,92 @@ mod tests {
 
             assert!(!terminal.backend().cursor_visible());
         }
+    }
+
+    /// A pane scrolled back is not showing where its program's cursor is, so the
+    /// caret must not blink on a row of history.
+    ///
+    /// Both ways a pane can be scrolled are covered, because they disagree about
+    /// where the offset lives. A local pane scrolls its own screen; a client
+    /// keeps no scrollback at all and swaps in a viewport the node built, whose
+    /// retained-row count -- and so whose own offset -- is always zero. Reading
+    /// the offset off the screen was right for the first and silently wrong for
+    /// the second, which is every pane in a `create` session.
+    #[test]
+    fn a_scrolled_back_pane_keeps_no_caret_whichever_screen_it_is_showing() {
+        let mut own_history = vt100::Parser::new(2, 9, 100);
+        own_history.process(b"one\r\ntwo\r\nthree\r\nfour");
+        // What the node hands a client for the same offset: the history rows,
+        // parsed fresh, with no retained rows behind them.
+        let mut node_viewport = vt100::Parser::new(2, 9, 0);
+        node_viewport.process(b"one\r\ntwo");
+
+        for parser in [&own_history, &node_viewport] {
+            let mut tui = MultiPaneTui::new(layout(
+                vec![Tab {
+                    tab_id: 1,
+                    root: Node::Leaf { pane_id: 1 },
+
+                    title: None,
+                }],
+                &[(1, 2, 9)],
+            ))
+            .expect("valid layout");
+            tui.set_pane_view(
+                1,
+                PaneViewState {
+                    ready: true,
+                    controller_peer_id: None,
+                    controller_active: false,
+                    scrollback: 0,
+                },
+            );
+            assert!(tui.set_pane_scrollback_offset(1, 2));
+            let screens = BTreeMap::from([(1, parser.screen())]);
+            let mut terminal = Terminal::new(TestBackend::new(11, 8)).expect("test terminal");
+
+            terminal
+                .draw(|frame| render_multi_pane(frame, &tui, &screens))
+                .expect("render");
+
+            assert!(!terminal.backend().cursor_visible());
+        }
+    }
+
+    /// Returning to the live edge gives the caret back.
+    #[test]
+    fn a_pane_back_at_the_live_edge_shows_its_caret_again() {
+        let mut parser = vt100::Parser::new(2, 9, 100);
+        parser.process(b"one\r\ntwo\r\nthree\r\nfour");
+        let mut tui = MultiPaneTui::new(layout(
+            vec![Tab {
+                tab_id: 1,
+                root: Node::Leaf { pane_id: 1 },
+
+                title: None,
+            }],
+            &[(1, 2, 9)],
+        ))
+        .expect("valid layout");
+        tui.set_pane_view(
+            1,
+            PaneViewState {
+                ready: true,
+                controller_peer_id: None,
+                controller_active: false,
+                scrollback: 0,
+            },
+        );
+        assert!(tui.set_pane_scrollback_offset(1, 2));
+        assert!(tui.set_pane_scrollback_offset(1, 0));
+        let screens = BTreeMap::from([(1, parser.screen())]);
+        let mut terminal = Terminal::new(TestBackend::new(11, 8)).expect("test terminal");
+
+        terminal
+            .draw(|frame| render_multi_pane(frame, &tui, &screens))
+            .expect("render");
+
+        assert!(terminal.backend().cursor_visible());
     }
 
     #[test]

--- a/src/tui/render/panes.rs
+++ b/src/tui/render/panes.rs
@@ -633,8 +633,14 @@ pub(in crate::tui) fn render_shared_multi_pane(
             // viewport the node built, whose retained-row count -- and so whose
             // offset -- is always zero. Asking the screen left the caret parked
             // on a row of history, at a position that belonged to the live edge.
+            //
+            // A dialog takes the keyboard, so it takes the caret with it: while
+            // one is up, keystrokes go to it and not to this pane, and a caret
+            // still blinking down in the pane says the opposite. The dialogs
+            // that own a text field place it themselves; the rest leave it off.
             if focused
                 && view.ready
+                && matches!(tui.modal, ModalState::None)
                 && scrollback == 0
                 && !screen.hide_cursor()
                 && !pane.exited


### PR DESCRIPTION
The caret is the only mark on screen that says where typing goes. Four separate
paths could leave it saying the wrong thing, and each of them also left the
pane's scrollback state disagreeing with what the pane was showing.

Found by driving real sessions under a PTY and replaying the captured bytes
through `vt100` — the caret's position is in the byte stream, so it can be
asserted on directly — and then reproduced at unit level.

## What was wrong

**A pane scrolled back kept the caret.** The gate asked the *screen* how far
back it was scrolled. That is right for a pane that scrolls its own screen and
silently wrong for every pane in a `create` session: a client keeps no
scrollback at all and renders history by swapping in a viewport the node built —
rows parsed fresh, nothing retained behind them, so its own offset is always
zero. Scroll up and the caret went on blinking at the live edge's row and
column, which is now a line of old output.

**A dialog never took the caret.** Ctrl+P then `e` opens the rename prompt; the
pane had already set the caret earlier in the same frame and no panel ever took
it back. The typing went to the panel and the caret stayed down in the pane —
which reads as a field that is not listening. The rename field now carries it,
at the end of the name so far; the dialogs that ask a question rather than take
an answer leave it off.

**Resizing while scrolled back landed at the live edge without saying so.** A
resize reflows every retained row, so the client drops the viewports it fetched.
What a scrolled-back pane falls back to is its live screen — but its offset
stayed where the wheel had left it, so the pane read as scrolled while showing
the newest output: no caret, and the next several notches of wheel-down spent
walking back through rows that were no longer there.

**So did losing the history another way.** A node answers "unavailable" for a
pane it does not host, for one on the alternate screen, and for a frozen session
it has since evicted — and the last of those can arrive for a pane that is
already parked in history. Same three things had to go together; now they do, in
one function.

## Reproducing the first two

```
p2pmux create
printf 'row %d\n' $(seq 1 300)
```

Wheel up: before, the caret sits on a row of history. Ctrl+P then `e` and type:
before, the caret is down in the pane while the letters appear in the panel.

## Tests

- `panes.rs` — a scrolled-back pane keeps no caret, for both kinds of screen it
  can be showing (its own, and a viewport the node built); back at the live edge
  it gets it again.
- `modals.rs` — every dialog takes the caret off the pane behind it; the rename
  field carries it at the end of what is typed, and at the front when empty.
- `scrollback.rs` — dropping the fetched history returns every pane to the live
  edge.
- `client.rs` — losing a pane's history returns it to the live edge, and takes
  the cached session and the queued burst with it.
- `scripts/e2e/scenario_ag_caret_cross.py` — 16 checks against a real session
  with one pane hosted on a DigitalOcean droplet, since every rule here depends
  on state the client assembles from somewhere else. Passing. `Peer.cursor_hidden`
  comes with it: p2pmux hides the caret on purpose, so a scenario has to be able
  to assert the absence and not only the position.

Local gates: `cargo fmt --check`, `cargo clippy --all-targets --all-features -D
warnings`, `cargo test --all-features` all green on macOS.

## Not addressed here

`DECSCUSR` (`CSI Ps SP q`) is still dropped, so a program in a pane cannot
change the caret's *shape* or blink — vim's insert-mode bar, a shell in vi mode.
`vt100` does not model it, and carrying it to the client means a field on the
screen frame and so a protocol pin move, which does not belong in a fix.
Remote-hosted panes still return no scrollback, as `docs/USAGE.md` says; what
changed is that asking for it no longer strands the pane.
