### PR TITLE
fix(tui): unfocused panes really are dimmer — NO_COLOR was resetting the attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ enrolment token — and a peer on the wrong side of it is refused rather than ha
 v0.1.10 that refusal says so in as many words, naming both protocol numbers and which machine is the
 old one; older peers still report it as a host they could not reach.
 
+## Unreleased
+
+Dimming the pane you are not typing into now reaches the terminal. The frame always asked for it,
+and on a terminal whose environment carries `NO_COLOR` the request was cancelled a byte before the
+text it applied to: crossterm answers that variable by writing a cell's colours as an SGR with no
+parameters, which is a full reset, and ratatui writes colours after attributes. Bold, reverse and
+underline died there too, so a selection did not look selected and a pane replaying a colourful
+program lost the emphasis that program chose. p2pmux now keeps its own attributes through
+`NO_COLOR`; a multiplexer draws mostly other programs' output, and each of those programs read the
+same variable and already answered it.
+
 ## v0.1.13 — 2026-08-22
 
 Six fixes and two additions, and no protocol change: what a pane draws and what you can copy out

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -737,6 +737,10 @@ lowercase named values (`white`, `yellow`, `gray`, `dark_gray`) or case-insensit
 values. The theme is client-local and is never synchronized over P2P; detach and reattach after
 editing the file to reload it.
 
+`NO_COLOR` in the environment does not blank this chrome. Most of what p2pmux puts on screen is
+the output of the programs in your panes, which inherit the variable and answer it themselves;
+overriding their answer is not p2pmux's call. Set the theme keys above to shape the chrome.
+
 `member_colors` under `[ui.theme]` is a list of up to eight colors, one per member slot in join
 order, used for the presence dots and chips. Listing fewer than eight overrides from the front and
 leaves the rest at their built-in color. The first slot — the session host — defaults to a vivid

--- a/scripts/e2e/check_dim_panes.py
+++ b/scripts/e2e/check_dim_panes.py
@@ -10,6 +10,13 @@ So this drives the real binary, splits a pane, writes a marker into each, and
 reads the *escape sequences* rather than the rendered text: SGR 2 is faint, SGR
 22 turns it back off. It then moves focus and checks the two panes swapped.
 
+Issue #113 added the second run. Crossterm reads `NO_COLOR` process-wide and
+then writes a cell's colours as `ESC [ ; m` -- a parameterless SGR, which is a
+full reset -- immediately after ratatui asked for faint and immediately before
+the glyph. Every attribute in the frame died there, and only a terminal whose
+environment carried `NO_COLOR` ever saw it, which is why the first run was green
+on the machine that shipped the feature.
+
 Run: python3 scripts/e2e/check_dim_panes.py
 """
 
@@ -53,18 +60,12 @@ def intensity_at(raw: str, marker: str) -> bool | None:
     return faint
 
 
-def main() -> int:
-    env = {"PATH": os.environ.get("PATH", "/usr/bin:/bin")}
-    baseline = p2pmux_pids()
-    failures = 0
+def split_and_read(label: str, env: dict[str, str]) -> str:
+    """Everything one client drew, from startup through a right-split.
 
