### PR TITLE
End leftover sessions when the attached terminal disappears

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ old one; older peers still report it as a host they could not reach.
 Three fixes, and no protocol change that costs anything: one field is added to the agent roster,
 absent from older peers and degrading to what they already sent.
 
+**Closing a p2pmux window now ends its local session.** A session stays available only after
+`Ctrl+Q` then `d` (Enter still chooses detach). Closing the terminal, losing SSH, or killing the
+client no longer leaves its node and panes running on this machine. Fleet-agent nodes and sleep
+behavior are unchanged.
+
 **An agent in another session on your machine reads as one again.** The second session's inbox
 called a pane-hosted agent `running outside p2pmux` and offered to start a second copy of it. The
 two halves of that row come from different places: whether an agent sits in a p2pmux pane is read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ old one; older peers still report it as a host they could not reach.
 
 ## Unreleased
 
-Three fixes, and no protocol change that costs anything: one field is added to the agent roster,
+Four fixes, and no protocol change that costs anything: one field is added to the agent roster,
 absent from older peers and degrading to what they already sent.
 
 **Closing a p2pmux window now ends its local session.** A session stays available only after

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ The join code lasts six hours. If rendezvous is down, `Ctrl+S` offers a ticket t
 | `Ctrl+T` | Tab mode |
 | `Ctrl+S` | Copy the join line |
 | `Ctrl+O` | Inbox |
