### PR TITLE
fix(tui): per-viewer crop of shared pane grids

### DIFF
--- a/src/tui/geometry.rs
+++ b/src/tui/geometry.rs
@@ -393,6 +393,42 @@ pub(in crate::tui) fn fixed_grid_viewport(inner: Rect, rows: u16, cols: u16) -> 
     let height = inner.height.min(rows);
     Rect::new(inner.x, inner.y, width, height)
 }
+/// Keeps a local view's origin within the shared fixed grid.
+pub(in crate::tui) fn clamp_grid_origin(
+    origin: ScreenCell,
+    grid: (u16, u16),
+    view: (u16, u16),
+) -> ScreenCell {
+    ScreenCell {
+        row: origin.row.min(grid.0.saturating_sub(view.0)),
+        col: origin.col.min(grid.1.saturating_sub(view.1)),
+    }
+}
+
+/// Follows the visible cursor with the smallest possible local camera move.
+pub(in crate::tui) fn nudge_grid_origin(
+    prior: ScreenCell,
+    grid: (u16, u16),
+    view: (u16, u16),
+    cursor: ScreenCell,
+    follow: bool,
+) -> ScreenCell {
+    let mut origin = clamp_grid_origin(prior, grid, view);
+    if !follow || view.0 == 0 || view.1 == 0 {
+        return origin;
+    }
+    if cursor.row < origin.row {
+        origin.row = cursor.row;
+    } else if cursor.row >= origin.row.saturating_add(view.0) {
+        origin.row = cursor.row.saturating_add(1).saturating_sub(view.0);
+    }
+    if cursor.col < origin.col {
+        origin.col = cursor.col;
+    } else if cursor.col >= origin.col.saturating_add(view.1) {
+        origin.col = cursor.col.saturating_add(1).saturating_sub(view.1);
+    }
+    clamp_grid_origin(origin, grid, view)
+}
 pub(in crate::tui) fn pane_content_rect(pane_rect: Rect) -> Rect {
     Block::bordered().inner(pane_rect)
 }