-    def check(name: str, ok: bool, detail: str = "") -> None:
-        nonlocal failures
-        if not ok:
-            failures += 1
-        print(f"  {'PASS' if ok else 'FAIL'}  {name}" + (f"  -- {detail}" if detail else ""))
-
-    with Harness("dim-panes") as harness:
+    Pane 1 holds AAAAA and loses focus to pane 2, which holds BBBBB.
+    """
+    with Harness(f"dim-panes-{label}") as harness:
         peer = harness.spawn(
             "solo", ["create", "--name", "dim", "--session-name", "dim"],
             cols=COLS, rows=ROWS, env=env,
@@ -81,17 +82,44 @@ def main() -> int:
         peer.run_in_shell("printf 'BBBBB\\n'")
         time.sleep(2.0)
 
-        # Everything the client has drawn since it started.
-        raw = peer.raw_text()
+        return peer.raw_text()
+
+
+def main() -> int:
+    base = {"PATH": os.environ.get("PATH", "/usr/bin:/bin")}
+    baseline = p2pmux_pids()
+    failures = 0
+
+    def check(name: str, ok: bool, detail: str = "") -> None:
+        nonlocal failures
+        if not ok:
+            failures += 1
+        print(f"  {'PASS' if ok else 'FAIL'}  {name}" + (f"  -- {detail}" if detail else ""))
+
+    # The same split, run in a plain environment and in one that sets NO_COLOR.
+    # A terminal multiplexer draws mostly other programs' output, so NO_COLOR is
+    # theirs to honour and not p2pmux's -- but either way it must never cost the
+    # frame its text attributes.
+    for label, extra in (("plain env", {}), ("NO_COLOR=1", {"NO_COLOR": "1"})):
+        print(f"  [{label}]")
+        raw = split_and_read(label.split("=")[0].replace(" ", "-"), {**base, **extra})
 
         first = intensity_at(raw, "AAAAA")
         second = intensity_at(raw, "BBBBB")
-        check("both panes drew their marker", first is not None and second is not None,
+        check(f"{label}: both panes drew their marker",
+              first is not None and second is not None,
               f"pane1={first} pane2={second}")
         if first is None or second is None:
-            return 1
-        check("the focused pane (2) is at full intensity", second is False, f"faint={second}")
-        check("the unfocused pane (1) is faint", first is True, f"faint={first}")
+            continue
+        check(f"{label}: the focused pane (2) is at full intensity",
+              second is False, f"faint={second}")
+        check(f"{label}: the unfocused pane (1) is faint", first is True, f"faint={first}")
+        # The empty SGR is the bug's fingerprint, not a symptom: it resets bold,
+        # reverse and underline along with the dim, so nothing the frame asked
+        # for survives it.
+        check(f"{label}: no parameterless SGR reaches the terminal",
+              "\x1b[;m" not in raw,
+              f"{raw.count(chr(27) + '[;m')} of them")
 
     leaked = orphans_after(baseline)
     if leaked:

--- a/src/client.rs
+++ b/src/client.rs
@@ -34,8 +34,9 @@ use crate::{
     tui::{
         AGENT_OVERLAY_ANIMATION_INTERVAL, AgentOverlayRow, KeyHandling, MultiPaneTui,
         PaneMouseProtocol, PaneViewState, QuitAction, ShareView, clear_before_first_frame,
-        copy_selection_to_clipboard, render_multi_pane_with_copy_feedback, resize_recheck_due,
-        share_copy_result, stale_node_size,
+        copy_selection_to_clipboard, keep_attributes_through_no_color,
+        render_multi_pane_with_copy_feedback, resize_recheck_due, share_copy_result,
+        stale_node_size,
     },
 };
 
@@ -341,6 +342,7 @@ pub fn run_on(
     let reader_thread = spawn_message_reader(reader, wake_tx.clone());
     let terminal_stop = Arc::new(AtomicBool::new(false));
     let mut guard = ClientTerminalGuard::enter(&descriptor.name)?;
+    keep_attributes_through_no_color();
     let backend = CrosstermBackend::new(io::stdout());
     let mut terminal = Terminal::with_options(
         backend,

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -67,8 +67,8 @@ pub use state::{
     AgentOverlayRow, ChordMode, HomeRowId, KeyHandling, MouseHandling, PairedMachine, PaneGeometry,
     PaneViewState, QuitAction, ShareCopy, ShareView, UiIntent,
 };
-pub(crate) use terminal::clear_before_first_frame;
 pub(in crate::tui) use terminal::{TerminalGuard, enable_keyboard_enhancement};
+pub(crate) use terminal::{clear_before_first_frame, keep_attributes_through_no_color};
 
 /// Kept as the module's public marker from the scaffold.
 pub struct Tui;

--- a/src/tui/runtime/run.rs
+++ b/src/tui/runtime/run.rs
@@ -26,7 +26,7 @@ use crate::{
             },
             keys::PendingEscape,
         },
-        missed_resize,
+        keep_attributes_through_no_color, missed_resize,
         pane::remote::{RemotePaneDrain, SharedRemotePane},
         render::{
             panes::render_shared_multi_pane,
@@ -125,6 +125,7 @@ impl SharedLayoutRuntime {
         guard.mouse_capture = true;
         execute!(io::stdout(), EnableMouseCapture)?;
         guard.keyboard_enhancement = enable_keyboard_enhancement()?;
+        keep_attributes_through_no_color();
         let backend = CrosstermBackend::new(io::stdout());
         let mut terminal = Terminal::with_options(
             backend,

--- a/src/tui/terminal.rs
+++ b/src/tui/terminal.rs
@@ -76,6 +76,32 @@ pub(crate) fn clear_before_first_frame<B: Backend>(
     terminal.resize(area)
 }
 
+/// Stop `NO_COLOR` from taking every text attribute down with the colours.
+///
+/// Crossterm reads `NO_COLOR` once, process-wide, and then makes every `Colored`
+/// render as the empty string. `SetColors` — the one command ratatui's backend
+/// uses, once per cell whose colour changed — still writes both halves and the
+/// separator around them, so what reaches the terminal is `ESC [ ; m`: an SGR
+/// with no parameters, which every terminal reads as SGR 0. A full reset.
+///
+/// Ratatui emits the modifier diff *before* the colours, so that reset lands
+/// between "this cell is faint" and the cell's own glyph. The stream carries the
+/// `ESC [ 2 m` and the cell is drawn at full intensity anyway — and so is
+/// everything else the frame asked for, because SGR 0 clears bold, reverse and
+/// underline with it. Unfocused panes stop looking unfocused, a text selection
+/// stops looking selected, and `vt100`'s replay of whatever is running in a pane
+/// loses the attributes that program chose.
+///
+/// So p2pmux opts out of crossterm's handling and keeps its own. A multiplexer
+/// is the wrong layer for `NO_COLOR` in any case: most of what it puts on screen
+/// is another program's output, and that program read `NO_COLOR` out of the
+/// environment p2pmux passed it and already decided for itself. Repainting its
+/// frame in the terminal's default colours would be p2pmux overriding an answer
+/// that was not its to give.
+pub(crate) fn keep_attributes_through_no_color() {
+    crossterm::style::Colored::set_ansi_color_disabled(false);
+}
+
 pub(in crate::tui) fn enable_keyboard_enhancement() -> io::Result<bool> {
     execute!(
         io::stdout(),
@@ -86,15 +112,17 @@ pub(in crate::tui) fn enable_keyboard_enhancement() -> io::Result<bool> {
 
 #[cfg(test)]
 mod tests {
+    use crossterm::style::Colored;
     use ratatui::{
         Terminal, TerminalOptions, Viewport,
-        backend::{Backend, TestBackend},
+        backend::{Backend, CrosstermBackend, TestBackend},
         buffer::Cell,
         layout::Rect,
+        style::{Color, Modifier, Style},
         widgets::Paragraph,
     };
 
-    use super::clear_before_first_frame;
+    use super::{clear_before_first_frame, keep_attributes_through_no_color};
 
     fn rendered(terminal: &Terminal<TestBackend>) -> String {
         terminal
@@ -142,5 +170,97 @@ mod tests {
         let screen = rendered(&terminal);
         assert!(!screen.contains('Z'), "stale cells survived: {screen:?}");
         assert!(screen.starts_with("hi"));
+    }
+
+    /// A pane border followed by the first faint cell of the body beside it,
+    /// drawn through the same backend the real client uses, as the escape
+    /// sequence a terminal would receive.
+    ///
+    /// The border carries a colour and the body does not, which is what makes
+    /// ratatui emit `SetColors` between the two — a run of same-coloured cells
+    /// never asks for its colours twice, and the bug rides on that command.
+    fn faint_body_after_border() -> String {
+        let mut border = Cell::default();
+        border.set_symbol("│");
+        border.set_style(Style::default().fg(Color::Yellow));
+        let mut body = Cell::default();
+        body.set_symbol("A");
+        body.set_style(Style::default().add_modifier(Modifier::DIM));
+        let cells = [(0_u16, 0_u16, &border), (1_u16, 0_u16, &body)];
+        let mut stream: Vec<u8> = Vec::new();
+        CrosstermBackend::new(&mut stream)
+            .draw(cells.into_iter())
+            .expect("draw two cells");
+        String::from_utf8(stream).expect("ansi is utf-8")
+    }
+
+    /// Whether the terminal would be in faint intensity by the time it draws
+    /// `A` — the same replay `scripts/e2e/check_dim_panes.py` does, and the only
+    /// question the user is actually asking of the frame.
+    fn faint_at_the_glyph(stream: &str) -> bool {
+        let glyph = stream.rfind('A').expect("the cell was drawn");
+        let mut faint = false;
+        let mut rest = &stream[..glyph];
+        while let Some(start) = rest.find("\u{1b}[") {
+            let Some(end) = rest[start..].find('m') else {
+                break;
+            };
+            let parameters = &rest[start + 2..start + end];
+            if parameters
+                .chars()
+                .all(|character| character.is_ascii_digit() || character == ';')
+            {
+                for value in parameters.split(';') {
+                    match if value.is_empty() { "0" } else { value } {
+                        "2" => faint = true,
+                        "0" | "22" => faint = false,
+                        _ => {}
+                    }
+                }
+            }
+            rest = &rest[start + end + 1..];
+        }
+        faint
+    }
+
+    /// Issue #113: the dim survived ratatui and died in crossterm.
+    ///
+    /// `NO_COLOR` makes crossterm render both halves of `SetColors` as nothing
+    /// while still writing the separator between them, so a cell's colours reach
+    /// the terminal as `ESC [ ; m` — a parameterless SGR, which is a full reset.
+    /// Ratatui writes the modifiers first, so that reset lands after the
+    /// `ESC [ 2 m` and before the glyph: the stream carries the dim and the
+    /// terminal never applies it.
+    ///
+    /// Both halves run in one test because the switch is process-wide state.
+    #[test]
+    fn no_color_does_not_reset_the_dim_before_the_glyph() {
+        // Stand in for the environment variable: crossterm memoises its
+        // `NO_COLOR` read at first use, so setting it here would be too late.
+        Colored::set_ansi_color_disabled(true);
+        let broken = faint_body_after_border();
+        assert!(
+            broken.contains("\u{1b}[;m"),
+            "expected crossterm's empty SGR to reproduce the bug: {broken:?}"
+        );
+        assert!(
+            !faint_at_the_glyph(&broken),
+            "the bug should leave the glyph at full intensity: {broken:?}"
+        );
+
+        keep_attributes_through_no_color();
+        let fixed = faint_body_after_border();
+        assert!(
+            !fixed.contains("\u{1b}[;m"),
+            "no parameterless SGR should reach the terminal: {fixed:?}"
+        );
+        assert!(
+            fixed.contains("\u{1b}[2m"),
+            "the frame still asks for faint intensity: {fixed:?}"
+        );
+        assert!(
+            faint_at_the_glyph(&fixed),
+            "the glyph is drawn faint: {fixed:?}"
+        );
     }
 }


### PR DESCRIPTION
Closes #113.

Unfocused panes were drawn at full intensity even though the frame asked for faint and the
stream carried the `ESC [ 2 m` that says so. `dim_unfocused_panes = false` correctly left them
not-faint, so only the on-switch was broken.

## What was happening

Crossterm reads `NO_COLOR` once, process-wide, and then renders every `Colored` as the empty
string — but `SetColors`, the one command ratatui's backend uses for a cell whose colours
changed, still writes the separator between the two halves. What reaches the terminal is
`ESC [ ; m`: an SGR with no parameters, which every terminal reads as SGR 0. A full reset.

Ratatui writes the modifier diff *before* the colours, so that reset landed between "this cell
is faint" and the cell's own glyph:

```
ESC[2m ESC[;m AAAAA
```

Dim was only the visible half. SGR 0 clears bold, reverse and underline too — 167 of those
resets in a single 30-row frame — so a text selection did not look selected and a pane replaying
a colourful program lost the emphasis that program chose.

Nothing in the repo sets `NO_COLOR`; the daily run's environment does, which is why the check
was green on the machine that shipped the dimming and red on the run that filed the issue.

## The fix

`keep_attributes_through_no_color()` in `src/tui/terminal.rs`, called at both
`CrosstermBackend` construction sites, opts p2pmux out of crossterm's handling. A multiplexer is
the wrong layer for `NO_COLOR` in any case: most of what it draws is another program's output,
and that program inherited the variable from the environment p2pmux handed it and already
answered it. `docs/USAGE.md` says so next to the theme keys.

## Verified

On a throwaway Ubuntu 24.04 droplet, both binaries built from source on the same machine, same
harness, same day (droplet and its key destroyed afterwards):

| | plain env | `NO_COLOR=1` |
|---|---|---|
| v0.1.13 (Linux) | PASS | **FAIL** — `pane1=False pane2=False`, 167 empty SGRs |
| this branch (Linux) | PASS | PASS |
| this branch (macOS) | PASS | PASS |

`scripts/e2e/check_dim_panes.py` now drives the split in both environments, and asserts no
parameterless SGR reaches the terminal at all — that is the fingerprint rather than a symptom,
so the check will not go green again the moment the next attribute breaks the same way.

The unit test renders a pane border and the faint body cell beside it through the real backend
and replays the SGR stream the way a terminal would. Its first half reproduces the bug before
the fix turns the switch off.

Linux `cargo test`: 605 lib tests and every integration suite green. macOS: 604 green, clippy
and rustfmt clean.

## Not from this branch

Two failures I hit while testing reproduce identically on the v0.1.13 binary and are untouched
here: `smoke.py` dies on macOS at `peer.send(b"d")` with `EIO` after Ctrl+Q in `p2pmux local`,
and `scenario_h_fidelity.py` sees no ticket within 25s on a droplet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WSBhtaK2w5Vu3x2KPDFpzg
