### PR TITLE
ctl: spawn --new and name guest-visible panes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,10 @@ numbers and which end is old. A node that does not know ctl yet is told to upgra
 left hanging.
 
 `spawn` reuses a live inbox pane (`chat: {command}`) on that machine, waits until the pane exists,
-and will not nest `p2pmux`. `send` is raw PTY bytes and fails out loud when another member holds
-the input lease.
+and will not nest `p2pmux`. `spawn --new` always starts a pane. The reply includes
+`visible_to_guests` when someone unpaired is in the session. `send` is raw PTY bytes and fails out
+loud when another member holds the input lease. A ctl client that hangs up is dropped rather than
+held until the cap.
 
 ## v0.1.15 — 2026-09-01
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -89,7 +89,7 @@ Stdout is JSON. Failures are one sentence on stderr. The six verbs:
 ```text
 p2pmux ctl [--session NAME] machines
 p2pmux ctl [--session NAME] agents
-p2pmux ctl [--session NAME] spawn --machine NAME -- <command...>
+p2pmux ctl [--session NAME] spawn [--new] --machine NAME -- <command...>
 p2pmux ctl [--session NAME] send <pane-id> [--] <keys>
 p2pmux ctl [--session NAME] focus <agent>
 p2pmux ctl [--session NAME] events
@@ -97,15 +97,24 @@ p2pmux ctl [--session NAME] events
 
 `machines` is the pairing-owned list, including this machine. `agents` is the same roster Ctrl+O
 shows. `spawn` starts an allowlisted command on a machine you own, or a login shell when the
-command is empty. A live pane already titled `chat: {command}` on that host is reused; a pane
-that has exited or finished is not. Nested `p2pmux` is refused. The command waits until the pane
-exists.
+command is empty. Nested `p2pmux` is refused. The command waits until the pane exists.
+
+Without `--new`, a live pane already titled `chat: {command}` on that host is reused; a pane that
+has exited or finished is not. `--new` always starts a pane, which is what two jobs on one
+machine need. The JSON includes `visible_to_guests` when someone unpaired is in the session: the
+pane still opens, and anyone holding the join code can see it. Omit `--session` so ctl talks to
+the fleet session; a runner that wanted a private fleet skips the spawn when that flag is true.
 
 `send` writes the keys as PTY bytes, with no extra newline and no key names. It fails if someone
-else holds the pane's input lease. `focus` only moves to an agent that already has a pane —
-`p2pmux ctl spawn` is how one gets there. `events` prints `needs_you` / `done` / `error` as JSON
-lines: a snapshot first, then each change. The `message` field is present only when this node
-already has it.
+else holds the pane's input lease. It is typing, not a way to hand work from one agent to
+another. `focus` only moves to an agent that already has a pane — `p2pmux ctl spawn` is how one
+gets there. `events` prints `needs_you` / `done` / `error` as JSON lines: a snapshot first, then
+each change. The `message` field is present only when this node already has it, so a laptop
+watching a droplet sees the state and not the sentence.
+
+One agent finishing so another can start: wait on `events` until that `pane_id` is `done`, then
+`spawn --new` with the next command. The payload belongs on the command line (`claude -p …`),
+not in `send`.
 
 Ctl has its own pin, currently 1, independent of the peer wire pin. A client and a node that do
 not share it are told both numbers and which end to upgrade. A node too old to speak ctl at all

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -234,6 +234,9 @@ enum CtlCommand {
     Spawn {
         #[arg(long)]
         machine: String,
+        /// Do not reuse a live pane titled `chat: {command}` on that machine.
+        #[arg(long)]
+        new: bool,
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         command: Vec<String>,
     },
@@ -502,9 +505,14 @@ fn run_ctl(session: Option<&str>, action: &CtlCommand) -> Result<(), Box<dyn Err
     let action = match action {
         CtlCommand::Machines => crate::ctl::CtlAction::Machines,
         CtlCommand::Agents => crate::ctl::CtlAction::Agents,
-        CtlCommand::Spawn { machine, command } => crate::ctl::CtlAction::Spawn {
+        CtlCommand::Spawn {
+            machine,
+            command,
+            new,
+        } => crate::ctl::CtlAction::Spawn {
             machine: machine.clone(),
             command: command.clone(),
+            new: *new,
         },
         CtlCommand::Send { pane, keys } => {
             let pane_id = pane

--- a/src/ctl.rs
+++ b/src/ctl.rs
@@ -73,6 +73,8 @@ pub enum CtlToClient {
     Spawned {
         pane_id: u64,
         reused: bool,
+        #[serde(default)]
+        visible_to_guests: bool,
     },
     Sent {
         pane_id: u64,
@@ -302,12 +304,18 @@ pub fn run(socket: &Path, action: CtlAction) -> Result<(), Box<dyn Error>> {
                 serde_json::to_string(&serde_json::json!({ "agents": agents }))?
             );
         }
-        Some(CtlToClient::Spawned { pane_id, reused }) => {
+        Some(CtlToClient::Spawned {
+            pane_id,
+            reused,
+            visible_to_guests,
+        }) => {
             println!(
                 "{}",
-                serde_json::to_string(
-                    &serde_json::json!({ "pane_id": pane_id, "reused": reused })
-                )?
+                serde_json::to_string(&serde_json::json!({
+                    "pane_id": pane_id,
+                    "reused": reused,
+                    "visible_to_guests": visible_to_guests,
+                }))?
             );
         }
         Some(CtlToClient::Sent { pane_id }) => {
@@ -455,6 +463,24 @@ mod tests {
         })
         .unwrap();
         assert_eq!(forced["new"], true);
+    }
+
+    #[test]
+    fn spawned_without_visible_to_guests_defaults_false() {
+        let spawned: CtlToClient = serde_json::from_value(serde_json::json!({
+            "type": "spawned",
+            "pane_id": 3,
+            "reused": true
+        }))
+        .unwrap();
+        assert_eq!(
+            spawned,
+            CtlToClient::Spawned {
+                pane_id: 3,
+                reused: true,
+                visible_to_guests: false,
+            }
+        );
     }
 
     #[test]

--- a/src/ctl.rs
+++ b/src/ctl.rs
@@ -38,6 +38,10 @@ pub enum CtlFromClient {
         machine: String,
         #[serde(default)]
         command: Vec<String>,
+        /// Skip reuse of a live `chat: {command}` pane. Omitted by older
+        /// clients, which keep the inbox behaviour.
+        #[serde(default)]
+        new: bool,
     },
     Send {
         pane_id: u64,
@@ -122,6 +126,7 @@ pub enum CtlAction {
     Spawn {
         machine: String,
         command: Vec<String>,
+        new: bool,
     },
     Send {
         pane_id: u64,
@@ -246,9 +251,14 @@ pub fn run(socket: &Path, action: CtlAction) -> Result<(), Box<dyn Error>> {
     let request = match &action {
         CtlAction::Machines => CtlFromClient::Machines,
         CtlAction::Agents => CtlFromClient::Agents,
-        CtlAction::Spawn { machine, command } => CtlFromClient::Spawn {
+        CtlAction::Spawn {
+            machine,
+            command,
+            new,
+        } => CtlFromClient::Spawn {
             machine: machine.clone(),
             command: command.clone(),
+            new: *new,
         },
         CtlAction::Send { pane_id, keys } => CtlFromClient::Send {
             pane_id: *pane_id,
@@ -264,13 +274,14 @@ pub fn run(socket: &Path, action: CtlAction) -> Result<(), Box<dyn Error>> {
     if matches!(action, CtlAction::Events) {
         reader.get_mut().set_read_timeout(None)?;
         loop {
-            match receive_json::<CtlToClient>(&mut reader)? {
-                Some(event @ CtlToClient::Event { .. }) => {
+            match receive_json::<CtlToClient>(&mut reader) {
+                Ok(Some(event @ CtlToClient::Event { .. })) => {
                     println!("{}", serde_json::to_string(&event)?);
                 }
-                Some(CtlToClient::Error { message }) => return Err(CtlError(message).into()),
-                Some(_) => {}
-                None => return Ok(()),
+                Ok(Some(CtlToClient::Error { message })) => return Err(CtlError(message).into()),
+                Ok(Some(_)) | Ok(None) => {}
+                Err(error) if error.kind() == io::ErrorKind::UnexpectedEof => return Ok(()),
+                Err(error) => return Err(error.into()),
             }
         }
     }
@@ -354,7 +365,10 @@ pub fn receive_json<T: for<'de> Deserialize<'de>>(
         Err(error) => return Err(error),
     };
     if count == 0 {
-        return Ok(None);
+        return Err(io::Error::new(
+            io::ErrorKind::UnexpectedEof,
+            "ctl connection closed",
+        ));
     }
     if count > MAX_FRAME {
         return Err(io::Error::new(
@@ -415,6 +429,32 @@ mod tests {
         assert!(is_nested_p2pmux(&[String::from("/usr/local/bin/p2pmux")]));
         assert!(!is_nested_p2pmux(&[String::from("claude")]));
         assert!(!is_nested_p2pmux(&[]));
+    }
+
+    #[test]
+    fn spawn_without_new_keeps_reusing() {
+        let spawn: CtlFromClient = serde_json::from_value(serde_json::json!({
+            "type": "spawn",
+            "machine": "droplet",
+            "command": ["claude"]
+        }))
+        .unwrap();
+        assert_eq!(
+            spawn,
+            CtlFromClient::Spawn {
+                machine: String::from("droplet"),
+                command: vec![String::from("claude")],
+                new: false,
+            }
+        );
+
+        let forced = serde_json::to_value(CtlFromClient::Spawn {
+            machine: String::from("droplet"),
+            command: vec![String::from("claude")],
+            new: true,
+        })
+        .unwrap();
+        assert_eq!(forced["new"], true);
     }
 
     #[test]

--- a/src/node.rs
+++ b/src/node.rs
@@ -1264,7 +1264,7 @@ struct CtlClient {
     events: bool,
     seen_events: BTreeSet<(String, String)>,
     spawn_wait: Option<u64>,
-    spawn_retry: Option<(String, Vec<String>)>,
+    spawn_retry: Option<(String, Vec<String>, bool)>,
 }
 
 fn accept_ctl_hello(mut reader: BufReader<UnixStream>, pin: u32, clients: &mut Vec<CtlClient>) {
@@ -1323,8 +1323,8 @@ fn poll_ctl_clients(clients: &mut Vec<CtlClient>, node: &mut SharedLayoutNode) -
 
 fn poll_one_ctl(client: &mut CtlClient, node: &mut SharedLayoutNode) -> io::Result<bool> {
     let mut did_work = false;
-    if let Some((machine, command)) = client.spawn_retry.clone() {
-        match dispatch_ctl_spawn(node, client, machine, command) {
+    if let Some((machine, command, new)) = client.spawn_retry.clone() {
+        match dispatch_ctl_spawn(node, client, machine, command, new) {
             Ok(true) => {
                 client.spawn_retry = None;
                 did_work = true;
@@ -1386,8 +1386,12 @@ fn poll_one_ctl(client: &mut CtlClient, node: &mut SharedLayoutNode) -> io::Resu
             )?;
             did_work = true;
         }
-        Ok(Some(CtlFromClient::Spawn { machine, command })) => {
-            match dispatch_ctl_spawn(node, client, machine, command) {
+        Ok(Some(CtlFromClient::Spawn {
+            machine,
+            command,
+            new,
+        })) => {
+            match dispatch_ctl_spawn(node, client, machine, command, new) {
                 Ok(_) => {}
                 Err(message) => {
                     ctl::write_json(client.reader.get_mut(), &CtlToClient::Error { message })?
@@ -1432,7 +1436,9 @@ fn poll_one_ctl(client: &mut CtlClient, node: &mut SharedLayoutNode) -> io::Resu
         Err(error)
             if matches!(
                 error.kind(),
-                io::ErrorKind::ConnectionReset | io::ErrorKind::BrokenPipe
+                io::ErrorKind::ConnectionReset
+                    | io::ErrorKind::BrokenPipe
+                    | io::ErrorKind::UnexpectedEof
             ) =>
         {
             return Err(error);
@@ -1447,8 +1453,9 @@ fn dispatch_ctl_spawn(
     client: &mut CtlClient,
     machine: String,
     command: Vec<String>,
+    new: bool,
 ) -> Result<bool, String> {
-    match node.runtime.ctl_try_spawn(&machine, command.clone()) {
+    match node.runtime.ctl_try_spawn(&machine, command.clone(), new) {
         Ok(crate::ctl::CtlSpawn::Reused(pane_id)) => {
             ctl::write_json(
                 client.reader.get_mut(),
@@ -1461,7 +1468,7 @@ fn dispatch_ctl_spawn(
             Ok(true)
         }
         Ok(crate::ctl::CtlSpawn::Busy) => {
-            client.spawn_retry = Some((machine, command));
+            client.spawn_retry = Some((machine, command, new));
             Ok(false)
         }
         Ok(crate::ctl::CtlSpawn::Started(request_id)) => {

--- a/src/node.rs
+++ b/src/node.rs
@@ -1342,13 +1342,9 @@ fn poll_one_ctl(client: &mut CtlClient, node: &mut SharedLayoutNode) -> io::Resu
     {
         client.spawn_wait = None;
         match result {
-            Ok(pane_id) => ctl::write_json(
-                client.reader.get_mut(),
-                &CtlToClient::Spawned {
-                    pane_id,
-                    reused: false,
-                },
-            )?,
+            Ok(pane_id) => {
+                ctl::write_json(client.reader.get_mut(), &ctl_spawned(node, pane_id, false))?
+            }
             Err(message) => {
                 ctl::write_json(client.reader.get_mut(), &CtlToClient::Error { message })?
             }
@@ -1457,14 +1453,8 @@ fn dispatch_ctl_spawn(
 ) -> Result<bool, String> {
     match node.runtime.ctl_try_spawn(&machine, command.clone(), new) {
         Ok(crate::ctl::CtlSpawn::Reused(pane_id)) => {
-            ctl::write_json(
-                client.reader.get_mut(),
-                &CtlToClient::Spawned {
-                    pane_id,
-                    reused: true,
-                },
-            )
-            .map_err(|error| error.to_string())?;
+            ctl::write_json(client.reader.get_mut(), &ctl_spawned(node, pane_id, true))
+                .map_err(|error| error.to_string())?;
             Ok(true)
         }
         Ok(crate::ctl::CtlSpawn::Busy) => {
@@ -1475,14 +1465,10 @@ fn dispatch_ctl_spawn(
             let _ = node.drain();
             if let Some(result) = node.runtime.ctl_take_result(request_id) {
                 match result {
-                    Ok(pane_id) => ctl::write_json(
-                        client.reader.get_mut(),
-                        &CtlToClient::Spawned {
-                            pane_id,
-                            reused: false,
-                        },
-                    )
-                    .map_err(|error| error.to_string())?,
+                    Ok(pane_id) => {
+                        ctl::write_json(client.reader.get_mut(), &ctl_spawned(node, pane_id, false))
+                            .map_err(|error| error.to_string())?
+                    }
                     Err(message) => {
                         return Err(message);
                     }
@@ -1493,6 +1479,14 @@ fn dispatch_ctl_spawn(
             Ok(true)
         }
         Err(message) => Err(message),
+    }
+}
+
+fn ctl_spawned(node: &mut SharedLayoutNode, pane_id: u64, reused: bool) -> CtlToClient {
+    CtlToClient::Spawned {
+        pane_id,
+        reused,
+        visible_to_guests: node.runtime.ctl_visible_to_guests(),
     }
 }
 

--- a/src/tui/home.rs
+++ b/src/tui/home.rs
@@ -1085,6 +1085,11 @@ pub(in crate::tui) fn machine_rows(tui: &MultiPaneTui) -> Vec<MachineRow> {
     rows
 }
 
+/// Whether a pane opened in this session is on a screen someone unpaired can see.
+pub(in crate::tui) fn spawn_visible_to_guests(tui: &MultiPaneTui) -> bool {
+    machine_rows(tui).iter().any(|row| !row.owned)
+}
+
 /// One machine on the inbox, and one row of `p2pmux machines`.
 ///
 /// Public because the CLI builds these too: the `m` key on Home and the command
@@ -1227,7 +1232,7 @@ mod tests {
 
     use super::{
         HOME_PAGE_MAX, HomeCard, MACHINE_RAIL_WIDTH, MachinePanel, chat_pane_title, home_card,
-        home_layout, home_page_size, machine_rows,
+        home_layout, home_page_size, machine_rows, spawn_visible_to_guests,
     };
     use crate::{
         layout::{Axis, Node, Tab},
@@ -1564,6 +1569,29 @@ mod tests {
             .expect("the paired machine is listed");
         assert!(!oldbox.reachable);
         assert_eq!(oldbox.accepts_work, Some(true));
+    }
+
+    #[test]
+    fn a_guest_in_the_session_makes_ctl_spawn_visible_to_guests() {
+        let mut tui = home_tui(&[("laptop", "claude", AgentRosterState::Working)]);
+        tui.local_peer_id = Some(b"host".to_vec());
+        tui.snapshot.members[0].display_name = String::from("laptop");
+        tui.snapshot.members.push(crate::layout::Member {
+            peer_id: vec![0xca, 0xfe],
+            endpoint_addr: vec![2],
+            display_name: String::from("sam"),
+            kind: crate::layout::MemberKind::Person,
+            machine_proof: Default::default(),
+            machine_id: Default::default(),
+        });
+
+        assert!(spawn_visible_to_guests(&tui));
+    }
+
+    #[test]
+    fn a_session_of_only_this_machine_is_not_visible_to_guests() {
+        let tui = home_tui(&[("laptop", "claude", AgentRosterState::Working)]);
+        assert!(!spawn_visible_to_guests(&tui));
     }
 
     #[test]

--- a/src/tui/runtime/ctl.rs
+++ b/src/tui/runtime/ctl.rs
@@ -72,6 +72,7 @@ impl SharedLayoutRuntime {
         &mut self,
         machine: &str,
         command: Vec<String>,
+        new: bool,
     ) -> Result<CtlSpawn, String> {
         if is_nested_p2pmux(&command) {
             return Err(String::from("p2pmux does not nest p2pmux in a pane"));
@@ -96,7 +97,7 @@ impl SharedLayoutRuntime {
                 "{machine} is asleep — start p2pmux on it and it rejoins on its own"
             ));
         };
-        if let Some(pane_id) = self.live_chat_pane(machine, &command) {
+        if !new && let Some(pane_id) = self.live_chat_pane(machine, &command) {
             return Ok(CtlSpawn::Reused(pane_id));
         }
         if self.pending_create.is_some() {

--- a/src/tui/runtime/ctl.rs
+++ b/src/tui/runtime/ctl.rs
@@ -125,6 +125,11 @@ impl SharedLayoutRuntime {
         Ok(CtlSpawn::Started(request_id))
     }
 
+    pub(crate) fn ctl_visible_to_guests(&mut self) -> bool {
+        self.ctl_prepare();
+        super::super::home::spawn_visible_to_guests(&self.tui)
+    }
+
     pub(crate) fn ctl_watch(&mut self, request_id: u64) {
         self.ctl_waiting.insert(request_id);
     }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -450,6 +450,14 @@ fn ctl_help_lists_the_six_verbs() {
 }
 
 #[test]
+fn spawn_help_lists_new() {
+    let output = run(&["ctl", "spawn", "--help"]);
+    assert!(output.status.success());
+    let help = String::from_utf8(output.stdout).expect("stdout should be UTF-8");
+    assert!(help.contains("--new"), "{help}");
+}
+
+#[test]
 fn ctl_without_a_session_does_not_start_one() {
     let session = FakeSession::empty();
     let output = run_with_home(session.home(), &["ctl", "machines"]);

--- a/tests/ctl.rs
+++ b/tests/ctl.rs
@@ -334,6 +334,27 @@ fn spawn_send_and_focus_drive_a_local_pane() {
     assert_eq!(second_json["pane_id"], pane_id, "{second_out}");
     assert_eq!(second_json["reused"], true, "{second_out}");
 
+    let third = ctl_cli(
+        &fixture,
+        &[
+            "ctl",
+            "spawn",
+            "--new",
+            "--machine",
+            "Test User",
+            "--",
+            "sleep",
+            "120",
+        ],
+    );
+    let third_out = String::from_utf8_lossy(&third.stdout);
+    let third_err = String::from_utf8_lossy(&third.stderr);
+    assert!(third.status.success(), "new spawn failed: {third_err}");
+    let third_json: serde_json::Value = serde_json::from_str(third_out.trim()).unwrap();
+    let new_pane = third_json["pane_id"].as_u64().expect("pane_id");
+    assert_ne!(new_pane, pane_id, "{third_out}");
+    assert_eq!(third_json["reused"], false, "{third_out}");
+
     let send = ctl_cli(&fixture, &["ctl", "send", &pane_id.to_string(), "x"]);
     let send_err = String::from_utf8_lossy(&send.stderr);
     assert!(send.status.success(), "send failed: {send_err}");
@@ -430,11 +451,12 @@ fn an_old_node_is_reported_when_hello_is_ignored() {
     writer.write_all(b"{\"type\":\"nope\"}\n").unwrap();
     writer.flush().unwrap();
     let started = Instant::now();
-    let reply = ctl::receive_json::<CtlToClient>(&mut reader).unwrap();
-    assert!(
-        reply.is_none(),
-        "an unknown first line must not look like ctl"
-    );
+    let reply = ctl::receive_json::<CtlToClient>(&mut reader);
+    match reply {
+        Ok(None) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::UnexpectedEof => {}
+        other => panic!("an unknown first line must not look like ctl: {other:?}"),
+    }
     assert!(
         started.elapsed() < Duration::from_secs(3),
         "the client should notice quickly that this is not a ctl node"

--- a/tests/ctl.rs
+++ b/tests/ctl.rs
@@ -314,6 +314,7 @@ fn spawn_send_and_focus_drive_a_local_pane() {
     let first_json: serde_json::Value = serde_json::from_str(first_out.trim()).unwrap();
     let pane_id = first_json["pane_id"].as_u64().expect("pane_id");
     assert_eq!(first_json["reused"], false, "{first_out}");
+    assert_eq!(first_json["visible_to_guests"], false, "{first_out}");
 
     let second = ctl_cli(
         &fixture,


### PR DESCRIPTION
## Summary
- `p2pmux ctl spawn --new` always starts a pane. Default spawn still reuses a live `chat: {command}` inbox pane.
- Spawn JSON now includes `visible_to_guests` when someone unpaired is in the session, so a runner can skip work that would show up on a guest's screen.
- USAGE says how to hand A→B: wait on `events` for that `pane_id`, then `spawn --new`. `send` stays typing, not a mailbox.

This is the factory-shaped follow-up to ctl (#136 / #138). The paired-only bus is #141, not this PR.

Closes #136.

## Test plan
- [ ] `p2pmux ctl spawn --machine <you> -- sleep 120` twice: second reply has `"reused": true` and the same `pane_id`
- [ ] same command with `--new`: a different `pane_id`, `"reused": false`
- [ ] a session with only this machine: `"visible_to_guests": false`
- [ ] `p2pmux ctl spawn --help` lists `--new`
- [ ] `cargo test --all-features --test ctl -- --test-threads=1`


Made with [Cursor](https://cursor.com)