### PR TITLE
ctl: drive a session from the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ enrolment token — and a peer on the wrong side of it is refused rather than ha
 v0.1.10 that refusal says so in as many words, naming both protocol numbers and which machine is the
 old one; older peers still report it as a host they could not reach.
 
+## Unreleased
+
+**`p2pmux ctl` drives a live session from the CLI, without taking the TUI seat.** Six verbs
+(`machines`, `agents`, `spawn`, `send`, `focus`, `events`) speak JSON on stdout to the session
+node. Ctl has its own pin, currently 1. The peer wire pin is still 12: a ctl client and a session
+peer are different sockets, and moving one does not move the other. A pin mismatch names both
+numbers and which end is old. A node that does not know ctl yet is told to upgrade it rather than
+left hanging.
+
+`spawn` reuses a live inbox pane (`chat: {command}`) on that machine, waits until the pane exists,
+and will not nest `p2pmux`. `send` is raw PTY bytes and fails out loud when another member holds
+the input lease.
+
 ## v0.1.15 — 2026-09-01
 
 Ten fixes and a shorter first-run telemetry ask, and no protocol change that costs anything: one field is added to the agent roster,

--- a/USAGE.md
+++ b/USAGE.md
@@ -77,6 +77,40 @@ Terminal 2: cargo run -- join <the code from Ctrl+S>
 Its PTY grid is fixed from the terminal size at startup: larger windows leave extra cells blank
 and smaller windows crop the upper-left fixed viewport.
 
+## Driving a session from a script
+
+`p2pmux ctl` talks to a live session without taking the TUI seat, so a fleet-agent node with
+nobody attached still answers. It does not start a session: if none is running, start `p2pmux`
+first. `--session` names one as `p2pmux list` prints it; omit it for the fleet session when this
+machine is paired, otherwise the newest live one.
+
+Stdout is JSON. Failures are one sentence on stderr. The six verbs:
+
+```text
+p2pmux ctl [--session NAME] machines
+p2pmux ctl [--session NAME] agents
+p2pmux ctl [--session NAME] spawn --machine NAME -- <command...>
+p2pmux ctl [--session NAME] send <pane-id> [--] <keys>
+p2pmux ctl [--session NAME] focus <agent>
+p2pmux ctl [--session NAME] events
+```
+
+`machines` is the pairing-owned list, including this machine. `agents` is the same roster Ctrl+O
+shows. `spawn` starts an allowlisted command on a machine you own, or a login shell when the
+command is empty. A live pane already titled `chat: {command}` on that host is reused; a pane
+that has exited or finished is not. Nested `p2pmux` is refused. The command waits until the pane
+exists.
+
+`send` writes the keys as PTY bytes, with no extra newline and no key names. It fails if someone
+else holds the pane's input lease. `focus` only moves to an agent that already has a pane —
+`p2pmux ctl spawn` is how one gets there. `events` prints `needs_you` / `done` / `error` as JSON
+lines: a snapshot first, then each change. The `message` field is present only when this node
+already has it.
+
+Ctl has its own pin, currently 1, independent of the peer wire pin. A client and a node that do
+not share it are told both numbers and which end to upgrade. A node too old to speak ctl at all
+says so after a short wait rather than hanging.
+
 ## Inviting someone
 
 `Ctrl+S` shows the line your guest runs. Enter copies it; send it as-is:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -208,11 +208,45 @@ enum Command {
     },
     /// Report whether each agent's hooks are wired up.
     Doctor,
+    /// Drive a live session from a script, without taking the TUI seat.
+    Ctl {
+        /// Session name as `p2pmux list` prints it. Omit it for the fleet
+        /// session when this machine is paired, otherwise the newest live one.
+        #[arg(long)]
+        session: Option<String>,
+        #[command(subcommand)]
+        action: CtlCommand,
+    },
     #[command(name = "__node", hide = true)]
     Node {
         #[arg(long)]
         bootstrap: std::path::PathBuf,
     },
+}
+
+#[derive(Debug, Subcommand)]
+enum CtlCommand {
+    /// Pairing-owned machines this session can start work on.
+    Machines,
+    /// The same agent list Ctrl+O would show.
+    Agents,
+    /// Start an allowlisted command on a machine you own.
+    Spawn {
+        #[arg(long)]
+        machine: String,
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        command: Vec<String>,
+    },
+    /// Write bytes into a pane as if they were typed.
+    Send {
+        pane: String,
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        keys: Vec<String>,
+    },
+    /// Move this node's focus to an agent that already has a pane.
+    Focus { agent: String },
+    /// Stream needs_you / done / error as JSON lines.
+    Events,
 }
 
 #[derive(Debug, Subcommand)]
@@ -411,6 +445,7 @@ pub fn run_without_runtime(cli: &Cli) -> Option<Result<(), Box<dyn Error>>> {
             None => crate::agent_setup::setup_all(false, false),
         }),
         Some(Command::Doctor) => Some(crate::agent_setup::doctor()),
+        Some(Command::Ctl { session, action }) => Some(run_ctl(session.as_deref(), action)),
         // Reading and writing one small file. A user asking what is being sent
         // about them wants the answer now, not after a thread pool starts.
         Some(Command::Telemetry { command }) => Some(run_telemetry(command.as_ref())),
@@ -459,6 +494,52 @@ fn run_telemetry(command: Option<&TelemetryCommand>) -> Result<(), Box<dyn Error
         }
     }
     Ok(())
+}
+
+/// Talk to a live node without taking its TUI seat, and without starting one.
+fn run_ctl(session: Option<&str>, action: &CtlCommand) -> Result<(), Box<dyn Error>> {
+    let descriptor = resolve_ctl_session(session)?;
+    let action = match action {
+        CtlCommand::Machines => crate::ctl::CtlAction::Machines,
+        CtlCommand::Agents => crate::ctl::CtlAction::Agents,
+        CtlCommand::Spawn { machine, command } => crate::ctl::CtlAction::Spawn {
+            machine: machine.clone(),
+            command: command.clone(),
+        },
+        CtlCommand::Send { pane, keys } => {
+            let pane_id = pane
+                .parse::<u64>()
+                .map_err(|_| crate::ctl::CtlError(String::from("pane id must be a number")))?;
+            let keys = match keys.split_first() {
+                Some((first, rest)) if first == "--" => rest.join(" "),
+                _ => keys.join(" "),
+            };
+            crate::ctl::CtlAction::Send { pane_id, keys }
+        }
+        CtlCommand::Focus { agent } => crate::ctl::CtlAction::Focus {
+            agent: agent.clone(),
+        },
+        CtlCommand::Events => crate::ctl::CtlAction::Events,
+    };
+    crate::ctl::run(&descriptor.socket_path, action)
+}
+
+fn resolve_ctl_session(
+    name: Option<&str>,
+) -> Result<crate::session_store::SessionDescriptor, Box<dyn Error>> {
+    if let Some(name) = name {
+        return find_live(name);
+    }
+    let live = crate::session_store::SessionStore::for_current_user()?.list_live()?;
+    let pairing = crate::pairing::load_or_empty();
+    let candidates = if pairing.can_rejoin() {
+        hosting_the_fleet(&live, pairing.ticket.as_deref())
+    } else {
+        live
+    };
+    newest_live(&candidates).ok_or_else(|| {
+        CliError("no live session here; start p2pmux first, then ctl talks to it").into()
+    })
 }
 
 /// The live sessions on this machine, as `ticket`, `code`, `attach`, `kill` and `rename` name them.
@@ -569,7 +650,8 @@ pub async fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
         | Some(Command::List)
         | Some(Command::Setup { .. })
         | Some(Command::Telemetry { .. })