@@ -512,8 +548,9 @@ mod tests {
 
     use super::{
         RESIZE_RECHECK_INTERVAL, allocate_node_with_preview, area_from_terminal_size,
-        grid_for_pane, initial_root_pane_grid, missed_resize, mouse_to_screen_cell,
-        nearest_in_direction, resize_recheck_due, stale_node_size,
+        clamp_grid_origin, grid_for_pane, initial_root_pane_grid, missed_resize,
+        mouse_to_screen_cell, nearest_in_direction, nudge_grid_origin, resize_recheck_due,
+        stale_node_size,
     };
     use crate::layout::PaneId;
     use crossterm::event::KeyCode;
@@ -523,6 +560,67 @@ mod tests {
         assert_eq!(
             area_from_terminal_size(Err(io::Error::from(io::ErrorKind::WouldBlock))),
             None
+        );
+    }
+
+    #[test]
+    fn grid_origin_follows_only_far_enough_to_reveal_the_cursor() {
+        assert_eq!(
+            nudge_grid_origin(
+                ScreenCell::default(),
+                (40, 120),
+                (10, 30),
+                ScreenCell { row: 39, col: 119 },
+                true,
+            ),
+            ScreenCell { row: 30, col: 90 },
+        );
+        assert_eq!(
+            nudge_grid_origin(
+                ScreenCell { row: 30, col: 90 },
+                (40, 120),
+                (10, 30),
+                ScreenCell::default(),
+                true,
+            ),
+            ScreenCell::default(),
+        );
+    }
+
+    #[test]
+    fn grid_origin_clamps_at_the_grid_edges() {
+        assert_eq!(
+            clamp_grid_origin(ScreenCell { row: 99, col: 99 }, (40, 120), (10, 30)),
+            ScreenCell { row: 30, col: 90 },
+        );
+        assert_eq!(
+            clamp_grid_origin(ScreenCell { row: 7, col: 8 }, (4, 5), (10, 30)),
+            ScreenCell::default(),
+        );
+    }
+
+    #[test]
+    fn grid_origin_stays_put_when_following_is_unneeded_or_disabled() {
+        let prior = ScreenCell { row: 5, col: 7 };
+        assert_eq!(
+            nudge_grid_origin(
+                prior,
+                (40, 120),
+                (10, 30),
+                ScreenCell { row: 8, col: 9 },
+                true
+            ),
+            prior,
+        );
+        assert_eq!(
+            nudge_grid_origin(
+                prior,
+                (40, 120),
+                (10, 30),
+                ScreenCell { row: 39, col: 119 },
+                false,
+            ),
+            prior,
         );
     }
 

--- a/src/tui/multi_pane/mod.rs
+++ b/src/tui/multi_pane/mod.rs
@@ -23,11 +23,12 @@ use crate::{
     protocol::AgentRosterState,
     tui::{
         AgentOverlayRow, ChordMode, ModalState, PairedMachine, PaneGeometry, PaneTextSelection,
-        PaneViewState, ShareCopy,
+        PaneViewState, ScreenCell, ShareCopy,
         debug_log::ui_debug_log,
         geometry::{
-            ResizeDrag, ResizePreview, allocate_node_with_preview, contains_leaf, first_leaf,
-            fixed_grid_viewport, pane_content_rect, visible_leaf_panes,
+            ResizeDrag, ResizePreview, allocate_node_with_preview, clamp_grid_origin,
+            contains_leaf, first_leaf, fixed_grid_viewport, nudge_grid_origin, pane_content_rect,
+            visible_leaf_panes,
         },
         render::panes::{
             TAB_BAR_SEPARATOR, TOP_BAR_BRAND, TOP_BAR_BRAND_SEPARATOR, TOP_BAR_TITLE_MAX_WIDTH,
@@ -372,13 +373,63 @@ impl MultiPaneTui {
         self.pane_views.get(&pane_id)
     }
 
+    /// The physical rectangle and local camera for one fixed shared grid.
+    pub(in crate::tui) fn pane_grid_viewport(
+        &self,
+        pane_id: PaneId,
+        inner: Rect,
+        grid: (u16, u16),
+    ) -> Option<Rect> {
+        let viewport = fixed_grid_viewport(inner, grid.0, grid.1);
+        let view = self.pane_views.get(&pane_id)?;
+        view.origin.set(clamp_grid_origin(
+            view.origin.get(),
+            grid,
+            (viewport.height, viewport.width),
+        ));
+        Some(viewport)
+    }
+
+    /// Moves a pane's local camera just enough to retain its visible cursor.
+    pub(in crate::tui) fn nudge_pane_origin(
+        &self,
+        pane_id: PaneId,
+        grid: (u16, u16),
+        viewport: Rect,
+        cursor: ScreenCell,
+        follow: bool,
+    ) -> Option<ScreenCell> {
+        let view = self.pane_views.get(&pane_id)?;
+        let origin = nudge_grid_origin(
+            view.origin.get(),
+            grid,
+            (viewport.height, viewport.width),
+            cursor,
+            follow,
+        );
+        view.origin.set(origin);
+        Some(origin)
+    }
+
+    pub(in crate::tui) fn source_cell(&self, pane_id: PaneId, cell: ScreenCell) -> ScreenCell {
+        let origin = self
+            .pane_views
+            .get(&pane_id)
+            .map_or(ScreenCell::default(), |view| view.origin.get());
+        ScreenCell {
+            row: origin.row.saturating_add(cell.row),
+            col: origin.col.saturating_add(cell.col),
+        }
+    }
+
     pub fn set_pane_view(&mut self, pane_id: PaneId, mut state: PaneViewState) -> bool {
         if self.snapshot.panes.contains_key(&pane_id) {
             state.scrollback = self.scrollback_offset(pane_id);
-            state.origin = self
-                .pane_views
-                .get(&pane_id)
-                .map_or_default(|view| view.origin);
+            state.origin.set(
+                self.pane_views
+                    .get(&pane_id)
+                    .map_or(ScreenCell::default(), |view| view.origin.get()),
+            );
             if self.pane_views.get(&pane_id) == Some(&state) {
                 return false;
             }
@@ -625,11 +676,11 @@ impl MultiPaneTui {
         let geometry = self.geometry(area);
         let pane_rect = geometry.panes.get(&self.focused_pane)?;
         let pane = self.snapshot.panes.get(&self.focused_pane)?;
-        Some(fixed_grid_viewport(
+        self.pane_grid_viewport(
+            self.focused_pane,
             pane_content_rect(*pane_rect),
-            pane.grid_rows,
-            pane.grid_cols,
-        ))
+            (pane.grid_rows, pane.grid_cols),
+        )
     }
 
     /// Aligns a reattached client's local selection with the node-owned focus.
@@ -757,7 +808,7 @@ mod tests {
     use crate::{
         layout::{LayoutError, Node, Tab},
         tui::{
-            MultiPaneTui, PaneViewState,
+            MultiPaneTui, PaneViewState, ScreenCell,
             test_support::{layout, split_layout},
         },
     };
@@ -820,7 +871,7 @@ mod tests {
             controller_peer_id: Some(b"controller".to_vec()),
             controller_active: true,
             scrollback: 0,
-            origin: ScreenCell::default(),
+            origin: Default::default(),
         };
         assert!(tui.set_pane_view(1, active.clone()));
         assert!(!tui.set_pane_view(1, active));
@@ -844,12 +895,16 @@ mod tests {
             &[(1, 1, 1)],
         ))
         .expect("layout");
-        tui.pane_views.get_mut(&1).expect("pane view").origin = ScreenCell { row: 4, col: 9 };
+        tui.pane_views
+            .get(&1)
+            .expect("pane view")
+            .origin
+            .set(ScreenCell { row: 4, col: 9 });
 
         tui.set_pane_view(1, PaneViewState::from_chrome(true, None, false));
 
         assert_eq!(
-            tui.pane_view(1).expect("pane view").origin,
+            tui.pane_view(1).expect("pane view").origin.get(),
             ScreenCell { row: 4, col: 9 },
         );
     }

--- a/src/tui/multi_pane/mod.rs
+++ b/src/tui/multi_pane/mod.rs
@@ -375,6 +375,10 @@ impl MultiPaneTui {
     pub fn set_pane_view(&mut self, pane_id: PaneId, mut state: PaneViewState) -> bool {
         if self.snapshot.panes.contains_key(&pane_id) {
             state.scrollback = self.scrollback_offset(pane_id);
+            state.origin = self
+                .pane_views
+                .get(&pane_id)
+                .map_or_default(|view| view.origin);
             if self.pane_views.get(&pane_id) == Some(&state) {
                 return false;
             }
@@ -816,6 +820,7 @@ mod tests {
             controller_peer_id: Some(b"controller".to_vec()),
             controller_active: true,
             scrollback: 0,
+            origin: ScreenCell::default(),
         };
         assert!(tui.set_pane_view(1, active.clone()));
         assert!(!tui.set_pane_view(1, active));
@@ -826,6 +831,27 @@ mod tests {
                 ..tui.pane_view(1).expect("pane view").clone()
             },
         ));
+    }
+
+    #[test]
+    fn pane_view_refresh_preserves_the_local_viewport_origin() {
+        let mut tui = MultiPaneTui::new(layout(
+            vec![Tab {
+                tab_id: 1,
+                root: Node::Leaf { pane_id: 1 },
+                title: None,
+            }],
+            &[(1, 1, 1)],
+        ))
+        .expect("layout");
+        tui.pane_views.get_mut(&1).expect("pane view").origin = ScreenCell { row: 4, col: 9 };
+
+        tui.set_pane_view(1, PaneViewState::from_chrome(true, None, false));
+
+        assert_eq!(
+            tui.pane_view(1).expect("pane view").origin,
+            ScreenCell { row: 4, col: 9 },
+        );
     }
 
     #[test]

--- a/src/tui/multi_pane/mouse.rs
+++ b/src/tui/multi_pane/mouse.rs
@@ -1203,7 +1203,7 @@ mod tests {
 
                 title: None,
             }],
-            &[(1, 19, 78)],
+            &[(1, 30, 100)],
         ))
         .expect("valid layout");
         let area = Rect::new(0, 0, 80, 24);
@@ -1223,7 +1223,7 @@ mod tests {
                 root: Node::Leaf { pane_id: 1 },
                 title: None,
             }],
-            &[(1, 19, 78)],
+            &[(1, 30, 100)],
         ))
         .expect("valid layout");
         let area = Rect::new(0, 0, 80, 24);
