### PR TITLE
Fix the three defects from the 17 Aug daily run (#98, #99, #100)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,39 @@ width, the way tmux, zellij and alacritty each handle it. Text that no longer fi
 scrollback instead of being dropped. An application in the alternate screen still repaints its own
 frame, and a resize that changes only the row count does no work at all.
 
+An agent in one p2pmux session now says what it needs in every other session on the same machine.
+
+Hooks reported to one place or the other: the pane's node socket when there was one, a
+machine-local record when there was not. So an agent in a pane told exactly one node what it was
+doing, and the inbox of any other session on the same box — which finds it by scanning processes,
+sees that it is inside a p2pmux, and names the session it is in — had nothing to say about it. A
+`claude` blocked on a permission prompt read `state unknown — no hooks` to the one person who could
+answer it. Hooks now write both, so the row says `needs you` wherever you are sitting. It still does
+not put a number on the `inbox N` badge: going to an agent is what answers its summons, and there is
+no going to that one from here.
+
+The keybinding bar is a whole tier or nothing, never half a chord.
+
+A footer notice is placed first and the hints are fitted into what it leaves, but the hint bar
+answered a width it could not honour and was then clipped where the room ran out. A long enough
+notice on a narrow enough terminal ended the bar `Ctrl+ <p` — a chord that does not exist, on the
+one line that exists to say what the chords are.
+
+Scrolling back in a pane that has no scrollback yet says nothing, instead of blaming the network.
+
+A wheel notch on a pane nothing had scrolled off answered with one sentence naming three causes —
+a remote pane, a full-screen program, an expired history — none of which described the one-second-old
+shell in front of you. Each cause now says only its own sentence, and a pane with no history says
+nothing at all: there is no error there, only a wheel with nowhere to go.
+
+The fleet agent's crash-loop ceiling is now enforced rather than ignored.
+
+`StartLimitIntervalSec` and `StartLimitBurst` were written under `[Service]`, where systemd has not
+read them since v229 — it logged `Unknown key name … ignoring` and used its own defaults instead, so
+the rate limit the v0.1.11 leak fix leaned on had never once applied. This matters most on systemd
+older than v254, where the escalating restart backoff is itself ignored and this is the only thing
+between a failing agent and twenty starts every five minutes.
+
 An upgrade no longer leaves the fleet agent unable to start anything.
 
 A node is launched by re-running the p2pmux binary, so an agent whose binary was replaced

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -393,10 +393,15 @@ An agent in another p2pmux session is drawn dim, and neither the cursor nor the 
 it. Its last line carries the way in instead:
 
 ```
- ○ laptop     claude                  running
-   state unknown — no hooks
+ ● laptop     claude                  needs you
+   permission: write to /etc/hosts
    another p2pmux session · p2pmux attach dakar
 ```
+
+What it is doing is read from this machine, not from the session it is in: its hooks leave a
+record next to the session sockets, and every p2pmux you run reads that back. So the state is as
+true here as it is over there. An agent with no hooks installed still says `state unknown — no
+hooks`, in that session and in this one alike.
 
 Run that from a terminal, not from a pane in here. Reaching it from inside would mean a whole
 second p2pmux nested in a pane of this one — which takes the prefix key from the mux around it

--- a/scripts/e2e/scenario_ae_empty_pane_wheel.py
+++ b/scripts/e2e/scenario_ae_empty_pane_wheel.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Issue #99: the wheel on a pane that has no scrollback yet.
+
+The daily run of 17 Aug wheeled up on a freshly created, zoomed pane and the
+footer became:
+
+    Ctrl+ <p  local scrollback is unavailable for this pane (remote, alternate
+    screen, or stale history)
+
+Two things wrong in one line. The reason is three guesses at a local shell one
+second old, none of which describes it; and the notice is long enough that the
+keybinding hints were drawn into the space it left and cut off mid-chord, so the
+bar advertised `Ctrl+ <p` — a chord that does not exist.
+
+This drives the real client on a real PTY at the reported width and checks both:
+
+  * a wheel notch on a pane with no history says nothing at all;
+  * the keybinding bar is a whole tier or absent, never a prefix of one;
+  * and a pane that *does* have history still scrolls, which is the thing all of
+    the above must not have cost.
+
+Zoom is in the repro because it is what put the empty pane under a pointer that
+had been over the pane with history — the wheel is addressed by the pointer, and
+a zoomed pane owns the whole content area. It is reproduced here for fidelity to
+the report, not because zoom is the trigger.
+
+Run: python3 scripts/e2e/scenario_ae_empty_pane_wheel.py [repeats]
+"""
+
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from driver import Harness  # noqa: E402
+
+CTRL_P = b"\x10"
+
+# The exact width from the report: 17 columns of floor tier plus a 92-column
+# notice needs 109, so 99 is comfortably inside the range that used to clip.
+COLS = 99
+ROWS = 30
+
+STALE_MESSAGE = "local scrollback is unavailable"
+
+
+def footer_of(screen: str) -> str:
+    """The last non-blank line, which is the help bar."""
+    for line in reversed(screen.split("\n")):
+        if line.strip():
+            return line
+    return ""
+
+
+def run_once(index: int, verbose: bool) -> list[tuple[str, bool, str]]:
+    results: list[tuple[str, bool, str]] = []
+
+    def check(name: str, ok: bool, detail: str = "") -> None:
+        results.append((name, ok, detail if not ok else ""))
+        if verbose or not ok:
+            print(
+                f"    {'PASS' if ok else 'FAIL'}  {name}"
+                + (f"  -- {detail}" if detail and not ok else "")
+            )
+
+    with Harness(f"ae-empty-pane-wheel-{index}") as harness:
+        host, _ticket = harness.create_room("host", cols=COLS, rows=ROWS)
+        host.wait_ready()
+
+        # Give pane #1 a history worth scrolling, so the last check below is
+        # about this change rather than about an empty session.
+        host.run_in_shell("seq 1 200")
+        host.wait_for("200", timeout=30)
+        host.settle(quiet_for=1.0, timeout=15)
+
+        # Ctrl+P n: a second pane, brand new and therefore empty.
+        host.send(CTRL_P)
+        time.sleep(0.35)
+        host.send(b"n")
+        time.sleep(1.2)
+
+        # Ctrl+P z: zoom it, which is what put it under the pointer.
+        host.send(CTRL_P)
+        time.sleep(0.35)
+        host.send(b"z")
+        time.sleep(1.2)
+        host.settle(quiet_for=0.8, timeout=10)
+
+        # More than one notch: the first is absorbed returning to the live edge,
+        # and the report's message came from the ones after it.
+        host.wheel_up(COLS // 2, ROWS // 2, times=6)
+        time.sleep(1.5)
+
+        screen = host.snapshot()
+        footer = footer_of(screen)
+
+        check(
+            "an empty pane's wheel does not claim the history is remote or stale",
+            STALE_MESSAGE not in screen,
+            f"footer: {footer!r}",
+        )
+
+        # The floor tier is `Ctrl+ <p> <t> <q>`. Anything shorter that still
+        # starts with `Ctrl` is the clipped bar from the report.
+        has_ctrl = "Ctrl" in footer
+        whole_tier = "<p>" in footer and "<t>" in footer and "<q>" in footer
+        check(
+            "the keybinding bar is a whole tier or none of one",
+            (not has_ctrl) or whole_tier,
+            f"footer: {footer!r}",
+        )
+
+        # Unzoom and confirm the pane that does have history still scrolls --
+        # the regression this fix must not have introduced.
+        host.send(CTRL_P)
+        time.sleep(0.35)
+        host.send(b"z")
+        time.sleep(1.0)
+        host.send(CTRL_P)
+        time.sleep(0.35)
+        host.send(b"\x1b[A")  # focus up, back to pane #1
+        time.sleep(1.0)
+        host.settle(quiet_for=0.8, timeout=10)
+
+        before = host.snapshot()
+        host.wheel_up(COLS // 2, 4, times=6)
+        time.sleep(1.5)
+        after = host.snapshot()
+
+        check(
+            "a pane that does have history still scrolls",
+            before != after,
+            "the wheel moved nothing on a pane holding 200 lines",
+        )
+
+    return results
+
+
+def main() -> int:
+    repeats = int(sys.argv[1]) if len(sys.argv) > 1 else 1
+    verbose = True
+    failures: list[tuple[str, str]] = []
+    for index in range(repeats):
+        print(f"  run {index + 1}/{repeats}")
+        for name, ok, detail in run_once(index, verbose):
+            if not ok:
+                failures.append((name, detail))
+    if failures:
+        print(f"\nFAILED ({len(failures)}):")
+        for name, detail in failures:
+            print(f"  - {name}: {detail}")
+        return 1
+    print("\nall checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/e2e/scenario_ai_other_session_state.py
+++ b/scripts/e2e/scenario_ai_other_session_state.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Issue #98: what the other session's agent is *doing*, not just where it is.
+
+Scenario AC already proves the row for an agent in another p2pmux session names
+that session and refuses the click. It gets its state there by stripping
+`P2PMUX_PANE_ID` and `P2PMUX_SOCK` from the hook, which sends the report down
+the path a bot outside every pane takes. Its own comment says why: reported
+through the pane instead, the status "would reach only the node hosting it, and
+the session doing the looking is not that one."
+
+That workaround is the bug. A real agent in a real pane has those variables set,
+so its status went to one node and no further, and the inbox of every other
+session on the same machine showed `state unknown — no hooks` — on a box where
+the hooks were installed and firing, to the one person who could answer the
+prompt it was blocked on.
+
+So this is scenario AC's setup with the workaround removed: the hook reports the
+ordinary way, from inside the pane, and the second session must still say
+`needs you`.
+
+The badge is checked too, and checked to stay *empty*. Going to an agent is what
+answers its summons and there is no going to this one from here, so a count
+including it could only ever rise. Saying the truth in the row and staying out
+of the badge are two separate promises and this change must keep both.
+
+Run: python3 scripts/e2e/scenario_ai_other_session_state.py [repeats]
+
+Both sessions live in the harness's sandbox HOME, so the sessions of whoever is
+running this are never touched -- but the *scan* sees the whole machine, so every
+check below is scoped to the one card this scenario put there.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from driver import BINARY, DeadlineExceeded, Harness, orphans_after, p2pmux_pids  # noqa: E402
+
+CTRL_O = b"\x0f"
+COLS, ROWS = 120, 36
+
+BLOCKED_ON = "permission: write to /etc/hosts"
+WAY_IN = "another p2pmux session · p2pmux attach other"
+NO_HOOKS = "state unknown — no hooks"
+
+# `opencode` rather than `claude`, for scenario AC's two reasons: a loose agent
+# descending from another of its own kind is folded into it, and this harness is
+# very often started from inside a `claude` -- so a fake claude here would be
+# that claude's descendant and never get a row at all. It also sorts to the top.
+AGENT_KIND = "opencode"
+
+# The whole point of this scenario: no `env -u`. The hook runs inside the pane
+# with the pane's own variables intact, which is what a real agent does and what
+# used to leave the other session with nothing to show.
+HOOKED_AGENT = """
+notify() {{ printf '{{"message":"%s"}}' "$2" \
+  | {binary} notify {kind} --status "$1" >/dev/null 2>&1 || true; }}
+echo AGENT-START
+notify running "reading the tests"
+sleep 2
+notify pending '{blocked}'
+echo AGENT-BLOCKED
+sleep 900
+""".strip()
+
+
+def card_holding(screen: str, needle: str) -> tuple[int, list[str]]:
+    """The (headline row, three lines) of the card whose location line matches."""
+    lines = screen.split("\n")
+    for index, line in enumerate(lines):
+        if needle in line:
+            headline = max(0, index - 2)
+            return headline, lines[headline : index + 1]
+    raise AssertionError(f"no card holding {needle!r} on screen:\n{screen}")
+
+
+def run_once(index: int, verbose: bool) -> list[tuple[str, bool, str]]:
+    results: list[tuple[str, bool, str]] = []
+
+    def check(name: str, ok: bool, detail: str = "") -> None:
+        results.append((name, ok, detail))
+        if verbose or not ok:
+            print(f"    {'PASS' if ok else 'FAIL'}  {name}" + (f"  -- {detail}" if detail else ""))
+
+    env = {"PATH": os.environ.get("PATH", "/usr/bin:/bin")}
+
+    with Harness(f"ai-other-session-state-{index}") as harness:
+        script = harness.home / "agent.sh"
+        script.write_text(
+            HOOKED_AGENT.format(binary=BINARY, blocked=BLOCKED_ON, kind=AGENT_KIND) + "\n"
+        )
+
+        other = harness.spawn(
+            "other", ["create", "--name", "other", "--session-name", "other"],
+            cols=COLS, rows=ROWS, env=env,
+        )
+        other.wait_ready(timeout=30)
+        other.run_in_shell(f"bash -c 'exec -a {AGENT_KIND} /bin/sh {script}'")
+        other.wait_for("AGENT-BLOCKED", timeout=60)
+
+        mine = harness.spawn(
+            "mine", ["create", "--name", "mine", "--session-name", "mine"],
+            cols=COLS, rows=ROWS, env=env,
+        )
+        mine.wait_ready(timeout=30)
+        mine.wait_until(lambda s: "Pane #1" in s, timeout=45, what="the session's first pane")
+
+        deadline = time.monotonic() + 30
+        while time.monotonic() < deadline and "Agents" not in mine.snapshot():
+            mine.send(CTRL_O)
+            time.sleep(2.0)
+
+        try:
+            screen = mine.wait_until(
+                lambda s: WAY_IN in s, timeout=60, what="the other session's agent"
+            )
+        except DeadlineExceeded:
+            check("the second session lists the first one's agent", False, mine.snapshot()[:600])
+            return results
+        check("the second session lists the first one's agent", True)
+
+        # The state is what this scenario is for, and the scan that fills it in
+        # runs on its own tick -- so the row can arrive before its status does.
+        try:
+            screen = mine.wait_until(
+                lambda s: "needs you" in "\n".join(card_holding(s, WAY_IN)[1]),
+                timeout=45,
+                what="the other session's agent saying what it needs",
+            )
+        except (DeadlineExceeded, AssertionError):
+            screen = mine.snapshot()
+
+        _, card = card_holding(screen, WAY_IN)
+        card_text = "\n".join(card)
+        summary = " / ".join(line.strip() for line in card)[:220]
+
+        check("the row says what the agent is blocked on", "needs you" in card_text, summary)
+        check(
+            "and never falls back to claiming the hooks are missing",
+            NO_HOOKS not in card_text,
+            summary,
+        )
+        check(
+            "the agent's own words reach the machine they are running on",
+            BLOCKED_ON in card_text,
+            summary,
+        )
+
+        # The badge must stay empty: this row is unreachable from here, so a
+        # count including it could never be cleared from here either.
+        tab_bar = screen.split("\n")[0]
+        badge = re.search(r"inbox\s+(\d+)", tab_bar)
+        check(
+            "and it still does not put a number on the inbox badge",
+            badge is None,
+            f"tab bar: {tab_bar.strip()[:120]!r}",
+        )
+
+    return results
+
+
+def main() -> int:
+    repeats = int(sys.argv[1]) if len(sys.argv) > 1 else 1
+    verbose = os.environ.get("VERBOSE", "1") != "0"
+    baseline = p2pmux_pids()
+    failures = 0
+    for index in range(1, repeats + 1):
+        print(f"scenario AI (another session's agent state) run {index}/{repeats}")
+        results = run_once(index, verbose)
+        failed = [name for name, ok, _ in results if not ok]
+        print(f"  {len(results) - len(failed)}/{len(results)} checks passed")
+        failures += len(failed)
+    leaked = orphans_after(baseline)
+    if leaked:
+        print(f"scenario AI: leaked p2pmux pids {sorted(leaked)}")
+        failures += 1
+    print(f"scenario AI: {'PASS' if failures == 0 else f'FAIL ({failures})'}")
+    return 0 if failures == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/agent_notify.rs
+++ b/src/agent_notify.rs
@@ -11,17 +11,27 @@
 //! - **It never errors into the agent.** Every failure — no session, no
 //!   socket, unparseable payload, a node that vanished — is a silent success.
 //!   A hook that fails is a hook the user disables.
-//! - **It never blocks.** One connect and one small write, both with timeouts.
+//! - **It never blocks.** One connect, one small write, and one rename over a
+//!   file in the per-user runtime directory. No waiting on a reader, because
+//!   neither sink has one: the socket write is fire-and-forget under a timeout,
+//!   and the record is read whenever somebody next opens an inbox.
 //!
-//! Note what is *not* sent: the user's prompt and the tool being run. Those
+//! Both sinks, not one or the other. The socket reaches the node that owns this
+//! pane, which is the session a person is looking at. The record reaches every
+//! *other* p2pmux on this machine, which is the only way an inbox in one session
+//! can say what an agent in another is doing — see [`record_on_this_machine`].
+//!
+//! Note what is *not* reported: the user's prompt and the tool being run. Those
 //! reach this process and are used only to decide the status.
 //!
-//! One line of the assistant's message *is* sent, and travels exactly as far as
-//! the Unix socket this writes to. The node that owns the pane keeps it for its
-//! own inbox and strips it from the roster it publishes — see
-//! `SharedLocalPane::agent_roster_entry`. A p2pmux session is shared with every
-//! member, and the agent's conversation is still not the mux's to publish; it is
-//! only the local user's to read, on their own machine, about their own pane.
+//! One line of the assistant's message *is* reported, and travels no further
+//! than this machine. The node that owns the pane keeps it for its own inbox and
+//! strips it from the roster it publishes — see
+//! `SharedLocalPane::agent_roster_entry` — and the record it is also written to
+//! is `0700` in this user's own runtime directory, read back only by a p2pmux
+//! that same user is running. A p2pmux session is shared with every member, and
+//! the agent's conversation is still not the mux's to publish; it is only the
+//! local user's to read, on their own machine.
 
 use std::{
     error::Error,
@@ -263,17 +273,33 @@ fn send(pane_id: u64, socket: &PathBuf, kind: AgentKind, update: HookUpdate) -> 
     (&stream).write_all(&line).ok()
 }
 
-/// Report a status for an agent that is not running in a p2pmux pane.
+/// Leave this status on the machine, keyed by the agent's own pid.
 ///
-/// There is no pane to name and no node socket to write to — the mux did not
-/// start this agent and may not be running at all — so the status goes to the
-/// machine-local record the process scan reads, keyed by the agent's own pid.
-/// See [`crate::agent_status`] for why that is a file and not a socket.
+/// Written by every hook, in a pane or out of one. Out of one it is the only
+/// report there is: the mux did not start this agent and may not be running at
+/// all, so there is no pane to name and no node socket to write to. In a pane it
+/// is the *second* report, and the one every other p2pmux on this machine can
+/// read.
+///
+/// That second copy is what #98 was missing. A pushed status reaches exactly one
+/// node — the one owning the pane — and the inbox of any other session on the
+/// same box finds the agent by scanning processes, sees it is in a p2pmux
+/// (`AgentScan::enclosing_node`), names the session it is in, and then has
+/// nothing to say about what it is doing. So a `claude` blocked on a permission
+/// prompt showed `state unknown — no hooks` to the one person who could answer
+/// it, on a machine where the hooks were installed and firing.
+///
+/// The state is a fact about the machine and belongs to whoever is at it. The
+/// agent's own words ride along in the same record, which does not widen who can
+/// read them: the file is `0700` in the per-user runtime directory, the same
+/// place and the same reasoning as the pane path's message, and the roster
+/// published to peers still has no field for it — see
+/// `SharedLayoutRuntime::agent_roster_entry` and the loose-agent arm beside it.
 ///
 /// The agent is found by walking up from this process: a hook runner is a child
 /// of the agent that spawned it. Nothing is written when no agent is found —
 /// the row this would name does not exist either.
-fn report_outside_a_pane(kind: AgentKind, update: HookUpdate) -> Option<()> {
+fn record_on_this_machine(kind: AgentKind, update: HookUpdate) -> Option<()> {
     let (pid, _, start_time) = crate::agent_detect::agent_ancestor(std::process::id(), kind)?;
     let directory = crate::agent_status::default_dir()?;
 
@@ -360,14 +386,13 @@ pub fn run(kind: AgentKind, status_arg: Option<&str>) -> Result<(), Box<dyn Erro
     let Some(update) = update else {
         return Ok(());
     };
-    match pane_and_socket() {
-        Some((pane_id, socket)) => {
-            let _ = send(pane_id, &socket, kind, update);
-        }
-        None => {
-            let _ = report_outside_a_pane(kind, update);
-        }
+    // The socket first: it is what the session around this pane redraws from,
+    // and it is the half a person is watching. The record after, for every
+    // other p2pmux on this machine — including the ones not running yet.
+    if let Some((pane_id, socket)) = pane_and_socket() {
+        let _ = send(pane_id, &socket, kind, update.clone());
     }
+    let _ = record_on_this_machine(kind, update);
     Ok(())
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -121,9 +121,16 @@ fn take_matching_pending(
 
 /// Give up on a pane's history and put it back at its live edge.
 ///
-/// The node answers "unavailable" for a pane it does not host, for one on the
-/// alternate screen, and for a frozen session it has since evicted — and the
-/// last of those can arrive for a pane that is *already* parked in history.
+/// The node answers with no window for a pane it does not host, for one on the
+/// alternate screen, for a frozen session it has since evicted, and for one
+/// that has no history yet — and the third of those can arrive for a pane that
+/// is *already* parked in history.
+///
+/// Only the first three carry a reason to show. A pane nothing has scrolled off
+/// yet answers with none, and `footer_notice` is assigned it unconditionally
+/// below: a wheel notch that found no history is not news, and the bar should
+/// keep whatever it was already saying rather than flash an error at a shell
+/// that has been alive for one second.
 /// Everything cached for it goes, so what the pane falls back to is its live
 /// screen; leaving the offset behind would leave it reading as scrolled while
 /// showing the newest output, which costs it its caret and swallows the next

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -276,11 +276,27 @@ impl ServiceUnit {
     /// somebody is typing in stutter, while a weight only yields when something
     /// else on the machine wants the processor. It is the same intent as
     /// launchd's `ProcessType=Background`.
+    ///
+    /// `StartLimitIntervalSec` and `StartLimitBurst` are `[Unit]` keys, not
+    /// `[Service]` ones — systemd moved them in v229 and logs `Unknown key
+    /// name … in section 'Service', ignoring` for the old spelling. Written
+    /// under `[Service]` the ceiling did not exist, which is the failure this
+    /// unit's own `MemoryMax` note calls worse than no limit at all.
+    ///
+    /// It matters most where it is least visible. On systemd v254 and newer the
+    /// escalating `RestartSteps`/`RestartMaxDelaySec` backoff reaches five
+    /// minutes on its own, so ten starts per five minutes is a ceiling nothing
+    /// ordinarily touches. Below v254 those two keys are themselves ignored and
+    /// every restart waits a flat `RestartSec` — twenty starts in the same
+    /// window — so on exactly the systems with no backoff, this is the only
+    /// thing that stops a crash loop.
     pub fn systemd_unit(&self) -> String {
         format!(
             "[Unit]\n\
              Description=p2pmux fleet agent\n\
              After=network-online.target\n\
+             StartLimitIntervalSec=300\n\
+             StartLimitBurst=10\n\
              \n\
              [Service]\n\
              Type=simple\n\
@@ -289,8 +305,6 @@ impl ServiceUnit {
              RestartSec={restart_sec}\n\
              RestartSteps=6\n\
              RestartMaxDelaySec={restart_max}\n\
-             StartLimitIntervalSec=300\n\
-             StartLimitBurst=10\n\
              MemoryHigh={memory_high}M\n\
              MemoryMax={memory_max}M\n\
              TasksMax={tasks_max}\n\
@@ -1011,8 +1025,6 @@ mod tests {
             )),
             "a crash loop should back off the same way a failed join does: {systemd}"
         );
-        assert!(systemd.contains("StartLimitBurst="), "{systemd}");
-
         let plist = unit().launchd_plist();
         assert!(
             plist.contains(&format!(
@@ -1021,6 +1033,79 @@ mod tests {
             )),
             "launchd throttles at 10s by default, which is faster than the tick: {plist}"
         );
+    }
+
+    /// Which `[section]` each key of the generated unit was written under.
+    fn systemd_sections() -> Vec<(String, String)> {
+        let unit = unit().systemd_unit();
+        let mut section = String::new();
+        let mut placed = Vec::new();
+        for line in unit.lines().map(str::trim) {
+            if let Some(name) = line.strip_prefix('[').and_then(|l| l.strip_suffix(']')) {
+                section = name.to_owned();
+            } else if let Some((key, _)) = line.split_once('=') {
+                placed.push((section.clone(), key.to_owned()));
+            }
+        }
+        placed
+    }
+
+    /// systemd ignores a key written under the wrong section, and says so only
+    /// in the journal of whoever installed it.
+    ///
+    /// `StartLimitIntervalSec` and `StartLimitBurst` sat under `[Service]`,
+    /// where systemd has not read them since v229. Both were accepted by the
+    /// old assertion — it asked whether the text appeared anywhere in the file,
+    /// which is true of a key in a section that ignores it. So the rate limit
+    /// the 16 Aug leak fix leaned on was never enforced on any machine, and
+    /// every `daemon install` logged `Unknown key name 'StartLimitIntervalSec'
+    /// in section 'Service', ignoring`.
+    ///
+    /// Asserted as a whole table rather than for those two keys: the next key
+    /// added to this unit is the one that will be misplaced, and it should fail
+    /// here rather than in somebody's journal.
+    #[test]
+    fn every_unit_key_is_written_under_the_section_systemd_reads_it_from() {
+        // From systemd.unit(5), systemd.service(5) and systemd.resource-control(5).
+        let expected = [
+            ("Description", "Unit"),
+            ("After", "Unit"),
+            ("StartLimitIntervalSec", "Unit"),
+            ("StartLimitBurst", "Unit"),
+            ("Type", "Service"),
+            ("ExecStart", "Service"),
+            ("Restart", "Service"),
+            ("RestartSec", "Service"),
+            ("RestartSteps", "Service"),
+            ("RestartMaxDelaySec", "Service"),
+            ("MemoryHigh", "Service"),
+            ("MemoryMax", "Service"),
+            ("TasksMax", "Service"),
+            ("CPUWeight", "Service"),
+            ("OOMPolicy", "Service"),
+            ("KillMode", "Service"),
+            ("TimeoutStopSec", "Service"),
+            ("WantedBy", "Install"),
+        ];
+        let placed = systemd_sections();
+        for (section, key) in &placed {
+            let Some((_, wanted)) = expected.iter().find(|(name, _)| name == key) else {
+                panic!(
+                    "{key} is new to this unit; add it to the table with the section \
+                     systemd.unit(5) says it belongs in"
+                );
+            };
+            assert_eq!(
+                section, wanted,
+                "systemd reads {key} from [{wanted}] and ignores it under [{section}]"
+            );
+        }
+        for (key, _) in expected {
+            assert!(
+                placed.iter().any(|(_, placed)| placed == key),
+                "{key} is in the table but no longer in the unit"
+            );
+        }
     }
 
     /// A service that resolved p2pmux from `PATH` would start whatever was

--- a/src/node.rs
+++ b/src/node.rs
@@ -98,6 +98,36 @@ const _: () =
     assert!(TETHERED_MEMORY_CEILING < (crate::daemon::MEMORY_MAX_MB as u64) * 1024 * 1024);
 const _: () = assert!(MEMORY_WARN_AT < TETHERED_MEMORY_CEILING);
 const MAX_FROZEN_SCROLLBACK_SESSIONS: usize = 8;
+
+/// Why a scrollback query came back with nothing, in the words the footer will
+/// show — one per cause, because the person reading it is looking at exactly
+/// one pane and only one of these is true of it.
+///
+/// There is deliberately no string for a pane that simply has no history yet.
+/// Nothing has scrolled off a shell that has just started, the wheel has
+/// nowhere to go, and an error about remote panes and expired sessions is three
+/// guesses at a pane the node can see perfectly well.
+const SCROLLBACK_EXPIRED: &str = "that scrollback expired — scroll again";
+const SCROLLBACK_ALTERNATE_SCREEN: &str = "a full-screen program owns this pane";
+const SCROLLBACK_NOT_OURS: &str = "that pane's history is on another machine";
+
+/// The longest a footer notice may be and still leave room for the keys.
+///
+/// The footer places a notice first and fits the keybinding hints into the
+/// columns it leaves, so a notice is not free: past a length it takes the whole
+/// bar. Eighty columns, less the seventeen the narrowest tier needs — `Ctrl+
+/// <p> <t> <q>`, the chords without which nothing else in the mux is reachable
+/// — less the two spaces between them.
+///
+/// The string these replaced was ninety characters and did exactly that, on a
+/// ninety-nine-column terminal, to report that a one-second-old shell had no
+/// scrollback.
+const MAX_FOOTER_NOTICE_CHARS: usize = 80 - 17 - 2;
+// Bytes rather than characters, because `chars().count()` is not const. It is
+// the conservative direction: a multi-byte dash counts for three.
+const _: () = assert!(SCROLLBACK_EXPIRED.len() <= MAX_FOOTER_NOTICE_CHARS);
+const _: () = assert!(SCROLLBACK_ALTERNATE_SCREEN.len() <= MAX_FOOTER_NOTICE_CHARS);
+const _: () = assert!(SCROLLBACK_NOT_OURS.len() <= MAX_FOOTER_NOTICE_CHARS);
 const OUTBOUND_QUEUE: usize = 64;
 
 pub struct SharedLayoutNode {
@@ -802,11 +832,19 @@ fn run_socket_loop(
                     offset,
                     request_id,
                 })) => {
+                    // `None` alongside no snapshot means "nothing to report",
+                    // not "nothing went wrong to report": the client shows this
+                    // string on the footer, and a pane that simply has no
+                    // history yet is not something to interrupt anybody about.
+                    let mut unavailable: Option<&'static str> = None;
                     let (history_id, result) = if let Some(history_id) = history_id {
                         let result = frozen_scrollback
                             .get_mut(&history_id)
                             .filter(|frozen| frozen.pane_id == pane_id)
                             .map(|frozen| frozen.viewport(offset));
+                        if result.is_none() {
+                            unavailable = Some(SCROLLBACK_EXPIRED);
+                        }
                         (history_id, result)
                     } else {
                         if frozen_scrollback.len() >= MAX_FROZEN_SCROLLBACK_SESSIONS {
@@ -817,34 +855,46 @@ fn run_socket_loop(
                         frozen_scrollback.retain(|_, frozen| frozen.pane_id != pane_id);
                         let history_id = next_history_id;
                         next_history_id = next_history_id.wrapping_add(1).max(1);
-                        let result = node.node_local_scrollback(pane_id).map(|window| {
-                            // Freeze first, then read through the map: `viewport` needs `&mut`
-                            // now that it moves the stored screen instead of copying it.
-                            frozen_scrollback.insert(
-                                history_id,
-                                FrozenScrollback {
-                                    pane_id,
-                                    total_rows: window.total_rows,
-                                    screen: window.screen,
-                                },
-                            );
-                            frozen_scrollback
-                                .get_mut(&history_id)
-                                .expect("the frozen session was just inserted")
-                                .viewport(offset)
-                        });
+                        let result = match node.node_local_scrollback(pane_id) {
+                            crate::tui::LocalScrollback::Window(window) => {
+                                // Freeze first, then read through the map: `viewport` needs `&mut`
+                                // now that it moves the stored screen instead of copying it.
+                                frozen_scrollback.insert(
+                                    history_id,
+                                    FrozenScrollback {
+                                        pane_id,
+                                        total_rows: window.total_rows,
+                                        screen: window.screen,
+                                    },
+                                );
+                                Some(
+                                    frozen_scrollback
+                                        .get_mut(&history_id)
+                                        .expect("the frozen session was just inserted")
+                                        .viewport(offset),
+                                )
+                            }
+                            // Nothing has scrolled off it yet. The wheel has
+                            // nowhere to go and there is nothing to say about
+                            // that, so the client is told to stay where it is
+                            // and the footer keeps whatever was on it.
+                            crate::tui::LocalScrollback::Empty => None,
+                            crate::tui::LocalScrollback::AlternateScreen => {
+                                unavailable = Some(SCROLLBACK_ALTERNATE_SCREEN);
+                                None
+                            }
+                            crate::tui::LocalScrollback::NotOurs => {
+                                unavailable = Some(SCROLLBACK_NOT_OURS);
+                                None
+                            }
+                        };
                         (history_id, result)
                     };
-                    let (total_rows, snapshot, unavailable) = match result {
-                        Some((total_rows, snapshot)) => (total_rows, Some(snapshot), None),
-                        None => (
-                            0,
-                            None,
-                            Some(String::from(
-                                "local scrollback is unavailable for this pane (remote, alternate screen, or stale history)",
-                            )),
-                        ),
+                    let (total_rows, snapshot) = match result {
+                        Some((total_rows, snapshot)) => (total_rows, Some(snapshot)),
+                        None => (0, None),
                     };
+                    let unavailable = unavailable.map(String::from);
                     let _ = client.writer.enqueue(NodeMessage::ScrollbackWindow {
                         pane_id,
                         request_id,
@@ -1840,10 +1890,7 @@ impl SharedLayoutNode {
     ) {
         self.runtime.node_snapshot()
     }
-    pub(crate) fn node_local_scrollback(
-        &self,
-        pane_id: u64,
-    ) -> Option<crate::tui::LocalScrollbackWindow> {
+    pub(crate) fn node_local_scrollback(&self, pane_id: u64) -> crate::tui::LocalScrollback {
         self.runtime.node_local_scrollback(pane_id)
     }
     pub(crate) fn node_remote_snapshot(&self, pane_id: u64) -> Option<Vec<u8>> {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -55,7 +55,8 @@ pub use runtime::{RolePersist, SharedLayoutRuntime};
 pub(crate) use selection::copy_selection_to_clipboard;
 pub(crate) use share::share_copy_result;
 pub(crate) use snapshot::{
-    LocalScrollbackWindow, NodeLeaseSnapshots, NodeScreenSnapshot, NodeScreenSnapshots,
+    LocalScrollback, LocalScrollbackWindow, NodeLeaseSnapshots, NodeScreenSnapshot,
+    NodeScreenSnapshots,
 };
 pub(in crate::tui) use state::{
     AddMachinePrompt, Invite, ModalState, PaneTextSelection, RenamePrompt, RenameTarget,

--- a/src/tui/render/footer.rs
+++ b/src/tui/render/footer.rs
@@ -90,12 +90,20 @@ const NORMAL_FOOTER_KEYS_ONLY: &[FooterSegment] = &[
 /// arrows are muscle memory, sharing happens once a session, and the agent overlay is opened
 /// constantly. `Ctrl+P/T/Q` is the floor — nothing else in the mux is reachable without them,
 /// so they outlive every other hint.
+///
+/// Below the floor is nothing at all, which is the last tier and a real one.
+/// A notice is placed first and the hints are fitted into what it leaves, so a
+/// long enough one leaves less than the floor's seventeen columns — and the
+/// floor was being drawn into that space anyway and clipped where it ran out,
+/// ending the bar `Ctrl+ <p`. Half a hint is worse than none: it names a chord
+/// that does not exist, on the one line the mux uses to say what its keys are.
 const NORMAL_FOOTER_TIERS: &[&[FooterSegment]] = &[
     NORMAL_FOOTER_FULL,
     NORMAL_FOOTER_NO_FOCUS,
     NORMAL_FOOTER_NO_SHARE,
     NORMAL_FOOTER_CORE,
     NORMAL_FOOTER_KEYS_ONLY,
+    &[],
 ];
 const PANE_FOOTER_FULL: &[FooterSegment] = &[
     FooterSegment::Text("  <"),
@@ -258,11 +266,13 @@ pub(in crate::tui) fn contextual_footer(
     width: u16,
 ) -> &'static [FooterSegment] {
     match chord_mode {
+        // The last tier is empty and therefore always fits, so the `unwrap_or`
+        // the other arms need is unreachable here by construction.
         ChordMode::None => NORMAL_FOOTER_TIERS
             .iter()
             .copied()
             .find(|tier| footer_segments_width(tier) <= width)
-            .unwrap_or(NORMAL_FOOTER_KEYS_ONLY),
+            .unwrap_or(&[]),
         ChordMode::Pane => PANE_FOOTER_TIERS
             .iter()
             .copied()
@@ -631,9 +641,99 @@ mod tests {
     };
 
     use super::{
-        FooterSegment, add_machine_help, chord_footer_badge, contextual_footer,
+        FooterSegment, add_machine_help, chord_footer_badge, contextual_footer, footer_layout,
         footer_segments_width, share_help,
     };
+
+    /// The help bar is a whole tier or it is nothing.
+    ///
+    /// A notice is laid out first and the hints are fitted into the columns it
+    /// leaves. `contextual_footer` used to answer a width it could not honour —
+    /// falling back to the narrowest tier whether or not that tier fit — and the
+    /// renderer then clipped it wherever the room ran out. The reported case was
+    /// a 90-character scrollback notice on a 99-column terminal, which left the
+    /// bar reading `Ctrl+ <p`: a chord that does not exist, on the one line that
+    /// exists to say what the chords are.
+    ///
+    /// Swept across every width a terminal can be rather than checked at the one
+    /// that was reported, because which tier is on the edge of fitting changes
+    /// with the notice, and the next notice will be a different length.
+    #[test]
+    fn the_help_bar_never_renders_a_tier_too_wide_for_its_span() {
+        let notices = [
+            "",
+            "that scrollback expired — scroll again",
+            "a full-screen program owns this pane",
+            "that pane's history is on another machine",
+            "coordinator unreachable; panes still live, structure frozen",
+            "local scrollback is unavailable for this pane (remote, alternate screen, or stale history)",
+        ];
+        for width in 1u16..=200 {
+            for notice in notices {
+                for status in ["", "relayed"] {
+                    let area = ratatui::layout::Rect::new(0, 0, width, 1);
+                    let notice = (!notice.is_empty()).then_some(notice);
+                    let layout = footer_layout(area, ChordMode::None, status, notice, None);
+                    let span = layout.help_end.saturating_sub(layout.help_start);
+                    assert!(
+                        footer_segments_width(layout.help) <= span,
+                        "width {width} notice {notice:?} status {status:?}: tier needs {} \
+                         columns and has {span}",
+                        footer_segments_width(layout.help),
+                    );
+                }
+            }
+        }
+    }
+
+    /// The reported geometry, drawn: a 99-column terminal carrying a notice too
+    /// long to leave room for even the narrowest tier.
+    ///
+    /// What the daily run of 17 Aug saw was `Ctrl+ <p  local scrollback is …`.
+    /// The keybinding half is either whole or absent; there is no width at which
+    /// it is a prefix of itself.
+    #[test]
+    fn a_notice_too_long_to_share_the_line_takes_it_rather_than_cutting_a_chord() {
+        let tui = MultiPaneTui::new(layout(
+            vec![Tab {
+                tab_id: 1,
+                root: Node::Leaf { pane_id: 1 },
+
+                title: None,
+            }],
+            &[(1, 2, 2)],
+        ))
+        .expect("valid layout");
+        let mut terminal = Terminal::new(TestBackend::new(99, 4)).expect("test terminal");
+        terminal
+            .draw(|frame| {
+                crate::tui::render::panes::render_shared_multi_pane(
+                    frame,
+                    &tui,
+                    &BTreeMap::new(),
+                    "",
+                    None,
+                    Some(
+                        "local scrollback is unavailable for this pane \
+                         (remote, alternate screen, or stale history)",
+                    ),
+                    crate::tui::ShareView::default(),
+                    None,
+                );
+            })
+            .expect("render");
+        let footer = (0..99)
+            .map(|x| terminal.backend().buffer()[(x, 3)].symbol())
+            .collect::<String>();
+        assert!(
+            footer.contains("local scrollback is unavailable"),
+            "the notice is what the line is for: {footer:?}"
+        );
+        assert!(
+            !footer.contains("Ctrl"),
+            "a chord that does not fit is dropped whole, not cut: {footer:?}"
+        );
+    }
 
     /// A modal always says how to leave it.
     ///

--- a/src/tui/runtime/node.rs
+++ b/src/tui/runtime/node.rs
@@ -18,8 +18,8 @@ use crate::{
         AgentRoster, AgentRosterState, MAX_AGENT_CWD_BYTES, MAX_AGENT_MESSAGE_BYTES, Presence,
     },
     tui::{
-        AgentOverlayRow, LocalScrollbackWindow, NodeLeaseSnapshots, NodeScreenSnapshot,
-        NodeScreenSnapshots, UiIntent,
+        AgentOverlayRow, LocalScrollback, LocalScrollbackWindow, NodeLeaseSnapshots,
+        NodeScreenSnapshot, NodeScreenSnapshots, UiIntent,
         clock::unix_ms_now,
         geometry::{contains_leaf, visible_leaf_panes},
         member_label,
@@ -267,16 +267,30 @@ impl SharedLayoutRuntime {
             .map(|(_, pending)| pending.command.clone())
     }
 
-    pub(crate) fn node_local_scrollback(&self, pane_id: PaneId) -> Option<LocalScrollbackWindow> {
-        let pane = self.local.get(&pane_id)?;
-        let (total_rows, _) = pane.screen.history_metadata();
-        if total_rows == 0 || pane.screen.screen().alternate_screen() {
-            return None;
+    /// What this node can offer for a pane the client wants to scroll back in.
+    ///
+    /// Three answers rather than one `Option`, because the caller has to say
+    /// something to the user and "no window" was being reported as a single
+    /// failure that named every cause it might have had — including two that
+    /// are impossible for the pane in front of them. A brand-new local shell
+    /// has no history for the ordinary reason that nothing has scrolled off it
+    /// yet, and telling that user about remote panes and stale sessions is
+    /// three guesses where the node knows the answer.
+    pub(crate) fn node_local_scrollback(&self, pane_id: PaneId) -> LocalScrollback {
+        let Some(pane) = self.local.get(&pane_id) else {
+            return LocalScrollback::NotOurs;
+        };
+        if pane.screen.screen().alternate_screen() {
+            return LocalScrollback::AlternateScreen;
         }
-        Some(LocalScrollbackWindow {
+        let (total_rows, _) = pane.screen.history_metadata();
+        if total_rows == 0 {
+            return LocalScrollback::Empty;
+        }
+        LocalScrollback::Window(Box::new(LocalScrollbackWindow {
             total_rows,
             screen: pane.screen.screen().clone(),
-        })
+        }))
     }
 
     pub(crate) fn node_remote_snapshot(&self, pane_id: PaneId) -> Option<Vec<u8>> {

--- a/src/tui/snapshot.rs
+++ b/src/tui/snapshot.rs
@@ -23,3 +23,24 @@ pub(crate) struct LocalScrollbackWindow {
     pub total_rows: u64,
     pub screen: vt100::Screen,
 }
+
+/// Why a node did or did not hand over a pane's history.
+///
+/// The three refusals are kept apart because each one has to be said to a
+/// person, and they are not the same sentence. [`Self::Empty`] is not even a
+/// refusal: a pane nothing has scrolled off yet has no history for the most
+/// ordinary reason there is, and the honest report of that is silence.
+///
+/// The window is boxed so the three refusals do not each carry its size. This
+/// is answered once per wheel notch and the window already owns a cloned
+/// screen, so the indirection costs nothing worth measuring.
+#[derive(Clone, Debug)]
+pub(crate) enum LocalScrollback {
+    Window(Box<LocalScrollbackWindow>),
+    /// Nothing has scrolled off this pane yet.
+    Empty,
+    /// A full-screen program owns the pane, and its screen is not scrollback.
+    AlternateScreen,
+    /// This node does not host that pane, so it has no history to give.
+    NotOurs,
+}


### PR DESCRIPTION
Three issues from the 17 Aug exploratory run, one commit each. All three are real; each was
reproduced against the real artefact before and after the change, not only in a unit test.

| | Issue | Reproduced on | Verified |
|---|---|---|---|
| `74fb9e8` | #100 systemd start-limit ignored | Ubuntu 24.04, systemd 255 (DigitalOcean droplet, destroyed after) | `StartLimitIntervalUSec` 10s → 5min |
| `43efbf0` | #99 wheel on a pane with no history | real client on a real PTY at the reported 99 columns | new e2e scenario AE fails pre-fix |
| `eadc178` | #98 other session's agent state | two real sessions, real hooks | new e2e scenario AI fails pre-fix |

---

### #100 — the ceiling was written where systemd does not read it

`StartLimitIntervalSec` and `StartLimitBurst` sat under `[Service]`. systemd moved both to `[Unit]`
in v229 and has ignored the old spelling since, saying so once per install and only in the journal
of whoever ran it. On a real Ubuntu 24.04 box, before:

```
StartLimitIntervalUSec=10s      <- systemd's default, not the 300 the unit asked for
Unknown key name 'StartLimitIntervalSec' in section 'Service', ignoring.
```

after:

```
StartLimitIntervalUSec=5min
systemd-analyze verify: clean
```

Ten starts per ten seconds is unreachable when every restart already waits `RestartSec=15`, so the
rate limit the 16 Aug leak fix leaned on had never applied anywhere.

**It matters most where it is least visible.** On systemd v254+ the `RestartSteps` backoff escalates
to five minutes by itself, so the ceiling is a backstop nothing ordinarily touches. Below v254 those
keys are themselves ignored and every restart waits a flat fifteen seconds — twenty starts per five
minutes — so on exactly the systems with no backoff, this is the only thing that stops a crash loop.

The old test asked whether `StartLimitBurst=` appeared *anywhere* in the file, which is true of a key
in a section that ignores it. It is replaced by one that parses the unit into sections and checks
every key against the section systemd reads it from, so the next key added here fails in CI rather
than in somebody's journal.

### #99 — two defects, and the title blames the wrong one

**The message was three guesses.** `node_local_scrollback` returned `Option`, and `None` meant any
of: this node does not host that pane, a full-screen program owns it, or nothing has scrolled off it
yet. That became one 90-character sentence naming the first two and "stale history" — none of which
is true of a shell one second old, which is the case that reaches it most often. It is now an enum
with a variant per cause. The fourth says nothing at all: a pane with no history has none for the
most ordinary reason there is, so the wheel stays put and the footer keeps what it had.

**The notice ate the keybindings.** 90 characters plus 2, against a floor tier of 17, needs 109
columns; on the reported 99-column terminal the bar read `Ctrl+ <p`. The tier list now ends in an
empty tier, so the last thing shed is the floor, whole.

**Zoom is incidental — the issue title has it wrong.** The wheel is addressed by the pointer, and a
zoomed pane owns the whole content area, so zooming moved the empty pane under a pointer that had
been over the pane *with* history. The trigger is a pane with no history, zoomed or not. Worth
retitling to "wheel on a pane with no history yet".

Notice strings are now named constants with a compile-time length budget, so the next one cannot
quietly grow back past the point where it takes the bar.

### #98 — the state existed and had nowhere to go

`p2pmux notify` reported to one sink *or* the other: the pane's node socket when it had one, the
machine-local record when it did not. So an agent in a pane told exactly one node what it was doing,
and every other session on the same box had nothing to say about it — `state unknown — no hooks`, on
a machine where the hooks were installed and firing, to the one person who could answer the prompt.

It now writes both. Everything else was already in place — `loose_agents` excludes the asking
session's panes, `name_their_sessions` resolves the node pid, `agent_status::attach` fills the state
in. The bug was that nobody wrote the record for an agent that had a socket.

Nothing else had to move, which is the argument that this is the right seam:

- the badge stays clean — `home_needs_you_count` filters on `reachable_from_here`;
- the hosting session does not double-list — its agent is under a pane root, so never loose;
- the agent's words do not travel — the published roster entry has no message field.

What did change is where that message rests, so the module doc no longer claims it "travels exactly
as far as the Unix socket". It now also sits in a `0700` file in this user's own runtime directory,
read back only by a p2pmux the same user is running.

Cost on the agent's critical path, over 25 invocations: **15.2ms with the record write against
13.5ms without**, both dominated by process spawn.

`docs/USAGE.md` was arguing with itself — the example showed `state unknown — no hooks` and the
paragraph under it promised the row "still says `needs you` … where it is true". The example now
shows what the code does.

---

### On the tests

`scripts/e2e/scenario_ai_other_session_state.py` is the existing scenario AC **with its workaround
removed**. AC gets its state by stripping `P2PMUX_PANE_ID` and `P2PMUX_SOCK` so the report takes the
loose path, and its own comment explains why: through the pane "it would reach only the node hosting
it, and the session doing the looking is not that one." That comment was describing this bug.

Both new scenarios were run against a binary built from `origin/main` and fail there with the exact
reported symptoms:

```
AE (pre-fix): footer: 'Ctrl+ <  local scrollback is unavailable for this pane (remote, ...)'
AI (pre-fix): opencode ... running / state unknown — no hooks
```

Existing scenario AC still passes 6/6, so the loose-agent path is unaffected.

### Gate

`cargo fmt --check`, `cargo clippy --all-targets --all-features -D warnings`, `cargo test
--all-features` (574 lib + every integration suite), and `cargo check --all-targets --all-features`
all pass on macOS. The systemd half was verified on Ubuntu 24.04; the droplet used for it has been
destroyed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0144Vcog7ejYYpnChPgyYCCK