### PR TITLE
Keep pairing joins and the share panel after PR #126

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ old one; older peers still report it as a host they could not reach.
 
 ## Unreleased
 
-Eight fixes, and no protocol change that costs anything: one field is added to the agent roster,
+Ten fixes, and no protocol change that costs anything: one field is added to the agent roster,
 absent from older peers and degrading to what they already sent.
 
 **Closing a p2pmux window now ends its local session.** A session stays available only after
@@ -30,6 +30,12 @@ REDRAW and Esc BACK stay together; narrower terminals lose whole hints instead o
 
 **A detached member comes back to its existing session.** Joining its ticket reattaches to that
 member instead of minting a second one and turning the badge into two members.
+
+**Pairing a machine keeps it there.** `p2pmux pair <code>` no longer drops that machine's node when
+the command exits, and the host records it when it joins instead of waiting for a later scan.
+
+**Share still opens before there is a short code.** `Ctrl+S` opens the panel with its ticket even if
+the key arrived before the first snapshot; a rendezvous outage still leaves that ticket working.
 
 **Doctor identifies the binary you ran.** It no longer calls it the latest release when PATH would
 still run another copy, or when GitHub could not be asked what the latest tag is.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1006,7 +1006,7 @@ async fn offer_pairing(accepts_work: bool) -> Result<(), Box<dyn Error>> {
     // The node publishes the code a moment after it starts, so a session
     // created two lines ago has not necessarily got one yet.
     let descriptor = wait_for_invite(&store, &descriptor.id).await?;
-    let ticket = descriptor.ticket.clone().ok_or(CliError(
+    let mut ticket = descriptor.ticket.clone().ok_or(CliError(
         "this machine is not hosting the session; pair from the machine that is",
     ))?;
     let mut pairing = crate::pairing::load()?;
@@ -1025,6 +1025,20 @@ async fn offer_pairing(accepts_work: bool) -> Result<(), Box<dyn Error>> {
     // guest used to end up in the fleet.
     pairing.open_pairing_window(crate::pairing::now_unix());
     crate::pairing::save(&pairing)?;
+
+    // Best-effort freshness, not an atomic handshake with discovery: a refresh
+    // can still land after this read, but do not knowingly mint the old ticket.
+    if let Some(live_ticket) = store
+        .list_live()?
+        .into_iter()
+        .find(|live| live.id == descriptor.id)
+        .and_then(|live| live.ticket)
+        && live_ticket != ticket
+    {
+        ticket = live_ticket;
+        pairing.ticket = Some(ticket.clone());
+        crate::pairing::save(&pairing)?;
+    }
 
     let mut stdout = io::stdout().lock();
     match mint_pairing_code(&ticket, &fleet_key).await {
@@ -1179,13 +1193,8 @@ async fn pair_with_code(code: &str, accepts_work: bool) -> Result<(), Box<dyn Er
     pairing.offered_here = false;
     crate::pairing::save(&pairing)?;
 
-    let descriptor = rejoin_paired_session(
-        &ticket_text,
-        None,
-        crate::node::Tether::Detached,
-        None,
-    )
-    .await?;
+    let descriptor =
+        rejoin_paired_session(&ticket_text, None, crate::node::Tether::Detached, None).await?;
     let peers = wait_for_peers(&descriptor).await;
     let mut pairing = crate::pairing::load()?;
     for peer in &peers {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1182,7 +1182,7 @@ async fn pair_with_code(code: &str, accepts_work: bool) -> Result<(), Box<dyn Er
     let descriptor = rejoin_paired_session(
         &ticket_text,
         None,
-        crate::node::Tether::UntilFirstAttach,
+        crate::node::Tether::Detached,
         None,
     )
     .await?;
@@ -2638,6 +2638,22 @@ mod tests {
             .0;
         assert!(create_arm.contains("launch_background_node("));
         assert!(create_arm.contains("crate::client::run(&descriptor)"));
+    }
+
+    #[test]
+    fn pairing_with_a_code_leaves_its_node_running() {
+        let source = include_str!("cli.rs");
+        let pair = source
+            .split_once("async fn pair_with_code(")
+            .expect("pair command")
+            .1
+            .split_once("async fn offer_pairing(")
+            .expect("next command")
+            .0;
+        assert!(
+            pair.contains("crate::node::Tether::Detached"),
+            "pair is a persistent machine join, not an interactive session"
+        );
     }
 
     /// Bare `p2pmux` says it is dialling *before* it dials.

--- a/src/client.rs
+++ b/src/client.rs
@@ -61,7 +61,9 @@ fn replay_early_key(
     pending_wake: &mut Option<WakeEvent>,
     queued: &mut VecDeque<crossterm::event::KeyEvent>,
 ) {
-    if pending_wake.is_none() && let Some(key) = queued.pop_front() {
+    if pending_wake.is_none()
+        && let Some(key) = queued.pop_front()
+    {
         *pending_wake = Some(WakeEvent::Terminal(Event::Key(key)));
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -2,7 +2,7 @@
 
 use std::{
     borrow::Cow,
-    collections::{BTreeMap, BTreeSet},
+    collections::{BTreeMap, BTreeSet, VecDeque},
     io::{self, BufRead, BufReader, Write},
     net::Shutdown,
     os::unix::net::UnixStream,
@@ -42,6 +42,29 @@ use crate::{
 
 const IPC_BATCH_PER_WAKE: usize = 32;
 const DETACH_ACK_TIMEOUT: Duration = Duration::from_millis(500);
+const EARLY_KEY_CAPACITY: usize = 8;
+
+fn queue_early_key(queued: &mut VecDeque<crossterm::event::KeyEvent>, event: Event) {
+    let Event::Key(key) = event else {
+        return;
+    };
+    if !matches!(key.kind, KeyEventKind::Press | KeyEventKind::Repeat) {
+        return;
+    }
+    if queued.len() == EARLY_KEY_CAPACITY {
+        queued.pop_front();
+    }
+    queued.push_back(key);
+}
+
+fn replay_early_key(
+    pending_wake: &mut Option<WakeEvent>,
+    queued: &mut VecDeque<crossterm::event::KeyEvent>,
+) {
+    if pending_wake.is_none() && let Some(key) = queued.pop_front() {
+        *pending_wake = Some(WakeEvent::Terminal(Event::Key(key)));
+    }
+}
 
 #[derive(Default)]
 struct HistoryCache {
@@ -404,6 +427,7 @@ pub fn run_on(
     let mut share_code: Option<String> = None;
     let mut share_notice: Option<String> = None;
     let mut pending_wake = None;
+    let mut early_keys = VecDeque::new();
     let mut next_perf_id = 1_u64;
     let mut draw_perf_id = None;
     // The viewport is fixed, so what is drawn only follows the window because
@@ -838,6 +862,9 @@ pub fn run_on(
             }
             dirty = false;
         }
+        if tui.is_some() {
+            replay_early_key(&mut pending_wake, &mut early_keys);
+        }
         if pending_wake.is_none() && resize_recheck_due(last_size_check, Instant::now()) {
             last_size_check = Some(Instant::now());
             if let Some((cols, rows)) = stale_node_size(
@@ -866,6 +893,7 @@ pub fn run_on(
             },
         };
         let Some(tui) = tui.as_mut() else {
+            queue_early_key(&mut early_keys, event);
             continue;
         };
         // Zoom lives entirely in this client -- it never becomes a layout
@@ -1811,6 +1839,32 @@ mod tests {
             &mut pending_focus,
         )
         .unwrap();
+    }
+
+    #[test]
+    fn ctrl_s_before_the_first_snapshot_opens_share() {
+        let mut tui = None;
+        let mut early_keys = VecDeque::new();
+        queue_early_key(
+            &mut early_keys,
+            Event::Key(KeyEvent::new(KeyCode::Char('s'), KeyModifiers::CONTROL)),
+        );
+        assert!(tui.is_none());
+
+        apply_rows(&mut tui, &[1], vec![]);
+
+        let mut pending_wake = None;
+        replay_early_key(&mut pending_wake, &mut early_keys);
+        let event = match pending_wake.take() {
+            Some(WakeEvent::Terminal(event)) => event,
+            _ => panic!("the queued key replays through the terminal event path"),
+        };
+        let Event::Key(key) = event else {
+            panic!("the queued event is a key");
+        };
+        let tui = tui.as_mut().expect("the snapshot built the tui");
+        let _ = tui.handle_key(key, Rect::new(0, 0, 80, 24));
+        assert!(tui.share_open());
     }
 
     fn apply_focus_snapshot(

--- a/src/session.rs
+++ b/src/session.rs
@@ -3691,6 +3691,19 @@ impl SharedLayoutHost {
                     eprintln!("p2pmux node: failed to record an enrolled machine: {error}");
                 }
             }
+            if receipt.identity.kind.declared_machine() {
+                let identity = receipt
+                    .identity
+                    .clone()
+                    .verified_for(&receipt.admitted_peer_id);
+                if let Err(error) = crate::pairing::pin_peers(&[crate::pairing::SeenMachine {
+                    name: receipt.display_name.clone(),
+                    machine_id: crate::machine_id::to_hex(&identity.machine_id),
+                    kind: receipt.identity.kind,
+                }]) {
+                    eprintln!("p2pmux node: failed to pin an admitted machine: {error}");
+                }
+            }
             admitted_peer_id = Some(receipt.admitted_peer_id.clone());
 
             let (writer, reader) = self.transport_open_control(&connection).await?;
@@ -5271,6 +5284,26 @@ mod control_queue_tests {
     use super::*;
     use crate::protocol::{AgentRosterEntry, AgentRosterState};
     use tokio::sync::oneshot;
+
+    #[test]
+    fn admission_pins_a_verified_machine_identity() {
+        let source = include_str!("session.rs");
+        let admission = source
+            .split_once("coordinator_guard.remember_admitted")
+            .expect("admission")
+            .1
+            .split_once("admitted_peer_id = Some")
+            .expect("end of admission")
+            .0;
+        assert!(
+            admission.contains(".verified_for(&receipt.admitted_peer_id)"),
+            "an admitted machine's id must be verified against its peer"
+        );
+        assert!(
+            admission.contains("crate::pairing::pin_peers(&[crate::pairing::SeenMachine {"),
+            "an admitted machine must be pinned immediately"
+        );
+    }
 
     /// The coordinator is usually the machine you are sitting at, so this is
     /// the common path and not an edge: it asks for a terminal on a droplet,

--- a/src/tui/runtime/failover.rs
+++ b/src/tui/runtime/failover.rs
@@ -271,13 +271,14 @@ impl SharedLayoutRuntime {
                 .ok()
                 .flatten()
                 .unwrap_or(ticket);
-            if let Ok(published) =
-                crate::hosted_rendezvous::PublishedCode::publish(ticket.to_string()).await
+            let published = crate::hosted_rendezvous::PublishedCode::publish(ticket.to_string())
+                .await
+                .ok();
+            let invite = PublishedInvite { ticket, published };
+            if let Err(error) = sender.send(invite)
+                && let Some(published) = error.0.published
             {
-                let invite = PublishedInvite { ticket, published };
-                if let Err(error) = sender.send(invite) {
-                    error.0.published.retire().await;
-                }
+                published.retire().await;
             }
         });
     }
@@ -297,13 +298,16 @@ impl SharedLayoutRuntime {
         self.retire_published_code();
         let sender = self.code_tx.clone();
         self.runtime.spawn(async move {
-            if let Ok(ticket) = ticket.parse::<JoinTicket>()
-                && let Ok(published) =
-                    crate::hosted_rendezvous::PublishedCode::publish(ticket.to_string()).await
-            {
+            if let Ok(ticket) = ticket.parse::<JoinTicket>() {
+                let published =
+                    crate::hosted_rendezvous::PublishedCode::publish(ticket.to_string())
+                        .await
+                        .ok();
                 let invite = PublishedInvite { ticket, published };
-                if let Err(error) = sender.send(invite) {
-                    error.0.published.retire().await;
+                if let Err(error) = sender.send(invite)
+                    && let Some(published) = error.0.published
+                {
+                    published.retire().await;
                 }
             }
         });
@@ -316,27 +320,38 @@ impl SharedLayoutRuntime {
     }
 
     /// Adopt a code whose publish finished, if this node is still the one coordinating.
-    fn drain_published_codes(&mut self) -> bool {
+    pub(in crate::tui) fn drain_published_codes(&mut self) -> bool {
         let mut changed = false;
         while let Ok(PublishedInvite { ticket, published }) = self.code_rx.try_recv() {
             if !matches!(self.control, SharedControl::Host(_)) {
                 // Stepped back down while the request was in flight. Publishing a code for a
                 // ticket nobody will answer is worse than having none.
-                self.runtime.spawn(async move { published.retire().await });
+                if let Some(published) = published {
+                    self.runtime.spawn(async move { published.retire().await });
+                }
                 continue;
             }
             if let SharedControl::Host(host) = &mut self.control {
                 host.set_ticket(ticket.clone());
             }
             self.invite.ticket = Some(ticket.to_string());
-            let code = published.code().printable();
-            self.invite.code = Some(code.clone());
             self.pending_role_persist = Some(super::RolePersist {
                 coordinating: true,
                 ticket: self.invite.ticket.clone(),
-                join_code: Some(code),
+                join_code: None,
             });
-            self.published_code = Some(published);
+            if let Some(published) = published {
+                let code = published.code().printable();
+                self.invite.code = Some(code.clone());
+                self.pending_role_persist = Some(super::RolePersist {
+                    coordinating: true,
+                    ticket: self.invite.ticket.clone(),
+                    join_code: Some(code),
+                });
+                self.published_code = Some(published);
+            } else {
+                self.invite.code = None;
+            }
             changed = true;
         }
         changed

--- a/src/tui/runtime/mod.rs
+++ b/src/tui/runtime/mod.rs
@@ -172,11 +172,10 @@ pub struct RolePersist {
     pub join_code: Option<String>,
 }
 
-/// A published short code and the ticket it resolves. They travel together so
-/// a ticket refreshed after discovery reaches the share panel atomically.
+/// A ticket refreshed after discovery and its optional short code.
 pub(in crate::tui) struct PublishedInvite {
     pub ticket: JoinTicket,
-    pub published: crate::hosted_rendezvous::PublishedCode,
+    pub published: Option<crate::hosted_rendezvous::PublishedCode>,
 }
 impl SharedLayoutRuntime {
     pub fn host(
@@ -472,7 +471,7 @@ mod tests {
         tui::{UiIntent, pane::local::SharedLocalPane},
     };
 
-    use super::SharedLayoutRuntime;
+    use super::{PublishedInvite, RolePersist, SharedLayoutRuntime};
 
     async fn loopback_transport() -> Transport {
         let endpoint = Endpoint::builder(presets::Minimal)
@@ -485,6 +484,82 @@ mod tests {
             .await
             .expect("loopback endpoint");
         Transport::from_endpoint(endpoint)
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_ticket_only_publication_refreshes_the_host_invite() {
+        let host = SharedLayoutHost::new(
+            HostSession::from_transport(loopback_transport().await).expect("host session"),
+            2,
+            8,
+        )
+        .expect("shared host");
+        let ticket = host.ticket().clone();
+        let ticket_text = ticket.to_string();
+        let pane_server = host.pane_server();
+        let host_id = host.ticket().endpoint_addr().id.as_bytes().to_vec();
+        let initial = SharedLocalPane::spawn(1, 2, 8, host_id.clone()).expect("initial pty");
+        pane_server
+            .register_local_pane(
+                PaneDescriptor {
+                    pane_id: 1,
+                    host_peer_id: host_id,
+                    grid_rows: 2,
+                    grid_cols: 8,
+                    title: None,
+                    locked: false,
+                    exited: false,
+                },
+                initial.channels(),
+            )
+            .expect("initial pane registered");
+        let state = host
+            .session_snapshot()
+            .expect("snapshot")
+            .state
+            .expect("layout state");
+        let snapshot = layout_snapshot_from_state(&state).expect("render layout");
+        let mut runtime = SharedLayoutRuntime::host(
+            host,
+            pane_server,
+            snapshot,
+            initial,
+            ticket_text.clone(),
+            Some(String::from("STALE")),
+            tokio::runtime::Handle::current(),
+        )
+        .expect("runtime");
+
+        if runtime
+            .code_tx
+            .send(PublishedInvite {
+                ticket: ticket.clone(),
+                published: None,
+            })
+            .is_err()
+        {
+            panic!("ticket-only publication queued");
+        }
+        assert!(runtime.drain_published_codes());
+
+        let crate::tui::pane::control::SharedControl::Host(host) = &runtime.control else {
+            panic!("the runtime is still hosting");
+        };
+        assert_eq!(
+            host.ticket(),
+            &ticket,
+            "the live host has the refreshed ticket"
+        );
+        assert_eq!(runtime.invite.ticket.as_deref(), Some(ticket_text.as_str()));
+        assert_eq!(runtime.invite.code, None, "a stale code is cleared");
+        assert_eq!(
+            runtime.pending_role_persist,
+            Some(RolePersist {
+                coordinating: true,
+                ticket: Some(ticket_text),
+                join_code: None,
+            })
+        );
     }
 
     /// One bot on one machine is one row, however many p2pmux that machine has

--- a/tests/node_survives_bad_clients.rs
+++ b/tests/node_survives_bad_clients.rs
@@ -170,10 +170,16 @@ fn a_detached_node_outlives_its_launcher_before_any_attachment() {
     launcher.wait().unwrap();
     let deadline = Instant::now() + RECEIVE_TIMEOUT;
     while Instant::now() < deadline {
-        assert!(fixture.running(), "the detached node stopped with its launcher");
+        assert!(
+            fixture.running(),
+            "the detached node stopped with its launcher"
+        );
         std::thread::sleep(Duration::from_millis(20));
     }
-    assert!(fixture.running(), "the detached node stopped with its launcher");
+    assert!(
+        fixture.running(),
+        "the detached node stopped with its launcher"
+    );
 }
 
 #[test]

--- a/tests/node_survives_bad_clients.rs
+++ b/tests/node_survives_bad_clients.rs
@@ -152,6 +152,31 @@ fn an_unattached_interactive_node_stops_with_its_launcher() {
 }
 
 #[test]
+fn a_detached_node_outlives_its_launcher_before_any_attachment() {
+    let mut launcher = Command::new("sleep")
+        .arg("30")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+    let supervisor = Supervisor {
+        pid: launcher.id(),
+        started_at: p2pmux::agent_detect::process_start_time(launcher.id()).unwrap(),
+    };
+    let mut fixture = Fixture::start_with("detached", Tether::Detached, Some(supervisor));
+
+    launcher.kill().unwrap();
+    launcher.wait().unwrap();
+    let deadline = Instant::now() + RECEIVE_TIMEOUT;
+    while Instant::now() < deadline {
+        assert!(fixture.running(), "the detached node stopped with its launcher");
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    assert!(fixture.running(), "the detached node stopped with its launcher");
+}
+
+#[test]
 fn a_lost_accepted_client_stops_its_node() {
     let mut fixture = Fixture::start("lost-accepted-client");
     let (stream, mut reader, _) = attach(&fixture.socket);


### PR DESCRIPTION
## Summary
- **#128:** `p2pmux pair CODE` was launching with `UntilFirstAttach` and never attaching a TUI, so the node died when the CLI exited. The host only pinned `[[machine]]` on a two-second scan, which lost the joiner. The pairing join now stays up (`Detached`, same as enrol) and is pinned at admission from the verified identity.
- **#127:** Ctrl+S before the first snapshot was discarded, so Share never opened even though the ticket already existed. Those keys are queued (cap 8) and replayed through the normal event path. A refreshed ticket also reaches the live host when rendezvous cannot publish a short code.

Fixes #127
Fixes #128

## Test plan
- [ ] `p2pmux pair CODE` on a second machine: host `p2pmux machines` lists it within a few seconds; `pairing.toml` has a `[[machine]]` row; the pairing node is still running after the CLI returns
- [ ] Fresh session with rendezvous unreachable: `p2pmux code` still says there is no short code; Ctrl+S as soon as the pane appears opens Share with the ticket
- [ ] `Ctrl+Q` then `d` still detaches; closing the window still ends an attached interactive session
- [ ] `cargo test --all-features`


Made with [Cursor](https://cursor.com)