@@ -1237,6 +1237,7 @@ mod tests {
             Some((1, ScreenCell { row: 9, col: 10 }))
         );
         assert!(tui.begin_selection_at(4, 6, area));
+        assert!(tui.extend_selection_at(5, 6, area));
         assert_eq!(
             tui.selection().expect("selection").anchor.cell,
             ScreenCell { row: 9, col: 10 },

--- a/src/tui/multi_pane/mouse.rs
+++ b/src/tui/multi_pane/mouse.rs
@@ -13,9 +13,8 @@ use crate::{
         MouseHandling, MultiPaneTui, PaneMouseProtocol, PaneTextSelection, ScreenCell,
         SelectionPoint, UiIntent,
         geometry::{
-            ResizeDrag, clamp_to_viewport, fixed_grid_viewport, mouse_to_screen_cell,
-            nearest_split_for_pane, pane_at, pane_content_rect, rect_contains, resize_border_hit,
-            resize_proposed_share,
+            ResizeDrag, clamp_to_viewport, mouse_to_screen_cell, nearest_split_for_pane, pane_at,
+            pane_content_rect, rect_contains, resize_border_hit, resize_proposed_share,
         },
         input::mouse::encode_mouse,
         selection::selection_text,
@@ -182,14 +181,17 @@ impl MultiPaneTui {
         let scrollback = self.scrollback_offset(aim.pane_id);
         let point = SelectionPoint {
             scrollback,
-            cell: ScreenCell {
-                row: if aim.up {
-                    0
-                } else {
-                    viewport.height.saturating_sub(1)
+            cell: self.source_cell(
+                aim.pane_id,
+                ScreenCell {
+                    row: if aim.up {
+                        0
+                    } else {
+                        viewport.height.saturating_sub(1)
+                    },
+                    col: aim.column,
                 },
-                col: aim.column,
-            },
+            ),
         };
         let Some(selection) = self.selection.as_mut() else {
             return false;
@@ -205,11 +207,11 @@ impl MultiPaneTui {
     fn pane_screen_viewport(&self, pane_id: PaneId, area: Rect) -> Option<Rect> {
         let rect = *self.geometry(area).panes.get(&pane_id)?;
         let pane = self.snapshot.panes.get(&pane_id)?;
-        Some(fixed_grid_viewport(
+        self.pane_grid_viewport(
+            pane_id,
             pane_content_rect(rect),
-            pane.grid_rows,
-            pane.grid_cols,
-        ))
+            (pane.grid_rows, pane.grid_cols),
+        )
     }
 
     pub(in crate::tui) fn end_selection_drag(&mut self) -> bool {
@@ -362,9 +364,13 @@ impl MultiPaneTui {
             rect_contains(*rect, column, row).then_some((*pane_id, *rect))
         })?;
         let pane = self.snapshot.panes.get(&pane_id)?;
-        let viewport =
-            fixed_grid_viewport(pane_content_rect(pane_rect), pane.grid_rows, pane.grid_cols);
-        mouse_to_screen_cell(viewport, column, row).map(|cell| (pane_id, cell))
+        let viewport = self.pane_grid_viewport(
+            pane_id,
+            pane_content_rect(pane_rect),
+            (pane.grid_rows, pane.grid_cols),
+        )?;
+        mouse_to_screen_cell(viewport, column, row)
+            .map(|cell| (pane_id, self.source_cell(pane_id, cell)))
     }
 
     pub(in crate::tui) fn pane_at_or_focused(&self, column: u16, row: u16, area: Rect) -> PaneId {
@@ -537,7 +543,12 @@ impl MultiPaneTui {
         }
         let viewport = self.pane_screen_viewport(pane_id, area)?;
         let cell = mouse_to_screen_cell(viewport, mouse.column, mouse.row)?;
-        encode_mouse(mouse.kind, mouse.modifiers, cell, protocol)
+        encode_mouse(
+            mouse.kind,
+            mouse.modifiers,
+            self.source_cell(pane_id, cell),
+            protocol,
+        )
     }
 
     /// Hands a mouse event to the focused pane's child when that child asked for
@@ -592,7 +603,12 @@ impl MultiPaneTui {
             _ => mouse_to_screen_cell(viewport, mouse.column, mouse.row)?,
         };
         Some(MouseHandling {
-            forward_bytes: encode_mouse(mouse.kind, mouse.modifiers, cell, protocol),
+            forward_bytes: encode_mouse(
+                mouse.kind,
+                mouse.modifiers,
+                self.source_cell(self.focused_pane, cell),
+                protocol,
+            ),
             ..MouseHandling::default()
         })
     }
@@ -1196,6 +1212,34 @@ mod tests {
         assert_eq!(
             tui.screen_cell_at(1, 2, area),
             Some((1, ScreenCell { row: 0, col: 0 }))
+        );
+    }
+
+    #[test]
+    fn selection_hit_testing_translates_the_local_viewport_origin() {
+        let mut tui = MultiPaneTui::new(layout(
+            vec![Tab {
+                tab_id: 1,
+                root: Node::Leaf { pane_id: 1 },
+                title: None,
+            }],
+            &[(1, 19, 78)],
+        ))
+        .expect("valid layout");
+        let area = Rect::new(0, 0, 80, 24);
+        tui.pane_view(1)
+            .expect("pane view")
+            .origin
+            .set(ScreenCell { row: 5, col: 7 });
+
+        assert_eq!(
+            tui.screen_cell_at(4, 6, area),
+            Some((1, ScreenCell { row: 9, col: 10 }))
+        );
+        assert!(tui.begin_selection_at(4, 6, area));
+        assert_eq!(
+            tui.selection().expect("selection").anchor.cell,
+            ScreenCell { row: 9, col: 10 },
         );
     }
 

--- a/src/tui/pane/local.rs
+++ b/src/tui/pane/local.rs
@@ -156,6 +156,7 @@ impl SharedLocalPane {
             controller_peer_id: Some(self.lease.state().controller_peer_id.clone()),
             controller_active: !self.lease.state().is_idle_at(Instant::now()),
             scrollback: 0,
+            origin: Default::default(),
         }
     }
 

--- a/src/tui/pane/remote.rs
+++ b/src/tui/pane/remote.rs
@@ -118,6 +118,7 @@ impl SharedRemotePane {
                 .as_ref()
                 .is_some_and(|lease| !lease.is_idle_at(Instant::now())),
             scrollback: 0,
+            origin: Default::default(),
         }
     }
 

--- a/src/tui/render/modals.rs
+++ b/src/tui/render/modals.rs
@@ -560,6 +560,7 @@ mod tests {
                 controller_peer_id: None,
                 controller_active: false,
                 scrollback: 0,
+                origin: Default::default(),
             },
         );
         tui.modal = modal;

--- a/src/tui/render/panes.rs
+++ b/src/tui/render/panes.rs
@@ -1287,6 +1287,7 @@ mod tests {
                 controller_peer_id: Some(b"peer".to_vec()),
                 controller_active: true,
                 scrollback: 0,
+                origin: Default::default(),
             },
         );
         let mut terminal = Terminal::new(TestBackend::new(36, 6)).expect("test terminal");