-        | Some(Command::Doctor) => Ok(()),
+        | Some(Command::Doctor)
+        | Some(Command::Ctl { .. }) => Ok(()),
         Some(Command::Local) => crate::tui::run_local(),
         Some(Command::Config { command }) => match command {
             ConfigCommand::Init => {

--- a/src/ctl.rs
+++ b/src/ctl.rs
@@ -1,0 +1,425 @@
+//! Pinned local control protocol. Separate from the TUI attach socket types.
+//!
+//! The attach JSON (`ClientMessage` / `NodeMessage`) stays a private implementation
+//! detail. This is the surface a script may pin against. A client on the wrong pin
+//! is refused with both numbers named, and never takes the interactive attachment
+//! slot.
+
+use std::{
+    error::Error,
+    io::{self, BufRead, BufReader, Write},
+    os::unix::net::UnixStream,
+    path::Path,
+    time::Duration,
+};
+
+use serde::{Deserialize, Serialize};
+
+use crate::protocol::AgentRosterState;
+
+/// Independent of the peer wire pin. Moving this does not break a session
+/// between two p2pmux binaries that still share [`crate::protocol::PROTOCOL_VERSION`].
+pub const CTL_PROTOCOL_PIN: u32 = 1;
+
+const HELLO_TIMEOUT: Duration = Duration::from_secs(2);
+const SPAWN_TIMEOUT: Duration = Duration::from_secs(45);
+const MAX_FRAME: usize = 1024 * 1024;
+
+/// What a ctl client sends after connecting.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum CtlFromClient {
+    CtlHello {
+        pin: u32,
+    },
+    Machines,
+    Agents,
+    Spawn {
+        machine: String,
+        #[serde(default)]
+        command: Vec<String>,
+    },
+    Send {
+        pane_id: u64,
+        keys: String,
+    },
+    Focus {
+        agent: String,
+    },
+    Events,
+}
+
+/// What the node writes back on a ctl connection.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum CtlToClient {
+    CtlHelloAck {
+        pin: u32,
+    },
+    CtlHelloRejected {
+        ours: u32,
+        theirs: u32,
+    },
+    Machines {
+        machines: Vec<CtlMachine>,
+    },
+    Agents {
+        agents: Vec<CtlAgent>,
+    },
+    Spawned {
+        pane_id: u64,
+        reused: bool,
+    },
+    Sent {
+        pane_id: u64,
+    },
+    Focused {
+        pane_id: u64,
+    },
+    Event {
+        id: String,
+        pane_id: u64,
+        kind: String,
+        machine: String,
+        state: String,
+        #[serde(default, skip_serializing_if = "String::is_empty")]
+        message: String,
+    },
+    Error {
+        message: String,
+    },
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct CtlMachine {
+    pub name: String,
+    pub reachable: bool,
+    pub this_machine: bool,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct CtlAgent {
+    pub id: String,
+    pub pane_id: u64,
+    pub kind: String,
+    pub host: String,
+    pub state: String,
+    pub needs_you: bool,
+    pub cwd: String,
+    pub message: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub session: String,
+    #[serde(default)]
+    pub in_another_session: bool,
+}
+
+/// The verbs `p2pmux ctl` runs. Kept here so clap in `cli` and the socket
+/// client share one mapping.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum CtlAction {
+    Machines,
+    Agents,
+    Spawn {
+        machine: String,
+        command: Vec<String>,
+    },
+    Send {
+        pane_id: u64,
+        keys: String,
+    },
+    Focus {
+        agent: String,
+    },
+    Events,
+}
+
+/// Outcome of asking the node to start a pane.
+pub enum CtlSpawn {
+    Reused(u64),
+    Busy,
+    Started(u64),
+}
+
+#[derive(Debug)]
+pub struct CtlError(pub String);
+
+impl std::fmt::Display for CtlError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+impl Error for CtlError {}
+
+/// What to tell somebody whose ctl client and the session node do not share a pin.
+pub fn unsupported_ctl_pin_message(theirs: u32) -> String {
+    let ours = CTL_PROTOCOL_PIN;
+    let older = if theirs < ours {
+        "The session node is running an older p2pmux than this one — upgrade it, not this machine."
+    } else {
+        "This machine is running an older p2pmux than the session node — upgrade this one."
+    };
+    format!(
+        "that session speaks p2pmux ctl pin {theirs} and this p2pmux speaks {ours}, \
+         so they cannot talk. {older} \
+         Upgrade with `curl -fsSL https://p2pmux.com/install.sh | sh`, or \
+         `brew upgrade p2pmux` if you installed it that way, then try again."
+    )
+}
+
+pub fn agent_id(pane_id: u64, process_pid: u32) -> String {
+    if pane_id != 0 {
+        pane_id.to_string()
+    } else {
+        format!("pid:{process_pid}")
+    }
+}
+
+pub fn agent_state_name(state: AgentRosterState) -> &'static str {
+    match state {
+        AgentRosterState::Idle => "idle",
+        AgentRosterState::Working => "working",
+        AgentRosterState::Done => "done",
+        AgentRosterState::Pending => "pending",
+        AgentRosterState::Error => "error",
+        AgentRosterState::Unknown => "unknown",
+    }
+}
+
+pub fn event_state_name(state: AgentRosterState) -> Option<&'static str> {
+    match state {
+        AgentRosterState::Pending => Some("needs_you"),
+        AgentRosterState::Done => Some("done"),
+        AgentRosterState::Error => Some("error"),
+        AgentRosterState::Idle | AgentRosterState::Working | AgentRosterState::Unknown => None,
+    }
+}
+
+pub fn is_nested_p2pmux(command: &[String]) -> bool {
+    let Some(first) = command.first() else {
+        return false;
+    };
+    let name = std::path::Path::new(first)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(first.as_str());
+    name == "p2pmux"
+}
+
+/// Talk to a live node. Stdout is JSON; errors are sentences.
+pub fn run(socket: &Path, action: CtlAction) -> Result<(), Box<dyn Error>> {
+    let stream = UnixStream::connect(socket).map_err(|_| {
+        CtlError(String::from(
+            "could not reach the session node; is it still running?",
+        ))
+    })?;
+    stream.set_read_timeout(Some(HELLO_TIMEOUT))?;
+    stream.set_write_timeout(Some(Duration::from_secs(5)))?;
+    let mut writer = stream.try_clone()?;
+    let mut reader = BufReader::new(stream);
+    write_json(
+        &mut writer,
+        &CtlFromClient::CtlHello {
+            pin: CTL_PROTOCOL_PIN,
+        },
+    )?;
+    match receive_json::<CtlToClient>(&mut reader) {
+        Ok(Some(CtlToClient::CtlHelloAck { pin })) if pin == CTL_PROTOCOL_PIN => {}
+        Ok(Some(CtlToClient::CtlHelloRejected { theirs, .. })) => {
+            return Err(CtlError(unsupported_ctl_pin_message(theirs)).into());
+        }
+        Ok(Some(CtlToClient::Error { message })) => return Err(CtlError(message).into()),
+        Ok(Some(_)) => {
+            return Err(CtlError(String::from(
+                "the session node answered ctl without a hello ack",
+            ))
+            .into());
+        }
+        Ok(None) | Err(_) => {
+            return Err(CtlError(String::from(
+                "this session's p2pmux is too old for ctl — upgrade the node",
+            ))
+            .into());
+        }
+    }
+
+    let request = match &action {
+        CtlAction::Machines => CtlFromClient::Machines,
+        CtlAction::Agents => CtlFromClient::Agents,
+        CtlAction::Spawn { machine, command } => CtlFromClient::Spawn {
+            machine: machine.clone(),
+            command: command.clone(),
+        },
+        CtlAction::Send { pane_id, keys } => CtlFromClient::Send {
+            pane_id: *pane_id,
+            keys: keys.clone(),
+        },
+        CtlAction::Focus { agent } => CtlFromClient::Focus {
+            agent: agent.clone(),
+        },
+        CtlAction::Events => CtlFromClient::Events,
+    };
+    write_json(&mut writer, &request)?;
+
+    if matches!(action, CtlAction::Events) {
+        reader.get_mut().set_read_timeout(None)?;
+        loop {
+            match receive_json::<CtlToClient>(&mut reader)? {
+                Some(event @ CtlToClient::Event { .. }) => {
+                    println!("{}", serde_json::to_string(&event)?);
+                }
+                Some(CtlToClient::Error { message }) => return Err(CtlError(message).into()),
+                Some(_) => {}
+                None => return Ok(()),
+            }
+        }
+    }
+
+    if matches!(action, CtlAction::Spawn { .. }) {
+        reader.get_mut().set_read_timeout(Some(SPAWN_TIMEOUT))?;
+    }
+    match receive_json::<CtlToClient>(&mut reader)? {
+        Some(CtlToClient::Machines { machines }) => {
+            println!(
+                "{}",
+                serde_json::to_string(&serde_json::json!({ "machines": machines }))?
+            );
+        }
+        Some(CtlToClient::Agents { agents }) => {
+            println!(
+                "{}",
+                serde_json::to_string(&serde_json::json!({ "agents": agents }))?
+            );
+        }
+        Some(CtlToClient::Spawned { pane_id, reused }) => {
+            println!(
+                "{}",
+                serde_json::to_string(
+                    &serde_json::json!({ "pane_id": pane_id, "reused": reused })
+                )?
+            );
+        }
+        Some(CtlToClient::Sent { pane_id }) => {
+            println!(
+                "{}",
+                serde_json::to_string(&serde_json::json!({ "pane_id": pane_id }))?
+            );
+        }
+        Some(CtlToClient::Focused { pane_id }) => {
+            println!(
+                "{}",
+                serde_json::to_string(&serde_json::json!({ "pane_id": pane_id }))?
+            );
+        }
+        Some(CtlToClient::Error { message }) => return Err(CtlError(message).into()),
+        Some(_) => return Err(CtlError(String::from("unexpected ctl reply")).into()),
+        None => {
+            let message = if matches!(action, CtlAction::Spawn { .. }) {
+                "the machine did not answer in time"
+            } else {
+                "the session node closed the ctl connection"
+            };
+            return Err(CtlError(String::from(message)).into());
+        }
+    }
+    Ok(())
+}
+
+pub fn write_json<T: Serialize>(stream: &mut UnixStream, message: &T) -> io::Result<()> {
+    let mut frame = serde_json::to_vec(message).map_err(io::Error::other)?;
+    if frame.len() + 1 > MAX_FRAME {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "ctl frame too large",
+        ));
+    }
+    frame.push(b'\n');
+    stream.write_all(&frame)?;
+    stream.flush()
+}
+
+pub fn receive_json<T: for<'de> Deserialize<'de>>(
+    reader: &mut BufReader<UnixStream>,
+) -> io::Result<Option<T>> {
+    let mut bytes = Vec::new();
+    let count = match reader.read_until(b'\n', &mut bytes) {
+        Ok(count) => count,
+        Err(error) if error.kind() == io::ErrorKind::WouldBlock => return Ok(None),
+        Err(error)
+            if error.kind() == io::ErrorKind::TimedOut
+                || error.kind() == io::ErrorKind::Interrupted =>
+        {
+            return Ok(None);
+        }
+        Err(error) => return Err(error),
+    };
+    if count == 0 {
+        return Ok(None);
+    }
+    if count > MAX_FRAME {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "ctl frame too large",
+        ));
+    }
+    serde_json::from_slice(&bytes)
+        .map(Some)
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "invalid ctl message"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pin_mismatch_names_both_numbers_and_which_end_is_old() {
+        let older = unsupported_ctl_pin_message(CTL_PROTOCOL_PIN - 1);
+        assert!(
+            older.contains(&format!("ctl pin {}", CTL_PROTOCOL_PIN - 1)),
+            "{older}"
+        );
+        assert!(
+            older.contains(&format!("speaks {CTL_PROTOCOL_PIN}")),
+            "{older}"
+        );
+        assert!(older.contains("upgrade it, not this machine"), "{older}");
+
+        let newer = unsupported_ctl_pin_message(CTL_PROTOCOL_PIN + 1);
+        assert!(newer.contains("upgrade this one"), "{newer}");
+        assert!(!newer.contains("could not reach"), "{newer}");
+    }
+
+    #[test]
+    fn hello_round_trips_as_tagged_json() {
+        let hello = CtlFromClient::CtlHello {
+            pin: CTL_PROTOCOL_PIN,
+        };
+        let value = serde_json::to_value(&hello).unwrap();
+        assert_eq!(value["type"], "ctl_hello");
+        assert_eq!(value["pin"], CTL_PROTOCOL_PIN);
+        assert_eq!(
+            serde_json::from_value::<CtlFromClient>(value).unwrap(),
+            hello
+        );
+    }
+
+    #[test]
+    fn a_tui_focus_frame_is_not_a_ctl_focus() {
+        let tui = serde_json::json!({"type":"focus","tab_id":1,"pane_id":2});
+        assert!(serde_json::from_value::<CtlFromClient>(tui).is_err());
+    }
+
+    #[test]
+    fn nested_p2pmux_is_refused_by_basename() {
+        assert!(is_nested_p2pmux(&[String::from("p2pmux")]));
+        assert!(is_nested_p2pmux(&[String::from("/usr/local/bin/p2pmux")]));
+        assert!(!is_nested_p2pmux(&[String::from("claude")]));
+        assert!(!is_nested_p2pmux(&[]));
+    }
+
+    #[test]
+    fn ctl_pin_does_not_move_the_wire_pin() {
+        assert_eq!(CTL_PROTOCOL_PIN, 1);
+        assert_eq!(crate::protocol::PROTOCOL_VERSION, 12);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod agent_status;
 pub mod cli;
 pub mod client;
 pub mod config;
+pub mod ctl;
 pub mod daemon;
 pub mod failover;
 pub mod fleet;

--- a/src/node.rs
+++ b/src/node.rs
@@ -5,7 +5,7 @@
 //! only component allowed to render a terminal.
 
 use std::{
-    collections::{BTreeMap, VecDeque},
+    collections::{BTreeMap, BTreeSet, VecDeque},
     error::Error,
     fs,
     io::{self, BufRead, BufReader, Write},
@@ -22,6 +22,7 @@ use std::{
 use serde::{Deserialize, Serialize};
 
 use crate::{
+    ctl::{self, CTL_PROTOCOL_PIN, CtlFromClient, CtlToClient},
     local_ipc::{
         AgentOverlaySnapshotRow, AttachmentGate, ClientMessage, NodeMessage, PaneLeaseSnapshot,
         PaneScreenSnapshot, PresenceRow, ScreenUpdate, SessionSummary,
@@ -39,6 +40,7 @@ use crate::{
 use crate::tui::SharedLayoutRuntime;
 
 const FIRST_MESSAGE_TIMEOUT: Duration = Duration::from_millis(5);
+const MAX_CTL_CLIENTS: usize = 8;
 const ATTACHED_IDLE_BACKOFF: Duration = Duration::from_millis(1);
 const DETACHED_IDLE_BACKOFF: Duration = Duration::from_millis(16);
 // A node with no local client still drains for remote guests, so it cannot simply sleep.
@@ -608,6 +610,7 @@ fn run_socket_loop(
     let fleet_host = crate::fleet::FleetHost::new(tokio::runtime::Handle::current());
     let mut warned_about_size = false;
     let mut last_work = Instant::now();
+    let mut ctl_clients: Vec<CtlClient> = Vec::new();
     loop {
         let mut shutdown = false;
         let mut did_work = false;
@@ -631,78 +634,100 @@ fn run_socket_loop(
                         continue;
                     };
                     let mut reader = BufReader::new(stream);
-                    match read_message(&mut reader) {
-                        // Probes and shutdowns are control requests. They must not consume or
-                        // contend with the single interactive attachment slot.
-                        Ok(Some(ClientMessage::Probe)) => {
-                            let _ = write_message(reader.get_mut(), &NodeMessage::ProbeAck);
-                        }
-                        // Like a probe: a one-shot request from a short-lived
-                        // process, not the interactive client, so it must not
-                        // contend for the single attachment slot. The producer
-                        // gets no reply — it has already exited by the time one
-                        // could be written, and a hook that blocks on the mux
-                        // is a hook that stalls the agent it is reporting on.
-                        Ok(Some(ClientMessage::AgentStatus {
-                            pane_id,
-                            kind,
-                            status,
-                            cwd,
-                            message,
-                        })) => {
-                            // Counted here rather than in `p2pmux notify`,
-                            // which is a separate process spawned by an agent
-                            // hook on every tool call: a file write there would
-                            // be a file write on the agent's critical path, and
-                            // this side already has the message.
-                            crate::telemetry::bump(crate::telemetry::Counter::Agents, 1);
-                            did_work |=
-                                node.apply_agent_status(pane_id, &kind, &status, &cwd, &message);
-                        }
-                        Ok(Some(ClientMessage::Shutdown { generation })) => {
-                            let _ = write_message(
-                                reader.get_mut(),
-                                &NodeMessage::ShutdownAck { generation },
-                            );
-                            shutdown = true;
-                            break;
-                        }
-                        Ok(Some(ClientMessage::Hello { cols, rows })) => {
-                            let Ok(generation) = gate.attach() else {
-                                let _ = write_message(
+                    match read_line(&mut reader) {
+                        Ok(Some(line)) => match serde_json::from_str::<CtlFromClient>(&line) {
+                            Ok(CtlFromClient::CtlHello { pin }) => {
+                                accept_ctl_hello(reader, pin, &mut ctl_clients);
+                                did_work = true;
+                            }
+                            Ok(_) => {
+                                let _ = ctl::write_json(
                                     reader.get_mut(),
-                                    &NodeMessage::AttachRejected {
-                                        reason: crate::local_ipc::ALREADY_ATTACHED.into(),
+                                    &CtlToClient::Error {
+                                        message: String::from("ctl hello is required first"),
                                     },
                                 );
-                                continue;
-                            };
-                            match attach_client(reader, generation, cols, rows, descriptor, node) {
-                                Ok(attached) => {
-                                    client = Some(attached);
-                                    if tether == Tether::UntilFirstAttach {
-                                        tether = Tether::Detached;
-                                    }
-                                    // Only now is anybody looking. Until this,
-                                    // this node had no location to broadcast.
-                                    node.runtime.set_client_attached(true);
-                                    did_work = true;
-                                }
-                                // Losing one client is not losing the session.
-                                // Everything this can fail on belongs to the
-                                // connection, not to the node: a peer that
-                                // hung up mid-handshake -- for which macOS
-                                // answers EINVAL to `setsockopt` rather than
-                                // anything about the peer -- or a descriptor
-                                // limit reached while duplicating its socket.
-                                // Ending the socket loop over any of them took
-                                // every pane down with it.
-                                Err(error) => {
-                                    eprintln!("p2pmux node: could not attach that client: {error}");
-                                    let _ = gate.detach(generation);
-                                }
                             }
-                        }
+                            Err(_) => match serde_json::from_str::<ClientMessage>(&line) {
+                                // Probes and shutdowns are control requests. They must not consume or
+                                // contend with the single interactive attachment slot.
+                                Ok(ClientMessage::Probe) => {
+                                    let _ = write_message(reader.get_mut(), &NodeMessage::ProbeAck);
+                                }
+                                // Like a probe: a one-shot request from a short-lived
+                                // process, not the interactive client, so it must not
+                                // contend for the single attachment slot. The producer
+                                // gets no reply — it has already exited by the time one
+                                // could be written, and a hook that blocks on the mux
+                                // is a hook that stalls the agent it is reporting on.
+                                Ok(ClientMessage::AgentStatus {
+                                    pane_id,
+                                    kind,
+                                    status,
+                                    cwd,
+                                    message,
+                                }) => {
+                                    // Counted here rather than in `p2pmux notify`,
+                                    // which is a separate process spawned by an agent
+                                    // hook on every tool call: a file write there would
+                                    // be a file write on the agent's critical path, and
+                                    // this side already has the message.
+                                    crate::telemetry::bump(crate::telemetry::Counter::Agents, 1);
+                                    did_work |= node.apply_agent_status(
+                                        pane_id, &kind, &status, &cwd, &message,
+                                    );
+                                }
+                                Ok(ClientMessage::Shutdown { generation }) => {
+                                    let _ = write_message(
+                                        reader.get_mut(),
+                                        &NodeMessage::ShutdownAck { generation },
+                                    );
+                                    shutdown = true;
+                                    break;
+                                }
+                                Ok(ClientMessage::Hello { cols, rows }) => {
+                                    let Ok(generation) = gate.attach() else {
+                                        let _ = write_message(
+                                            reader.get_mut(),
+                                            &NodeMessage::AttachRejected {
+                                                reason: crate::local_ipc::ALREADY_ATTACHED.into(),
+                                            },
+                                        );
+                                        continue;
+                                    };
+                                    match attach_client(
+                                        reader, generation, cols, rows, descriptor, node,
+                                    ) {
+                                        Ok(attached) => {
+                                            client = Some(attached);
+                                            if tether == Tether::UntilFirstAttach {
+                                                tether = Tether::Detached;
+                                            }
+                                            // Only now is anybody looking. Until this,
+                                            // this node had no location to broadcast.
+                                            node.runtime.set_client_attached(true);
+                                            did_work = true;
+                                        }
+                                        // Losing one client is not losing the session.
+                                        // Everything this can fail on belongs to the
+                                        // connection, not to the node: a peer that
+                                        // hung up mid-handshake -- for which macOS
+                                        // answers EINVAL to `setsockopt` rather than
+                                        // anything about the peer -- or a descriptor
+                                        // limit reached while duplicating its socket.
+                                        // Ending the socket loop over any of them took
+                                        // every pane down with it.
+                                        Err(error) => {
+                                            eprintln!(
+                                                "p2pmux node: could not attach that client: {error}"
+                                            );
+                                            let _ = gate.detach(generation);
+                                        }
+                                    }
+                                }
+                                Ok(_) | Err(_) => {}
+                            },
+                        },
                         Ok(None) => {}
                         Err(error)
                             if matches!(
@@ -712,7 +737,7 @@ fn run_socket_loop(
                                     | io::ErrorKind::ConnectionReset
                                     | io::ErrorKind::BrokenPipe
                             ) => {}
-                        Err(_) | Ok(Some(_)) => {}
+                        Err(_) => {}
                     }
                 }
                 Err(error) if error.kind() == io::ErrorKind::WouldBlock => break,
@@ -745,6 +770,9 @@ fn run_socket_loop(
                 .drain()
                 .map_err(|error| io::Error::other(error.to_string()))?;
             drain_elapsed = drain_started.elapsed();
+        }
+        if !ctl_clients.is_empty() && poll_ctl_clients(&mut ctl_clients, node) {
+            did_work = true;
         }
         // A takeover or a step-down changes what this machine is advertising about itself.
         // `p2pmux ls` and `p2pmux ticket <name>` read the record out of process, so until it
@@ -1207,14 +1235,21 @@ fn socket_loop_backoff(
     }
 }
 
-fn read_message(reader: &mut BufReader<UnixStream>) -> io::Result<Option<ClientMessage>> {
+fn read_line(reader: &mut BufReader<UnixStream>) -> io::Result<Option<String>> {
     let mut line = String::new();
     match reader.read_line(&mut line) {
         Ok(0) => Ok(None),
-        Ok(_) => serde_json::from_str(&line)
+        Ok(_) => Ok(Some(line)),
+        Err(error) => Err(error),
+    }
+}
+
+fn read_message(reader: &mut BufReader<UnixStream>) -> io::Result<Option<ClientMessage>> {
+    match read_line(reader)? {
+        Some(line) => serde_json::from_str(&line)
             .map(Some)
             .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "invalid local IPC message")),
-        Err(error) => Err(error),
+        None => Ok(None),
     }
 }
 fn write_message(stream: &mut UnixStream, message: &NodeMessage) -> io::Result<()> {
@@ -1222,6 +1257,258 @@ fn write_message(stream: &mut UnixStream, message: &NodeMessage) -> io::Result<(
     frame.push(b'\n');
     stream.write_all(&frame)?;
     stream.flush()
+}
+
+struct CtlClient {
+    reader: BufReader<UnixStream>,
+    events: bool,
+    seen_events: BTreeSet<(String, String)>,
+    spawn_wait: Option<u64>,
+    spawn_retry: Option<(String, Vec<String>)>,
+}
+
+fn accept_ctl_hello(mut reader: BufReader<UnixStream>, pin: u32, clients: &mut Vec<CtlClient>) {
+    if pin != CTL_PROTOCOL_PIN {
+        let _ = ctl::write_json(
+            reader.get_mut(),
+            &CtlToClient::CtlHelloRejected {
+                ours: CTL_PROTOCOL_PIN,
+                theirs: pin,
+            },
+        );
+        return;
+    }
+    if clients.len() >= MAX_CTL_CLIENTS {
+        let _ = ctl::write_json(
+            reader.get_mut(),
+            &CtlToClient::Error {
+                message: String::from("too many ctl clients"),
+            },
+        );
+        return;
+    }
+    if ctl::write_json(
+        reader.get_mut(),
+        &CtlToClient::CtlHelloAck {
+            pin: CTL_PROTOCOL_PIN,
+        },
+    )
+    .is_err()
+    {
+        return;
+    }
+    let _ = reader
+        .get_mut()
+        .set_read_timeout(Some(Duration::from_millis(1)));
+    clients.push(CtlClient {
+        reader,
+        events: false,
+        seen_events: BTreeSet::new(),
+        spawn_wait: None,
+        spawn_retry: None,
+    });
+}
+
+fn poll_ctl_clients(clients: &mut Vec<CtlClient>, node: &mut SharedLayoutNode) -> bool {
+    let mut did_work = false;
+    clients.retain_mut(|client| match poll_one_ctl(client, node) {
+        Ok(worked) => {
+            did_work |= worked;
+            true
+        }
+        Err(_) => false,
+    });
+    did_work
+}
+
+fn poll_one_ctl(client: &mut CtlClient, node: &mut SharedLayoutNode) -> io::Result<bool> {
+    let mut did_work = false;
+    if let Some((machine, command)) = client.spawn_retry.clone() {
+        match dispatch_ctl_spawn(node, client, machine, command) {
+            Ok(true) => {
+                client.spawn_retry = None;
+                did_work = true;
+            }
+            Ok(false) => {}
+            Err(message) => {
+                client.spawn_retry = None;
+                ctl::write_json(client.reader.get_mut(), &CtlToClient::Error { message })?;
+                return Ok(true);
+            }
+        }
+    }
+    if let Some(request_id) = client.spawn_wait
+        && let Some(result) = node.runtime.ctl_take_result(request_id)
+    {
+        client.spawn_wait = None;
+        match result {
+            Ok(pane_id) => ctl::write_json(
+                client.reader.get_mut(),
+                &CtlToClient::Spawned {
+                    pane_id,
+                    reused: false,
+                },
+            )?,
+            Err(message) => {
+                ctl::write_json(client.reader.get_mut(), &CtlToClient::Error { message })?
+            }
+        }
+        return Ok(true);
+    }
+    if client.events {
+        did_work |= publish_ctl_events(client, node)?;
+    }
+    match ctl::receive_json::<CtlFromClient>(&mut client.reader) {
+        Ok(Some(CtlFromClient::CtlHello { .. })) => {
+            ctl::write_json(
+                client.reader.get_mut(),
+                &CtlToClient::Error {
+                    message: String::from("already said hello"),
+                },
+            )?;
+            did_work = true;
+        }
+        Ok(Some(CtlFromClient::Machines)) => {
+            ctl::write_json(
+                client.reader.get_mut(),
+                &CtlToClient::Machines {
+                    machines: node.runtime.ctl_machines(),
+                },
+            )?;
+            did_work = true;
+        }
+        Ok(Some(CtlFromClient::Agents)) => {
+            ctl::write_json(
+                client.reader.get_mut(),
+                &CtlToClient::Agents {
+                    agents: node.runtime.ctl_agents(),
+                },
+            )?;
+            did_work = true;
+        }
+        Ok(Some(CtlFromClient::Spawn { machine, command })) => {
+            match dispatch_ctl_spawn(node, client, machine, command) {
+                Ok(_) => {}
+                Err(message) => {
+                    ctl::write_json(client.reader.get_mut(), &CtlToClient::Error { message })?
+                }
+            }
+            did_work = true;
+        }
+        Ok(Some(CtlFromClient::Send { pane_id, keys })) => {
+            match node.runtime.ctl_send(pane_id, &keys) {
+                Ok(pane_id) => {
+                    ctl::write_json(client.reader.get_mut(), &CtlToClient::Sent { pane_id })?
+                }
+                Err(message) => {
+                    ctl::write_json(client.reader.get_mut(), &CtlToClient::Error { message })?
+                }
+            }
+            did_work = true;
+        }
+        Ok(Some(CtlFromClient::Focus { agent })) => {
+            match node.runtime.ctl_focus(&agent) {
+                Ok(pane_id) => {
+                    ctl::write_json(client.reader.get_mut(), &CtlToClient::Focused { pane_id })?
+                }
+                Err(message) => {
+                    ctl::write_json(client.reader.get_mut(), &CtlToClient::Error { message })?
+                }
+            }
+            did_work = true;
+        }
+        Ok(Some(CtlFromClient::Events)) => {
+            client.events = true;
+            client.seen_events.clear();
+            publish_ctl_events(client, node)?;
+            did_work = true;
+        }
+        Ok(None) => {}
+        Err(error)
+            if matches!(
+                error.kind(),
+                io::ErrorKind::WouldBlock | io::ErrorKind::TimedOut | io::ErrorKind::Interrupted
+            ) => {}
+        Err(error)
+            if matches!(
+                error.kind(),
+                io::ErrorKind::ConnectionReset | io::ErrorKind::BrokenPipe
+            ) =>
+        {
+            return Err(error);
+        }
+        Err(_) => return Err(io::Error::other("ctl client gone")),
+    }
+    Ok(did_work)
+}
+
+fn dispatch_ctl_spawn(
+    node: &mut SharedLayoutNode,
+    client: &mut CtlClient,
+    machine: String,
+    command: Vec<String>,
+) -> Result<bool, String> {
+    match node.runtime.ctl_try_spawn(&machine, command.clone()) {
+        Ok(crate::ctl::CtlSpawn::Reused(pane_id)) => {
+            ctl::write_json(
+                client.reader.get_mut(),
+                &CtlToClient::Spawned {
+                    pane_id,
+                    reused: true,
+                },
+            )
+            .map_err(|error| error.to_string())?;
+            Ok(true)
+        }
+        Ok(crate::ctl::CtlSpawn::Busy) => {
+            client.spawn_retry = Some((machine, command));
+            Ok(false)
+        }
+        Ok(crate::ctl::CtlSpawn::Started(request_id)) => {
+            let _ = node.drain();
+            if let Some(result) = node.runtime.ctl_take_result(request_id) {
+                match result {
+                    Ok(pane_id) => ctl::write_json(
+                        client.reader.get_mut(),
+                        &CtlToClient::Spawned {
+                            pane_id,
+                            reused: false,
+                        },
+                    )
+                    .map_err(|error| error.to_string())?,
+                    Err(message) => {
+                        return Err(message);
+                    }
+                }
+            } else {
+                client.spawn_wait = Some(request_id);
+            }
+            Ok(true)
+        }
+        Err(message) => Err(message),
+    }
+}
+
+fn publish_ctl_events(client: &mut CtlClient, node: &mut SharedLayoutNode) -> io::Result<bool> {
+    let mut wrote = false;
+    let mut seen = BTreeSet::new();
+    for event in node.runtime.ctl_event_snapshot() {
+        let crate::ctl::CtlToClient::Event {
+            ref id, ref state, ..
+        } = event
+        else {
+            continue;
+        };
+        let key = (id.clone(), state.clone());
+        seen.insert(key.clone());
+        if client.seen_events.contains(&key) {
+            continue;
+        }
+        ctl::write_json(client.reader.get_mut(), &event)?;
+        wrote = true;
+    }
+    client.seen_events = seen;
+    Ok(wrote)
 }
 
 struct AttachedClient {

--- a/src/tui/runtime/ctl.rs
+++ b/src/tui/runtime/ctl.rs
@@ -1,0 +1,270 @@
+//! Ctl verbs, implemented on the session node rather than the attached TUI.
+
+use std::time::Instant;
+
+use crate::{
+    ctl::{
+        CtlAgent, CtlMachine, CtlSpawn, agent_id, agent_state_name, event_state_name,
+        is_nested_p2pmux,
+    },
+    layout::PaneId,
+    lease::IDLE_AFTER,
+    protocol::AgentRosterState,
+    tui::{AgentOverlayRow, geometry::contains_leaf, member_label, pane::remote::RemoteInput},
+};
+
+use super::SharedLayoutRuntime;
+
+impl SharedLayoutRuntime {
+    pub(crate) fn ctl_prepare(&mut self) {
+        self.tui.set_local_peer_id(self.control.peer_id());
+        let pairing = crate::pairing::load_or_empty();
+        let _ = self.tui.set_paired_machines(pairing.machines);
+        let rows = self.agent_overlay_rows();
+        self.tui.set_agent_rows(rows);
+    }
+
+    pub(crate) fn ctl_machines(&mut self) -> Vec<CtlMachine> {
+        self.ctl_prepare();
+        super::super::home::machine_rows(&self.tui)
+            .into_iter()
+            .filter(|row| row.owned)
+            .map(|row| CtlMachine {
+                name: row.name,
+                reachable: row.reachable,
+                this_machine: row.this_machine,
+            })
+            .collect()
+    }
+
+    pub(crate) fn ctl_agents(&mut self) -> Vec<CtlAgent> {
+        self.ctl_prepare();
+        let mut rows = self.agent_overlay_rows();
+        rows.sort_by(|left, right| {
+            super::super::home::home_rank(right.state)
+                .cmp(&super::super::home::home_rank(left.state))
+                .then_with(|| left.host.cmp(&right.host))
+                .then_with(|| left.kind.cmp(&right.kind))
+                .then_with(|| left.pane_id.cmp(&right.pane_id))
+        });
+        rows.into_iter().map(ctl_agent_from_row).collect()
+    }
+
+    pub(crate) fn ctl_event_snapshot(&mut self) -> Vec<crate::ctl::CtlToClient> {
+        self.ctl_prepare();
+        self.agent_overlay_rows()
+            .into_iter()
+            .filter_map(|row| {
+                let state = event_state_name(row.state)?;
+                Some(crate::ctl::CtlToClient::Event {
+                    id: agent_id(row.pane_id, row.process_pid),
+                    pane_id: row.pane_id,
+                    kind: row.kind,
+                    machine: row.host,
+                    state: state.to_owned(),
+                    message: row.message,
+                })
+            })
+            .collect()
+    }
+
+    pub(crate) fn ctl_try_spawn(
+        &mut self,
+        machine: &str,
+        command: Vec<String>,
+    ) -> Result<CtlSpawn, String> {
+        if is_nested_p2pmux(&command) {
+            return Err(String::from("p2pmux does not nest p2pmux in a pane"));
+        }
+        if self.structural_edits_frozen() {
+            return Err(String::from(
+                "coordinator unreachable; layout changes are paused",
+            ));
+        }
+        self.ctl_prepare();
+        let rows = super::super::home::machine_rows(&self.tui);
+        let Some(row) = rows.iter().find(|row| row.name == machine) else {
+            return Err(format!("no paired machine named {machine}"));
+        };
+        if !row.owned {
+            return Err(format!(
+                "{machine} is someone else's machine — p2pmux does not start terminals on it"
+            ));
+        }
+        let Some(peer_id) = row.peer_id.clone() else {
+            return Err(format!(
+                "{machine} is asleep — start p2pmux on it and it rejoins on its own"
+            ));
+        };
+        if let Some(pane_id) = self.live_chat_pane(machine, &command) {
+            return Ok(CtlSpawn::Reused(pane_id));
+        }
+        if self.pending_create.is_some() {
+            return Ok(CtlSpawn::Busy);
+        }
+        let (grid_rows, grid_cols) = self.ctl_spawn_grid();
+        // Watch before the layout call: a local coordinator answers inside
+        // `begin_create_on`, clears `pending_create`, and would otherwise look
+        // like a spawn that never started.
+        let request_id = self.next_request_id;
+        self.ctl_watch(request_id);
+        if let Err(error) = self.begin_create_on(
+            None,
+            grid_rows,
+            grid_cols,
+            None,
+            peer_id,
+            command,
+            machine.to_owned(),
+        ) {
+            self.ctl_waiting.remove(&request_id);
+            self.ctl_results.remove(&request_id);
+            return Err(error.to_string());
+        }
+        Ok(CtlSpawn::Started(request_id))
+    }
+
+    pub(crate) fn ctl_watch(&mut self, request_id: u64) {
+        self.ctl_waiting.insert(request_id);
+    }
+
+    pub(crate) fn ctl_complete(&mut self, request_id: u64, result: Result<u64, String>) {
+        if self.ctl_waiting.remove(&request_id) {
+            self.ctl_results.insert(request_id, result);
+        }
+    }
+
+    pub(crate) fn ctl_take_result(&mut self, request_id: u64) -> Option<Result<u64, String>> {
+        self.ctl_results.remove(&request_id)
+    }
+
+    pub(crate) fn ctl_send(&mut self, pane_id: u64, keys: &str) -> Result<u64, String> {
+        if keys.is_empty() {
+            return Err(String::from("nothing to send"));
+        }
+        let Some(pane) = self.tui.snapshot().panes.get(&pane_id).cloned() else {
+            return Err(String::from("no pane with that id"));
+        };
+        if pane.exited {
+            return Err(String::from("that pane has exited"));
+        }
+        if !self.input_allowed(pane_id) {
+            return Err(String::from("input is not allowed on that pane"));
+        }
+        if let Some(local) = self.local.get(&pane_id) {
+            let state = local.lease.state();
+            if !state.controller_peer_id.is_empty()
+                && state.controller_peer_id != local.host_peer_id
+                && !state.is_idle_at(Instant::now())
+            {
+                return Err(String::from("someone else is controlling that pane"));
+            }
+        }
+        if let Some(remote) = self.remote.get(&pane_id)
+            && let Some(lease) = remote.lease.as_ref()
+        {
+            let idle = remote.last_lease.elapsed() >= IDLE_AFTER;
+            if crate::tui::pane::remote::remote_input_decision(
+                &lease.controller_peer_id,
+                remote.pane.controls.peer_id(),
+                remote.pending_control,
+                remote.held_input.is_empty(),
+                idle,
+            ) == RemoteInput::Ignore
+            {
+                return Err(String::from("someone else is controlling that pane"));
+            }
+        }
+        self.node_input(Some(pane_id), keys.as_bytes().to_vec())
+            .map_err(|error| error.to_string())?
+            .ok_or_else(|| String::from("input is not allowed on that pane"))
+    }
+
+    pub(crate) fn ctl_focus(&mut self, agent: &str) -> Result<u64, String> {
+        self.ctl_prepare();
+        let pane_id = self.resolve_ctl_agent(agent)?;
+        let tab_id = self
+            .tui
+            .snapshot()
+            .tabs
+            .iter()
+            .find(|tab| contains_leaf(&tab.root, pane_id))
+            .map(|tab| tab.tab_id)
+            .ok_or_else(|| String::from("that pane is not on any tab"))?;
+        self.node_focus(tab_id, pane_id)
+            .map_err(|error| error.to_string())?;
+        Ok(pane_id)
+    }
+
+    fn resolve_ctl_agent(&self, agent: &str) -> Result<PaneId, String> {
+        if let Some(pid) = agent.strip_prefix("pid:") {
+            let pid: u32 = pid
+                .parse()
+                .map_err(|_| String::from("that is not an agent id"))?;
+            let row = self
+                .agent_overlay_rows()
+                .into_iter()
+                .find(|row| row.pane_id == 0 && row.process_pid == pid);
+            return match row {
+                Some(row) if row.pane_id != 0 => Ok(row.pane_id),
+                Some(_) => Err(String::from(
+                    "that agent has no pane; `p2pmux ctl spawn` starts one",
+                )),
+                None => Err(String::from("no agent with that id")),
+            };
+        }
+        let pane_id: PaneId = agent
+            .parse()
+            .map_err(|_| String::from("that is not an agent id"))?;
+        if self.tui.snapshot().panes.contains_key(&pane_id) {
+            return Ok(pane_id);
+        }
+        Err(String::from("no pane with that id"))
+    }
+
+    fn live_chat_pane(&self, host: &str, command: &[String]) -> Option<PaneId> {
+        if command.is_empty() {
+            return None;
+        }
+        let title = super::super::home::chat_pane_title(command);
+        let pane = self.tui.snapshot().panes.values().find(|pane| {
+            pane.title.as_deref() == Some(title.as_str())
+                && !pane.exited
+                && member_label(&pane.host_peer_id, &self.tui.snapshot().members) == host
+        })?;
+        let state = self
+            .agent_overlay_rows()
+            .into_iter()
+            .find(|row| row.pane_id == pane.pane_id)
+            .map(|row| row.state);
+        if state.is_some_and(AgentRosterState::is_completion) {
+            return None;
+        }
+        Some(pane.pane_id)
+    }
+
+    fn ctl_spawn_grid(&self) -> (u16, u16) {
+        self.tui
+            .snapshot()
+            .panes
+            .values()
+            .find(|pane| pane.grid_rows > 0 && pane.grid_cols > 0)
+            .map(|pane| (pane.grid_rows, pane.grid_cols))
+            .unwrap_or((24, 80))
+    }
+}
+
+fn ctl_agent_from_row(row: AgentOverlayRow) -> CtlAgent {
+    CtlAgent {
+        id: agent_id(row.pane_id, row.process_pid),
+        pane_id: row.pane_id,
+        kind: row.kind,
+        host: row.host,
+        state: agent_state_name(row.state).to_owned(),
+        needs_you: row.state.needs_you(),
+        cwd: row.cwd,
+        message: row.message,
+        session: row.session,
+        in_another_session: row.in_another_session,
+    }
+}

--- a/src/tui/runtime/layout.rs
+++ b/src/tui/runtime/layout.rs
@@ -248,7 +248,9 @@ impl SharedLayoutRuntime {
                 .map(|pane| pane.pane_id)
                 .find(|pane_id| !self.tui.snapshot().panes.contains_key(pane_id));
             if let Some(pane_id) = arrived {
+                let request_id = pending.request_id;
                 self.pending_create = None;
+                self.ctl_complete(request_id, Ok(pane_id));
                 if let Some(tab) = snapshot
                     .tabs
                     .iter()
@@ -888,6 +890,10 @@ impl SharedLayoutRuntime {
                     refused: false,
                 });
                 self.status = format!("pane spawn failed: {error}");
+                self.ctl_complete(
+                    pending.request_id,
+                    Err(format!("pane spawn failed: {error}")),
+                );
                 return Ok(());
             }
         };
@@ -908,6 +914,10 @@ impl SharedLayoutRuntime {
                 refused: false,
             });
             self.status = format!("pane registration failed: {error}");
+            self.ctl_complete(
+                pending.request_id,
+                Err(format!("pane registration failed: {error}")),
+            );
             return Ok(());
         }
         self.provisional
@@ -941,12 +951,16 @@ impl SharedLayoutRuntime {
         // this machine is the only peer allowed to name it — the layout lets a
         // pane's host rename it and nobody else. That title is what makes
         // pressing Enter on the same agent twice find the pane instead of
-        // opening a second one.
+        // opening a second one. Ctl reports the pane after the name is on it,
+        // or the next spawn would miss the live one and open another.
         if !pending.command.is_empty() {
             self.handle_intent(UiIntent::RenamePane {
                 pane_id: reservation.pane_id,
                 title: crate::tui::home::chat_pane_title(&pending.command),
             })?;
+        }
+        if asked_here {
+            self.ctl_complete(pending.request_id, Ok(reservation.pane_id));
         }
         Ok(())
     }
@@ -987,7 +1001,8 @@ impl SharedLayoutRuntime {
         // refuses and the screen left Home, opened nothing, and said nothing —
         // three sentences written for exactly this moment, none of them ever
         // seen by a user.
-        self.status = notice;
+        self.status = notice.clone();
+        self.ctl_complete(request_id, Err(notice));
     }
 
     pub(in crate::tui) fn reject_request(&mut self, request_id: u64) {

--- a/src/tui/runtime/mod.rs
+++ b/src/tui/runtime/mod.rs
@@ -3,6 +3,7 @@
 //!
 //! The inherent impl is split by concern across this module's files.
 
+mod ctl;
 mod failover;
 mod forward;
 mod layout;
@@ -10,7 +11,7 @@ mod node;
 mod run;
 
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeMap, BTreeSet, HashMap},
     error::Error,
     io,
     time::{Duration, Instant},
@@ -57,6 +58,8 @@ pub struct SharedLayoutRuntime {
     pub(in crate::tui) subscription_rx:
         tokio::sync::mpsc::UnboundedReceiver<(PaneId, Result<GuestPane, String>)>,
     pub(in crate::tui) pending_create: Option<PendingCreate>,
+    pub(in crate::tui) ctl_waiting: BTreeSet<u64>,
+    pub(in crate::tui) ctl_results: BTreeMap<u64, Result<u64, String>>,
     /// A terminal another machine of yours asked for here, waiting for the
     /// person at this machine to say yes.
     ///
@@ -275,6 +278,8 @@ impl SharedLayoutRuntime {
             subscription_tx,
             subscription_rx,
             pending_create: None,
+            ctl_waiting: BTreeSet::new(),
+            ctl_results: BTreeMap::new(),
             pending_remote: None,
             provisional: BTreeMap::new(),
             pending_locks: BTreeMap::new(),

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -439,6 +439,29 @@ fn enroll_is_kept_for_machine_images_and_kept_out_of_the_help() {
     assert!(help.contains("pair"), "{help}");
 }
 
+#[test]
+fn ctl_help_lists_the_six_verbs() {
+    let output = run(&["ctl", "--help"]);
+    assert!(output.status.success());
+    let help = String::from_utf8(output.stdout).expect("stdout should be UTF-8");
+    for verb in ["machines", "agents", "spawn", "send", "focus", "events"] {
+        assert!(help.contains(verb), "ctl help missing {verb}: {help}");
+    }
+}
+
+#[test]
+fn ctl_without_a_session_does_not_start_one() {
+    let session = FakeSession::empty();
+    let output = run_with_home(session.home(), &["ctl", "machines"]);
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
+    assert!(
+        stderr.contains("no live session here; start p2pmux first"),
+        "{stderr}"
+    );
+    assert!(stderr.contains("then ctl talks to it"), "{stderr}");
+}
+
 fn minted_ticket() -> JoinTicket {
     JoinTicket::mint(
         EndpointAddr::new(SecretKey::from_bytes(&[9; 32]).public())

--- a/tests/ctl.rs
+++ b/tests/ctl.rs
@@ -8,6 +8,7 @@ use std::{
     os::unix::net::UnixStream,
     path::{Path, PathBuf},
     process::{Child, Command, Stdio},
+    sync::Mutex,
     time::{Duration, Instant},
 };
 
@@ -21,6 +22,10 @@ use p2pmux::{
 
 const READY_TIMEOUT: Duration = Duration::from_secs(30);
 const RECEIVE_TIMEOUT: Duration = Duration::from_secs(8);
+/// One node at a time while it opens its first PTY. Six of these in parallel
+/// on Linux CI was enough for a later spawn to come back as a reservation
+/// failure.
+static START: Mutex<()> = Mutex::new(());
 
 struct Fixture {
     root: PathBuf,
@@ -38,6 +43,7 @@ impl Drop for Fixture {
 
 impl Fixture {
     fn start(name: &str) -> Self {
+        let _start = START.lock().expect("fixture start");
         let root = PathBuf::from(format!("/tmp/p2pmux-{name}-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&root);
         std::fs::create_dir_all(root.join("home")).unwrap();
@@ -353,26 +359,9 @@ fn events_stream_without_a_tui() {
     let mut fixture = Fixture::start("ctl-events");
     fixture.wait_until_ctl_answers();
 
-    let spawn = ctl_cli(
-        &fixture,
-        &[
-            "ctl",
-            "spawn",
-            "--machine",
-            "Test User",
-            "--",
-            "sleep",
-            "120",
-        ],
-    );
-    assert!(
-        spawn.status.success(),
-        "{}",
-        String::from_utf8_lossy(&spawn.stderr)
-    );
-    let spawned: serde_json::Value =
-        serde_json::from_str(String::from_utf8_lossy(&spawn.stdout).trim()).unwrap();
-    let pane_id = spawned["pane_id"].as_u64().unwrap();
+    // The node already hosts pane 1. Opening another PTY here raced the other
+    // ctl tests on Linux CI and came back as a reservation failure.
+    let pane_id = 1;
 
     let (mut writer, mut reader, reply) = hello(&fixture.socket, CTL_PROTOCOL_PIN);
     assert!(

--- a/tests/ctl.rs
+++ b/tests/ctl.rs
@@ -1,0 +1,454 @@
+//! `p2pmux ctl` talks to a live node without taking the TUI seat.
+//!
+//! The node here is given its own `HOME` and its own socket, so these never
+//! see a session the developer is sitting in.
+
+use std::{
+    io::{BufReader, Write},
+    os::unix::net::UnixStream,
+    path::{Path, PathBuf},
+    process::{Child, Command, Stdio},
+    time::{Duration, Instant},
+};
+
+use p2pmux::{
+    client,
+    ctl::{self, CTL_PROTOCOL_PIN, CtlFromClient, CtlToClient},
+    local_ipc::{ClientMessage, NodeMessage},
+    node::{NodeBootstrap, NodeBootstrapKind, Tether, write_bootstrap},
+    session_store::{SessionDescriptor, SessionRole, generate_id},
+};
+
+const READY_TIMEOUT: Duration = Duration::from_secs(30);
+const RECEIVE_TIMEOUT: Duration = Duration::from_secs(8);
+
+struct Fixture {
+    root: PathBuf,
+    socket: PathBuf,
+    node: Child,
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let _ = self.node.kill();
+        let _ = self.node.wait();
+        let _ = std::fs::remove_dir_all(&self.root);
+    }
+}
+
+impl Fixture {
+    fn start(name: &str) -> Self {
+        let root = PathBuf::from(format!("/tmp/p2pmux-{name}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(root.join("home")).unwrap();
+        let socket = root.join("n.sock");
+        let bootstrap = root.join("n.bootstrap");
+        let descriptor = SessionDescriptor::new(
+            generate_id().unwrap(),
+            "lisbon".into(),
+            socket.clone(),
+            1,
+            SessionRole::Coordinator,
+        );
+        write_bootstrap(
+            &bootstrap,
+            &NodeBootstrap {
+                descriptor,
+                kind: NodeBootstrapKind::Create {
+                    display_name: "Test User".into(),
+                    cols: 80,
+                    rows: 24,
+                },
+                tether: Tether::Detached,
+                supervisor: None,
+            },
+        )
+        .unwrap();
+        let node = Command::new(env!("CARGO_BIN_EXE_p2pmux"))
+            .arg("__node")
+            .arg("--bootstrap")
+            .arg(&bootstrap)
+            .env("HOME", root.join("home"))
+            .env_remove("P2PMUX_PANE_ID")
+            .env_remove("P2PMUX_SOCK")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .unwrap();
+        let mut fixture = Self { root, socket, node };
+        let deadline = Instant::now() + READY_TIMEOUT;
+        while !fixture.socket.exists() {
+            assert!(
+                fixture.node.try_wait().unwrap().is_none(),
+                "node exited before binding its socket"
+            );
+            assert!(Instant::now() < deadline, "node never bound its socket");
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        fixture
+    }
+
+    fn running(&mut self) -> bool {
+        self.node.try_wait().unwrap().is_none()
+    }
+
+    fn home(&self) -> PathBuf {
+        self.root.join("home")
+    }
+
+    fn wait_until_ctl_answers(&self) {
+        let deadline = Instant::now() + READY_TIMEOUT;
+        loop {
+            if ping_machines(&self.socket) {
+                return;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "node never answered ctl machines"
+            );
+            std::thread::sleep(Duration::from_millis(50));
+        }
+    }
+}
+
+fn ping_machines(socket: &Path) -> bool {
+    let Ok(stream) = UnixStream::connect(socket) else {
+        return false;
+    };
+    let _ = stream.set_read_timeout(Some(Duration::from_millis(400)));
+    let _ = stream.set_write_timeout(Some(Duration::from_secs(2)));
+    let Ok(mut writer) = stream.try_clone() else {
+        return false;
+    };
+    let mut reader = BufReader::new(stream);
+    if ctl::write_json(
+        &mut writer,
+        &CtlFromClient::CtlHello {
+            pin: CTL_PROTOCOL_PIN,
+        },
+    )
+    .is_err()
+    {
+        return false;
+    }
+    match ctl::receive_json::<CtlToClient>(&mut reader) {
+        Ok(Some(CtlToClient::CtlHelloAck { pin })) if pin == CTL_PROTOCOL_PIN => {}
+        _ => return false,
+    }
+    if ctl::write_json(&mut writer, &CtlFromClient::Machines).is_err() {
+        return false;
+    }
+    matches!(
+        ctl::receive_json::<CtlToClient>(&mut reader),
+        Ok(Some(CtlToClient::Machines { .. }))
+    )
+}
+
+fn ctl_cli(fixture: &Fixture, args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_p2pmux"))
+        .args(args)
+        .env("HOME", fixture.home())
+        .env_remove("XDG_STATE_HOME")
+        .env_remove("XDG_CONFIG_HOME")
+        .output()
+        .expect("p2pmux binary should run")
+}
+
+fn connect_ctl(socket: &Path) -> (UnixStream, BufReader<UnixStream>) {
+    let stream = UnixStream::connect(socket).unwrap();
+    stream
+        .set_read_timeout(Some(Duration::from_secs(2)))
+        .unwrap();
+    stream
+        .set_write_timeout(Some(Duration::from_secs(5)))
+        .unwrap();
+    let writer = stream.try_clone().unwrap();
+    (writer, BufReader::new(stream))
+}
+
+fn hello(socket: &Path, pin: u32) -> (UnixStream, BufReader<UnixStream>, CtlToClient) {
+    let (mut writer, mut reader) = connect_ctl(socket);
+    ctl::write_json(&mut writer, &CtlFromClient::CtlHello { pin }).unwrap();
+    let reply = ctl::receive_json(&mut reader)
+        .unwrap()
+        .expect("node should answer hello");
+    (writer, reader, reply)
+}
+
+fn attach(socket: &Path) -> (UnixStream, BufReader<UnixStream>, u64) {
+    let mut stream = UnixStream::connect(socket).unwrap();
+    stream
+        .set_read_timeout(Some(Duration::from_secs(2)))
+        .unwrap();
+    send_client(&mut stream, &ClientMessage::Hello { cols: 80, rows: 24 });
+    let mut reader = BufReader::new(stream.try_clone().unwrap());
+    let generation = match receive_node(&mut reader) {
+        NodeMessage::AttachAccepted { generation, .. } => generation,
+        message => panic!("unexpected attach response: {message:?}"),
+    };
+    (stream, reader, generation)
+}
+
+fn send_client(stream: &mut UnixStream, message: &ClientMessage) {
+    let mut frame = serde_json::to_vec(message).unwrap();
+    frame.push(b'\n');
+    stream.write_all(&frame).unwrap();
+    stream.flush().unwrap();
+}
+
+fn receive_node(reader: &mut BufReader<UnixStream>) -> NodeMessage {
+    let deadline = Instant::now() + RECEIVE_TIMEOUT;
+    loop {
+        match client::read_message(reader) {
+            Ok(Some(message)) => return message,
+            Ok(None) => panic!("the node closed its socket"),
+            Err(error)
+                if error.kind() == std::io::ErrorKind::WouldBlock
+                    || error.kind() == std::io::ErrorKind::TimedOut => {}
+            Err(error) => panic!("reading from the node failed: {error}"),
+        }
+        assert!(Instant::now() < deadline, "the node said nothing in time");
+    }
+}
+
+#[test]
+fn a_wrong_ctl_pin_is_refused_and_does_not_take_the_tui_seat() {
+    let mut fixture = Fixture::start("ctl-pin");
+    fixture.wait_until_ctl_answers();
+
+    let (_writer, _reader, reply) = hello(&fixture.socket, CTL_PROTOCOL_PIN + 1);
+    match reply {
+        CtlToClient::CtlHelloRejected { ours, theirs } => {
+            assert_eq!(ours, CTL_PROTOCOL_PIN);
+            assert_eq!(theirs, CTL_PROTOCOL_PIN + 1);
+        }
+        other => panic!("expected a pin refusal, got {other:?}"),
+    }
+
+    let (_stream, mut reader, _) = attach(&fixture.socket);
+    let mut saw_snapshot = false;
+    let deadline = Instant::now() + RECEIVE_TIMEOUT;
+    while Instant::now() < deadline {
+        if let NodeMessage::Snapshot { .. } = receive_node(&mut reader) {
+            saw_snapshot = true;
+            break;
+        }
+    }
+    assert!(saw_snapshot, "the TUI should still be able to attach");
+    assert!(
+        fixture.running(),
+        "a refused ctl client must not end the node"
+    );
+}
+
+#[test]
+fn ctl_and_the_tui_share_a_node() {
+    let mut fixture = Fixture::start("ctl-tui");
+    fixture.wait_until_ctl_answers();
+    let (_stream, _reader, _) = attach(&fixture.socket);
+
+    let output = ctl_cli(&fixture, &["ctl", "machines"]);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "ctl should work while a TUI is attached: {stderr}"
+    );
+    assert!(stdout.contains("machines"), "{stdout}");
+    assert!(
+        stdout.contains("Test User"),
+        "this machine should be listed: {stdout}"
+    );
+    assert!(fixture.running());
+}
+
+#[test]
+fn spawn_send_and_focus_drive_a_local_pane() {
+    let mut fixture = Fixture::start("ctl-spawn");
+    fixture.wait_until_ctl_answers();
+
+    let nested = ctl_cli(
+        &fixture,
+        &["ctl", "spawn", "--machine", "Test User", "--", "p2pmux"],
+    );
+    let nested_err = String::from_utf8_lossy(&nested.stderr);
+    assert!(!nested.status.success(), "{nested_err}");
+    assert!(
+        nested_err.contains("p2pmux does not nest p2pmux"),
+        "{nested_err}"
+    );
+
+    let missing = ctl_cli(
+        &fixture,
+        &["ctl", "spawn", "--machine", "nobody", "--", "sleep", "30"],
+    );
+    let missing_err = String::from_utf8_lossy(&missing.stderr);
+    assert!(!missing.status.success(), "{missing_err}");
+    assert!(
+        missing_err.contains("no paired machine named nobody"),
+        "{missing_err}"
+    );
+
+    let first = ctl_cli(
+        &fixture,
+        &[
+            "ctl",
+            "spawn",
+            "--machine",
+            "Test User",
+            "--",
+            "sleep",
+            "120",
+        ],
+    );
+    let first_out = String::from_utf8_lossy(&first.stdout);
+    let first_err = String::from_utf8_lossy(&first.stderr);
+    assert!(first.status.success(), "spawn failed: {first_err}");
+    let first_json: serde_json::Value = serde_json::from_str(first_out.trim()).unwrap();
+    let pane_id = first_json["pane_id"].as_u64().expect("pane_id");
+    assert_eq!(first_json["reused"], false, "{first_out}");
+
+    let second = ctl_cli(
+        &fixture,
+        &[
+            "ctl",
+            "spawn",
+            "--machine",
+            "Test User",
+            "--",
+            "sleep",
+            "120",
+        ],
+    );
+    let second_out = String::from_utf8_lossy(&second.stdout);
+    let second_err = String::from_utf8_lossy(&second.stderr);
+    assert!(second.status.success(), "reuse spawn failed: {second_err}");
+    let second_json: serde_json::Value = serde_json::from_str(second_out.trim()).unwrap();
+    assert_eq!(second_json["pane_id"], pane_id, "{second_out}");
+    assert_eq!(second_json["reused"], true, "{second_out}");
+
+    let send = ctl_cli(&fixture, &["ctl", "send", &pane_id.to_string(), "x"]);
+    let send_err = String::from_utf8_lossy(&send.stderr);
+    assert!(send.status.success(), "send failed: {send_err}");
+
+    let focus = ctl_cli(&fixture, &["ctl", "focus", &pane_id.to_string()]);
+    let focus_err = String::from_utf8_lossy(&focus.stderr);
+    assert!(focus.status.success(), "focus failed: {focus_err}");
+
+    let agents = ctl_cli(&fixture, &["ctl", "agents"]);
+    let agents_out = String::from_utf8_lossy(&agents.stdout);
+    assert!(
+        agents.status.success(),
+        "{}",
+        String::from_utf8_lossy(&agents.stderr)
+    );
+    assert!(agents_out.contains("agents"), "{agents_out}");
+
+    assert!(fixture.running());
+}
+
+#[test]
+fn events_stream_without_a_tui() {
+    let mut fixture = Fixture::start("ctl-events");
+    fixture.wait_until_ctl_answers();
+
+    let spawn = ctl_cli(
+        &fixture,
+        &[
+            "ctl",
+            "spawn",
+            "--machine",
+            "Test User",
+            "--",
+            "sleep",
+            "120",
+        ],
+    );
+    assert!(
+        spawn.status.success(),
+        "{}",
+        String::from_utf8_lossy(&spawn.stderr)
+    );
+    let spawned: serde_json::Value =
+        serde_json::from_str(String::from_utf8_lossy(&spawn.stdout).trim()).unwrap();
+    let pane_id = spawned["pane_id"].as_u64().unwrap();
+
+    let (mut writer, mut reader, reply) = hello(&fixture.socket, CTL_PROTOCOL_PIN);
+    assert!(
+        matches!(reply, CtlToClient::CtlHelloAck { pin } if pin == CTL_PROTOCOL_PIN),
+        "{reply:?}"
+    );
+    ctl::write_json(&mut writer, &CtlFromClient::Events).unwrap();
+
+    let mut status = UnixStream::connect(&fixture.socket).unwrap();
+    send_client(
+        &mut status,
+        &ClientMessage::AgentStatus {
+            pane_id,
+            kind: "claude".into(),
+            status: "pending".into(),
+            cwd: "/tmp".into(),
+            message: "shall I continue?".into(),
+        },
+    );
+    drop(status);
+
+    let deadline = Instant::now() + RECEIVE_TIMEOUT;
+    let mut saw_needs_you = false;
+    while Instant::now() < deadline {
+        match ctl::receive_json::<CtlToClient>(&mut reader) {
+            Ok(Some(CtlToClient::Event { state, message, .. })) => {
+                if state == "needs_you" {
+                    assert_eq!(message, "shall I continue?");
+                    saw_needs_you = true;
+                    break;
+                }
+            }
+            Ok(Some(_)) | Ok(None) => {}
+            Err(error)
+                if error.kind() == std::io::ErrorKind::WouldBlock
+                    || error.kind() == std::io::ErrorKind::TimedOut => {}
+            Err(error) => panic!("events stream failed: {error}"),
+        }
+    }
+    assert!(saw_needs_you, "events should report the local needs_you");
+    assert!(fixture.running());
+}
+
+#[test]
+fn a_bad_ctl_client_does_not_end_the_session() {
+    let mut fixture = Fixture::start("ctl-bad");
+    fixture.wait_until_ctl_answers();
+
+    let mut stream = UnixStream::connect(&fixture.socket).unwrap();
+    stream.write_all(b"{{{{ not json\n").unwrap();
+    stream.flush().unwrap();
+    drop(stream);
+
+    fixture.wait_until_ctl_answers();
+    assert!(fixture.running());
+}
+
+#[test]
+fn an_old_node_is_reported_when_hello_is_ignored() {
+    // A first line the node does not understand is dropped the same way an
+    // older build would drop `ctl_hello`. The client must say so, not hang.
+    let mut fixture = Fixture::start("ctl-old");
+    fixture.wait_until_ctl_answers();
+
+    let (mut writer, mut reader) = connect_ctl(&fixture.socket);
+    writer.write_all(b"{\"type\":\"nope\"}\n").unwrap();
+    writer.flush().unwrap();
+    let started = Instant::now();
+    let reply = ctl::receive_json::<CtlToClient>(&mut reader).unwrap();
+    assert!(
+        reply.is_none(),
+        "an unknown first line must not look like ctl"
+    );
+    assert!(
+        started.elapsed() < Duration::from_secs(3),
+        "the client should notice quickly that this is not a ctl node"
+    );
+    assert!(fixture.running());
+}


### PR DESCRIPTION
Closes #136.

## Summary
- Add `p2pmux ctl` with six verbs (`machines`, `agents`, `spawn`, `send`, `focus`, `events`) that talk JSON to a live local node without taking the TUI seat.
- Ctl has its own pin (currently 1). The peer wire pin stays at 12; a mismatch names both numbers and which end to upgrade.
- `spawn` reuses a live inbox pane (`chat: {command}`), waits until it exists, and refuses nested `p2pmux`. `send` is raw PTY bytes and fails if another member holds the input lease.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features` (including live-node tests in `tests/ctl.rs`)
- [ ] Two-machine `work allow` / guest spawn refusal still wants a pair of boxes (not in CI)


Made with [Cursor](https://cursor.com)