-| `Ctrl+Q` | Detach or end the session |
+| `Ctrl+Q` | `d` detaches; closing the window ends the session |
 
 Keys, mouse, scrollback, pairing, agent hooks, and config: [USAGE.md](./USAGE.md).
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -49,7 +49,8 @@ finder descriptor is the only durable session data, under `~/Library/Application
 on macOS and `$XDG_STATE_HOME/p2pmux/` (`~/.local/state/p2pmux/` unless you set it) on Linux.
 The Unix socket is under `$XDG_RUNTIME_DIR/p2pmux/` where Linux provides one, and `/tmp/p2pmux-$UID/`
 otherwise, which is also where macOS keeps it. Screens, PTYs, tickets, layout state, and focus are
-never restored from disk. The node survives terminal closure. It is not managed by launchd or systemd
+never restored from disk. The node survives an explicit Ctrl+Q, then `d`, detach; closing the terminal ends it.
+It is not managed by launchd or systemd
 itself. The *fleet agent* is managed that way, only if you asked for it: `p2pmux daemon install` writes a
 launchd agent on macOS or a systemd user unit on Linux, so a paired machine rejoins its home
 session at boot and can be invited into sessions you start later. `p2pmux pair` offers to install

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -21,6 +21,8 @@ use crate::{
     transport::Transport,
 };
 
+const BARE_FLEET_BUDGET: Duration = Duration::from_millis(750);
+
 /// The temporary p2pmux command-line interface.
 #[derive(Debug, Parser)]
 #[command(
@@ -612,6 +614,7 @@ pub async fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
                 // place would move the whole fleet into a session that was
                 // never meant to be one.
                 FleetRole::Bystander,
+                None,
             )?;
             if std::env::var_os("P2PMUX_LEGACY_FOREGROUND").is_none() {
                 return crate::client::run(&descriptor);
@@ -714,6 +717,7 @@ pub async fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
                 crate::node::Tether::UntilFirstAttach,
                 // Somebody else's session, reached with somebody else's code.
                 FleetRole::Bystander,
+                None,
             )?;
             if std::env::var_os("P2PMUX_LEGACY_FOREGROUND").is_none() {
                 return crate::client::run(&descriptor);
@@ -1171,8 +1175,13 @@ async fn pair_with_code(code: &str, accepts_work: bool) -> Result<(), Box<dyn Er
     pairing.offered_here = false;
     crate::pairing::save(&pairing)?;
 
-    let descriptor =
-        rejoin_paired_session(&ticket_text, None, crate::node::Tether::UntilFirstAttach).await?;
+    let descriptor = rejoin_paired_session(
+        &ticket_text,
+        None,
+        crate::node::Tether::UntilFirstAttach,
+        None,
+    )
+    .await?;
     let peers = wait_for_peers(&descriptor).await;
     let mut pairing = crate::pairing::load()?;
     for peer in &peers {
@@ -1528,7 +1537,7 @@ async fn enroll_with_token(
     // a network that was never the problem.
     let mut joined = None;
     for ticket in fleet_addresses(&pairing).await {
-        match rejoin_paired_session(&ticket, None, crate::node::Tether::Detached).await {
+        match rejoin_paired_session(&ticket, None, crate::node::Tether::Detached, None).await {
             Ok(descriptor) => {
                 joined = Some((descriptor, ticket));
                 break;
@@ -1725,6 +1734,7 @@ async fn open_home() -> Result<(), Box<dyn Error>> {
     // session offered to a machine that never came for it is still worth
     // attaching to while it is running here, and never worth dialling once it
     // is not. See `Pairing::rejoin_ticket`.
+    let bare_deadline = Instant::now() + BARE_FLEET_BUDGET;
     for ticket in fleet_addresses(&pairing).await {
         // Said before the dial, not after it. A sleeping paired machine still
         // makes the short rejoin window visible, where silence reads exactly
@@ -1738,8 +1748,17 @@ async fn open_home() -> Result<(), Box<dyn Error>> {
             )?;
             stderr.flush()?;
         }
-        match rejoin_paired_session(&ticket, Some(5000), crate::node::Tether::UntilFirstAttach)
-            .await
+        let remaining = bare_deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        match rejoin_paired_session(
+            &ticket,
+            Some(remaining.as_millis().try_into().unwrap_or(u64::MAX)),
+            crate::node::Tether::UntilFirstAttach,
+            Some(bare_deadline),
+        )
+        .await
         {
             Ok(descriptor) => {
                 // The address that worked, kept for the next run. It is what
@@ -1914,6 +1933,7 @@ async fn rejoin_paired_session(
     ticket: &str,
     connect_timeout_ms: Option<u64>,
     tether: crate::node::Tether,
+    ready_deadline: Option<Instant>,
 ) -> Result<crate::session_store::SessionDescriptor, Box<dyn Error>> {
     let ticket = resolve_join_ticket(ticket).await?;
     let display_name = display_name_or_hostname()?;
@@ -1935,6 +1955,7 @@ async fn rejoin_paired_session(
         FleetRole::Home {
             stands_in_for: None,
         },
+        ready_deadline,
     )
 }
 
@@ -1965,6 +1986,7 @@ fn start_solo_session(
         crate::session_store::SessionRole::Coordinator,
         tether,
         fleet_role,
+        None,
     )
 }
 
@@ -2186,6 +2208,7 @@ pub(crate) fn launch_background_node(
     role: crate::session_store::SessionRole,
     tether: crate::node::Tether,
     fleet_role: FleetRole,
+    ready_deadline: Option<Instant>,
 ) -> Result<crate::session_store::SessionDescriptor, Box<dyn Error>> {
     // Every session on this machine comes through here, hosted or joined, so
     // this is the one place the count cannot drift from what actually ran.
@@ -2268,7 +2291,7 @@ pub(crate) fn launch_background_node(
     // never the thing the user read. The cap is now past that dial, and the loop leaves
     // early the moment the node resolves either way, so a session that starts normally
     // is not slowed by it.
-    let deadline = Instant::now() + Duration::from_secs(60);
+    let deadline = ready_deadline.unwrap_or_else(|| Instant::now() + Duration::from_secs(60));
     let take_node_error = || -> Option<String> {
         let message = std::fs::read_to_string(&error_path).ok()?;
         let message = message.trim().to_owned();
@@ -2688,7 +2711,7 @@ mod tests {
             .find("rejoining the session this machine is paired with")
             .expect("open_home should say it is rejoining");
         let dial = body
-            .find("rejoin_paired_session(&ticket, Some(5000))")
+            .find("match rejoin_paired_session(")
             .expect("open_home should rejoin");
         assert!(
             announcement < dial,
@@ -2716,7 +2739,8 @@ mod tests {
             .expect("background join")
             .0;
 
-        assert!(open_home.contains("rejoin_paired_session(&ticket, Some(5000))"));
+        assert!(open_home.contains("BARE_FLEET_BUDGET"));
+        assert!(open_home.contains("Some(bare_deadline)"));
         assert!(explicit_join.contains("connect_timeout_ms: None"));
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -606,9 +606,7 @@ pub async fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
                     .map(Ok)
                     .unwrap_or_else(crate::session_store::generate_name)?,
                 crate::session_store::SessionRole::Coordinator,
-                // A session somebody typed `create` for outlives the terminal
-                // they typed it in. That is what the separate process is for.
-                crate::node::Tether::Detached,
+                crate::node::Tether::UntilFirstAttach,
                 // `create` is a session of its own, however many of your own
                 // machines end up in it. Publishing it as the fleet's meeting
                 // place would move the whole fleet into a session that was
@@ -713,7 +711,7 @@ pub async fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
                 },
                 crate::session_store::generate_name()?,
                 crate::session_store::SessionRole::Member,
-                crate::node::Tether::Detached,
+                crate::node::Tether::UntilFirstAttach,
                 // Somebody else's session, reached with somebody else's code.
                 FleetRole::Bystander,
             )?;
@@ -990,9 +988,12 @@ async fn offer_pairing(accepts_work: bool) -> Result<(), Box<dyn Error>> {
         Some(descriptor) => descriptor,
         // The session this pairing is about to hand out is, by construction,
         // the one the fleet will meet in.
-        None => start_solo_session(FleetRole::Home {
-            stands_in_for: None,
-        })?,
+        None => start_solo_session(
+            FleetRole::Home {
+                stands_in_for: None,
+            },
+            crate::node::Tether::Detached,
+        )?,
     };
     // The node publishes the code a moment after it starts, so a session
     // created two lines ago has not necessarily got one yet.
@@ -1170,7 +1171,8 @@ async fn pair_with_code(code: &str, accepts_work: bool) -> Result<(), Box<dyn Er
     pairing.offered_here = false;
     crate::pairing::save(&pairing)?;
 
-    let descriptor = rejoin_paired_session(&ticket_text, None).await?;
+    let descriptor =
+        rejoin_paired_session(&ticket_text, None, crate::node::Tether::UntilFirstAttach).await?;
     let peers = wait_for_peers(&descriptor).await;
     let mut pairing = crate::pairing::load()?;
     for peer in &peers {
@@ -1526,7 +1528,7 @@ async fn enroll_with_token(
     // a network that was never the problem.
     let mut joined = None;
     for ticket in fleet_addresses(&pairing).await {
-        match rejoin_paired_session(&ticket, None).await {
+        match rejoin_paired_session(&ticket, None, crate::node::Tether::Detached).await {
             Ok(descriptor) => {
                 joined = Some((descriptor, ticket));
                 break;
@@ -1736,7 +1738,9 @@ async fn open_home() -> Result<(), Box<dyn Error>> {
             )?;
             stderr.flush()?;
         }
-        match rejoin_paired_session(&ticket, Some(5000)).await {
+        match rejoin_paired_session(&ticket, Some(5000), crate::node::Tether::UntilFirstAttach)
+            .await
+        {
             Ok(descriptor) => {
                 // The address that worked, kept for the next run. It is what
                 // gets dialled when the store cannot be reached, and a machine
@@ -1771,9 +1775,12 @@ async fn open_home() -> Result<(), Box<dyn Error>> {
     // here was a race against those, lost on a machine where publishing the
     // role takes a moment longer than it does on a laptop, and losing it left
     // every later `p2pmux` paying the rejoin window again.
-    let descriptor = start_solo_session(FleetRole::Home {
-        stands_in_for: failed_rejoin_ticket,
-    })?;
+    let descriptor = start_solo_session(
+        FleetRole::Home {
+            stands_in_for: failed_rejoin_ticket,
+        },
+        crate::node::Tether::UntilFirstAttach,
+    )?;
     // The session screen, not the inbox. A session created a moment ago has one
     // pane and no agents in it, so Home would open on an empty list — the blank
     // screen a first run is least able to interpret. Rejoining a fleet session
@@ -1906,6 +1913,7 @@ fn newest_live(
 async fn rejoin_paired_session(
     ticket: &str,
     connect_timeout_ms: Option<u64>,
+    tether: crate::node::Tether,
 ) -> Result<crate::session_store::SessionDescriptor, Box<dyn Error>> {
     let ticket = resolve_join_ticket(ticket).await?;
     let display_name = display_name_or_hostname()?;
@@ -1920,7 +1928,7 @@ async fn rejoin_paired_session(
         },
         crate::session_store::generate_name()?,
         crate::session_store::SessionRole::Member,
-        crate::node::Tether::Detached,
+        tether,
         // Reached by looking the fleet up, so this is the fleet's home session
         // — and if this machine is later promoted to coordinate it, it is the
         // one that has to keep saying where the fleet is.
@@ -1943,6 +1951,7 @@ async fn rejoin_paired_session(
 /// whole fleet into it.
 fn start_solo_session(
     fleet_role: FleetRole,
+    tether: crate::node::Tether,
 ) -> Result<crate::session_store::SessionDescriptor, Box<dyn Error>> {
     let display_name = display_name_or_hostname()?;
     let (cols, rows) = terminal_size_or_default();
@@ -1954,7 +1963,7 @@ fn start_solo_session(
         },
         crate::session_store::generate_name()?,
         crate::session_store::SessionRole::Coordinator,
-        crate::node::Tether::Detached,
+        tether,
         fleet_role,
     )
 }
@@ -2208,9 +2217,12 @@ pub(crate) fn launch_background_node(
         kind,
         // Resolved here rather than in the node, which cannot ask "who launched
         // me" once its parent has already gone -- the case the tether exists for.
+        tether,
         supervisor: match tether {
             crate::node::Tether::Detached => None,
-            crate::node::Tether::ToLauncher => crate::node::Supervisor::current(),
+            crate::node::Tether::ToLauncher | crate::node::Tether::UntilFirstAttach => {
+                crate::node::Supervisor::current()
+            }
         },
     };
     let bootstrap_path = descriptor.socket_path.with_extension("bootstrap");

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1708,7 +1708,6 @@ fn machine_rows() -> Result<Vec<crate::tui::MachineRow>, Box<dyn Error>> {
 async fn open_home() -> Result<(), Box<dyn Error>> {
     let store = crate::session_store::SessionStore::for_current_user()?;
     let pairing = crate::pairing::load_or_empty();
-    let mut failed_rejoin_ticket = None;
     // A node here is already in the fleet's session: use it rather than standing
     // up a second one alongside it. Only while it is free — an occupied one
     // falls through to a node of this terminal's own, which lands in the same
@@ -1724,63 +1723,41 @@ async fn open_home() -> Result<(), Box<dyn Error>> {
     {
         return result;
     }
-    // Where the fleet says it is meeting, and then — if that is unreachable or
-    // unknown — the last place this machine saw it. Two addresses rather than
-    // one, because they fail in different ways: the record is right about a
-    // fleet that has moved and silent when the store is down, and the stored
-    // ticket is the reverse.
-    //
-    // Which is a different question from whether there is a ticket at all: the
-    // session offered to a machine that never came for it is still worth
-    // attaching to while it is running here, and never worth dialling once it
-    // is not. See `Pairing::rejoin_ticket`.
     let bare_deadline = Instant::now() + BARE_FLEET_BUDGET;
-    for ticket in fleet_addresses(&pairing).await {
-        // Said before the dial, not after it. A sleeping paired machine still
-        // makes the short rejoin window visible, where silence reads exactly
-        // like a command that hung.
-        {
-            let mut stderr = io::stderr().lock();
-            writeln!(
-                stderr,
-                "rejoining the session this machine is paired with; this can take \
-                 a few seconds if the other machine is asleep…"
-            )?;
-            stderr.flush()?;
-        }
+    let ticket = match locate_bare_fleet(&pairing, bare_deadline).await {
+        BareFleetLookup::NoFleet | BareFleetLookup::Nobody => None,
+        BareFleetLookup::Located(ticket) => Some(ticket),
+        BareFleetLookup::Unreachable => pairing
+            .rejoin_ticket(crate::pairing::now_unix())
+            .map(str::to_owned),
+    };
+    let failed_rejoin_ticket = if let Some(ticket) = ticket {
         let remaining = bare_deadline.saturating_duration_since(Instant::now());
-        if remaining.is_zero() {
-            break;
-        }
-        match rejoin_paired_session(
-            &ticket,
-            Some(remaining.as_millis().try_into().unwrap_or(u64::MAX)),
-            crate::node::Tether::UntilFirstAttach,
-            Some(bare_deadline),
-        )
-        .await
-        {
-            Ok(descriptor) => {
-                // The address that worked, kept for the next run. It is what
-                // gets dialled when the store cannot be reached, and a machine
-                // that has been in a fleet all week should not depend on a
-                // third party being up to find its own session.
-                remember_fleet_session(&ticket);
-                return crate::client::run_on(&descriptor, crate::client::StartScreen::Home);
-            }
-            // A paired machine that is asleep, or a session whose coordinator
-            // is gone, must not leave the user with nothing. Say so and open a
-            // session here — the inbox still has this machine's agents on it.
-            Err(error) => {
-                failed_rejoin_ticket = Some(ticket);
-                let mut stderr = io::stderr().lock();
-                writeln!(stderr, "could not rejoin the paired session: {error}")?;
+        if !remaining.is_zero() {
+            let mut stderr = io::stderr().lock();
+            writeln!(stderr, "rejoining the session this machine is paired with…")?;
+            stderr.flush()?;
+            match rejoin_paired_session(
+                &ticket,
+                Some(remaining.as_millis().try_into().unwrap_or(u64::MAX)),
+                crate::node::Tether::UntilFirstAttach,
+                Some(bare_deadline),
+            )
+            .await
+            {
+                Ok(descriptor) => {
+                    remember_fleet_session(&ticket);
+                    return crate::client::run_on(&descriptor, crate::client::StartScreen::Home);
+                }
+                Err(error) => eprintln!("could not rejoin the paired session: {error}"),
             }
         }
-    }
+        Some(ticket)
+    } else {
+        None
+    };
     if failed_rejoin_ticket.is_some() {
-        let mut stderr = io::stderr().lock();
-        writeln!(stderr, "starting a session on this machine instead")?;
+        eprintln!("starting a session on this machine instead");
     }
     // The fallback is this machine's answer to that ticket, and remembering it
     // is what lets the next bare command attach here instead of attempting the
@@ -1850,6 +1827,39 @@ fn hosting_the_fleet(
         })
         .cloned()
         .collect()
+}
+
+/// The one bounded question bare `p2pmux` asks before opening a shell.
+/// Enrollment keeps using `fleet_addresses`: its unattended retry is allowed
+/// to wait for a directory that an interactive command is not.
+#[derive(Debug, Eq, PartialEq)]
+enum BareFleetLookup {
+    NoFleet,
+    Located(String),
+    Nobody,
+    Unreachable,
+}
+
+async fn locate_bare_fleet(
+    pairing: &crate::pairing::Pairing,
+    deadline: Instant,
+) -> BareFleetLookup {
+    let Some(key) = pairing.fleet_key() else {
+        return BareFleetLookup::NoFleet;
+    };
+    let remaining = deadline.saturating_duration_since(Instant::now());
+    if remaining.is_zero() {
+        return BareFleetLookup::Unreachable;
+    }
+    match tokio::time::timeout(remaining, crate::fleet::locate(&key)).await {
+        Ok(Ok(record)) => BareFleetLookup::Located(record.ticket),
+        Ok(Err(crate::fleet::LocateError::Nobody)) => BareFleetLookup::Nobody,
+        Ok(Err(crate::fleet::LocateError::Unreachable(error))) => {
+            crate::perf::log(&format!("P2PMUX_FLEET locate failed: {error}"));
+            BareFleetLookup::Unreachable
+        }
+        Err(_) => BareFleetLookup::Unreachable,
+    }
 }
 
 /// Every address worth dialling to reach this fleet, best first.
@@ -2542,7 +2552,12 @@ fn wait_for_enter() -> io::Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{apply_accepts_work, fleet_addresses_from, hosting_the_fleet};
+    use std::time::{Duration, Instant};
+
+    use super::{
+        BareFleetLookup, apply_accepts_work, fleet_addresses_from, hosting_the_fleet,
+        locate_bare_fleet,
+    };
 
     #[test]
     fn saying_yes_to_starting_work_here_allows_something_to_be_started() {
@@ -2693,55 +2708,22 @@ mod tests {
         assert!(fleet_addresses_from(None, None).is_empty());
     }
 
-    /// answering, and a half-minute of CI per run is a worse trade than this.
-    #[test]
-    fn bare_p2pmux_announces_the_rejoin_before_it_waits_on_one() {
-        let source = include_str!("cli.rs");
-        let body = source
-            .split_once("async fn open_home()")
-            .expect("open_home")
-            .1
-            .split_once("\nasync fn ")
-            .map_or_else(
-                || source.split_once("async fn open_home()").unwrap().1,
-                |split| split.0,
-            );
-
-        let announcement = body
-            .find("rejoining the session this machine is paired with")
-            .expect("open_home should say it is rejoining");
-        let dial = body
-            .find("match rejoin_paired_session(")
-            .expect("open_home should rejoin");
-        assert!(
-            announcement < dial,
-            "the notice must be printed before the dial it explains, not after it"
-        );
-        assert!(body.contains("a few seconds"));
-        assert!(!body.contains("up to half a minute"));
+    #[tokio::test]
+    async fn a_bare_command_with_no_fleet_skips_the_network_lookup() {
+        let outcome = locate_bare_fleet(
+            &crate::pairing::Pairing::default(),
+            Instant::now() + Duration::from_secs(1),
+        )
+        .await;
+        assert_eq!(outcome, BareFleetLookup::NoFleet);
     }
 
-    #[test]
-    fn only_bare_home_uses_the_short_rejoin_timeout() {
-        let source = include_str!("cli.rs");
-        let open_home = source
-            .split_once("async fn open_home()")
-            .expect("open_home")
-            .1
-            .split_once("\nasync fn rejoin_paired_session")
-            .expect("next function")
-            .0;
-        let explicit_join = source
-            .split_once("Some(Command::Join { ticket, name }) => {")
-            .expect("explicit join")
-            .1
-            .split_once("if std::env::var_os(\"P2PMUX_LEGACY_FOREGROUND\")")
-            .expect("background join")
-            .0;
-
-        assert!(open_home.contains("BARE_FLEET_BUDGET"));
-        assert!(open_home.contains("Some(bare_deadline)"));
-        assert!(explicit_join.contains("connect_timeout_ms: None"));
+    #[tokio::test]
+    async fn an_expired_bare_budget_never_starts_a_directory_request() {
+        let mut pairing = crate::pairing::Pairing::default();
+        pairing.fleet_key = Some(crate::fleet::FleetKey::mint().unwrap().hex().to_owned());
+        let outcome = locate_bare_fleet(&pairing, Instant::now()).await;
+        assert_eq!(outcome, BareFleetLookup::Unreachable);
     }
 
     /// The node has no terminal, so whatever it writes to stderr is the only

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2778,8 +2778,10 @@ mod tests {
 
     #[tokio::test]
     async fn an_expired_bare_budget_never_starts_a_directory_request() {
-        let mut pairing = crate::pairing::Pairing::default();
-        pairing.fleet_key = Some(crate::fleet::FleetKey::mint().unwrap().hex().to_owned());
+        let pairing = crate::pairing::Pairing {
+            fleet_key: Some(crate::fleet::FleetKey::mint().unwrap().hex().to_owned()),
+            ..Default::default()
+        };
         let outcome = locate_bare_fleet(&pairing, Instant::now()).await;
         assert_eq!(outcome, BareFleetLookup::Unreachable);
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -41,6 +41,7 @@ use crate::{
 };
 
 const IPC_BATCH_PER_WAKE: usize = 32;
+const DETACH_ACK_TIMEOUT: Duration = Duration::from_millis(500);
 
 #[derive(Default)]
 struct HistoryCache {
@@ -370,7 +371,8 @@ pub fn run_on(
     let mut dirty = false;
     let mut node_ended = false;
     let mut attach_error = None;
-    let mut detach_sent = false;
+    let mut detach_requested_at: Option<Instant> = None;
+    let mut detach_acknowledged = false;
     let mut killed = false;
     let mut last_agent_overlay_animation = Instant::now();
     // Started before the attach rather than after it, so the answer is usually
@@ -415,6 +417,9 @@ pub fn run_on(
     let mut last_size_check: Option<Instant> = None;
 
     'attached: loop {
+        if detach_requested_at.is_some_and(|sent| sent.elapsed() >= DETACH_ACK_TIMEOUT) {
+            break;
+        }
         for _ in 0..IPC_BATCH_PER_WAKE {
             let wake = pending_wake
                 .take()
@@ -422,6 +427,12 @@ pub fn run_on(
                 .unwrap_or_else(|| wakes.try_recv());
             match wake {
                 Ok(WakeEvent::Ipc(ReaderEvent::Message(message))) => match *message {
+                    NodeMessage::DetachAck { generation: ack }
+                        if detach_requested_at.is_some() && ack == generation =>
+                    {
+                        detach_acknowledged = true;
+                        break 'attached;
+                    }
                     NodeMessage::Snapshot {
                         room_name,
                         layout,
@@ -876,8 +887,7 @@ pub fn run_on(
                 match tui.handle_key(key, terminal.size()?.into()) {
                     KeyHandling::Quit(QuitAction::Detach) => {
                         write_message(&mut stream, &ClientMessage::Detach { generation })?;
-                        detach_sent = true;
-                        break;
+                        detach_requested_at = Some(Instant::now());
                     }
                     // The node stops, so its panes stop with it. The record is
                     // removed here rather than left for the finder to reap, so
@@ -885,7 +895,6 @@ pub fn run_on(
                     // — the same order `p2pmux kill` uses.
                     KeyHandling::Quit(QuitAction::Kill) => {
                         write_message(&mut stream, &ClientMessage::Shutdown { generation })?;
-                        detach_sent = true;
                         killed = true;
                         break;
                     }
@@ -1089,8 +1098,11 @@ pub fn run_on(
             desired_scroll.clear();
         }
     }
-    if !node_ended && !detach_sent {
-        let _ = write_message(&mut stream, &ClientMessage::Detach { generation });
+    if !node_ended && !killed && detach_requested_at.is_none() {
+        // This is not a detach: terminal failure and every other implicit exit
+        // end the local session. A requested detach that timed out merely
+        // closes the socket, letting the node distinguish it from an acked one.
+        let _ = write_message(&mut stream, &ClientMessage::Shutdown { generation });
     }
     let _ = stream.shutdown(Shutdown::Both);
     terminal_stop.store(true, Ordering::Release);
@@ -1109,11 +1121,13 @@ pub fn run_on(
             Some(reason) => println!("p2pmux node ended: {reason}"),
             None => println!("p2pmux node ended"),
         }
-    } else {
+    } else if detach_acknowledged {
         println!(
             "Detached. Resume: p2pmux --resume  |  Attach: p2pmux attach {}  |  Kill: p2pmux kill {}",
             descriptor.name, descriptor.name
         );
+    } else {
+        println!("p2pmux node ended");
     }
     Ok(())
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -1082,8 +1082,11 @@ fn run_socket_loop(
                 Err(error)
                     if error.kind() == io::ErrorKind::WouldBlock
                         || error.kind() == io::ErrorKind::TimedOut => {}
-                Ok(None) => detached = true,
-                Err(_) => detached = true,
+                // An accepted interactive client owns this node unless it
+                // completed the detach handshake. EOF is a closed window,
+                // dropped SSH connection, or dead client process — none leave
+                // a session behind.
+                Ok(None) | Err(_) => shutdown = !client.close_after_ack,
             }
             did_work |= changed;
             if !detached && !client.close_after_ack && !client.shutdown_after_ack {
@@ -1109,7 +1112,7 @@ fn run_socket_loop(
                     Ok(published) => did_work |= published,
                     Err(error) => {
                         eprintln!("p2pmux node: failed to write local update: {error}");
-                        detached = true;
+                        shutdown = !client.close_after_ack;
                     }
                 }
             }

--- a/src/node.rs
+++ b/src/node.rs
@@ -169,15 +169,9 @@ pub enum NodeBootstrapKind {
     },
 }
 
-/// Whether a launched node should outlive the process that started it.
+/// The lifetime a launched node has relative to the process that started it.
 ///
-/// `p2pmux create` and `p2pmux join` are typed by a person at a terminal, and
-/// the entire reason the node is a separate process is that closing that
-/// terminal must not take the session down. tmux and zellij daemonise their
-/// servers for the same reason, and a node that died with its client would be a
-/// multiplexer that does not multiplex.
-///
-/// The fleet agent is the opposite case. Its node is the machine's presence in
+/// The fleet agent's node is the machine's presence in
 /// the fleet, rebuilt within a tick of the agent coming back, and nobody is
 /// sitting in front of it. A node that survives its agent is not a rescued
 /// session — it is a process nothing is watching, which is precisely what nine
@@ -190,12 +184,19 @@ pub enum Tether {
     Detached,
     /// Stops when its launcher does, however the launcher goes.
     ToLauncher,
+    /// Stops if its launching interactive client goes away before the first
+    /// successful attachment. Afterwards the client protocol owns its lifetime.
+    UntilFirstAttach,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct NodeBootstrap {
     pub descriptor: SessionDescriptor,
     pub kind: NodeBootstrapKind,
+    /// A supervisor alone cannot distinguish a persistent fleet node from an
+    /// interactive launch that is only waiting for its first client.
+    #[serde(default)]
+    pub tether: Tether,
     /// The process this node is tethered to, if it is tethered to one.
     ///
     /// Checked by the node rather than enforced by the launcher, because the
@@ -541,6 +542,7 @@ pub async fn run_background(bootstrap: NodeBootstrap) -> Result<(), Box<dyn Erro
         &mut descriptor,
         &store,
         bootstrap.supervisor,
+        bootstrap.tether,
     );
     // `SharedLayoutRuntime` owns a Tokio handle for its asynchronous pane/control cleanup.
     // The node itself runs on this runtime, so perform that blocking teardown outside its worker.
@@ -595,6 +597,7 @@ fn run_socket_loop(
     descriptor: &mut SessionDescriptor,
     store: &SessionStore,
     supervisor: Option<Supervisor>,
+    mut tether: Tether,
 ) -> io::Result<()> {
     let gate = AttachmentGate::default();
     let mut client: Option<AttachedClient> = None;
@@ -616,6 +619,19 @@ fn run_socket_loop(
     loop {
         let mut shutdown = false;
         let mut did_work = false;
+        // This belongs on the socket loop rather than the slow self-check: an
+        // interactive launcher that dies before attaching has no session to
+        // leave behind.
+        if client.is_none()
+            && tether == Tether::UntilFirstAttach
+            && let Some(supervisor) = supervisor
+            && !supervisor.is_alive()
+        {
+            eprintln!(
+                "p2pmux node: the interactive launcher left before its first attachment — stopping"
+            );
+            shutdown = true;
+        }
         loop {
             match listener.accept() {
                 Ok((stream, _)) => {
@@ -672,6 +688,9 @@ fn run_socket_loop(
                             match attach_client(reader, generation, cols, rows, descriptor, node) {
                                 Ok(attached) => {
                                     client = Some(attached);
+                                    if tether == Tether::UntilFirstAttach {
+                                        tether = Tether::Detached;
+                                    }
                                     // Only now is anybody looking. Until this,
                                     // this node had no location to broadcast.
                                     node.runtime.set_client_attached(true);
@@ -777,7 +796,8 @@ fn run_socket_loop(
         if self_check_due(last_self_check, drain_started) {
             last_self_check = Some(drain_started);
             // A tethered node outlives nothing.
-            if let Some(supervisor) = supervisor
+            if tether == Tether::ToLauncher
+                && let Some(supervisor) = supervisor
                 && !supervisor.is_alive()
             {
                 // Said out loud. A node that vanished without a word is how the
@@ -787,7 +807,7 @@ fn run_socket_loop(
             }
             if let Some(held) = crate::agent_detect::process_memory(std::process::id()) {
                 let megabytes = held / (1024 * 1024);
-                if supervisor.is_some() && held > TETHERED_MEMORY_CEILING {
+                if tether == Tether::ToLauncher && held > TETHERED_MEMORY_CEILING {
                     eprintln!(
                         "p2pmux node: holding {megabytes}MB, past the {}MB a fleet node is \
                          allowed — stopping. The agent starts a fresh one.",
@@ -2074,7 +2094,7 @@ mod tests {
             .expect("the tests, which are not the loop")
             .0;
         assert!(
-            loop_source.contains("supervisor.is_some() && held > TETHERED_MEMORY_CEILING"),
+            loop_source.contains("tether == Tether::ToLauncher && held > TETHERED_MEMORY_CEILING"),
             "only a node nobody is sitting in front of may be stopped for its size"
         );
 
@@ -2170,11 +2190,10 @@ mod tests {
         );
     }
 
-    /// Only the agent's nodes are tethered. A session somebody typed `create`
-    /// for has to survive the terminal it was typed in -- that is the entire
-    /// reason the node is a separate process.
+    /// An interactive node belongs to the launcher's first client, not merely
+    /// to the launcher process that gave it a socket.
     #[test]
-    fn an_interactive_session_is_not_tethered_to_the_command_that_started_it() {
+    fn an_interactive_session_waits_only_for_its_first_client() {
         let source = include_str!("cli.rs");
         let interactive = source
             .split_once("Some(Command::Create {")
@@ -2184,8 +2203,8 @@ mod tests {
             .expect("the create arm's tether")
             .1;
         assert!(
-            interactive.starts_with("Detached"),
-            "`create` must outlive its terminal"
+            interactive.starts_with("UntilFirstAttach"),
+            "`create` must not survive a terminal that never attached"
         );
 
         let agent = include_str!("daemon.rs");
@@ -2971,6 +2990,7 @@ mod tests {
                     cols: 80,
                     rows: 24,
                 },
+                tether: Tether::Detached,
                 supervisor: None,
             },
         )
@@ -2981,6 +3001,22 @@ mod tests {
         );
         assert_eq!(read_bootstrap(&path).unwrap().descriptor, descriptor);
         assert!(!path.exists());
+    }
+
+    #[test]
+    fn old_bootstrap_defaults_to_a_detached_lifecycle() {
+        let bootstrap: NodeBootstrap = serde_json::from_value(serde_json::json!({
+            "descriptor": SessionDescriptor::new(
+                "0123456789abcdef0123456789abcdef".into(),
+                "lisbon".into(),
+                "/tmp/p2pmux-test.sock".into(),
+                1,
+                SessionRole::Coordinator,
+            ),
+            "kind": { "Create": { "display_name": "A", "cols": 80, "rows": 24 } }
+        }))
+        .expect("an old bootstrap parses");
+        assert_eq!(bootstrap.tether, Tether::Detached);
     }
 
     #[test]

--- a/src/node.rs
+++ b/src/node.rs
@@ -309,6 +309,7 @@ pub fn follow_fleet_invite(ticket: &str, tether: Tether) -> Result<bool, Box<dyn
         crate::cli::FleetRole::Home {
             stands_in_for: None,
         },
+        None,
     )?;
     Ok(true)
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -22,7 +22,6 @@ use std::{
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    hosted_rendezvous::PublishedCode,
     local_ipc::{
         AgentOverlaySnapshotRow, AttachmentGate, ClientMessage, NodeMessage, PaneLeaseSnapshot,
         PaneScreenSnapshot, PresenceRow, ScreenUpdate, SessionSummary,
@@ -404,7 +403,7 @@ pub async fn run_background(bootstrap: NodeBootstrap) -> Result<(), Box<dyn Erro
         // place in its own fleet.
         crate::layout::MemberKind::Unspecified
     });
-    let (mut node, published_code) = match bootstrap.kind {
+    let mut node = match bootstrap.kind {
         NodeBootstrapKind::Create {
             display_name,
             cols,
@@ -442,25 +441,17 @@ pub async fn run_background(bootstrap: NodeBootstrap) -> Result<(), Box<dyn Erro
             // the attaching client both read it from there rather than minting their own.
             let ticket = host.ticket().to_string();
             descriptor.ticket = Some(ticket.clone());
-            // The short code is a convenience layered on the ticket, so a rendezvous outage
-            // degrades the invite rather than failing the session: the ticket still works,
-            // and the share panel says there is no code instead of showing a dead one.
-            let published_code = PublishedCode::publish(ticket.clone()).await.ok();
-            let code = published_code
-                .as_ref()
-                .map(|published| published.code().printable());
-            descriptor.join_code = code.clone();
             let session_id = host.ticket().session_id().to_vec();
             let handle = tokio::runtime::Handle::current();
             let mut runtime = crate::tui::SharedLayoutRuntime::host(
-                host, panes, layout, initial, ticket, code, handle,
+                host, panes, layout, initial, ticket, None, handle,
             )?;
             runtime.set_session_id(session_id);
             // The runtime owns the accept loop from here: losing every member is one of the
             // shapes a coordinator's own failover takes, and stepping down means this
             // endpoint has to stop answering joins and start behaving like a member.
             runtime.set_accept_task(dispatcher_task);
-            (SharedLayoutNode::new(runtime), published_code)
+            SharedLayoutNode::new(runtime)
         }
         NodeBootstrapKind::Join {
             ticket,
@@ -529,7 +520,7 @@ pub async fn run_background(bootstrap: NodeBootstrap) -> Result<(), Box<dyn Erro
             // Handed over for the same reason as on the coordinator, in the other direction:
             // a member that gets promoted has to start answering joins on this endpoint.
             runtime.set_accept_task(dispatcher_task);
-            (SharedLayoutNode::new(runtime), None)
+            SharedLayoutNode::new(runtime)
         }
     };
     let store = SessionStore::for_current_user()?;
@@ -537,6 +528,9 @@ pub async fn run_background(bootstrap: NodeBootstrap) -> Result<(), Box<dyn Erro
     let listener = UnixListener::bind(&descriptor.socket_path)?;
     listener.set_nonblocking(true)?;
     store.write(&descriptor)?;
+    // The local session is now attachable. Discovery and rendezvous publication
+    // are deliberately asynchronous so neither delays a first shell.
+    node.publish_initial_code_after_online();
     let result = run_socket_loop(
         &mut node,
         listener,
@@ -548,9 +542,6 @@ pub async fn run_background(bootstrap: NodeBootstrap) -> Result<(), Box<dyn Erro
     // `SharedLayoutRuntime` owns a Tokio handle for its asynchronous pane/control cleanup.
     // The node itself runs on this runtime, so perform that blocking teardown outside its worker.
     tokio::task::block_in_place(|| node.shutdown());
-    if let Some(published) = published_code {
-        published.retire().await;
-    }
     let _ = fs::remove_file(&descriptor.socket_path);
     let _ = store.remove(&descriptor.id);
     result.map_err(Into::into)
@@ -2071,6 +2062,10 @@ impl SharedLayoutNode {
         self.runtime.take_role_persist()
     }
 
+    pub fn publish_initial_code_after_online(&mut self) {
+        self.runtime.publish_initial_code_after_online();
+    }
+
     pub fn shutdown(self) {
         self.runtime.shutdown_node();
     }
@@ -3056,6 +3051,29 @@ mod tests {
             .0;
 
         assert!(invite.contains("connect_timeout_ms: None"));
+    }
+
+    #[test]
+    fn a_new_session_serves_locally_before_it_publishes_a_short_code() {
+        let source = include_str!("node.rs");
+        let create = source
+            .split_once("NodeBootstrapKind::Create {")
+            .expect("create arm")
+            .1
+            .split_once("NodeBootstrapKind::Join {")
+            .expect("join arm")
+            .0;
+        assert!(
+            !create.contains("PublishedCode::publish"),
+            "a rendezvous request must not delay the create arm"
+        );
+        let socket = source
+            .find("let listener = UnixListener::bind")
+            .expect("socket bind");
+        let publish = source
+            .find("node.publish_initial_code_after_online()")
+            .expect("asynchronous publish");
+        assert!(socket < publish, "the local socket must be ready first");
     }
 
     /// Issue #107: a machine that was switched off must not decide it is still

--- a/src/session.rs
+++ b/src/session.rs
@@ -2221,12 +2221,21 @@ impl HostSession {
 
     pub async fn create_with_session_name(session_name: String) -> Result<Self, SessionError> {
         let transport = Transport::bind().await?;
-        let address_ready = transport.wait_until_online().await;
-        let ticket = JoinTicket::mint(transport.endpoint_addr()).map_err(SessionError::Ticket)?;
+        let ticket = match JoinTicket::mint(transport.endpoint_addr()) {
+            Ok(ticket) => ticket,
+            // A just-bound endpoint normally has a direct address immediately.
+            // Only the narrow no-address case waits for discovery before the
+            // initial ticket can be minted.
+            Err(TicketError::MissingAddresses) => {
+                transport.wait_until_online().await;
+                JoinTicket::mint(transport.endpoint_addr()).map_err(SessionError::Ticket)?
+            }
+            Err(error) => return Err(SessionError::Ticket(error)),
+        };
         Ok(Self {
             transport,
             ticket,
-            address_ready,
+            address_ready: true,
             session_name,
             coordinator_epoch: 0,
         })
@@ -2284,6 +2293,27 @@ impl HostSession {
 
     pub fn address_ready(&self) -> bool {
         self.address_ready
+    }
+
+    /// Wait for discovery after the local session is already usable, then keep
+    /// its existing secret while replacing a changed endpoint address.
+    pub async fn refresh_ticket_after_online(
+        &mut self,
+    ) -> Result<Option<JoinTicket>, SessionError> {
+        if !self.transport.wait_until_online().await {
+            return Ok(None);
+        }
+        self.address_ready = true;
+        let ticket = JoinTicket::from_parts(
+            self.ticket.session_id().to_vec(),
+            self.transport.endpoint_addr(),
+        )
+        .map_err(SessionError::Ticket)?;
+        if ticket.endpoint_addr() == self.ticket.endpoint_addr() {
+            return Ok(None);
+        }
+        self.ticket = ticket.clone();
+        Ok(Some(ticket))
     }
 
     pub async fn accept_incoming(&self) -> Result<Incoming, SessionError> {
@@ -3129,6 +3159,37 @@ impl SharedLayoutHost {
 
     pub fn ticket(&self) -> &JoinTicket {
         self.host.ticket()
+    }
+
+    /// Adopt an address refresh that this host already committed to the
+    /// coordinator state from its asynchronous discovery task.
+    pub fn set_ticket(&mut self, ticket: JoinTicket) {
+        self.host.ticket = ticket;
+    }
+
+    /// Refresh the initial invitation after discovery without making clients
+    /// wait for it. The coordinator's own member entry changes with the ticket
+    /// so a later snapshot never advertises the stale endpoint.
+    pub async fn refresh_ticket_after_online(
+        &mut self,
+    ) -> Result<Option<JoinTicket>, SessionError> {
+        let Some(ticket) = self.host.refresh_ticket_after_online().await? else {
+            return Ok(None);
+        };
+        let peer_id = ticket.endpoint_addr().id.as_bytes().to_vec();
+        let change = self
+            .coordinator
+            .lock()
+            .map_err(|_| SessionError::PeerTask)?
+            .update_member_endpoint(&peer_id, ticket.endpoint_addr().clone())?;
+        broadcast_envelope(
+            &self.peers,
+            coordinator_envelope(&peer_id, envelope::Body::LayoutCommit(change.commit)),
+        );
+        if let Some(reject) = change.invalidated_reservation {
+            deliver_reject(&self.peers, &peer_id, &self.own_rejects, reject);
+        }
+        Ok(Some(ticket))
     }
 
     /// How many takeovers this session has been through, this one included.

--- a/src/tui/runtime/failover.rs
+++ b/src/tui/runtime/failover.rs
@@ -270,7 +270,7 @@ impl SharedLayoutRuntime {
                 .await
                 .ok()
                 .flatten()
-                .map_or(ticket, |ticket| ticket);
+                .unwrap_or(ticket);
             if let Ok(published) =
                 crate::hosted_rendezvous::PublishedCode::publish(ticket.to_string()).await
             {

--- a/src/tui/runtime/failover.rs
+++ b/src/tui/runtime/failover.rs
@@ -30,7 +30,7 @@ use crate::{
     tui::pane::control::SharedControl,
 };
 
-use super::SharedLayoutRuntime;
+use super::{PublishedInvite, SharedLayoutRuntime};
 
 /// How long to leave between attempts to reach a coordinator that is not answering.
 ///
@@ -255,6 +255,33 @@ impl SharedLayoutRuntime {
         self.swap_accept_loop(false);
     }
 
+    /// Publish a fresh session only after its local socket is serving. Discovery
+    /// runs in this task so a slow rendezvous path never delays attachment.
+    pub fn publish_initial_code_after_online(&mut self) {
+        let SharedControl::Host(host) = &self.control else {
+            return;
+        };
+        let mut host = host.clone();
+        let ticket = host.ticket().clone();
+        let sender = self.code_tx.clone();
+        self.runtime.spawn(async move {
+            let ticket = host
+                .refresh_ticket_after_online()
+                .await
+                .ok()
+                .flatten()
+                .map_or(ticket, |ticket| ticket);
+            if let Ok(published) =
+                crate::hosted_rendezvous::PublishedCode::publish(ticket.to_string()).await
+            {
+                let invite = PublishedInvite { ticket, published };
+                if let Err(error) = sender.send(invite) {
+                    error.0.published.retire().await;
+                }
+            }
+        });
+    }
+
     /// Put a fresh short code in front of the new ticket.
     ///
     /// The code a session was created with is sealed under a secret only its creator holds,
@@ -270,8 +297,14 @@ impl SharedLayoutRuntime {
         self.retire_published_code();
         let sender = self.code_tx.clone();
         self.runtime.spawn(async move {
-            if let Ok(published) = crate::hosted_rendezvous::PublishedCode::publish(ticket).await {
-                let _ = sender.send(published);
+            if let Ok(ticket) = ticket.parse::<JoinTicket>()
+                && let Ok(published) =
+                    crate::hosted_rendezvous::PublishedCode::publish(ticket.to_string()).await
+            {
+                let invite = PublishedInvite { ticket, published };
+                if let Err(error) = sender.send(invite) {
+                    error.0.published.retire().await;
+                }
             }
         });
     }
@@ -285,13 +318,17 @@ impl SharedLayoutRuntime {
     /// Adopt a code whose publish finished, if this node is still the one coordinating.
     fn drain_published_codes(&mut self) -> bool {
         let mut changed = false;
-        while let Ok(published) = self.code_rx.try_recv() {
+        while let Ok(PublishedInvite { ticket, published }) = self.code_rx.try_recv() {
             if !matches!(self.control, SharedControl::Host(_)) {
                 // Stepped back down while the request was in flight. Publishing a code for a
                 // ticket nobody will answer is worse than having none.
                 self.runtime.spawn(async move { published.retire().await });
                 continue;
             }
+            if let SharedControl::Host(host) = &mut self.control {
+                host.set_ticket(ticket.clone());
+            }
+            self.invite.ticket = Some(ticket.to_string());
             let code = published.code().printable();
             self.invite.code = Some(code.clone());
             self.pending_role_persist = Some(super::RolePersist {

--- a/src/tui/runtime/mod.rs
+++ b/src/tui/runtime/mod.rs
@@ -25,6 +25,7 @@ use crate::{
         GuestPane, PaneLayoutReconciler, PaneServer, SharedLayoutHost, SharedLayoutMember,
         layout_snapshot_from_state,
     },
+    ticket::JoinTicket,
     transport::Transport,
     tui::{
         Invite, MultiPaneTui,
@@ -153,10 +154,8 @@ pub struct SharedLayoutRuntime {
     /// The one a session starts with belongs to whoever created it; this is the replacement,
     /// and holding it here is what lets it be retired when this node stops.
     pub(in crate::tui) published_code: Option<crate::hosted_rendezvous::PublishedCode>,
-    pub(in crate::tui) code_tx:
-        tokio::sync::mpsc::UnboundedSender<crate::hosted_rendezvous::PublishedCode>,
-    pub(in crate::tui) code_rx:
-        tokio::sync::mpsc::UnboundedReceiver<crate::hosted_rendezvous::PublishedCode>,
+    pub(in crate::tui) code_tx: tokio::sync::mpsc::UnboundedSender<PublishedInvite>,
+    pub(in crate::tui) code_rx: tokio::sync::mpsc::UnboundedReceiver<PublishedInvite>,
     /// A role change the durable session record has not caught up with yet.
     ///
     /// `p2pmux ls` and `p2pmux ticket <name>` read that record out of process, so a takeover
@@ -171,6 +170,13 @@ pub struct RolePersist {
     pub coordinating: bool,
     pub ticket: Option<String>,
     pub join_code: Option<String>,
+}
+
+/// A published short code and the ticket it resolves. They travel together so
+/// a ticket refreshed after discovery reaches the share panel atomically.
+pub(in crate::tui) struct PublishedInvite {
+    pub ticket: JoinTicket,
+    pub published: crate::hosted_rendezvous::PublishedCode,
 }
 impl SharedLayoutRuntime {
     pub fn host(

--- a/tests/detach_resume_node.rs
+++ b/tests/detach_resume_node.rs
@@ -11,7 +11,7 @@ use std::{
 use p2pmux::{
     client,
     local_ipc::{ClientMessage, NodeMessage, ScreenUpdate},
-    node::{NodeBootstrap, NodeBootstrapKind, write_bootstrap},
+    node::{NodeBootstrap, NodeBootstrapKind, Supervisor, Tether, write_bootstrap},
     session_store::{SessionDescriptor, SessionRole, SessionStore, generate_id},
 };
 
@@ -102,10 +102,10 @@ fn detached_node_serves_real_snapshots_and_accepts_a_new_attachment() {
                 cols: 80,
                 rows: 24,
             },
-            tether: p2pmux::node::Tether::Detached,
-            // Untethered: detach and resume is the behaviour of a session
-            // somebody started by hand, which outlives whatever started it.
-            supervisor: None,
+            // A fleet node remains supervised by its agent, but an interactive
+            // attach and explicit detach must not make it stop with the TUI.
+            tether: Tether::ToLauncher,
+            supervisor: Supervisor::current(),
         },
     )
     .unwrap();

--- a/tests/detach_resume_node.rs
+++ b/tests/detach_resume_node.rs
@@ -102,6 +102,7 @@ fn detached_node_serves_real_snapshots_and_accepts_a_new_attachment() {
                 cols: 80,
                 rows: 24,
             },
+            tether: p2pmux::node::Tether::Detached,
             // Untethered: detach and resume is the behaviour of a session
             // somebody started by hand, which outlives whatever started it.
             supervisor: None,

--- a/tests/node_survives_bad_clients.rs
+++ b/tests/node_survives_bad_clients.rs
@@ -152,6 +152,28 @@ fn an_unattached_interactive_node_stops_with_its_launcher() {
 }
 
 #[test]
+fn a_lost_accepted_client_stops_its_node() {
+    let mut fixture = Fixture::start("lost-accepted-client");
+    let (stream, mut reader, _) = attach(&fixture.socket);
+    receive_until_snapshot(&mut reader);
+    drop(reader);
+    drop(stream);
+
+    let deadline = Instant::now() + RECEIVE_TIMEOUT;
+    while fixture.running() && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    assert!(
+        !fixture.running(),
+        "the node outlived an accepted client that closed without detaching"
+    );
+    assert!(
+        !fixture.socket.exists(),
+        "the stopped node left its socket behind"
+    );
+}
+
+#[test]
 fn a_session_outlives_every_kind_of_bad_local_client() {
     let mut fixture = Fixture::start("rude");
 

--- a/tests/node_survives_bad_clients.rs
+++ b/tests/node_survives_bad_clients.rs
@@ -21,7 +21,7 @@ use std::{
 use p2pmux::{
     client,
     local_ipc::{ClientMessage, NodeMessage},
-    node::{NodeBootstrap, NodeBootstrapKind, write_bootstrap},
+    node::{NodeBootstrap, NodeBootstrapKind, Supervisor, Tether, write_bootstrap},
     session_store::{SessionDescriptor, SessionRole, SessionStore, generate_id},
 };
 
@@ -53,6 +53,10 @@ impl Fixture {
     /// is 104 bytes on macOS, and a temp directory under the target directory
     /// would not fit.
     fn start(name: &str) -> Self {
+        Self::start_with(name, Tether::Detached, None)
+    }
+
+    fn start_with(name: &str, tether: Tether, supervisor: Option<Supervisor>) -> Self {
         let root = PathBuf::from(format!("/tmp/p2pmux-{name}-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&root);
         std::fs::create_dir_all(root.join("home")).unwrap();
@@ -74,8 +78,9 @@ impl Fixture {
                     cols: 80,
                     rows: 24,
                 },
+                tether,
                 // Untethered: this node stands in for one a person started.
-                supervisor: None,
+                supervisor,
             },
         )
         .unwrap();
@@ -109,6 +114,41 @@ impl Fixture {
     fn running(&mut self) -> bool {
         self.node.try_wait().unwrap().is_none()
     }
+}
+
+#[test]
+fn an_unattached_interactive_node_stops_with_its_launcher() {
+    let mut launcher = Command::new("sleep")
+        .arg("30")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+    let supervisor = Supervisor {
+        pid: launcher.id(),
+        started_at: p2pmux::agent_detect::process_start_time(launcher.id()).unwrap(),
+    };
+    let mut fixture = Fixture::start_with(
+        "until-first-attach",
+        Tether::UntilFirstAttach,
+        Some(supervisor),
+    );
+
+    launcher.kill().unwrap();
+    launcher.wait().unwrap();
+    let deadline = Instant::now() + RECEIVE_TIMEOUT;
+    while fixture.running() && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    assert!(
+        !fixture.running(),
+        "the unattached node outlived its launcher"
+    );
+    assert!(
+        !fixture.socket.exists(),
+        "the stopped node left its socket behind"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Closing the p2pmux window, losing SSH, or killing the client now ends this machine's node (same as `k`). The session stays up only after explicit `Ctrl+Q` then `d` (Enter still chooses detach). Fleet-agent nodes and lid-close/sleep are unchanged.
- Bare `p2pmux` no longer waits the old 5s/10s fleet rejoin when nobody is hosting. Locate plus one rejoin share a 750ms launch budget; a missing fleet creates a new shell immediately.
- New sessions mint the join ticket and accept the local TUI before Iroh is fully online, then refresh the ticket if the address later changes. Ctrl+S can copy that ticket before the short join code exists.

## Test plan
- [x] `cargo fmt --check && cargo clippy --all-features -- -D warnings && cargo test --all-features`
- [x] Local e2e: SIGKILL the client → node gone; `Ctrl+Q` `d` → node stays and reattach works
- [x] Cross-machine e2e on a throwaway droplet: explicit detach/reattach 10/10; kill remote client without detach 2/2 (droplet session gone, Mac coordinator still alive)
- [ ] Manual: `p2pmux` with no home session should attach in ~1s, not ~5s
- [ ] Manual: close the terminal window on an attached session and confirm `p2pmux attach` has nothing to resume until a new create


Made with [Cursor](https://cursor.com)