### PR TITLE
Metrics: week two, and why crates.io's 142 downloads is not 142 people

### DIFF
--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -26,6 +26,32 @@ means ship the inbox and widen to ~10 hand-picked users, > 5 means build hard.**
 | Date | Downloads | Stranger issues | Visitors 14d | Escalations | Notes |
 | --- | --- | --- | --- | --- | --- |
 | 2026-08-02 | 23 | **0** | 4 | 0 | Baseline. See caveats below. |
+| 2026-08-16 | 57 | **0** | 10 | 0 | First distribution went out the same day, too late to show here. |
+
+### 2026-08-16 — two weeks on, and the funnel is still empty
+
+Eight releases shipped in the fortnight (`v0.1.3` through `v0.1.10`), which is most of what moved
+downloads. Nothing had been posted anywhere until today, so read this as the *pre-distribution*
+reading rather than as a result.
+
+- **10 unique visitors in 14 days**, up from 4. Against 157 views. Still nobody, and still the number
+  every other one is downstream of. The referrers are `github.com` (6 uniques), Google (2) and
+  crates.io (2) — no external site sends anyone here, because no external site mentions it.
+- **Downloads 23 → 57.** Eight releases in the window and a chunk of the count is our own install
+  verification, so the honest figure for *distinct humans who tried it* is still close to zero.
+- **crates.io says 142 downloads, 133 of them recent. Do not report that number to anyone.** The
+  daily series is 14, 14, 16, 2, 12, 12, 9 — flat, every day, uncorrelated with releases and
+  uncorrelated with the days that had visitors. A real audience is spiky and follows posting. This
+  is mirrors and scanners, exactly like the clone count this page already refuses to quote.
+- **Stranger-opened issues: still zero.** Unchanged, and the only number that would prove use.
+
+**On the 200-download decision rule.** It has not triggered and is further away than it looks: the
+rule counts release assets, so we are at 57 of 200, and the fraction of that 57 which is a person is
+small. Do not invoke the rule early on the crates.io figure — that is the mistake this page's whole
+tone exists to prevent.
+
+The three list PRs and the iroh discussion all went out on 2026-08-16, after this snapshot. The next
+row is the first one that can say anything about whether distribution works.
 
 ### 2026-08-02 — baseline
 


### PR DESCRIPTION
GitHub discards traffic data after 14 days, so this row only exists if it is taken now. Taken
*before* today's distribution landed, which makes it a clean pre-distribution reading rather than a
result.

| Date | Downloads | Stranger issues | Visitors 14d | Escalations |
| --- | --- | --- | --- | --- |
| 2026-08-02 | 23 | **0** | 4 | 0 |
| 2026-08-16 | 57 | **0** | 10 | 0 |

Eight releases shipped in the window, which is most of what moved downloads. Referrers are
`github.com` (6 uniques), Google (2) and crates.io (2) — no external site sends anyone here, because
until today no external site mentioned it.

## The number worth writing down is the one that would have been misread

crates.io reports **142 downloads, 133 of them recent**, and it is tempting to treat that as the
real figure. The daily series says otherwise:

```
08-09  14
08-10  14
08-11  16
08-13   2
08-14  12
08-15  12
08-16   9
```

Flat, every day, uncorrelated with the eight releases in the window and uncorrelated with the days
that had visitors. A real audience is spiky and follows posting, and there was no posting. This is
mirrors and scanners — the same thing `METRICS.md` already refuses to quote clone counts for.

**Why it matters rather than being a footnote:** the 200-download rule on that page decides whether
to stop marketing and conclude the problem is the product. On the rule's own metric (release
`.tar.gz` assets) we are at 57, and much of that 57 is releases and our own install verification.
Invoking the rule on the crates.io figure would retire the campaign roughly four times too early.

Row generated with `sh scripts/metrics.sh`, as the page instructs.