@@ -1324,6 +1325,7 @@ mod tests {
                 controller_peer_id: None,
                 controller_active: false,
                 scrollback: 0,
+                origin: Default::default(),
             },
         );
         let mut terminal = Terminal::new(TestBackend::new(40, 6)).expect("test terminal");
@@ -1372,6 +1374,7 @@ mod tests {
                     controller_peer_id: None,
                     controller_active: false,
                     scrollback: 0,
+                    origin: Default::default(),
                 },
             );
         }
@@ -1459,6 +1462,7 @@ mod tests {
                     controller_peer_id: Some(Vec::new()),
                     controller_active: false,
                     scrollback: 0,
+                    origin: Default::default(),
                 },
             );
         }
@@ -1501,6 +1505,7 @@ mod tests {
                 controller_peer_id: Some(b"peer".to_vec()),
                 controller_active: true,
                 scrollback: 0,
+                origin: Default::default(),
             },
         );
         assert!(
@@ -1521,6 +1526,7 @@ mod tests {
                 controller_peer_id: Some(Vec::new()),
                 controller_active: false,
                 scrollback: 0,
+                origin: Default::default(),
             },
         );
         assert!(right_is_dim(&tui), "and it goes back once they let go");
@@ -1577,6 +1583,7 @@ mod tests {
                 controller_peer_id: None,
                 controller_active: false,
                 scrollback: 0,
+                origin: Default::default(),
             },
         );
         let screens = BTreeMap::from([(1, parser.screen())]);
