### PR TITLE
fix(screen): a narrower pane rewraps its text instead of losing it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,19 @@ old one; older peers still report it as a host they could not reach.
 
 ## Unreleased
 
+Narrowing a pane no longer destroys the text it hides.
+
+Dragging a split, unzooming, or attaching a second viewer with a smaller window used to cut every
+visible line at the new width and throw the rest away, so widening the pane again came back to
+blanks rather than to the text. Nothing could undo it: the processes that printed those lines had
+already exited, and a pane's text lives only in the terminal state p2pmux keeps for it. A 300
+character line put through a 118 → 38 → 118 column round trip came back as its first 38 characters.
+
+The visible grid is now read out as logical lines before the resize and laid out again at the new
+width, the way tmux, zellij and alacritty each handle it. Text that no longer fits scrolls into
+scrollback instead of being dropped. An application in the alternate screen still repaints its own
+frame, and a resize that changes only the row count does no work at all.
+
 An upgrade no longer leaves the fleet agent unable to start anything.
 
 A node is launched by re-running the p2pmux binary, so an agent whose binary was replaced

--- a/scripts/e2e/scenario_ah_reflow_cross.py
+++ b/scripts/e2e/scenario_ah_reflow_cross.py
@@ -1,0 +1,164 @@
+"""Scenario AH -- a pane keeps its text when the machine hosting it narrows and widens.
+
+A pane's text lives in one place: the terminal state the machine hosting its PTY keeps
+for it. Nothing else can rebuild it -- the process that printed a line has usually
+exited by the time anyone resizes anything, so there is no repaint to ask for. Cutting
+the visible rows to a narrower width therefore destroys text outright, and it destroys
+it for every viewer at once, not only for the one who dragged the divider.
+
+This drives that from the far end: the droplet hosts the pane, prints a line far wider
+than the pane, then takes its own window down to a third of its width and back. Both
+peers then have to still show the whole line -- the droplet because it did the reflow,
+and the Mac because the reflowed frame has to survive the trip.
+
+Run:  python3 scripts/e2e/scenario_ah_reflow_cross.py
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from driver import Harness  # noqa: E402
+from remote import RemoteError, RemoteHost, hosts_from_manifest  # noqa: E402
+
+CTRL_P = b"\x10"
+
+WIDE = 140
+NARROW = 50
+ROWS = 30
+
+# 300 characters with no spaces in them: wider than either pane at either width, and
+# a partial survivor reads as obviously truncated rather than as a plausible line.
+MARKER = "ABCDEFGHIJ" * 30
+
+checks: list[tuple[str, bool, str]] = []
+
+
+def check(label: str, passed: bool, detail: str = "") -> None:
+    checks.append((label, passed, detail))
+    mark = "PASS" if passed else "FAIL"
+    print(f"  [{mark}] {label}{(' -- ' + detail) if detail else ''}", flush=True)
+
+
+def chord(peer, lead: bytes, letter: bytes, settle: float = 1.5) -> None:
+    peer.send(lead)
+    time.sleep(0.35)
+    peer.send(letter)
+    time.sleep(settle)
+
+
+def pane_strips(snapshot: str) -> list[str]:
+    """Each pane's own column strip, joined down the frame.
+
+    A pane border sits between the halves of every soft-wrapped line, so reading the
+    snapshot row by row reports a wrapped line as truncated whether it is or not.
+    Taking one pane's columns and joining them puts the line back together.
+
+    Side-by-side panes put their borders back to back, so a row reads `│…││…│` and
+    splitting on the border leaves a zero-width piece between the two. Dropping the
+    empty pieces is what keeps a pane's index the same on every row.
+    """
+    strips: dict[int, list[str]] = {}
+    for line in snapshot.split("\n"):
+        for index, segment in enumerate(
+            piece for piece in line.split("│")[1:-1] if piece
+        ):
+            strips.setdefault(index, []).append(segment)
+    return ["".join(parts) for parts in strips.values()]
+
+
+def shows_marker(snapshot: str) -> bool:
+    """Whether some pane holds the marker whole. Which pane is which depends on the
+    order the two peers created theirs, and this scenario is not asserting on that."""
+    return any(MARKER in strip for strip in pane_strips(snapshot))
+
+
+def main() -> int:
+    # The throwaway lab if one is up, the standing box otherwise. Only one droplet is
+    # needed here: the second peer is this Mac. `--host=` picks a different one, which
+    # is how the same run is repeated against a droplet carrying an older binary.
+    wanted = next(
+        (arg.split("=", 1)[1] for arg in sys.argv[1:] if arg.startswith("--host=")),
+        None,
+    )
+    try:
+        hosts = hosts_from_manifest()
+        remote = next((h for h in hosts if h.alias == wanted), None) or hosts[0]
+    except (RemoteError, IndexError):
+        remote = RemoteHost()
+    print(f"== scenario AH: {remote.alias} ==", flush=True)
+    if not remote.binary_ready():
+        print(f"droplet has no release binary yet at {remote.binary}", file=sys.stderr)
+        return 2
+
+    remote.reset_network()
+    remote.reset_home()
+
+    try:
+        with Harness("scenario_ah_reflow_cross") as harness:
+            host, ticket = harness.create_room("mac", cols=WIDE, rows=ROWS)
+            guest = harness.spawn(
+                "droplet",
+                ["join", ticket, "--name", "droplet"],
+                cols=WIDE,
+                rows=ROWS,
+                launcher=remote.launcher(),
+            )
+            guest.wait_ready(timeout=45.0)
+            guest.wait_for(r"Pane #\d+", timeout=60.0)
+            check("droplet joined over the internet", True)
+
+            # The droplet has to host the pane itself: a pane's grid is decided by the
+            # machine whose PTY it is, so only that machine's resize can reflow it.
+            chord(guest, CTRL_P, b"n")
+            guest.settle(quiet_for=1.0, timeout=15.0)
+            host.wait_for(r"host: droplet", timeout=45.0)
+            check("droplet hosts a pane in the shared layout", True)
+
+            guest.run_in_shell(f"printf '{MARKER}\\n'")
+            guest.wait_until(shows_marker, timeout=30.0)
+            check("the line printed on the droplet", True)
+            host.wait_until(shows_marker, timeout=45.0)
+            check("the line reached the mac whole", True)
+
+            # The round trip. Before the reflow this took the line with it: the shrink
+            # cut every row at 23 columns and widening again came back to blanks.
+            guest.resize(NARROW, ROWS)
+            guest.settle(quiet_for=1.0, timeout=20.0)
+            narrow = guest.snapshot()
+            guest.resize(WIDE, ROWS)
+            guest.settle(quiet_for=1.0, timeout=20.0)
+
+            kept = shows_marker(guest.snapshot())
+            check("the droplet still has the whole line", kept)
+            if not kept:
+                print("\n--- droplet at its narrowest ---", flush=True)
+                print(narrow, flush=True)
+                print("\n--- droplet back at full width ---", flush=True)
+                print(guest.snapshot(), flush=True)
+
+            try:
+                host.wait_until(shows_marker, timeout=45.0)
+                check("the mac still has the whole line", True)
+            except AssertionError:
+                check("the mac still has the whole line", False)
+                print("\n--- mac ---", flush=True)
+                print(host.snapshot(), flush=True)
+
+            check("droplet peer still alive", guest.alive)
+            check("mac peer still alive", host.alive)
+    finally:
+        remote.reap()
+        remote.reset_network()
+
+    failures = [label for label, passed, _ in checks if not passed]
+    print(f"\n{len(checks) - len(failures)}/{len(checks)} checks passed", flush=True)
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -435,7 +435,27 @@ impl HostScreen {
             .sequence
             .checked_add(1)
             .ok_or(ScreenError::SequenceExhausted)?;
+        // Read the text out before `set_size` truncates every visible row to the new
+        // width. Only a width change can lose anything, and only on the normal screen:
+        // an application drawing in the alternate screen owns the whole frame and
+        // repaints it on the resize, so replaying the old one would fight its redraw.
+        let reflow = (cols != self.parser.screen().size().1
+            && !self.parser.screen().alternate_screen())
+        .then(|| {
+            (
+                capture_visible_text(self.parser.screen()),
+                self.parser.screen().attributes_formatted(),
+            )
+        });
         self.parser.screen_mut().set_size(rows, cols);
+        if let Some((text, pen)) = reflow {
+            self.parser
+                .process(&reflow_payload(&text, rows, cols, &pen));
+            // Rows the replay pushed past the top are history now, and the monotonic
+            // end position has to count them or scrollback addressing drifts.
+            let (_, scrolled) = replay_extent(&text, rows, cols);
+            self.history_end = self.history_end.saturating_add(scrolled as u64);
+        }
         // Replaying the batch keeps the baseline in step everywhere except here: `set_size`
         // reflows against the retained row buffer, which the scrollback-free baseline does
         // not have. Rebuild it from the live visible state instead, exactly as the client
@@ -565,6 +585,223 @@ fn retained_scrollback_len(screen: &mut vt100::Screen) -> usize {
     let retained = screen.scrollback();
     screen.set_scrollback(restore);
     retained
+}
+
+/// One logical line of the visible grid, joined back across the soft wraps the
+/// old width imposed on it.
+struct LogicalLine {
+    /// Styled bytes that redraw the line's cells at whatever width they land on.
+    bytes: Vec<u8>,
+    /// Printable width in columns, so a replay's height can be predicted.
+    width: usize,
+}
+
+/// The visible grid as text that outlives a width change.
+struct VisibleText {
+    lines: Vec<LogicalLine>,
+    /// Which logical line the cursor sits on, and how far into it.
+    cursor: (usize, usize),
+}
+
+/// One cell's drawing attributes, compared to decide when to re-emit an SGR.
+#[derive(Clone, Copy, Default, PartialEq, Eq)]
+struct CellStyle {
+    fgcolor: vt100::Color,
+    bgcolor: vt100::Color,
+    bold: bool,
+    dim: bool,
+    italic: bool,
+    underline: bool,
+    inverse: bool,
+}
+
+impl CellStyle {
+    fn of(cell: &vt100::Cell) -> Self {
+        Self {
+            fgcolor: cell.fgcolor(),
+            bgcolor: cell.bgcolor(),
+            bold: cell.bold(),
+            dim: cell.dim(),
+            italic: cell.italic(),
+            underline: cell.underline(),
+            inverse: cell.inverse(),
+        }
+    }
+
+    /// Writes the whole style rather than a diff against the previous one. A
+    /// resize is rare and the payload is thrown away immediately, so the few
+    /// extra bytes buy a function with no state to get wrong.
+    fn write(self, out: &mut Vec<u8>) {
+        out.extend_from_slice(b"\x1b[0");
+        for (enabled, code) in [
+            (self.bold, "1"),
+            (self.dim, "2"),
+            (self.italic, "3"),
+            (self.underline, "4"),
+            (self.inverse, "7"),
+        ] {
+            if enabled {
+                out.push(b';');
+                out.extend_from_slice(code.as_bytes());
+            }
+        }
+        out.extend_from_slice(color_params(self.fgcolor, 3).as_bytes());
+        out.extend_from_slice(color_params(self.bgcolor, 4).as_bytes());
+        out.push(b'm');
+    }
+}
+
+/// SGR parameters for one color, as a foreground (`base` 3) or background (`base` 4).
+fn color_params(color: vt100::Color, base: u8) -> String {
+    match color {
+        vt100::Color::Default => String::new(),
+        vt100::Color::Idx(index) if index < 8 => format!(";{}", base * 10 + index),
+        vt100::Color::Idx(index) if index < 16 => format!(";{}", base * 10 + 52 + index),
+        vt100::Color::Idx(index) => format!(";{base}8;5;{index}"),
+        vt100::Color::Rgb(red, green, blue) => format!(";{base}8;2;{red};{green};{blue}"),
+    }
+}
+
+/// Whether a cell puts anything on screen, and so has to survive a reflow.
+///
+/// A blank cell still counts when it carries a background or a decoration: that
+/// is a painted run, and trimming it would lose the paint.
+fn cell_is_painted(cell: &vt100::Cell) -> bool {
+    cell.has_contents()
+        || cell.bgcolor() != vt100::Color::Default
+        || cell.inverse()
+        || cell.underline()
+}
+
+/// One past the last painted column of `row`, so trailing blanks are not replayed.
+fn last_painted_column(screen: &vt100::Screen, row: u16, cols: u16) -> u16 {
+    (0..cols)
+        .rev()
+        .find(|col| screen.cell(row, *col).is_some_and(cell_is_painted))
+        .map_or(0, |col| col + 1)
+}
+
+/// Reads the visible grid as logical lines, before a resize truncates it.
+///
+/// `vt100::Screen::set_size` resizes every visible row with `Vec::resize`, which
+/// drops the cells past the new width outright — widening the pane afterwards
+/// leaves blanks where the text was. Joining the rows the old width wrapped, and
+/// replaying them once the grid has its new size, is what tmux, zellij and
+/// alacritty all do; this is the same idea expressed through `vt100`'s public API.
+fn capture_visible_text(screen: &vt100::Screen) -> VisibleText {
+    let (rows, cols) = screen.size();
+    let (cursor_row, cursor_col) = screen.cursor_position();
+    let mut lines = Vec::new();
+    let mut cursor = (0, 0);
+    let mut row = 0;
+    while row < rows {
+        let start = row;
+        while row + 1 < rows && screen.row_wrapped(row) {
+            row += 1;
+        }
+        let end = row;
+        row += 1;
+        if (start..=end).contains(&cursor_row) {
+            cursor = (
+                lines.len(),
+                usize::from(cursor_row - start) * usize::from(cols) + usize::from(cursor_col),
+            );
+        }
+        lines.push(capture_logical_line(screen, start, end, cols));
+    }
+    // Blank rows under the last line are the grid's own padding, not text. Replaying
+    // them would scroll real content off the top the moment the text grows taller
+    // than the pane, so they are dropped -- except any the cursor is parked on.
+    let used = lines
+        .iter()
+        .rposition(|line| line.width > 0)
+        .map_or(0, |last| last + 1);
+    lines.truncate(used.max(cursor.0 + 1));
+    VisibleText { lines, cursor }
+}
+
+fn capture_logical_line(screen: &vt100::Screen, start: u16, end: u16, cols: u16) -> LogicalLine {
+    let mut bytes = Vec::new();
+    let mut width = 0;
+    let mut style = CellStyle::default();
+    let last = last_painted_column(screen, end, cols);
+    for row in start..=end {
+        let limit = if row == end { last } else { cols };
+        let mut col = 0;
+        while col < limit {
+            let Some(cell) = screen.cell(row, col) else {
+                break;
+            };
+            // The second half of a wide character carries no contents of its own;
+            // the character was already emitted with the cell that owns it.
+            if cell.is_wide_continuation() {
+                col += 1;
+                continue;
+            }
+            let cell_style = CellStyle::of(cell);
+            if cell_style != style {
+                cell_style.write(&mut bytes);
+                style = cell_style;
+            }
+            match cell.contents() {
+                "" => bytes.push(b' '),
+                contents => bytes.extend_from_slice(contents.as_bytes()),
+            }
+            let cell_width = 1 + u16::from(cell.is_wide());
+            width += usize::from(cell_width);
+            col += cell_width;
+        }
+    }
+    LogicalLine { bytes, width }
+}
+
+/// How many rows the replayed text occupies at `cols`, and how many of them
+/// scroll off the top of a `rows`-tall grid.
+fn replay_extent(text: &VisibleText, rows: u16, cols: u16) -> (usize, usize) {
+    let total: usize = text.lines.iter().map(|line| line_height(line, cols)).sum();
+    (total, total.saturating_sub(usize::from(rows)))
+}
+
+fn line_height(line: &LogicalLine, cols: u16) -> usize {
+    line.width.div_ceil(usize::from(cols)).max(1)
+}
+
+/// Where the cursor lands once the text has been laid out again at `cols`.
+fn replay_cursor(text: &VisibleText, rows: u16, cols: u16) -> (u16, u16) {
+    let (_, scrolled) = replay_extent(text, rows, cols);
+    let before: usize = text
+        .lines
+        .iter()
+        .take(text.cursor.0)
+        .map(|line| line_height(line, cols))
+        .sum();
+    let row = (before + text.cursor.1 / usize::from(cols)).saturating_sub(scrolled);
+    let col = text.cursor.1 % usize::from(cols);
+    (
+        row.min(usize::from(rows) - 1) as u16,
+        col.min(usize::from(cols) - 1) as u16,
+    )
+}
+
+/// The byte stream that redraws captured text into a freshly resized grid.
+///
+/// `pen` is the screen's own drawing attributes, restored at the end so the
+/// application's next write is styled the way it left off.
+fn reflow_payload(text: &VisibleText, rows: u16, cols: u16, pen: &[u8]) -> Vec<u8> {
+    // Clear with default attributes: erasing under a coloured pen would paint the
+    // whole grid in that background before a single cell is replayed.
+    let mut out = b"\x1b[m\x1b[H\x1b[2J".to_vec();
+    for (index, line) in text.lines.iter().enumerate() {
+        if index > 0 {
+            out.extend_from_slice(b"\r\n");
+        }
+        out.extend_from_slice(&line.bytes);
+    }
+    out.extend_from_slice(b"\x1b[m");
+    let (row, col) = replay_cursor(text, rows, cols);
+    out.extend_from_slice(format!("\x1b[{};{}H", row + 1, col + 1).as_bytes());
+    out.extend_from_slice(pen);
+    out
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -889,6 +1126,101 @@ mod tests {
         assert_eq!(host.retained_scrollback(), clone_and_clamp(host.screen()));
     }
 
+    /// The visible grid read back with its soft wraps joined away.
+    fn unwrapped(host: &HostScreen) -> String {
+        host.screen().contents().replace('\n', "")
+    }
+
+    #[test]
+    /// A pane that narrows and widens again has to come back with its text.
+    ///
+    /// `vt100::Screen::set_size` resizes each visible row with `Vec::resize`, so before
+    /// the reflow the shrink dropped every cell past the new width and the widening
+    /// filled the gap with blanks -- the line came back as its first 40 characters.
+    fn a_narrower_pane_rewraps_its_text_instead_of_losing_it() {
+        let line = "abcdefghij".repeat(12);
+        let mut host = HostScreen::new(24, 100).expect("valid dimensions");
+        host.process_pty(line.as_bytes()).expect("processed");
+        assert!(unwrapped(&host).contains(&line));
+
+        host.resize(24, 40).expect("valid dimensions");
+        assert!(unwrapped(&host).contains(&line), "the shrink lost text");
+
+        host.resize(24, 100).expect("valid dimensions");
+        assert!(unwrapped(&host).contains(&line), "the widening lost text");
+    }
+
+    #[test]
+    /// Text taller than the pane after a shrink belongs in history, not in the bin.
+    fn a_shrink_that_outgrows_the_pane_scrolls_the_overflow_into_scrollback() {
+        let mut host = HostScreen::new(4, 60).expect("valid dimensions");
+        for index in 0..4 {
+            host.process_pty(format!("line{index} {}\r\n", "x".repeat(50)).as_bytes())
+                .expect("processed");
+        }
+        let (_, before_end) = host.history_metadata();
+        let before_retained = host.retained_scrollback();
+
+        // At 20 columns each of those lines needs three rows, so most of them cannot
+        // fit a four-row pane and have to move up into history rather than vanish.
+        host.resize(4, 20).expect("valid dimensions");
+        let (total_rows, end) = host.history_metadata();
+        assert!(end > before_end, "the scrolled rows never reached history");
+        assert!(total_rows > 0, "expected retained history after the reflow");
+        assert_eq!(
+            host.retained_scrollback(),
+            before_retained + (end - before_end) as usize,
+            "history and its monotonic end disagree about the reflow",
+        );
+    }
+
+    #[test]
+    fn a_reflow_keeps_the_colours_and_puts_the_cursor_back_on_its_character() {
+        let mut host = HostScreen::new(10, 20).expect("valid dimensions");
+        // 37 printable characters: two rows at 20 columns, one at 40.
+        host.process_pty(b"\x1b[31mred\x1b[m plain and then a much longer tail")
+            .expect("processed");
+        assert_eq!(host.screen().cursor_position(), (1, 17));
+
+        host.resize(10, 40).expect("valid dimensions");
+        assert_eq!(host.screen().cursor_position(), (0, 37));
+        assert_eq!(
+            host.screen().cell(0, 0).map(vt100::Cell::fgcolor),
+            Some(vt100::Color::Idx(1)),
+            "the reflow dropped the styling it replayed",
+        );
+        assert!(unwrapped(&host).contains("red plain and then a much longer tail"));
+    }
+
+    #[test]
+    /// An application in the alternate screen owns the whole frame and repaints it
+    /// when it sees the new size, so the columns a shrink takes are its to redraw.
+    /// Replaying the old frame instead would only fight that redraw.
+    fn the_alternate_screen_is_left_for_its_application_to_repaint() {
+        let mut host = HostScreen::new(10, 20).expect("valid dimensions");
+        host.process_pty(b"\x1b[?1049h").expect("processed");
+        host.process_pty(b"a full width row of text")
+            .expect("processed");
+
+        host.resize(10, 10).expect("valid dimensions");
+        assert!(
+            !unwrapped(&host).contains("a full width row of text"),
+            "the alternate screen was reflowed instead of left alone",
+        );
+    }
+
+    #[test]
+    fn a_resize_that_only_changes_rows_leaves_the_text_where_it_was() {
+        let mut host = HostScreen::new(10, 20).expect("valid dimensions");
+        host.process_pty(b"first\r\nsecond").expect("processed");
+        let drawn = host.screen().contents();
+        let cursor = host.screen().cursor_position();
+
+        host.resize(20, 20).expect("valid dimensions");
+        assert_eq!(host.screen().contents(), drawn);
+        assert_eq!(host.screen().cursor_position(), cursor);
+    }
+
     #[test]
     fn scrollback_free_baseline_produces_the_same_deltas_as_a_cloned_screen() {
         let mut host = HostScreen::new(24, 80).expect("valid dimensions");
@@ -1094,7 +1426,9 @@ mod tests {
 
         screen.resize(2, 10).unwrap();
         let (after_total, after) = screen.visual_scrollback(4, 4096);
-        assert_eq!(after_total, before_total);
+        // Not equal: rewrapping the visible rows at ten columns makes them taller than
+        // the pane, and the rows pushed past the top join history like any other scroll.
+        assert!(after_total >= before_total);
         assert_eq!(after.len(), 4);
     }
 

--- a/src/session_store.rs
+++ b/src/session_store.rs
@@ -1118,7 +1118,15 @@ mod tests {
     fn dead_sockets_are_swept_but_a_bound_one_without_a_record_survives() {
         use std::os::unix::net::UnixListener;
 
-        let root = PathBuf::from(format!("/tmp/p2pmux-sweep-{}", std::process::id()));
+        // `/tmp` rather than `temp_dir()` because this test binds a socket, and macOS
+        // caps a socket path at 104 bytes -- which `$TMPDIR` there very nearly spends on
+        // its own. The name has to differ from every other root in this module all the
+        // same: on Linux `temp_dir()` *is* `/tmp`, so a shared name is a shared
+        // directory, and these tests run as threads of one process with one pid between
+        // them. Sharing it with `a_sweep_removes_the_leftovers_of_launches_that_produced
+        // _no_session` had each test's `remove_dir_all` deleting the other's fixture
+        // mid-run, which reddened Linux CI at random and never macOS.
+        let root = PathBuf::from(format!("/tmp/p2pmux-dead-sockets-{}", std::process::id()));
         let _ = fs::remove_dir_all(&root);
         let store = SessionStore::at(root.join("s"), root.join("k"));
 


### PR DESCRIPTION
Shrinking a pane destroyed the text it hid, and widening it again did not bring it back.

`vt100::Screen::set_size` resizes every visible row with `Vec::resize`, so the cells past the new width are dropped outright and a later grow refills them with blanks. Nothing could undo that: a pane's text lives only in the terminal state p2pmux keeps for it, and the processes that printed those lines have usually exited by the time anyone resizes anything, so there is no repaint to ask for.

It fires on ordinary gestures — dragging a split divider, unzooming, a second viewer attaching with a smaller window — and because the damage happens on the machine hosting the PTY, it lands on every viewer at once, not just the one who resized.

## What changed

The visible grid is read out as logical lines before the resize, joining the rows the old width soft-wrapped, then replayed once the grid has its new size so the parser lays them out again. This is the design tmux (`grid_reflow` + `GRID_LINE_WRAPPED`), zellij (`is_canonical` + `split_to_rows_of_length`) and alacritty (`WRAPLINE`) all converged on, expressed here through `vt100`'s public API — **no dependency changes, no emulator swap**.

Text that outgrows the pane scrolls into scrollback like any other output rather than being dropped, so `history_end` counts those rows.

## Cost

Two early returns keep this off the common paths:

- **rows-only resize** — returns before any work
- **alternate screen** — returns before any work. An application there owns the frame and repaints it on the resize; replaying the old one would fight that redraw. kitty added the same guard for the same reason (#9142), and zellij returns early on `alternate_screen_state`.

On a width change it walks the visible grid only — never the 10k-row scrollback, which `set_size` already leaves alone — and replays one buffer. That is one `process()` over roughly the size of a normal output batch, and it runs when a split is committed, not on every frame of a drag.

## Verification

**Unit** — 5 new tests in `src/screen.rs`: the shrink/grow round trip, overflow scrolling into history, colours and cursor surviving, the alternate-screen guard, and a rows-only resize being a no-op. One existing assertion was relaxed from `==` to `>=` where it had encoded the old lossy behaviour.

**In the running app** — drove `p2pmux create` under a pty through 118 → 38 → 118 columns and replayed the capture through `vt100`. On `main`: 0 intact copies of a 300-character line, every row cut at 38. On this branch: intact.

**Across machines** — new `scripts/e2e/scenario_ah_reflow_cross.py`, run against a pair of throwaway DigitalOcean droplets (nyc3 + fra1, since destroyed). The droplet hosts the pane and takes its own window 140 → 50 → 140.

| droplet binary | result |
|---|---|
| this branch | 8/8 checks — line whole on both peers |
| `main` | 6/8 — every row cut at 23 chars, pane back at 68 wide, **and the Mac shows the same damage** |

That last column is the point: the loss is at the host, not a clipping artifact in the viewer.

## One unrelated commit, because it blocked this

`6664ab4` fixes a pre-existing Linux-only flake that failed this branch's first CI run. Two `session_store` tests build fixtures in the same directory: one uses `std::env::temp_dir()`, the other hardcodes `/tmp`. On macOS those differ (`$TMPDIR`); on Linux `temp_dir()` **is** `/tmp`, so both became `/tmp/p2pmux-sweep-<pid>` — same path, same pid, two threads of one test binary, each calling `remove_dir_all` on the other's fixture.

Nothing to do with the reflow, which touches no files and no clock; five new tests just shifted the interleaving. Confirmed by giving macOS the Linux path — `TMPDIR=/tmp cargo test --lib session_store::` fails 8/8 on `main` at 2664770, and the full lib suite 4/6. After the rename: 10/10 and 6/6 green.

The `/tmp` stays deliberately — that test binds a socket and macOS caps a socket path at 104 bytes, which `$TMPDIR` there nearly spends by itself. Only the name had to change. Every other temp root in `src/` and `tests/` was checked for the same hazard; the remaining repeats never touch the filesystem.

Happy to split this into its own PR if you'd rather.

## Not in scope

A remote pane's grid is still decided by whichever machine hosts it, so a viewer whose window differs sees the pane clipped or letterboxed. tmux answers this with an explicit `window-size` option (`largest | smallest | manual | latest`); p2pmux currently does an accidental `largest` with no way to opt out. Worth a follow-up, separate from this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pca4iPC2kAkHCnZ7GDKJb4
