### PR TITLE
Shorten the first-run telemetry prompt

### DIFF
--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -282,15 +282,8 @@ pub fn consent() -> Consent {
 /// by reflex, and the honest way to raise a yes rate is to make the ask small
 /// and the reason plain, not to skip it.
 pub const PROMPT: &str = "\
-p2pmux can send one anonymous line a day: a random id, the version, the OS, how
-many sessions you started, whether anybody joined one, and nothing else. No
-hostnames, no directories, no session names, nothing you typed. Terminal traffic
-never goes near it — that stays peer to peer.
-
-It is how a project with no analytics finds out whether anyone came back.
-
-  p2pmux telemetry show    print the exact line this machine would send
-  p2pmux telemetry off     stop sending it, any time
+p2pmux can send anonymous usage information to help improve the product.
+Terminal traffic is never sent, that stays peer to peer.
 
 Send it? [Y/n] ";
 
@@ -336,7 +329,7 @@ pub fn ask_once() {
         stderr,
         "{}\n",
         match answer {
-            Consent::Granted => "Thanks — one line a day. `p2pmux telemetry off` stops it.",
+            Consent::Granted => "p2pmux telemetry off stops it.",
             _ => "Nothing will be sent.",
         }
     );


### PR DESCRIPTION
## Summary
- The first-run telemetry ask is now two lines: anonymous usage to improve the product, and that terminal traffic stays peer to peer.
- After yes, it says `p2pmux telemetry off stops it.` Enter is still yes. A refusal still prints `Nothing will be sent.`

## Test plan
- [ ] Fresh config (no telemetry consent yet): run `p2pmux` and confirm the prompt is the two-line version with `Send it? [Y/n]`
- [ ] Enter / `y` prints `p2pmux telemetry off stops it.`
- [ ] `n` prints `Nothing will be sent.`
- [ ] `p2pmux telemetry show` still prints the payload; `DO_NOT_TRACK=1` still skips the ask


Made with [Cursor](https://cursor.com)