@@ -1615,6 +1622,7 @@ mod tests {
                     controller_peer_id: None,
                     controller_active: false,
                     scrollback: 0,
+                    origin: Default::default(),
                 },
             );
             let screens = BTreeMap::from([(1, parser.screen())]);
@@ -1664,6 +1672,7 @@ mod tests {
                     controller_peer_id: None,
                     controller_active: false,
                     scrollback: 0,
+                    origin: Default::default(),
                 },
             );
             assert!(tui.set_pane_scrollback_offset(1, 2));
@@ -1700,6 +1709,7 @@ mod tests {
                 controller_peer_id: None,
                 controller_active: false,
                 scrollback: 0,
+                origin: Default::default(),
             },
         );
         assert!(tui.set_pane_scrollback_offset(1, 2));

--- a/src/tui/render/panes.rs
+++ b/src/tui/render/panes.rs
@@ -98,6 +98,47 @@ pub(in crate::tui) fn tab_presence_width(watchers: usize) -> u16 {
 
 pub(in crate::tui) const PRESENCE_WATCHING: &str = "●";
 
+fn render_clip_indicators(
+    frame: &mut Frame<'_>,
+    rect: ratatui::layout::Rect,
+    viewport: ratatui::layout::Rect,
+    grid: (u16, u16),
+    origin: ScreenCell,
+    style: Style,
+    bottom_chrome: bool,
+) {
+    if bottom_chrome
+        || rect.width < 8
+        || rect.height < 3
+        || viewport.width == 0
+        || viewport.height == 0
+    {
+        return;
+    }
+    let mut left = String::new();
+    if origin.col > 0 {
+        left.push('<');
+    }
+    if origin.row > 0 {
+        left.push('^');
+    }
+    let mut right = String::new();
+    if origin.row.saturating_add(viewport.height) < grid.0 {
+        right.push('v');
+    }
+    if origin.col.saturating_add(viewport.width) < grid.1 {
+        right.push('>');
+    }
+    let buffer = frame.buffer_mut();
+    let bottom = rect.bottom().saturating_sub(1);
+    if !left.is_empty() {
+        buffer.set_string(rect.x.saturating_add(1), bottom, left, style);
+    }
+    if !right.is_empty() {
+        buffer.set_string(rect.right().saturating_sub(3), bottom, right, style);
+    }
+}
+
 /// Right-aligned chips for the members watching a pane, one initial each.
 ///
 /// This lives on the bottom border because the top one is already carrying
@@ -631,19 +672,22 @@ pub(in crate::tui) fn render_shared_multi_pane(
         // hidden or were never there. Bottom-left, because the top border is
         // already carrying the metadata and a right-aligned lock badge, and a
         // pane can be locked and zoomed at once.
-        if tui.zoomed_pane() == Some(pane_id) {
+        let zoomed = tui.zoomed_pane() == Some(pane_id);
+        if zoomed {
             block = block.title_bottom(
                 Line::styled(" zoom ", Style::default().fg(theme.footer_accent))
                     .alignment(Alignment::Left),
             );
         }
-        if let Some(chips) = pane_presence_chips(
+        let chips = pane_presence_chips(
             &tui.pane_watchers(pane_id),
             view.controller_peer_id.as_deref(),
             &tui.snapshot.members,
             theme,
             title_width,
-        ) {
+        );
+        let bottom_chrome = zoomed || chips.is_some();
+        if let Some(chips) = chips {
             block = block.title_bottom(chips);
         }
         let content = pane_content_rect(rect);
@@ -683,6 +727,15 @@ pub(in crate::tui) fn render_shared_multi_pane(
                     .at_scrollback(scrollback)
                     .dimmed(pane_recedes(tui, pane_id, &view, focused, scrollback)),
                 viewport,
+            );
+            render_clip_indicators(
+                frame,
+                rect,
+                viewport,
+                (grid_rows, grid_cols),
+                origin,
+                Style::default().fg(border_color),
+                bottom_chrome,
             );
             // `scrollback`, not the screen's own offset: a client keeps no
             // scrollback of its own and renders history by swapping in a
@@ -1614,7 +1667,7 @@ mod tests {
     fn focused_pane_crops_to_the_cursor_and_places_its_cursor_locally() {
         let mut parser = vt100::Parser::new(3, 5, 0);
         parser.process(b"abcde\r\nfghij\r\nklmno\x1b[3;5H");
-        let tui = MultiPaneTui::new(layout(
+        let mut tui = MultiPaneTui::new(layout(
             vec![Tab {
                 tab_id: 1,
                 root: Node::Leaf { pane_id: 1 },
@@ -1623,6 +1676,7 @@ mod tests {
             &[(1, 3, 5)],
         ))
         .expect("valid layout");
+        tui.set_pane_view(1, PaneViewState::from_chrome(true, None, false));
         let screens = BTreeMap::from([(1, parser.screen())]);
         let mut terminal = Terminal::new(TestBackend::new(5, 5)).expect("test terminal");
 
@@ -1638,12 +1692,43 @@ mod tests {
         terminal.backend_mut().assert_cursor_position((3, 2));
     }
 
+    #[test]
+    fn cropped_pane_marks_each_hidden_grid_edge() {
+        let mut parser = vt100::Parser::new(3, 10, 0);
+        parser.process(b"\x1b[?25l");
+        let tui = MultiPaneTui::new(layout(
+            vec![Tab {
+                tab_id: 1,
+                root: Node::Leaf { pane_id: 1 },
+                title: None,
+            }],
+            &[(1, 3, 10)],
+        ))
+        .expect("valid layout");
+        tui.pane_view(1)
+            .expect("pane view")
+            .origin
+            .set(ScreenCell { row: 1, col: 1 });
+        let screens = BTreeMap::from([(1, parser.screen())]);
+        let mut terminal = Terminal::new(TestBackend::new(10, 5)).expect("test terminal");
+
+        terminal
+            .draw(|frame| render_multi_pane(frame, &tui, &screens))
+            .expect("render");
+
+        let buffer = terminal.backend().buffer();
+        assert_eq!(buffer[(1, 3)].symbol(), "<");
+        assert_eq!(buffer[(2, 3)].symbol(), "^");
+        assert_eq!(buffer[(7, 3)].symbol(), "v");
+        assert_eq!(buffer[(8, 3)].symbol(), ">");
+    }
+
     /// Clipped means "outside the pane it is drawn in", not "outside the grid
     /// the layout last recorded" — the screen's own size is what the viewport
     /// follows, so a descriptor lagging behind a reflow no longer hides a cursor
     /// that is plainly on screen. A cursor past the pane's own border still is.
     #[test]
-    fn focused_pane_never_draws_a_hidden_or_clipped_vt_cursor() {
+    fn focused_pane_hides_a_hidden_cursor_and_follows_a_visible_one() {
         for sequence in [b"\x1b[?25l".as_slice(), b"abcdefgh".as_slice()] {
             let mut parser = vt100::Parser::new(1, 9, 0);
             parser.process(sequence);
@@ -1674,7 +1759,12 @@ mod tests {
                 .draw(|frame| render_multi_pane(frame, &tui, &screens))
                 .expect("render");
 
-            assert!(!terminal.backend().cursor_visible());
+            if parser.screen().hide_cursor() {
+                assert!(!terminal.backend().cursor_visible());
+            } else {
+                assert!(terminal.backend().cursor_visible());
+                assert_eq!(tui.pane_view(1).expect("pane view").origin.get().col, 2,);
+            }
         }
     }
 

--- a/src/tui/render/panes.rs
+++ b/src/tui/render/panes.rs
@@ -17,9 +17,9 @@ use crate::{
     config::UiTheme,
     layout::PaneId,
     tui::{
-        ChordMode, ModalState, MultiPaneTui, PaneViewState, ShareView,
+        ChordMode, ModalState, MultiPaneTui, PaneViewState, ScreenCell, ShareView,
         app::{member_color, member_initial},
-        geometry::{fixed_grid_viewport, pane_content_rect, visible_leaf_panes},
+        geometry::{pane_content_rect, visible_leaf_panes},
         member_label,
         render::{
             footer::render_contextual_footer,
@@ -658,11 +658,24 @@ pub(in crate::tui) fn render_shared_multi_pane(
             // the descriptor letterboxes a pane that has already grown -- which is
             // most visible on a zoom, where the pane doubles in size in one frame.
             let (grid_rows, grid_cols) = screen.size();
-            let viewport = fixed_grid_viewport(content, grid_rows, grid_cols);
             let scrollback = tui.scrollback_offset(pane_id);
             let screen = viewed_screen(screen, scrollback);
+            let viewport = tui
+                .pane_grid_viewport(pane_id, content, (grid_rows, grid_cols))
+                .expect("visible pane has a local view");
+            let (row, col) = screen.cursor_position();
+            let origin = tui
+                .nudge_pane_origin(
+                    pane_id,
+                    (grid_rows, grid_cols),
+                    viewport,
+                    ScreenCell { row, col },
+                    scrollback == 0 && !screen.hide_cursor(),
+                )
+                .expect("visible pane has a local view");
             frame.render_widget(
                 VtScreen::new(screen.as_ref())
+                    .at_origin(origin)
                     .with_selection(
                         tui.selection()
                             .filter(|selection| selection.pane_id == pane_id),
@@ -671,7 +684,6 @@ pub(in crate::tui) fn render_shared_multi_pane(
                     .dimmed(pane_recedes(tui, pane_id, &view, focused, scrollback)),
                 viewport,
             );
-            let (row, col) = screen.cursor_position();
             // `scrollback`, not the screen's own offset: a client keeps no
             // scrollback of its own and renders history by swapping in a
             // viewport the node built, whose retained-row count -- and so whose
@@ -688,12 +700,14 @@ pub(in crate::tui) fn render_shared_multi_pane(
                 && scrollback == 0
                 && !screen.hide_cursor()
                 && !pane.exited
-                && row < viewport.height
-                && col < viewport.width
+                && row >= origin.row
+                && col >= origin.col
+                && row.saturating_sub(origin.row) < viewport.height
+                && col.saturating_sub(origin.col) < viewport.width
             {
                 frame.set_cursor_position((
-                    viewport.x.saturating_add(col),
-                    viewport.y.saturating_add(row),
+                    viewport.x.saturating_add(col.saturating_sub(origin.col)),
+                    viewport.y.saturating_add(row.saturating_sub(origin.row)),
                 ));
             }
         } else if !view.ready {
@@ -732,7 +746,7 @@ mod tests {
         config::UiTheme,
         layout::{Axis, Node, Tab},
         tui::{
-            ChordMode, MultiPaneTui, PaneViewState, ShareView,
+            ChordMode, MultiPaneTui, PaneViewState, ScreenCell, ShareView,
             geometry::visible_leaf_panes,
             test_support::{
                 home_tui, layout, named_members, split_layout, two_tab_presence_tui, watcher,
@@ -1593,6 +1607,34 @@ mod tests {
             .draw(|frame| render_multi_pane(frame, &tui, &screens))
             .expect("render");
 
+        terminal.backend_mut().assert_cursor_position((3, 2));
+    }
+
+    #[test]
+    fn focused_pane_crops_to_the_cursor_and_places_its_cursor_locally() {
+        let mut parser = vt100::Parser::new(3, 5, 0);
+        parser.process(b"abcde\r\nfghij\r\nklmno\x1b[3;5H");
+        let tui = MultiPaneTui::new(layout(
+            vec![Tab {
+                tab_id: 1,
+                root: Node::Leaf { pane_id: 1 },
+                title: None,
+            }],
+            &[(1, 3, 5)],
+        ))
+        .expect("valid layout");
+        let screens = BTreeMap::from([(1, parser.screen())]);
+        let mut terminal = Terminal::new(TestBackend::new(5, 5)).expect("test terminal");
+
+        terminal
+            .draw(|frame| render_multi_pane(frame, &tui, &screens))
+            .expect("render");
+
+        assert_eq!(
+            tui.pane_view(1).expect("pane view").origin.get(),
+            ScreenCell { row: 2, col: 2 },
+        );
+        assert_eq!(terminal.backend().buffer()[(1, 2)].symbol(), "m");
         terminal.backend_mut().assert_cursor_position((3, 2));
     }
 

--- a/src/tui/render/vt.rs
+++ b/src/tui/render/vt.rs
@@ -26,6 +26,7 @@ pub(in crate::tui) struct VtScreen<'a> {
     scrollback: usize,
     /// Whether this pane is one the user is not typing into.
     dimmed: bool,
+    origin: ScreenCell,
 }
 impl<'a> VtScreen<'a> {
     pub(in crate::tui) fn new(screen: &'a vt100::Screen) -> Self {
@@ -34,6 +35,7 @@ impl<'a> VtScreen<'a> {
             selection: None,
             scrollback: 0,
             dimmed: false,
+            origin: ScreenCell::default(),
         }
     }
 
@@ -63,6 +65,11 @@ impl<'a> VtScreen<'a> {
         self.scrollback = scrollback;
         self
     }
+
+    pub(in crate::tui) fn at_origin(mut self, origin: ScreenCell) -> Self {
+        self.origin = origin;
+        self
+    }
 }
 /// The screen as seen from `scrollback` rows back, copying only when it has to.
 ///
@@ -90,12 +97,21 @@ pub(in crate::tui) fn available_scrollback(screen: &vt100::Screen) -> usize {
 impl Widget for VtScreen<'_> {
     fn render(self, area: Rect, buf: &mut Buffer) {
         let (rows, cols) = self.screen.size();
-        for row in 0..rows.min(area.height) {
-            for col in 0..cols.min(area.width) {
-                let Some(source) = self.screen.cell(row, col) else {
+        for row in 0..area.height.min(rows.saturating_sub(self.origin.row)) {
+            for col in 0..area.width.min(cols.saturating_sub(self.origin.col)) {
+                let source_row = self.origin.row.saturating_add(row);
+                let source_col = self.origin.col.saturating_add(col);
+                let Some(source) = self.screen.cell(source_row, source_col) else {
                     continue;
                 };
                 if source.is_wide_continuation() {
+                    if col == 0 {
+                        buf[(area.x + col, area.y + row)].reset();
+                    }
+                    continue;
+                }
+                if source.is_wide() && col.saturating_add(1) >= area.width {
+                    buf[(area.x + col, area.y + row)].reset();
                     continue;
                 }
                 let target = &mut buf[(area.x + col, area.y + row)];
@@ -114,7 +130,13 @@ impl Widget for VtScreen<'_> {
                     NonZeroU16::new(reserved).expect("1 and 2 are both nonzero"),
                 ));
                 let style = if self.selection.is_some_and(|selection| {
-                    selection.contains(ScreenCell { row, col }, self.scrollback)
+                    selection.contains(
+                        ScreenCell {
+                            row: source_row,
+                            col: source_col,
+                        },
+                        self.scrollback,
+                    )
                 }) {
                     // Never dimmed. A selection is something the user made a
                     // moment ago and is about to copy, and it can perfectly
@@ -391,6 +413,41 @@ mod tests {
     }
 
     #[test]
+    fn renderer_crops_selection_in_source_coordinates() {
+        let mut parser = vt100::Parser::new(3, 4, 0);
+        parser.process(b"abcd\r\nefgh\r\nijkl");
+        let selection = PaneTextSelection {
+            pane_id: 1,
+            anchor: SelectionPoint {
+                scrollback: 0,
+                cell: ScreenCell { row: 1, col: 2 },
+            },
+            cursor: SelectionPoint {
+                scrollback: 0,
+                cell: ScreenCell { row: 1, col: 3 },
+            },
+        };
+        let mut terminal = Terminal::new(TestBackend::new(2, 2)).expect("test terminal");
+
+        terminal
+            .draw(|frame| {
+                frame.render_widget(
+                    VtScreen::new(parser.screen())
+                        .at_origin(ScreenCell { row: 1, col: 1 })
+                        .with_selection(Some(selection)),
+                    frame.area(),
+                )
+            })
+            .expect("render");
+
+        let buffer = terminal.backend().buffer();
+        assert_eq!(buffer[(0, 0)].symbol(), "f");
+        assert_eq!(buffer[(1, 0)].symbol(), "g");
+        assert_eq!(buffer[(1, 0)].bg, Color::DarkGray);
+        assert_eq!(buffer[(0, 1)].symbol(), "j");
+    }
+
+    #[test]
     fn renderer_keeps_the_parser_grid_fixed() {
         let mut parser = vt100::Parser::new(2, 3, 0);
         parser.process(b"abc\r\ndef");
@@ -498,6 +555,28 @@ mod tests {
         let buffer = terminal.backend().buffer();
         assert_eq!(buffer[(0, 0)].symbol(), "\u{4f60}");
         assert_eq!(buffer[(2, 0)].symbol(), "\u{597d}");
+    }
+
+    #[test]
+    fn renderer_blanks_wide_glyphs_cut_by_a_viewport_edge() {
+        let mut parser = vt100::Parser::new(1, 3, 0);
+        parser.process("你a".as_bytes());
+        let mut terminal = Terminal::new(TestBackend::new(1, 1)).expect("test terminal");
+
+        terminal
+            .draw(|frame| frame.render_widget(VtScreen::new(parser.screen()), frame.area()))
+            .expect("render");
+        assert_eq!(terminal.backend().buffer()[(0, 0)].symbol(), " ");
+
+        terminal
+            .draw(|frame| {
+                frame.render_widget(
+                    VtScreen::new(parser.screen()).at_origin(ScreenCell { row: 0, col: 1 }),
+                    frame.area(),
+                )
+            })
+            .expect("render");
+        assert_eq!(terminal.backend().buffer()[(0, 0)].symbol(), " ");
     }
 
     /// A row of what an agent pane actually prints, with the four ways a cluster

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -1,7 +1,7 @@
 //! The value types the multi-pane UI keeps: chord and modal state, per-pane
 //! view state, the intents a keystroke turns into, and text selection.
 
-use std::collections::BTreeMap;
+use std::{cell::Cell, collections::BTreeMap};
 
 use ratatui::layout::Rect;
 use serde::{Deserialize, Serialize};
@@ -27,7 +27,7 @@ pub struct PaneViewState {
     pub controller_active: bool,
     pub(in crate::tui) scrollback: usize,
     /// The top-left cell of this terminal's local view into the shared grid.
-    pub(in crate::tui) origin: ScreenCell,
+    pub(in crate::tui) origin: Cell<ScreenCell>,
 }
 impl PaneViewState {
     pub fn from_chrome(
@@ -40,7 +40,7 @@ impl PaneViewState {
             controller_peer_id,
             controller_active,
             scrollback: 0,
-            origin: ScreenCell::default(),
+            origin: Cell::new(ScreenCell::default()),
         }
     }
 }

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -26,6 +26,8 @@ pub struct PaneViewState {
     pub controller_peer_id: Option<Vec<u8>>,
     pub controller_active: bool,
     pub(in crate::tui) scrollback: usize,
+    /// The top-left cell of this terminal's local view into the shared grid.
+    pub(in crate::tui) origin: ScreenCell,
 }
 impl PaneViewState {
     pub fn from_chrome(
@@ -38,6 +40,7 @@ impl PaneViewState {
             controller_peer_id,
             controller_active,
             scrollback: 0,
+            origin: ScreenCell::default(),
         }
     }
 }
@@ -376,7 +379,7 @@ pub struct PaneGeometry {
     pub panes: BTreeMap<PaneId, Rect>,
 }
 /// One cell in a pane's fixed VT grid.
-#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Default, Eq, Ord, PartialEq, PartialOrd)]
 pub(in crate::tui) struct ScreenCell {
     pub(in crate::tui) row: u16,
     pub(in crate::tui) col: u16,


### PR DESCRIPTION
## Summary
- Smaller viewers were always drawing the host pane grid from cell `(0,0)`, so bottom-anchored UI (Claude Code's prompt) disappeared. Each terminal now keeps a local camera into the shared grid and nudges it only enough to keep a visible live-edge cursor on screen.
- Rendering, text selection, and forwarded mouse input share that origin, so clicks hit the same cells that are drawn. Host PTY size, snapshots, and deltas are unchanged — no extra wire traffic.
- Clipped edges get compact overflow marks when the local slice is not the full grid.

Fixes #132

## Test plan
- [ ] Join a session from two terminals of different sizes; put Claude Code (or another bottom-prompt TUI) in a pane hosted by the larger window
- [ ] Confirm the smaller viewer can see the prompt once the cursor is in that region (camera follows, does not recenter)
- [ ] Resize the smaller window and confirm letterboxing still works when it is *larger* than the host grid
- [ ] Click / select text in the cropped view and confirm the hit cells match what is on screen
- [ ] Scroll a pane back; confirm the camera does not jump to chase the live cursor
- [ ] `cargo test --all-features`


Made with [Cursor](https://cursor.com)